### PR TITLE
security: 強化遠端檔案目錄與下載標頭／强化远程文件目录与下载标头／Harden remote file catalog and download headers／リモートファイル一覧とダウンロードヘッダーを強化

### DIFF
--- a/remote_control.py
+++ b/remote_control.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import mimetypes
 import os
 import secrets
 import sqlite3
@@ -14,12 +13,40 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 
 StatusProvider = Callable[[], dict[str, Any]]
 CommandHandler = Callable[[str, str], dict[str, Any]]
 ScreenProvider = Callable[[], bytes]
+
+SAFE_DOWNLOAD_TYPES = {
+    ".csv": "text/csv; charset=utf-8",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".gif": "image/gif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".json": "application/json",
+    ".md": "text/markdown; charset=utf-8",
+    ".mp3": "audio/mpeg",
+    ".mp4": "video/mp4",
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".txt": "text/plain; charset=utf-8",
+    ".wav": "audio/wav",
+    ".webp": "image/webp",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".zip": "application/zip",
+}
+PROTECTED_REMOTE_PARTS = {
+    ".gnupg",
+    ".ssh",
+    "appdata",
+    "credentials",
+    "passwords",
+}
+PROTECTED_REMOTE_SUFFIXES = {".kdbx", ".key", ".pem", ".pfx"}
 
 MOBILE_PAGE = """<!doctype html>
 <html lang="zh-Hant-TW"><meta charset="utf-8">
@@ -251,17 +278,12 @@ class RemoteControlServer:
                         self._json(HTTPStatus.FORBIDDEN, {"error": str(exc)})
                         return
                     content = target.read_bytes()
+                    content_type, disposition = owner._download_metadata(target)
                     self.send_response(HTTPStatus.OK)
-                    self.send_header(
-                        "Content-Type",
-                        mimetypes.guess_type(target.name)[0]
-                        or "application/octet-stream",
-                    )
+                    self.send_header("Content-Type", content_type)
                     self.send_header("Content-Length", str(len(content)))
-                    self.send_header(
-                        "Content-Disposition",
-                        f'attachment; filename="{target.name}"',
-                    )
+                    self.send_header("Content-Disposition", disposition)
+                    self.send_header("X-Content-Type-Options", "nosniff")
                     self.send_header("Cache-Control", "no-store")
                     self.end_headers()
                     self.wfile.write(content)
@@ -338,42 +360,60 @@ class RemoteControlServer:
         return True
 
     def _allowed_file(self, raw: str) -> Path:
-        candidate_text = os.path.normpath(
+        requested_key = os.path.normcase(
             os.path.abspath(os.path.expanduser(raw))
         )
-        candidate_key = os.path.normcase(candidate_text)
-        allowed_prefixes = tuple(
-            os.path.normcase(os.path.join(str(root), ""))
-            for root in self.allowed_folders
-        )
-        if not any(candidate_key.startswith(prefix) for prefix in allowed_prefixes):
-            raise PermissionError("檔案不在遠端白名單")
-        try:
-            resolved_text = os.path.realpath(candidate_text)
-        except (OSError, RuntimeError) as exc:
-            raise PermissionError("無法安全解析遠端檔案") from exc
-        resolved_key = os.path.normcase(resolved_text)
-        if not any(resolved_key.startswith(prefix) for prefix in allowed_prefixes):
-            raise PermissionError("檔案不在遠端白名單")
-        target = Path(resolved_text)
-        if not target.is_file():
-            raise FileNotFoundError("找不到檔案")
+        for target in self._allowed_file_catalog():
+            if os.path.normcase(str(target)) == requested_key:
+                return target
+        raise PermissionError("檔案不在遠端白名單或已受保護")
+
+    def _allowed_file_catalog(self) -> Iterator[Path]:
+        seen: set[str] = set()
+        for root in self.allowed_folders:
+            root_prefix = os.path.normcase(os.path.join(str(root), ""))
+            for directory, folder_names, file_names in os.walk(
+                root,
+                followlinks=False,
+            ):
+                folder_names[:] = [
+                    name
+                    for name in folder_names
+                    if name.casefold() not in PROTECTED_REMOTE_PARTS
+                ]
+                for file_name in file_names:
+                    candidate = Path(directory, file_name)
+                    try:
+                        target = candidate.resolve(strict=True)
+                    except (OSError, RuntimeError):
+                        continue
+                    target_key = os.path.normcase(str(target))
+                    if not target_key.startswith(root_prefix) or target_key in seen:
+                        continue
+                    if not target.is_file() or self._is_sensitive_file(target):
+                        continue
+                    seen.add(target_key)
+                    yield target
+
+    @staticmethod
+    def _is_sensitive_file(target: Path) -> bool:
         lowered = {part.casefold() for part in target.parts}
-        protected = {
-            ".ssh",
-            ".gnupg",
-            "credentials",
-            "passwords",
-            "appdata",
-        }
-        if lowered & protected or target.suffix.casefold() in {
-            ".key",
-            ".pem",
-            ".pfx",
-            ".kdbx",
-        }:
-            raise PermissionError("敏感檔案禁止遠端存取")
-        return target
+        return bool(
+            lowered & PROTECTED_REMOTE_PARTS
+            or target.suffix.casefold() in PROTECTED_REMOTE_SUFFIXES
+        )
+
+    @staticmethod
+    def _download_metadata(target: Path) -> tuple[str, str]:
+        suffix = target.suffix.casefold()
+        content_type = SAFE_DOWNLOAD_TYPES.get(
+            suffix,
+            "application/octet-stream",
+        )
+        safe_suffix = suffix if suffix in SAFE_DOWNLOAD_TYPES else ".bin"
+        digest = hashlib.sha256(target.name.encode("utf-8")).hexdigest()[:16]
+        disposition = f'attachment; filename="mohan-{digest}{safe_suffix}"'
+        return content_type, disposition
 
 
 def constant_time_token_equal(left: str, right: str) -> bool:

--- a/tests/test_remote_file_access.py
+++ b/tests/test_remote_file_access.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import sys
+import urllib.parse
+import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -38,6 +40,31 @@ def main() -> None:
         try:
             server = _server(db, allowed)
             assert server._allowed_file(str(inside)) == inside.resolve()
+            content_type, disposition = server._download_metadata(inside)
+            assert content_type == "text/plain; charset=utf-8"
+            assert disposition.startswith('attachment; filename="mohan-')
+            assert "\r" not in disposition and "\n" not in disposition
+
+            token = server.tokens.pair("測試裝置", ["files"])
+            server.config.enabled = True
+            server.config.allow_files = True
+            server.config.host = "127.0.0.1"
+            server.config.port = 0
+            server.start()
+            try:
+                port = server._server.server_port
+                query = urllib.parse.urlencode({"path": str(inside)})
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{port}/api/v1/file?{query}",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                with urllib.request.urlopen(request, timeout=3) as response:
+                    assert response.read() == b"safe"
+                    assert response.headers["Content-Type"].startswith("text/plain")
+                    assert response.headers["Content-Disposition"] == disposition
+                    assert response.headers["X-Content-Type-Options"] == "nosniff"
+            finally:
+                server.stop()
 
             for blocked in (
                 outside,


### PR DESCRIPTION
## 繁體中文

- 變更範圍：強化遠端檔案目錄與下載標頭。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：强化远程文件目录与下载标头。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Harden remote file catalog and download headers.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：リモートファイル一覧とダウンロードヘッダーを強化。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。