### PR TITLE
docs: 在 README 新增墨寒聲援劇場／在 README 新增墨寒声援剧场／Add MoHan support theater to README／README に墨寒応援シアターを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ tokens, or private user data.
   </tr>
 </table>
 
+## 支持墨寒 / Support MoHan
+
+如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源
+開發，歡迎自願贊助這個專案。每一份支持都會成為持續維護、測試與改進
+墨寒的動力。請先照顧好自己的生活，量力而為即可。
+
+If you enjoy MoHan and would like to support continued work on character
+interaction, natural voice, safety-first tools, and open-source development,
+voluntary contributions are warmly welcome. Please take care of yourself first
+and contribute only if it is comfortable for you.
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong><br><sub>“I am not waiting for support… merely inspecting our provisions.”</sub></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong><br><sub>“If you truly wish to help… I shall remember it.”</sub></td>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong><br><sub>“No overdoing it! Take care of yourself first—understood?”</sub></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
 ---
 
 # 繁體中文

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -50,6 +50,17 @@ def main() -> int:
     assert b"ftyp" in header, "demonstration video is not an MP4 container"
     assert "docs/media/mohan-demo.mp4" in readme
 
+    support_requirements = (
+        "## 支持墨寒 / Support MoHan",
+        "assets/expressions/proud_front.png",
+        "assets/expressions/shy_cute_front.png",
+        "assets/expressions/mock_hit_front.png",
+        "https://buymeacoffee.com/flameblade_studio",
+        "https://www.paypal.com/paypalme/flamebladestudio",
+    )
+    for requirement in support_requirements:
+        assert requirement in readme, f"missing project support content: {requirement}"
+
     security = (ROOT / "SECURITY.md").read_text(encoding="utf-8").lower()
     assert "private vulnerability reporting" in security
     assert "api key" in security and "oauth" in security


### PR DESCRIPTION
## 繁體中文

- 變更範圍：在 README 新增墨寒聲援劇場。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：在 README 新增墨寒声援剧场。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Add MoHan support theater to README.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：README に墨寒応援シアターを追加。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。