### PR TITLE
feat: 墨寒遷移至 Python 3.14／墨寒迁移至 Python 3.14／Migrate MoHan to Python 3.14／墨寒を Python 3.14 へ移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
 
       - name: Install runtime and release dependencies

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
 
       - name: Install audit tool

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
 
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
       - name: Install runtime dependencies
         run: python -m pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <p align="center">
   <strong>Author / 軟體作者：CHOU MING HUA</strong><br>
   Current public preview / 目前公開預覽版：v2.0.14 RC3<br>
-  Windows 10/11 · Python 3.12 · PySide6 · MIT License
+  Windows 10/11 · Python 3.14 · PySide6 · MIT License
 </p>
 
 > 墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，
@@ -365,10 +365,12 @@ Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
 
 ## 從原始碼執行
 
-需求：Windows 10/11、Python 3.12+。
+需求：Windows 10/11、Python 3.14.x。
+升級、資料保留與回復方式請見
+[Python 3.14 遷移說明](docs/PYTHON-3.14-MIGRATION.md)。
 
 ```powershell
-py -3.12 -m venv .venv
+py -3.14 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install -r requirements.txt
 python app.py
@@ -644,10 +646,12 @@ Read [PRIVACY.md](PRIVACY.md), [SECURITY.md](SECURITY.md), and
 
 ## Run from source
 
-Requirements: Windows 10/11 and Python 3.12+.
+Requirements: Windows 10/11 and Python 3.14.x.
+See the [Python 3.14 migration guide](docs/PYTHON-3.14-MIGRATION.md) for data
+preservation and rollback details.
 
 ```powershell
-py -3.12 -m venv .venv
+py -3.14 -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install -r requirements.txt
 python app.py

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 [安全说明](SECURITY.md)
 
 > 当前公开预览版本：v2.0.14 RC3<br>
-> Windows 10/11 · Python 3.12 · PySide6 · MIT License
+> Windows 10/11 · Python 3.14 · PySide6 · MIT License
 
 墨寒是一款重视安全、隐私与角色连续感的 Windows 桌面虚拟助手。她以来自
 北宋、寄宿于赤焰剑中的千年女剑魂为角色背景，结合透明桌面角色、文字与
@@ -108,10 +108,12 @@ Google Gmail、Calendar 与 Drive 已完成当前项目的真实连接测试，�
 
 ## 从源代码运行
 
-需求：Windows 10/11、Python 3.12+。
+需求：Windows 10/11、Python 3.14.x。
+升级、数据保留与回退方式请见
+[Python 3.14 迁移说明](docs/PYTHON-3.14-MIGRATION.md)。
 
 ```powershell
-py -3.12 -m venv .venv
+py -3.14 -m venv .venv
 .venv\Scripts\Activate.ps1
 python -m pip install -r requirements.txt
 python app.py

--- a/build.ps1
+++ b/build.ps1
@@ -27,10 +27,16 @@ if (-not $Python) {
     throw "Python was not found. Activate a virtual environment or pass -Python."
 }
 
+$PythonVersion = (& $Python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')").Trim()
+if ($LASTEXITCODE -ne 0 -or $PythonVersion -notmatch '^3\.14(?:\.|$)') {
+    throw "MoHan RC4 packages must be built with Python 3.14.x; found $PythonVersion."
+}
+
 $BuildInfo = Join-Path $ProjectRoot "build-info.json"
 @{
     version = $Version
     repository = "hitoshic1982/MoHan-PC-Desktop-Assistant"
+    python = $PythonVersion
 } | ConvertTo-Json | Set-Content -Encoding utf8 $BuildInfo
 
 try {

--- a/docs/PYTHON-3.14-MIGRATION.md
+++ b/docs/PYTHON-3.14-MIGRATION.md
@@ -1,0 +1,38 @@
+# Python 3.14 migration / Python 3.14 遷移 / Python 3.14 迁移
+
+## 繁體中文
+
+RC4 的原始碼、Windows CI、安全稽核與正式封裝統一使用 Python 3.14.x。
+Python 3.13 起移除的 `audioop` 已由專案內部的 PCM16 音訊層取代，涵蓋音量
+調整、立體聲轉單聲道及 Realtime 串流重採樣，避免增加新的第三方供應鏈依賴。
+
+升級不會搬移或重建使用者資料庫。RC3 的設定、對話、記憶與工作資料仍沿用
+既有資料位置。開發期間保留 Python 3.12 環境只供回歸與回復驗證；RC4 安裝包
+不得以 Python 3.12 封裝。若 RC4 候選版驗證失敗，可移除 RC4 並重新執行已
+驗證的 RC3 安裝包，且不得刪除使用者資料目錄。
+
+## 简体中文
+
+RC4 的源代码、Windows CI、安全审计与正式打包统一使用 Python 3.14.x。
+Python 3.13 起移除的 `audioop` 已由项目内部的 PCM16 音频层取代，涵盖音量
+调整、立体声转单声道及 Realtime 流式重采样，避免增加新的第三方供应链依赖。
+
+升级不会迁移或重建用户数据库。RC3 的设置、对话、记忆与工作数据继续使用
+原有数据位置。开发期间保留 Python 3.12 环境仅用于回归与回退验证；RC4 安装
+包不得使用 Python 3.12 打包。若 RC4 候选版验证失败，可移除 RC4 并重新运行
+已验证的 RC3 安装包，同时不得删除用户数据目录。
+
+## English
+
+RC4 standardizes source validation, Windows CI, security auditing, and release
+packaging on Python 3.14.x. The `audioop` module removed in Python 3.13 is
+replaced by an in-project PCM16 layer for gain, stereo-to-mono mixing, and
+stateful Realtime stream resampling. This avoids adding another third-party
+supply-chain dependency.
+
+The upgrade neither moves nor recreates the user database. Existing RC3
+settings, conversations, memories, and work data keep their current location.
+Python 3.12 remains available during development only for regression and
+rollback validation; RC4 artifacts must not be packaged with it. If RC4
+candidate validation fails, remove RC4 and reinstall the verified RC3 package
+without deleting the user data directory.

--- a/pcm_audio.py
+++ b/pcm_audio.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from array import array
+from dataclasses import dataclass
+import math
+import sys
+
+
+class PcmAudioError(ValueError):
+    """Raised when a PCM16 buffer or conversion request is invalid."""
+
+
+@dataclass(frozen=True)
+class Pcm16RateState:
+    """Small, serializable state used between streamed resampling chunks."""
+
+    tail_frame: tuple[int, ...]
+    phase: int
+
+
+def _decode_pcm16(data: bytes, channels: int = 1) -> array[int]:
+    if channels < 1:
+        raise PcmAudioError("channels must be at least one")
+    frame_width = channels * 2
+    if len(data) % frame_width:
+        raise PcmAudioError("PCM16 data must contain complete frames")
+    samples = array("h")
+    samples.frombytes(data)
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return samples
+
+
+def _encode_pcm16(samples: array[int]) -> bytes:
+    if sys.byteorder != "little":
+        samples.byteswap()
+    return samples.tobytes()
+
+
+def _clip_pcm16(value: float) -> int:
+    return max(-32768, min(32767, math.floor(value)))
+
+
+def scale_pcm16(data: bytes, factor: float) -> bytes:
+    """Scale little-endian signed PCM16 samples with saturation."""
+    if not math.isfinite(factor):
+        raise PcmAudioError("gain factor must be finite")
+    samples = _decode_pcm16(data)
+    adjusted = array("h", (_clip_pcm16(sample * factor) for sample in samples))
+    return _encode_pcm16(adjusted)
+
+
+def stereo_to_mono_pcm16(
+    data: bytes,
+    left_factor: float = 0.5,
+    right_factor: float = 0.5,
+) -> bytes:
+    """Mix interleaved stereo PCM16 into mono PCM16."""
+    if not math.isfinite(left_factor) or not math.isfinite(right_factor):
+        raise PcmAudioError("mix factors must be finite")
+    samples = _decode_pcm16(data, channels=2)
+    mixed = array(
+        "h",
+        (
+            _clip_pcm16(
+                samples[index] * left_factor
+                + samples[index + 1] * right_factor
+            )
+            for index in range(0, len(samples), 2)
+        ),
+    )
+    return _encode_pcm16(mixed)
+
+
+def rate_convert_pcm16(
+    data: bytes,
+    channels: int,
+    input_rate: int,
+    output_rate: int,
+    state: Pcm16RateState | None = None,
+) -> tuple[bytes, Pcm16RateState | None]:
+    """Linearly resample streamed PCM16 while preserving chunk continuity."""
+    if input_rate <= 0 or output_rate <= 0:
+        raise PcmAudioError("sample rates must be positive")
+    samples = _decode_pcm16(data, channels=channels)
+    if input_rate == output_rate:
+        return data, None
+    if not samples:
+        return b"", state
+
+    frames = [
+        tuple(samples[index : index + channels])
+        for index in range(0, len(samples), channels)
+    ]
+    if state is None:
+        phase = 0
+    else:
+        if len(state.tail_frame) != channels:
+            raise PcmAudioError("resampling state channel count changed")
+        frames.insert(0, state.tail_frame)
+        phase = state.phase
+
+    last_index = len(frames) - 1
+    last_position = last_index * output_rate
+    converted = array("h")
+    while phase <= last_position:
+        source_index, fraction = divmod(phase, output_rate)
+        if source_index == last_index and fraction:
+            break
+        if fraction == 0:
+            converted.extend(frames[source_index])
+        else:
+            next_frame = frames[source_index + 1]
+            current_frame = frames[source_index]
+            converted.extend(
+                _clip_pcm16(
+                    current_frame[channel]
+                    + (
+                        next_frame[channel] - current_frame[channel]
+                    )
+                    * fraction
+                    / output_rate
+                )
+                for channel in range(channels)
+            )
+        phase += input_rate
+
+    next_state = Pcm16RateState(
+        tail_frame=frames[-1],
+        phase=phase - last_position,
+    )
+    return _encode_pcm16(converted), next_state

--- a/realtime_voice.py
+++ b/realtime_voice.py
@@ -12,7 +12,6 @@ import sys
 import threading
 import time
 import uuid
-import audioop
 import wave
 
 from PySide6.QtCore import QObject, Signal
@@ -21,6 +20,7 @@ from lip_sync import (
     VISEME_CUES_PER_SECOND,
     infer_vowel_pcm16,
 )
+from pcm_audio import rate_convert_pcm16, scale_pcm16
 from speech import transcribe_wav_bytes
 
 
@@ -631,8 +631,8 @@ class RealtimeVoiceClient(QObject):
             if self._microphone_blocked():
                 continue
             if input_rate != 24000:
-                audio, rate_state = audioop.ratecv(
-                    audio, 2, 1, input_rate, 24000, rate_state
+                audio, rate_state = rate_convert_pcm16(
+                    audio, 1, input_rate, 24000, rate_state
                 )
             ws = self.ws
             if not ws or not ws.sock or not ws.sock.connected:
@@ -680,9 +680,8 @@ class RealtimeVoiceClient(QObject):
                     self.viseme_cue.emit(vowel_level, vowel)
                     playback_chunk = source_chunk
                     if output_rate != 24000:
-                        playback_chunk, rate_state = audioop.ratecv(
+                        playback_chunk, rate_state = rate_convert_pcm16(
                             source_chunk,
-                            2,
                             1,
                             24000,
                             output_rate,
@@ -694,11 +693,7 @@ class RealtimeVoiceClient(QObject):
                         else self.volume_percent / 100.0
                     )
                     if gain != 1.0:
-                        playback_chunk = audioop.mul(
-                            playback_chunk,
-                            2,
-                            gain,
-                        )
+                        playback_chunk = scale_pcm16(playback_chunk, gain)
                     output_stream.write(playback_chunk)
             except Exception as exc:
                 self._finish_assistant_audio(force=True)

--- a/speech.py
+++ b/speech.py
@@ -25,6 +25,7 @@ from lip_sync import (
     VISEME_CUES_PER_SECOND,
     infer_vowel_pcm16,
 )
+from pcm_audio import PcmAudioError, scale_pcm16, stereo_to_mono_pcm16
 
 
 CREATE_NO_WINDOW = 0x08000000
@@ -140,18 +141,14 @@ def apply_wav_volume(
     if gain == 1.0:
         return audio
     try:
-        import audioop
-
         with wave.open(io.BytesIO(audio), "rb") as source:
             params = source.getparams()
+            if params.sampwidth != 2:
+                return audio
             frame_chunks = []
             while chunk := source.readframes(4096):
                 frame_chunks.append(chunk)
-        adjusted = audioop.mul(
-            b"".join(frame_chunks),
-            params.sampwidth,
-            gain,
-        )
+        adjusted = scale_pcm16(b"".join(frame_chunks), gain)
         output = io.BytesIO()
         with wave.open(output, "wb") as target:
             # Streaming WAV responses may use 0xFFFFFFFF as a temporary data
@@ -165,7 +162,7 @@ def apply_wav_volume(
             target.setcomptype(params.comptype, params.compname)
             target.writeframes(adjusted)
         return output.getvalue()
-    except (OSError, EOFError, wave.Error, audioop.error):
+    except (OSError, EOFError, wave.Error, PcmAudioError):
         return audio
 
 
@@ -528,9 +525,7 @@ class WindowsTTS(QObject):
                     if width != 2:
                         continue
                     if channels == 2:
-                        import audioop
-
-                        chunk = audioop.tomono(chunk, 2, 0.5, 0.5)
+                        chunk = stereo_to_mono_pcm16(chunk)
                     vowel_level, vowel = infer_vowel_pcm16(chunk, rate)
                     deadline = (
                         started_at
@@ -647,9 +642,7 @@ class OpenAITTS(QObject):
                     if width != 2:
                         continue
                     if channels == 2:
-                        import audioop
-
-                        chunk = audioop.tomono(chunk, 2, 0.5, 0.5)
+                        chunk = stereo_to_mono_pcm16(chunk)
                     vowel_level, vowel = infer_vowel_pcm16(chunk, rate)
                     deadline = (
                         started_at

--- a/tests/test_pcm_audio.py
+++ b/tests/test_pcm_audio.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from array import array
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pcm_audio import (  # noqa: E402
+    PcmAudioError,
+    rate_convert_pcm16,
+    scale_pcm16,
+    stereo_to_mono_pcm16,
+)
+
+
+def pcm(*samples: int) -> bytes:
+    return array("h", samples).tobytes()
+
+
+def unpack(data: bytes) -> tuple[int, ...]:
+    samples = array("h")
+    samples.frombytes(data)
+    return tuple(samples)
+
+
+def test_gain_clips_and_preserves_silence() -> None:
+    assert unpack(scale_pcm16(pcm(-32768, -1001, 0, 1001, 32767), 0.5)) == (
+        -16384,
+        -501,
+        0,
+        500,
+        16383,
+    )
+    assert unpack(scale_pcm16(pcm(-20000, 20000), 2.0)) == (-32768, 32767)
+    assert scale_pcm16(pcm(100, -100), 0.0) == pcm(0, 0)
+
+
+def test_stereo_mix_uses_complete_frames_and_saturates() -> None:
+    assert unpack(
+        stereo_to_mono_pcm16(pcm(1000, -1000, 1001, -1001, 32767, 32767))
+    ) == (0, 0, 32767)
+    try:
+        stereo_to_mono_pcm16(b"\x00\x00")
+    except PcmAudioError:
+        pass
+    else:
+        raise AssertionError("incomplete stereo frame was accepted")
+
+
+def test_streamed_resampling_is_continuous_across_chunk_boundaries() -> None:
+    first, state = rate_convert_pcm16(pcm(0, 1000, 2000, 3000), 1, 4, 8)
+    second, state = rate_convert_pcm16(pcm(4000, 5000), 1, 4, 8, state)
+    assert unpack(first + second) == (
+        0,
+        500,
+        1000,
+        1500,
+        2000,
+        2500,
+        3000,
+        3500,
+        4000,
+        4500,
+        5000,
+    )
+    assert state is not None
+
+
+def test_downsampling_and_stereo_channels_remain_aligned() -> None:
+    converted, _state = rate_convert_pcm16(
+        pcm(0, 100, 1000, 1100, 2000, 2100, 3000, 3100),
+        2,
+        4,
+        2,
+    )
+    assert unpack(converted) == (0, 100, 2000, 2100)
+
+
+def main() -> None:
+    test_gain_clips_and_preserves_silence()
+    test_stereo_mix_uses_complete_frames_and_saturates()
+    test_streamed_resampling_is_continuous_across_chunk_boundaries()
+    test_downsampling_and_stereo_channels_remain_aligned()
+    print("PCM_AUDIO_TESTS_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -19,6 +19,20 @@ from tools.sync_wordpress_download_page import (
 
 
 def main() -> None:
+    build_script = (ROOT / "build.ps1").read_text(encoding="utf-8")
+    assert "Python 3.14.x" in build_script
+    assert "python = $PythonVersion" in build_script
+    for workflow_name in (
+        "windows-ci.yml",
+        "security-audit.yml",
+        "release.yml",
+    ):
+        workflow = (
+            ROOT / ".github" / "workflows" / workflow_name
+        ).read_text(encoding="utf-8")
+        assert 'python-version: "3.14"' in workflow
+        assert 'python-version: "3.12"' not in workflow
+
     inno_script = (ROOT / "installer" / "mohan.iss").read_text(encoding="utf-8")
     traditional_messages = ROOT / "installer" / "languages" / "ChineseTraditional.isl"
     simplified_messages = ROOT / "installer" / "languages" / "ChineseSimplified.isl"


### PR DESCRIPTION
## 繁體中文

- 變更範圍：墨寒遷移至 Python 3.14。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：墨寒迁移至 Python 3.14。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Migrate MoHan to Python 3.14.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：墨寒を Python 3.14 へ移行。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。