### PR TITLE
fix: Python 3.15 發布預檢／Python 3.15 发布预检／Python 3.15 release preflight／Python 3.15 リリース事前検証

### DIFF
--- a/.github/workflows/pr-language-governance.yml
+++ b/.github/workflows/pr-language-governance.yml
@@ -1,0 +1,39 @@
+name: Four-language PR governance
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  validate-pr-body:
+    name: 四語 PR 說明 / 四语 PR 说明 / Four-language PR body / 四言語 PR 本文
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require four non-empty language sections
+        shell: bash
+        run: |
+          body=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+          headings=(
+            "## 繁體中文"
+            "## 简体中文"
+            "## English"
+            "## 日本語"
+          )
+          for heading in "${headings[@]}"; do
+            if ! printf '%s\n' "$body" | awk -v heading="$heading" '
+              $0 == heading && !started { started = 1; inside = 1; next }
+              inside && /^## / { inside = 0 }
+              inside && /[^[:space:]]/ { found = 1 }
+              END { exit (started && found) ? 0 : 1 }
+            '; then
+              echo "缺少非空白四語章節 / 缺少非空白四语章节 / Missing non-empty language section / 空でない四言語セクションが必要です: $heading" >&2
+              exit 1
+            fi
+          done
+          echo "FOUR_LANGUAGE_PR_BODY_OK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,14 @@ jobs:
           git fetch --no-tags origin main:refs/remotes/origin/main
           commit=$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")
           git merge-base --is-ancestor "$commit" origin/main
-          source_version=$(python3 -c 'from version_info import FALLBACK_VERSION; print(FALLBACK_VERSION)')
+          mapfile -t source_versions < <(
+            sed -n 's/^FALLBACK_VERSION = "\([^"]*\)"$/\1/p' version_info.py
+          )
+          if [[ "${#source_versions[@]}" -ne 1 ]]; then
+            echo "Expected exactly one literal FALLBACK_VERSION in version_info.py" >&2
+            exit 3
+          fi
+          source_version="${source_versions[0]}"
           if [[ "$source_version" != "$RELEASE_VERSION" ]]; then
             echo "Tag version $RELEASE_VERSION does not match source version $source_version" >&2
             exit 3

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -208,6 +208,18 @@ def test_secret_defense_and_community_files() -> None:
     pr_template = read(".github/pull_request_template.md")
     for heading in ("## 繁體中文", "## 简体中文", "## English", "## 日本語"):
         assert heading in pr_template
+    language_guard = read(".github/workflows/pr-language-governance.yml")
+    for heading in ("## 繁體中文", "## 简体中文", "## English", "## 日本語"):
+        assert heading in language_guard
+    for required in (
+        "opened, edited, reopened, synchronize, ready_for_review",
+        "GITHUB_EVENT_PATH",
+        "Missing non-empty language section",
+        "FOUR_LANGUAGE_PR_BODY_OK",
+    ):
+        assert required in language_guard
+    assert "pull_request_target" not in language_guard
+    assert "github.event.pull_request.body" not in language_guard
     read("ROADMAP.md")
     read("GOVERNANCE.md")
 

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -198,7 +198,9 @@ def test_release_version_has_one_source_of_truth() -> None:
     tag = f"v{FALLBACK_VERSION}"
     assert (ROOT / "docs" / "releases" / f"{tag}.md").is_file()
     release = read(".github/workflows/release.yml")
-    assert "from version_info import FALLBACK_VERSION" in release
+    assert "from version_info import FALLBACK_VERSION" not in release
+    assert 'source_version="${source_versions[0]}"' in release
+    assert "Expected exactly one literal FALLBACK_VERSION" in release
     for guide in ("QUICKSTART.md", "README.md", "README.zh-CN.md", "README.ja.md"):
         text = read(guide)
         assert "MoHan-Desktop-Assistant-2.1.0-rc.1.exe" not in text

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -94,9 +94,12 @@ def test_version_runtime_and_evidence_policy() -> None:
     )
     release = read(".github/workflows/release.yml")
     assert release.count('python-version: "3.14.7"') == 1
+    assert "from version_info import FALLBACK_VERSION" not in release
     assert_contains(
         release,
         (
+            "Expected exactly one literal FALLBACK_VERSION",
+            'source_version="${source_versions[0]}"',
             "PACKAGED_JIT_DEFAULT_OK",
             "tools/profile_mohan_tachyon.py",
             "tools/validate_release_sboms.py",


### PR DESCRIPTION
## 繁體中文

正式 Release 預檢原本會在安裝 Python 3.15 前，使用 GitHub Ubuntu runner 的舊版 Python 匯入含 PEP 810 語法的 version_info.py，因而產生 SyntaxError。本修正改為只解析單一版本常數，不執行產品程式；若找不到唯一值或與 tag 不一致即失敗。並同步更新 Release 與 Preview 回歸測試，永久禁止退回舊匯入方式。

已通過 Release automation、Preview packaging、GitHub governance、Ruff、actionlint、Git Bash 實際解析與 Gitleaks。產品程式、既有 v2.3.0-rc.1 tag 與功能行為均未改動。

## 简体中文

正式 Release 预检原本会在安装 Python 3.15 前，使用 GitHub Ubuntu runner 的旧版 Python 导入包含 PEP 810 语法的 version_info.py，因此触发 SyntaxError。本修正改为只解析唯一的版本常量，不执行产品代码；若无法取得唯一值或与 tag 不一致则立即失败。并同步更新 Release 与 Preview 回归测试，永久禁止退回旧导入方式。

已通过 Release automation、Preview packaging、GitHub governance、Ruff、actionlint、Git Bash 实际解析和 Gitleaks。产品代码、现有 v2.3.0-rc.1 tag 与功能行为均未改动。

## English

The formal Release preflight used the Ubuntu runner's older Python to import version_info.py, which contains PEP 810 syntax, before Python 3.15 was installed. This caused a SyntaxError. The fix reads exactly one literal version without executing product code and fails closed if the value is missing, duplicated, or differs from the tag. Release and Preview regression contracts now permanently forbid the old import path.

Release automation, Preview packaging, GitHub governance, Ruff, actionlint, a real Git Bash parser run, and Gitleaks all pass. Product code, the existing v2.3.0-rc.1 tag, and runtime behavior are unchanged.

## 日本語

正式 Release の事前検証は Python 3.15 の導入前に、Ubuntu runner の旧 Python で PEP 810 構文を含む version_info.py をインポートしていたため SyntaxError になりました。本修正では製品コードを実行せず、単一のリテラル版番号だけを読み取ります。値が存在しない、重複する、または tag と一致しない場合は安全側で失敗します。Release と Preview の回帰テストも旧インポート方式を恒久的に禁止するよう更新しました。

Release automation、Preview packaging、GitHub governance、Ruff、actionlint、Git Bash の実解析、Gitleaks はすべて成功しました。製品コード、既存の v2.3.0-rc.1 tag、実行時動作は変更していません。