### PR TITLE
test: 防止托腮說話嘴角覆蓋問題復發／防止托腮说话嘴角覆盖问题复发／Guard against regressions in chin-rest speaking mouth coverage／頬杖で話す際の口角被覆の再発を防止

### DIFF
--- a/tests/test_mouth_visual_continuity.py
+++ b/tests/test_mouth_visual_continuity.py
@@ -49,6 +49,27 @@ def outside_mouth_signature(image: QImage, mouth: QRect) -> tuple[int, ...]:
     return tuple(values)
 
 
+def changed_pixel_count(first: QImage, second: QImage, rect: QRect) -> int:
+    return sum(
+        first.pixel(x, y) != second.pixel(x, y)
+        for y in range(rect.top(), rect.bottom() + 1)
+        for x in range(rect.left(), rect.right() + 1)
+    )
+
+
+def outside_region_changed_pixel_count(
+    first: QImage,
+    second: QImage,
+    rect: QRect,
+) -> int:
+    return sum(
+        first.pixel(x, y) != second.pixel(x, y)
+        for y in range(first.height())
+        for x in range(first.width())
+        if not rect.contains(x, y)
+    )
+
+
 def run() -> None:
     with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         os.environ["LOCALAPPDATA"] = temp_dir
@@ -74,6 +95,54 @@ def run() -> None:
             frames: list[QImage] = []
             eye_rect = QRect(160, 135, 95, 48)
             mouth_rect = window.mouth_clips[""]
+            expected_cheek_mouth_rect = QRect(168, 195, 64, 40)
+            legacy_cheek_mouth_rect = QRect(174, 198, 52, 34)
+            assert mouth_rect == expected_cheek_mouth_rect, (
+                "the chin-rest portrait must replace both upturned idle mouth "
+                "corners, not only the narrower legacy lip rectangle"
+            )
+            legacy_residual_corner_strips = {
+                "left": QRect(
+                    mouth_rect.left(),
+                    mouth_rect.top(),
+                    legacy_cheek_mouth_rect.left() - mouth_rect.left(),
+                    mouth_rect.height(),
+                ),
+                "right": QRect(
+                    legacy_cheek_mouth_rect.right() + 1,
+                    mouth_rect.top(),
+                    mouth_rect.right() - legacy_cheek_mouth_rect.right(),
+                    mouth_rect.height(),
+                ),
+            }
+            clean_base = (
+                window.expression_pixmaps["idle"]
+                .toImage()
+                .convertToFormat(QImage.Format_ARGB32)
+            )
+            for expression in ("speaking", "mouth_i"):
+                speech_frame = (
+                    window.expression_pixmaps[expression]
+                    .toImage()
+                    .convertToFormat(QImage.Format_ARGB32)
+                )
+                for side, strip in legacy_residual_corner_strips.items():
+                    changed = changed_pixel_count(
+                        clean_base,
+                        speech_frame,
+                        strip,
+                    )
+                    assert changed >= strip.width() * strip.height() // 10, (
+                        f"{expression} left the {side} upturned idle mouth "
+                        f"corner visible ({changed} changed pixels)"
+                    )
+                assert outside_region_changed_pixel_count(
+                    clean_base,
+                    speech_frame,
+                    mouth_rect,
+                ) == 0, (
+                    f"{expression} changed pixels outside the cheek mouth clip"
+                )
             vowels = (
                 "A",
                 "A",
@@ -117,9 +186,6 @@ def run() -> None:
                 for frame in frames
             }
             assert len(eye_signatures) == 1, "eyes changed during mouth animation"
-            clean_base = window.expression_pixmaps["idle"].toImage().convertToFormat(
-                QImage.Format_ARGB32
-            )
             clean_outside = outside_mouth_signature(clean_base, mouth_rect)
             assert all(
                 outside_mouth_signature(frame, mouth_rect) == clean_outside


### PR DESCRIPTION
## 繁體中文

- 變更範圍：防止托腮說話嘴角覆蓋問題復發。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：防止托腮说话嘴角覆盖问题复发。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Guard against regressions in chin-rest speaking mouth coverage.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：頬杖で話す際の口角被覆の再発を防止。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。