### PR TITLE
docs: 將 README 策士劇場卡片頂端對齊／将 README 策士剧场卡片顶部对齐／Top-align README strategist-theater cards／README の策士シアターカードを上揃え

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ tokens, or private user data.
 
 <table>
   <tr>
-    <td width="25%" align="center"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查 · Code review</strong><br>妾只是確認這段程式碼配不配入主分支。<br><sub>Reviewing whether this code deserves a place on main.</sub></td>
-    <td width="25%" align="center"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時 · When praised</strong><br>做得尚可。別一直盯著妾看。<br><sub>Accepting praise—strictly for engineering quality.</sub></td>
-    <td width="25%" align="center"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作 · Dangerous action</strong><br>未經確認便想執行？先過妾這一劍。<br><sub>Dangerous actions still require explicit approval.</sub></td>
-    <td width="25%" align="center"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧 · Provisions received</strong><br>妾會記下這份心意……僅此而已。<br><sub>Voluntary support is remembered, never required.</sub></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查 · Code review</strong><br>妾只是確認這段程式碼配不配入主分支。<br><sub>Reviewing whether this code deserves a place on main.</sub></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時 · When praised</strong><br>做得尚可。別一直盯著妾看。<br><sub>Accepting praise—strictly for engineering quality.</sub></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作 · Dangerous action</strong><br>未經確認便想執行？先過妾這一劍。<br><sub>Dangerous actions still require explicit approval.</sub></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧 · Provisions received</strong><br>妾會記下這份心意……僅此而已。<br><sub>Voluntary support is remembered, never required.</sub></td>
   </tr>
 </table>
 

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -87,6 +87,10 @@ def main() -> int:
         "support columns must be top-aligned so shorter captions cannot push "
         "the complete image-and-text column downward on GitHub"
     )
+    assert readme.count('width="25%" align="center" valign="top"') == 4, (
+        "all four strategist-theatre cards must be top-aligned so shorter "
+        "captions cannot push the first images and text downward on GitHub"
+    )
 
     github_requirements = (
         "actions/workflows/windows-ci.yml/badge.svg",


### PR DESCRIPTION
## 繁體中文

- 變更範圍：將 README 策士劇場卡片頂端對齊。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：将 README 策士剧场卡片顶部对齐。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Top-align README strategist-theater cards.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：README の策士シアターカードを上揃え。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。