### PR TITLE
fix: 修正托腮說話時的嘴角殘影／修复托腮说话时的嘴角残影／Fix mouth-corner ghosting during cheek-rest speech／頬杖で話す際の口角残像を修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -394,6 +394,12 @@ EXPRESSION_SPEECH_MOUTH_RECTS.update({
     "exasperated_front": QRect(199, 201, 58, 47),
     "eureka_front": QRect(197, 190, 58, 48),
 })
+CHEEK_SPEECH_CLOSED_EXPRESSION = "idle_speech_neutral"
+# Keep the photographed cheek-rest mouth corners outside the animated region.
+# At the runtime 465 px canvas, the visible central lips occupy roughly
+# x=184..207; widening this mask reaches both smile corners and recreates the
+# Joker-like corner flutter reported in rapid A/I/U/E/O transitions.
+CHEEK_SPEECH_CENTRAL_MOUTH_RECT = QRect(184, 198, 24, 34)
 GESTURE_SPEECH_MOUTH_RECTS = {
     expression: EXPRESSION_SPEECH_MOUTH_RECTS[expression]
     for expression in GESTURE_SPEECH_EXPRESSIONS
@@ -6544,6 +6550,11 @@ class CompanionWindow(QMainWindow):
             return "mouth_mid_front"
         return "mouth_mid"
 
+    def _closed_speech_expression(self) -> str:
+        if self.idle_pose == "cheek":
+            return CHEEK_SPEECH_CLOSED_EXPRESSION
+        return self._idle_expression()
+
     def _build_mouth_frames(self) -> None:
         mouth_clips = {
             # The cheek-rest portrait has a wider closed smile than its
@@ -6577,6 +6588,63 @@ class CompanionWindow(QMainWindow):
                 )
             painter.end()
             self.mouth_masks[suffix] = mask
+        self.viseme_mouth_masks = dict(self.mouth_masks)
+        central_mask = QPixmap(465, 465)
+        central_mask.fill(Qt.transparent)
+        painter = QPainter(central_mask)
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setPen(Qt.NoPen)
+        for inset, alpha in (
+            (0, 52),
+            (1, 82),
+            (2, 128),
+            (3, 255),
+        ):
+            painter.setBrush(QColor(255, 255, 255, alpha))
+            painter.drawRoundedRect(
+                CHEEK_SPEECH_CENTRAL_MOUTH_RECT.adjusted(
+                    inset,
+                    inset,
+                    -inset,
+                    -inset,
+                ),
+                9,
+                9,
+            )
+        painter.end()
+        self.viseme_mouth_masks[""] = central_mask
+
+        # The cheek-rest idle portrait has a deliberately upturned smile.
+        # During speech, freeze neutral corners from its identity-matched open
+        # frame once, then let A/I/U/E/O replace only the central lips. This
+        # keeps the smiling eyes while preventing both corners from fluttering
+        # on every viseme transition.
+        cheek_idle = self.expression_pixmaps["idle"]
+        cheek_neutral = QPixmap(cheek_idle)
+        painter = QPainter(cheek_neutral)
+        painter.drawPixmap(
+            0,
+            0,
+            self._masked_mouth_patch(
+                self.expression_pixmaps["speaking"],
+                "",
+            ),
+        )
+        painter.drawPixmap(
+            0,
+            0,
+            self._masked_region(
+                cheek_idle,
+                self.viseme_mouth_masks[""],
+            ),
+        )
+        painter.end()
+        self.expression_pixmaps[
+            CHEEK_SPEECH_CLOSED_EXPRESSION
+        ] = cheek_neutral
+        self.physics_expression_poses[
+            CHEEK_SPEECH_CLOSED_EXPRESSION
+        ] = "cheek"
         self.gesture_mouth_masks = {}
         for expression, mouth_rect in (
             EXPRESSION_SPEECH_MOUTH_RECTS.items()
@@ -6755,7 +6823,11 @@ class CompanionWindow(QMainWindow):
             ("idle_lean", "speaking_lean", "mouth_mid_lean"),
             ("idle_front", "speaking_front", "mouth_mid_front"),
         ):
-            closed = self.expression_pixmaps[closed_name]
+            closed = self.expression_pixmaps[
+                CHEEK_SPEECH_CLOSED_EXPRESSION
+                if closed_name == "idle"
+                else closed_name
+            ]
             raw_opened = self.expression_pixmaps[open_name]
             suffix = closed_name.removeprefix("idle")
             mouth_clip = mouth_clips[suffix]
@@ -6764,7 +6836,10 @@ class CompanionWindow(QMainWindow):
             painter.drawPixmap(
                 0,
                 0,
-                self._masked_mouth_patch(raw_opened, suffix),
+                self._masked_region(
+                    raw_opened,
+                    self.viseme_mouth_masks[suffix],
+                ),
             )
             painter.end()
             self.expression_pixmaps[open_name] = opened
@@ -6778,7 +6853,10 @@ class CompanionWindow(QMainWindow):
             painter.drawPixmap(
                 0,
                 0,
-                self._masked_mouth_patch(mid_source, suffix),
+                self._masked_region(
+                    mid_source,
+                    self.viseme_mouth_masks[suffix],
+                ),
             )
             painter.end()
             self.expression_pixmaps[mid_name] = mid_frame
@@ -6798,7 +6876,10 @@ class CompanionWindow(QMainWindow):
             painter.drawPixmap(
                 0,
                 0,
-                self._masked_mouth_patch(source, suffix),
+                self._masked_region(
+                    source,
+                    self.viseme_mouth_masks[suffix],
+                ),
             )
             painter.end()
             return normalized
@@ -6806,7 +6887,11 @@ class CompanionWindow(QMainWindow):
         for suffix, mouth_clip in mouth_clips.items():
             closed_name = f"idle{suffix}"
             opened_name = f"speaking{suffix}"
-            closed = self.expression_pixmaps[closed_name]
+            closed = self.expression_pixmaps[
+                CHEEK_SPEECH_CLOSED_EXPRESSION
+                if suffix == ""
+                else closed_name
+            ]
             opened = self.expression_pixmaps[opened_name]
             wide_source = self.expression_pixmaps.get(
                 f"viseme_wide{suffix}",
@@ -7981,6 +8066,15 @@ class CompanionWindow(QMainWindow):
                     self.speech_gesture_expression
                 ],
             )
+        if (
+            suffix == ""
+            and self.speech_closed_expression
+            == CHEEK_SPEECH_CLOSED_EXPRESSION
+        ):
+            return self._masked_region(
+                source,
+                self.viseme_mouth_masks[""],
+            )
         return self._masked_mouth_patch(
             source,
             suffix,
@@ -8306,7 +8400,9 @@ class CompanionWindow(QMainWindow):
             self.speech_open_expression = frames["open"]
         else:
             self.speech_closed_expression = (
-                f"idle{self.speech_pose_suffix}"
+                CHEEK_SPEECH_CLOSED_EXPRESSION
+                if self.speech_pose_suffix == ""
+                else f"idle{self.speech_pose_suffix}"
             )
             self.speech_mid_expression = (
                 f"mouth_mid{self.speech_pose_suffix}"
@@ -8666,7 +8762,9 @@ class CompanionWindow(QMainWindow):
                 if self.idle_pose == "front"
                 else ""
             )
-            self.speech_closed_expression = self._idle_expression()
+            self.speech_closed_expression = (
+                self._closed_speech_expression()
+            )
             self.speech_mid_expression = self._mouth_mid_expression()
             self.speech_open_expression = self._speaking_expression()
             self._start_mouth_animation(audio_driven=True)

--- a/tests/test_mouth_visual_continuity.py
+++ b/tests/test_mouth_visual_continuity.py
@@ -13,7 +13,11 @@ from PySide6.QtCore import QRect, QTimer
 from PySide6.QtGui import QImage
 from PySide6.QtWidgets import QApplication
 
-from app import CompanionWindow
+from app import (
+    CHEEK_SPEECH_CENTRAL_MOUTH_RECT,
+    CHEEK_SPEECH_CLOSED_EXPRESSION,
+    CompanionWindow,
+)
 
 
 def region_signature(image: QImage, rect: QRect) -> tuple[int, ...]:
@@ -83,7 +87,7 @@ def run() -> None:
             window.idle_pose = "cheek"
             window.state = "speaking"
             window.speech_pose_suffix = ""
-            window.speech_closed_expression = "idle"
+            window.speech_closed_expression = window._closed_speech_expression()
             window.speech_mid_expression = "mouth_mid"
             window.speech_open_expression = "speaking"
             window.audio_driven_mouth = True
@@ -96,53 +100,85 @@ def run() -> None:
             eye_rect = QRect(160, 135, 95, 48)
             mouth_rect = window.mouth_clips[""]
             expected_cheek_mouth_rect = QRect(168, 195, 64, 40)
-            legacy_cheek_mouth_rect = QRect(174, 198, 52, 34)
             assert mouth_rect == expected_cheek_mouth_rect, (
-                "the chin-rest portrait must replace both upturned idle mouth "
-                "corners, not only the narrower legacy lip rectangle"
+                "the chin-rest portrait must provide a stable neutral frame "
+                "for both speech corners"
             )
-            legacy_residual_corner_strips = {
+            assert window.speech_closed_expression == (
+                CHEEK_SPEECH_CLOSED_EXPRESSION
+            )
+            fixed_corner_strips = {
                 "left": QRect(
                     mouth_rect.left(),
                     mouth_rect.top(),
-                    legacy_cheek_mouth_rect.left() - mouth_rect.left(),
+                    CHEEK_SPEECH_CENTRAL_MOUTH_RECT.left()
+                    - mouth_rect.left(),
                     mouth_rect.height(),
                 ),
                 "right": QRect(
-                    legacy_cheek_mouth_rect.right() + 1,
+                    CHEEK_SPEECH_CENTRAL_MOUTH_RECT.right() + 1,
                     mouth_rect.top(),
-                    mouth_rect.right() - legacy_cheek_mouth_rect.right(),
+                    mouth_rect.right()
+                    - CHEEK_SPEECH_CENTRAL_MOUTH_RECT.right(),
                     mouth_rect.height(),
                 ),
             }
-            clean_base = (
+            idle_base = (
                 window.expression_pixmaps["idle"]
                 .toImage()
                 .convertToFormat(QImage.Format_ARGB32)
             )
-            for expression in ("speaking", "mouth_i"):
+            neutral_base = (
+                window.expression_pixmaps[CHEEK_SPEECH_CLOSED_EXPRESSION]
+                .toImage()
+                .convertToFormat(QImage.Format_ARGB32)
+            )
+            assert changed_pixel_count(
+                idle_base,
+                neutral_base,
+                mouth_rect,
+            ) > mouth_rect.width() * mouth_rect.height() // 12
+            assert outside_region_changed_pixel_count(
+                idle_base,
+                neutral_base,
+                mouth_rect,
+            ) == 0
+
+            speech_expressions = (
+                "speaking",
+                "mouth_mid",
+                "mouth_wide",
+                "mouth_round",
+                "mouth_i",
+                "mouth_o",
+            )
+            central_signatures: set[tuple[int, ...]] = set()
+            for expression in speech_expressions:
                 speech_frame = (
                     window.expression_pixmaps[expression]
                     .toImage()
                     .convertToFormat(QImage.Format_ARGB32)
                 )
-                for side, strip in legacy_residual_corner_strips.items():
-                    changed = changed_pixel_count(
-                        clean_base,
+                central_signatures.add(
+                    region_signature(
                         speech_frame,
-                        strip,
+                        CHEEK_SPEECH_CENTRAL_MOUTH_RECT,
                     )
-                    assert changed >= strip.width() * strip.height() // 10, (
-                        f"{expression} left the {side} upturned idle mouth "
-                        f"corner visible ({changed} changed pixels)"
-                    )
+                )
+                for side, strip in fixed_corner_strips.items():
+                    assert region_signature(speech_frame, strip) == (
+                        region_signature(neutral_base, strip)
+                    ), f"{expression} changed the fixed {side} speech corner"
                 assert outside_region_changed_pixel_count(
-                    clean_base,
+                    idle_base,
                     speech_frame,
                     mouth_rect,
                 ) == 0, (
                     f"{expression} changed pixels outside the cheek mouth clip"
                 )
+            assert len(central_signatures) >= 4, (
+                "fixed corners must not flatten the central A/I/U/E/O shapes"
+            )
             vowels = (
                 "A",
                 "A",
@@ -186,11 +222,17 @@ def run() -> None:
                 for frame in frames
             }
             assert len(eye_signatures) == 1, "eyes changed during mouth animation"
-            clean_outside = outside_mouth_signature(clean_base, mouth_rect)
+            clean_outside = outside_mouth_signature(idle_base, mouth_rect)
             assert all(
                 outside_mouth_signature(frame, mouth_rect) == clean_outside
                 for frame in frames
             ), "pixels outside the frozen mouth region changed"
+            for frame in frames:
+                for side, strip in fixed_corner_strips.items():
+                    assert region_signature(frame, strip) == region_signature(
+                        neutral_base,
+                        strip,
+                    ), f"transition changed the fixed {side} speech corner"
             assert window._active_speech_pose_suffix() == ""
 
             direct_difference = mean_region_difference(

--- a/tools/capture_mouth_continuity_preview.py
+++ b/tools/capture_mouth_continuity_preview.py
@@ -27,9 +27,12 @@ def main() -> int:
         window.bubble.hide()
         window.idle_pose = "cheek"
         window.state = "speaking"
-        window.audio_driven_mouth = True
+        window.speech_pose_suffix = ""
+        window.speech_closed_expression = window._closed_speech_expression()
+        window.speech_mid_expression = window._mouth_mid_expression()
+        window.speech_open_expression = window._speaking_expression()
         window.speech_blinking = False
-        window._set_expression("idle", fade=False)
+        window._start_mouth_animation(audio_driven=True)
 
         frames: list[QImage] = []
         crop = QRect(155, 165, 120, 100)


### PR DESCRIPTION
## 繁體中文

- 變更範圍：修正托腮說話時的嘴角殘影。
- 狀態：此歷史 PR 已合併；GitHub 上的實作與驗證紀錄保持可追溯。
- 四語稽核：本次僅統一 PR 說明資料；原始提交、檔案差異、檢查紀錄、合併狀態與 Release 資產均未變更。
- 技術追溯：完整實作與驗證證據保留於本 PR 的「Files changed」與「Checks」。

## 简体中文

- 变更范围：修复托腮说话时的嘴角残影。
- 状态：此历史 PR 已合并；GitHub 上的实现与验证记录保持可追溯。
- 四语审计：本次仅统一 PR 说明资料；原始提交、文件差异、检查记录、合并状态与 Release 资产均未变更。
- 技术追溯：完整实现与验证证据保留于本 PR 的“Files changed”与“Checks”。

## English

- Scope: Fix mouth-corner ghosting during cheek-rest speech.
- Status: This historical PR was merged; its implementation and verification history remains traceable on GitHub.
- Four-language audit: This update normalizes PR metadata only; original commits, file diffs, check history, merge state, and Release assets remain unchanged.
- Technical traceability: Full implementation and verification evidence remains available under “Files changed” and “Checks”.

## 日本語

- 変更範囲：頬杖で話す際の口角残像を修正。
- 状態：この過去の PR はマージ済みです。GitHub 上の実装と検証履歴は追跡可能なままです。
- 四言語監査：今回の更新は PR の説明情報のみを統一します。元のコミット、ファイル差分、チェック履歴、マージ状態、Release 資産は変更しません。
- 技術的追跡性：完全な実装と検証証跡は、この PR の「Files changed」と「Checks」に保持されています。