### PR TITLE
fix: 維持舊版轉錄預設中立／保持旧版转录默认值中立／Keep legacy transcription defaults neutral／従来の文字起こし既定値を中立に維持

### DIFF
--- a/db.py
+++ b/db.py
@@ -12,6 +12,7 @@ from memory_index import (
     hashed_text_vector,
 )
 from language_support import (
+    LEGACY_AUTHOR_ORGANIZATION,
     LEGACY_TRANSCRIPTION_PROMPT,
     localized_transcription_prompt,
 )
@@ -457,8 +458,11 @@ class StudioDB:
                     str(profile["ui_language"] or "zh-TW"),
                     assistant_name=str(profile["assistant_name"] or ""),
                     user_title=str(profile["user_title"] or ""),
-                    organization_name=str(
-                        profile["organization_name"] or ""
+                    organization_name=(
+                        ""
+                        if str(profile["organization_name"] or "").strip()
+                        == LEGACY_AUTHOR_ORGANIZATION
+                        else str(profile["organization_name"] or "")
                     ),
                     wake_word=str(profile["wake_word"] or ""),
                 )

--- a/language_support.py
+++ b/language_support.py
@@ -13,6 +13,11 @@ LEGACY_TRANSCRIPTION_PROMPT = (
     "請保留原意，不要改寫。"
 )
 
+# This value belonged to the original author's private profile.  It may be
+# present in databases created before the public onboarding flow existed, but
+# it must never become part of another user's built-in transcription hints.
+LEGACY_AUTHOR_ORGANIZATION = "炎劍文化工作室"
+
 TRANSCRIPTION_PROMPT_BASES = {
     "zh-TW": (
         "請使用台灣繁體中文準確轉錄。請保留專有名詞、數字與其他語言的原文，"

--- a/tests/test_localized_transcription_prompts.py
+++ b/tests/test_localized_transcription_prompts.py
@@ -17,16 +17,22 @@ from language_support import (
 from realtime_voice import RealtimeVoiceClient
 
 
-def _create_existing_profile(path: Path, prompt: str) -> None:
+def _create_existing_profile(
+    path: Path,
+    prompt: str,
+    *,
+    organization_name: str = "測試工作室",
+    ui_language: str = "zh-CN",
+) -> None:
     conn = sqlite3.connect(path)
     conn.execute(
         "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
     )
     values = {
-        "ui_language": "zh-CN",
+        "ui_language": ui_language,
         "assistant_name": "墨寒",
         "user_title": "主上",
-        "organization_name": "測試工作室",
+        "organization_name": organization_name,
         "wake_word": "小寒",
         "transcription_prompt": prompt,
     }
@@ -97,6 +103,26 @@ def run() -> None:
         assert "測試工作室" in migrated
         assert "Pubu" not in migrated
         legacy.close()
+
+        for language, expected in profiles.items():
+            legacy_brand_path = Path(temp) / (
+                f"legacy-author-brand-{language}.db"
+            )
+            _create_existing_profile(
+                legacy_brand_path,
+                LEGACY_TRANSCRIPTION_PROMPT,
+                organization_name="炎劍文化工作室",
+                ui_language=language,
+            )
+            legacy_brand = StudioDB(legacy_brand_path)
+            neutral = str(legacy_brand.setting("transcription_prompt"))
+            assert expected in neutral
+            assert "炎劍文化工作室" not in neutral
+            assert "赤焰劍" not in neutral
+            assert "斬空劍主" not in neutral
+            assert "Pubu" not in neutral
+            assert "DistroKid" not in neutral
+            legacy_brand.close()
 
         custom_path = Path(temp) / "custom.db"
         custom_prompt = "请准确转录。我的专有词：海风计划。"


### PR DESCRIPTION
## 繁體中文

- 變更範圍：維持舊版轉錄預設中立。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：保持旧版转录默认值中立。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Keep legacy transcription defaults neutral.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：従来の文字起こし既定値を中立に維持。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。