### PR TITLE
fix: 修正草稿 Release 的原子復原／修复草稿 Release 的原子恢复／Fix atomic draft-Release recovery／ドラフト Release のアトミック復旧を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,8 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ needs.resolve-release.outputs.tag }}"
-          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          existing_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\") | .id" | head -n 1)"
+          if [[ -n "$existing_id" ]]; then
             echo "Release $tag already exists; refusing to overwrite it." >&2
             exit 7
           fi
@@ -460,16 +461,15 @@ jobs:
             exit "$status"
           }
           trap cleanup_failed_draft EXIT
-          gh release create "$tag" \
+          gh release create "$tag" "${assets[@]}" \
             --repo "${{ github.repository }}" \
             --verify-tag \
             --draft \
             --prerelease \
             --title "MoHan Desktop Assistant $tag" \
             --notes-file "docs/releases/$tag.md"
-          release_id="$(gh api "repos/${{ github.repository }}/releases/tags/$tag" --jq '.id')"
+          release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\" and .draft == true) | .id" | head -n 1)"
           [[ "$release_id" =~ ^[0-9]+$ ]]
-          gh release upload "$tag" "${assets[@]}" --repo "${{ github.repository }}"
           mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
           mapfile -t expected_assets < <(printf '%s\n' "${assets[@]##*/}" | sort)
           [[ "$(printf '%s\n' "${actual_assets[@]}")" == "$(printf '%s\n' "${expected_assets[@]}")" ]] || {

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -146,7 +146,9 @@ def test_build_tool_and_release_gate_are_pinned() -> None:
     assert "gh release create" in release
     assert "artifact-metadata: write" in release
     assert "--draft" in release
-    assert "gh release upload" in release
+    assert 'gh release create "$tag" "${assets[@]}"' in release
+    assert "/releases/tags/$tag" not in release
+    assert "and .draft == true" in release
     assert "draft=false" in release
     assert "cleanup_failed_draft" in release
     assert "Draft Release assets differ from the exact verified set" in release


### PR DESCRIPTION
## 繁體中文

- 變更範圍：修正草稿 Release 的原子復原。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：修复草稿 Release 的原子恢复。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Fix atomic draft-Release recovery.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：ドラフト Release のアトミック復旧を修正。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。