### PR TITLE
docs: 將墨寒聲援圖片與說明欄頂端對齊／将墨寒声援图片与说明栏顶部对齐／Top-align MoHan support images and caption columns／墨寒応援画像と説明列を上揃え

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ MoHan remains free and MIT-licensed. Support never buys privileges or limits par
 
 <table>
   <tr>
-    <td width="33%" align="center"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong><br><sub>“I am not waiting for support… merely inspecting our provisions.”</sub></td>
-    <td width="33%" align="center"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong><br><sub>“If you truly wish to help… I shall remember it.”</sub></td>
-    <td width="33%" align="center"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong><br><sub>“No overdoing it! Take care of yourself first—understood?”</sub></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong><br><sub>“I am not waiting for support… merely inspecting our provisions.”</sub></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong><br><sub>“If you truly wish to help… I shall remember it.”</sub></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong><br><sub>“No overdoing it! Take care of yourself first—understood?”</sub></td>
   </tr>
 </table>
 

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -83,6 +83,10 @@ def main() -> int:
         assert (
             f'src="docs/media/{filename}" width="220" height="220"' in readme
         ), f"support portrait lacks fixed aligned dimensions: {filename}"
+    assert readme.count('width="33%" align="center" valign="top"') == 3, (
+        "support columns must be top-aligned so shorter captions cannot push "
+        "the complete image-and-text column downward on GitHub"
+    )
 
     github_requirements = (
         "actions/workflows/windows-ci.yml/badge.svg",

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -169,7 +169,7 @@ def main() -> None:
         'width="33%" align="center"><img src="assets/expressions/'
     )
     support_cards = readme.count(
-        'width="33%" align="center"><img src="docs/media/support-'
+        'width="33%" align="center" valign="top"><img src="docs/media/support-'
     )
     assert expression_cards >= 6
     assert support_cards == 3


### PR DESCRIPTION
## 繁體中文

- 變更範圍：將墨寒聲援圖片與說明欄頂端對齊。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：将墨寒声援图片与说明栏顶部对齐。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Top-align MoHan support images and caption columns.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：墨寒応援画像と説明列を上揃え。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。