### PR TITLE
ci: 安全驗證既有 Release／安全验证现有 Release／Safely verify existing Release／既存 Release を安全検証

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing v2.2.0-rc.N tag to package and publish"
+        description: "Existing v2.2.0-rc.N tag to package"
         required: true
         type: string
+      publish:
+        description: "Publish a new pre-release after verification"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -354,7 +359,7 @@ jobs:
           retention-days: 30
 
   publish:
-    name: attest-and-publish-one-release
+    name: verify-or-publish-one-release
     needs: [resolve-release, metadata]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -419,6 +424,7 @@ jobs:
           )
 
       - name: Attest every published artifact
+        if: ${{ github.event_name == 'push' || inputs.publish }}
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: release-artifacts/*
@@ -437,7 +443,30 @@ jobs:
             exit 4
           fi
 
+      - name: Verify existing pre-release without modifying it
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve-release.outputs.tag }}"
+          release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\") | .id" | head -n 1)"
+          [[ "$release_id" =~ ^[0-9]+$ ]] || {
+            echo "Expected an existing Release for verification: $tag" >&2
+            exit 7
+          }
+          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq '.draft == false and .prerelease == true')" == true ]]
+          mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
+          mapfile -t expected_assets < <(find release-artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
+          [[ "$(printf '%s\n' "${actual_assets[@]}")" == "$(printf '%s\n' "${expected_assets[@]}")" ]] || {
+            echo "Existing Release assets differ from the exact verified set." >&2
+            exit 8
+          }
+          echo "Release $tag is unchanged and matches the verified artifact set."
+
       - name: Publish one GitHub pre-release
+        if: ${{ github.event_name == 'push' || inputs.publish }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -70,6 +70,10 @@ def main() -> None:
     assert "commit: ${{ steps.source.outputs.commit }}" in release
     assert "ref: ${{ needs.resolve-release.outputs.commit }}" in release
     assert "Release tag changed after validation" in release
+    assert 'default: false\n        type: boolean' in release
+    assert "Verify existing pre-release without modifying it" in release
+    assert "Existing Release assets differ from the exact verified set." in release
+    assert "github.event_name == 'push' || inputs.publish" in release
     assert "metadata:" in release
     assert "name: generate-release-metadata" in release
     assert "name: Re-verify exact artifact set and SHA256 catalog" in release


### PR DESCRIPTION
## 繁體中文

- 目的：為手動執行的 Release workflow 新增安全的「只驗證、不發布」預設模式。
- 行為：完整重建既有 RC、驗證 Artifact 上傳與下載，以及核對既有 Release 資產集合；預設不重新發布、不覆寫既有 Release。
- 發布邊界：只有 tag push 或操作者明確選擇 publish 時，才沿用正式發布流程。
- 驗證：更新治理測試，鎖定安全預設與條件式發布；不修改產品程式、資料庫、封裝內容或使用者資料。

## 简体中文

- 目的：为手动执行的 Release workflow 新增安全的“只验证、不发布”默认模式。
- 行为：完整重建现有 RC、验证 Artifact 上传与下载，并核对现有 Release 资产集合；默认不重新发布、不覆盖现有 Release。
- 发布边界：只有 tag push 或操作人员明确选择 publish 时，才沿用正式发布流程。
- 验证：更新治理测试，锁定安全默认值与条件式发布；不修改产品程序、数据库、打包内容或用户资料。

## English

- Purpose: Add a safe verification-only default mode for manually dispatched Release workflows.
- Behavior: Fully rebuild an existing RC, verify Artifact upload and download, and compare the existing Release asset set; do not republish or overwrite the existing Release by default.
- Publication boundary: Preserve the formal publication path only for tag pushes or when the operator explicitly selects publish.
- Verification: Update governance tests to lock the safe default and conditional publication behavior; no product code, database, package content, or user data is changed.

## 日本語

- 目的：手動実行する Release workflow に、安全な「検証のみ・公開しない」既定モードを追加します。
- 動作：既存 RC を完全に再ビルドし、Artifact のアップロードとダウンロード、既存 Release の資産一式を検証します。既定では再公開も既存 Release の上書きもしません。
- 公開境界：tag push、または操作者が publish を明示的に選択した場合に限り、正式公開経路を維持します。
- 検証：安全な既定値と条件付き公開を固定するガバナンステストを更新します。製品コード、データベース、パッケージ内容、ユーザーデータは変更しません。