### PR TITLE
建立完整四語文件與發布治理／建立完整四语文档与发布治理／Enforce complete four-language documentation and release governance／完全な四言語文書とリリース統制を適用

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,81 @@
+# 變更說明／变更说明／Change description／変更説明
+
 ## 繁體中文
 
 說明修改、原因、使用者影響與驗證結果。
 
+### 安全與隱私
+
+- [ ] 未新增 API 金鑰、OAuth 權杖、錄音、資料庫或個人資料。
+- [ ] 既有權限與確認邊界保持不變。
+- [ ] 資料庫遷移會保留既有使用者資料。
+
+### 驗證
+
+- [ ] `python tests/run_all.py`
+- [ ] 已檢查相關的 Windows 實機行為。
+- [ ] 行為或設定變更時已同步更新文件。
+
+### 相容性
+
+列出 Windows、語音、模型、資料庫或封裝的相容性影響。
+
 ## 简体中文
 
-说明修改、原因、用户影响及验证结果。
+说明修改、原因、用户影响与验证结果。
+
+### 安全与隐私
+
+- [ ] 未新增 API 密钥、OAuth 令牌、录音、数据库或个人资料。
+- [ ] 现有权限与确认边界保持不变。
+- [ ] 数据库迁移会保留现有用户数据。
+
+### 验证
+
+- [ ] `python tests/run_all.py`
+- [ ] 已检查相关的 Windows 真机行为。
+- [ ] 行为或设置变更时已同步更新文档。
+
+### 兼容性
+
+列出 Windows、语音、模型、数据库或打包的兼容性影响。
 
 ## English
 
-Describe the change, reason, user impact, and verification.
+Describe the change, reason, user impact, and verification results.
+
+### Safety and privacy
+
+- [ ] No API keys, OAuth tokens, recordings, databases, or personal data were added.
+- [ ] Existing permission and confirmation boundaries remain intact.
+- [ ] Database migrations preserve existing user data.
+
+### Verification
+
+- [ ] `python tests/run_all.py`
+- [ ] Relevant behavior was checked on a physical Windows device.
+- [ ] Documentation was updated when behavior or settings changed.
+
+### Compatibility
+
+List any Windows, voice, model, database, or packaging compatibility impact.
 
 ## 日本語
 
 変更内容、理由、利用者への影響、検証結果を説明してください。
 
-## 安全與隱私 / 安全与隐私 / Safety and privacy / 安全とプライバシー
+### 安全性とプライバシー
 
-- [ ] No API keys, OAuth tokens, recordings, databases, or personal data added.
-- [ ] Existing permission and confirmation boundaries remain intact.
-- [ ] Database migrations preserve existing user data.
+- [ ] API キー、OAuth トークン、録音、データベース、個人情報を追加していません。
+- [ ] 既存の権限と確認境界を維持しています。
+- [ ] データベース移行は既存の利用者データを保持します。
 
-## 驗證 / 验证 / Verification / 検証
+### 検証
 
 - [ ] `python tests/run_all.py`
-- [ ] Relevant manual Windows behavior checked.
-- [ ] Documentation updated when behavior or settings changed.
+- [ ] 関連する動作を Windows 実機で確認しました。
+- [ ] 動作または設定を変更した場合、文書も更新しました。
 
-## 相容性 / 兼容性 / Compatibility / 互換性
+### 互換性
 
-List any Windows, voice, model, database, or packaging compatibility impact.
+Windows、音声、モデル、データベース、パッケージへの互換性影響を記載してください。

--- a/.github/workflows/pr-language-governance.yml
+++ b/.github/workflows/pr-language-governance.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   validate-pr-body:
@@ -15,10 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require four non-empty language sections
+      - name: Require minimum four-language PR metadata
         shell: bash
         run: |
+          title=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
           body=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+          IFS='／' read -r -a title_parts <<< "$title"
+          if [[ ${#title_parts[@]} -ne 4 ]]; then
+            echo "標題必須有四段翻譯 / 标题必须有四段翻译 / Title requires four translations / タイトルには四つの翻訳が必要です" >&2
+            exit 1
+          fi
+          for part in "${title_parts[@]}"; do
+            if [[ -z "${part//[[:space:]]/}" ]]; then
+              echo "四語標題不得留白 / 四语标题不得留白 / Title translations cannot be empty / タイトルの翻訳を空欄にできません" >&2
+              exit 1
+            fi
+          done
           headings=(
             "## 繁體中文"
             "## 简体中文"
@@ -36,4 +49,33 @@ jobs:
               exit 1
             fi
           done
-          echo "FOUR_LANGUAGE_PR_BODY_OK"
+          mapfile -t actual_headings < <(
+            printf '%s\n' "$body" |
+              grep -E '^## (繁體中文|简体中文|English|日本語)$' || true
+          )
+          if [[ ${#actual_headings[@]} -ne 4 ]]; then
+            echo "四語章節必須各出現一次 / 四语章节必须各出现一次 / Each language section must appear once / 各言語セクションは一度だけ必要です" >&2
+            exit 1
+          fi
+          for index in "${!headings[@]}"; do
+            if [[ "${actual_headings[$index]}" != "${headings[$index]}" ]]; then
+              echo "四語順序錯誤 / 四语顺序错误 / Incorrect language order / 四言語の順序が正しくありません" >&2
+              exit 1
+            fi
+          done
+          echo "FOUR_LANGUAGE_PR_METADATA_MINIMUM_OK"
+
+      - name: Check out the proposed documentation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python 3.15
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.15.0-rc.1"
+          allow-prereleases: true
+
+      - name: Require structurally equivalent PR metadata
+        run: python tools/check_four_language_pr.py
+
+      - name: Require structurally equivalent four-language documentation
+        run: python tools/check_four_language_docs.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,10 +491,7 @@ jobs:
         run: |
           notes="docs/releases/${{ needs.resolve-release.outputs.tag }}.md"
           [[ -s "$notes" ]]
-          grep -q '^## 繁體中文' "$notes"
-          grep -q '^## 简体中文' "$notes"
-          grep -q '^## English' "$notes"
-          grep -q '^## 日本語' "$notes"
+          python tools/check_four_language_docs.py
 
       - name: Upload read-only generated metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -649,7 +646,7 @@ jobs:
             --verify-tag \
             --draft \
             --prerelease \
-            --title "MoHan Desktop Assistant $tag" \
+            --title "墨寒桌面助理 $tag／墨寒桌面助手 $tag／MoHan Desktop Assistant $tag／墨寒デスクトップアシスタント $tag" \
             --notes-file "docs/releases/$tag.md"
           release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\" and .draft == true) | .id" | head -n 1)"
           [[ "$release_id" =~ ^[0-9]+$ ]]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,130 +1,281 @@
-# MoHan architecture
+# 墨寒架構／墨寒架构／MoHan Architecture／墨寒アーキテクチャ
 
-This file is the maintenance contract for human contributors and Codex.
+## 繁體中文
 
-## Dependency direction
+本文件是人類貢獻者與 Codex 共同遵守的維護契約。
+
+### 依賴方向
+
+依賴只能向下指向：
+
+1. `app.py` 是 Windows 角色外殼；`service_container.py` 是明確的執行期組裝根。`preview_app.py` 則是獨立且刻意受限的 macOS／Linux 預覽封裝外殼；它可以顯示平台狀態與在地化內容，但不得匯入 `app.py`、建立雲端／語音／工具服務，或顯示機密輸入欄位。
+2. UI 模組（`flagship_ui.py`、`profile_transfer_ui.py`）可以呼叫服務的公開 API。
+3. 服務（`profile_transfer.py`、`speech.py`、`realtime_voice.py`、`ai_client.py`、`cloud_connectors.py`、`home_assistant.py`、`remote_control.py`）可以使用領域與儲存模組。
+4. 領域與儲存模組（`db.py`、`flagship_core.py`、`expression_system.py`、`lip_sync.py`、`workflow_engine.py`）絕不匯入 UI 或 `app.py`。
+
+禁止本機模組循環匯入，並由 `tests/test_architecture_contracts.py` 強制檢查。
+
+### 功能邊界
+
+- 儀表板分頁透過 `DashboardFeatureRegistry` 掛載。新增分頁只應變更組裝清單，不得變更無關分頁。
+- 跨視窗呼叫必須使用公開方法或 Qt signal。`CompanionWindow` 絕不得呼叫私有的 `Dashboard._method`。
+- 可替換的語音、Realtime、機密儲存與監聽器依賴，由 `contracts.py` 內小型的 `typing.Protocol` 連接埠描述，並透過 `CompanionServices` 注入 `CompanionWindow`。
+- 桌面作業系統行為必須透過 `PlatformServicePort`，以及明確的 `platform_windows.py`、`platform_macos.py`、`platform_linux.py` 介接器進入。核心模組不得無條件匯入 `winreg`、`winsound`、`ctypes.windll` 或 `os.startfile`。
+- 桌面依賴注入以建構式為基礎。FastAPI 的 `Depends` 只屬於未來的 HTTP 邊界；禁止將 FastAPI 匯入 PySide 桌面核心。
+- OpenAI／Windows 語音時序只有一個真實來源：`lip_sync.py`。
+- 可替換的文字轉語音引擎透過 `speech_providers.py` 註冊。供應器可以合成音訊，但不得擁有嘴型同步、表情狀態、UI、權限或備援政策；經 Windows 驗證的女性本機語音是權威離線備援。
+- 持久化的本機語音選擇使用平台中立的 `system-local` 供應器 ID。舊字面 ID `windows-local` 與在地化標籤只可作為遷移輸入，絕不得成為第二個供應器。
+- 語言政策、回覆語言指示及內建提醒遷移只有一個真實來源：`language_support.py`。英文、簡體中文顯示字串及穩定的內部值至顯示值對應存放於 `ui_localization.py`；在地化標籤絕不得取代持久化的內部設定值。簡體中文對話路徑不得通過台灣繁體中文輸出正規化器。
+- 回覆前等待表情政策只有一個真實來源：`expression_system.plan_wait_expressions`。畫面上的「思考中」狀態僅供資訊顯示，絕不得自行選擇角色表情。
+- 可攜式設定檔規則只有一個真實來源：`profile_transfer.py`。
+- 機密絕不儲存於 SQLite，也絕不進入可攜式設定檔。
+- 受限的預覽封裝不得削弱前述規則。在原生安全儲存完成實作並經真實裝置驗證前，預覽 UI 不顯示金鑰、OAuth 或 token 欄位，也不得建立可能持久化這些資料的功能服務。
+
+### 封裝邊界
+
+- Windows ZIP、EXE 與 MSI 仍是唯一完整產品封裝。
+- 分開提供的 macOS Apple Silicon（arm64）、Intel（x86_64）DMG，以及 Linux x86_64 AppImage，內含 `preview_app.py`，而非 Windows 的 `app.py` 外殼。其用途是驗證原生封裝、啟動、在地化、路徑與安全邊界。
+- Pull Request 可在封裝層級 smoke test 通過後上傳短期 artifact，但絕不建立 GitHub Release。
+- 只有既有的 `v2.3.0-rc.N` tag 可以發布多平台候選版本。唯讀中繼資料工作負責收集全部平台輸出並建立 SBOM、中繼資料與 checksum；另一個最小權限工作則重新檢查完全相同的 artifact 與 tag commit、產生證明，並發布單一 Release。
+- 發布證據把可觀測性與供應鏈資料視為門檻，而非裝飾。Tachyon 證據必須完成淨化、JIT 驗證、取樣品質檢查，且可由單一二進位資料流重現；原始資料流僅能暫存。CycloneDX 1.7 清冊必須符合鎖定的執行期需求、包含完整根依賴邊、PURL 與宣告的 SPDX 授權，通過官方 schema 與隱私門檻，並分開追蹤僅建置使用的工具。
+- 每一個 Windows 與預覽二進位發行包，都必須在終端使用者可閱讀的位置攜帶 MIT 授權與第三方聲明。
+- 只有當 AppImage 建置工具的官方來源 commit、資產身分與 SHA-256 均符合已審查常數時，才可接受該工具。GitHub Actions 必須固定至完整 commit SHA。
+
+### 資料所有權
+
+- `db.py`：對話、記憶、任務、靈感、工作紀錄與設定。
+- `secret_store.py`：可注入的 `PlatformSecretStoreFactory` 邊界。Windows 使用與使用者綁定的 DPAPI 儲存；未驗證平台使用安全失敗儲存，絕不使用功能區域內的明文備援。
+- `platform_contracts.py`：平台能力、每位使用者的路徑及桌面服務協定。在尚無經驗證原生安全儲存的平台上，機密持久化必須安全失敗，不得寫入明文。
+- `profile_transfer.py`：可攜的共用進度；排除機器權限與機密。每一個套件都有 snapshot ID；重複匯入相同 snapshot 會被阻擋，較舊 snapshot 則會收到覆寫警告。
+- `backup_manager.py`：經驗證的本機變更前備份與每日備份。
+
+### 新增功能的方法
+
+1. 將領域邏輯放入名稱精確的新模組。
+2. 定義小型公開 API；不得直接存取其他類別的私有狀態。
+3. UI 若不只是小型控制項，請放入獨立的 `<feature>_ui.py` 模組。
+4. 在組裝點註冊其分頁或面板。
+5. 為該功能單獨加入一項契約測試，並加入一項整合 smoke test。
+6. 執行 `test_architecture_contracts.py` 與完整回歸測試套件。
+
+若某項行為已有權威擁有者，不得新增第二份設定、計時器或 signal；應擴充該擁有者的公開 API。
+
+### Codex 導向維護規則
+
+- 優先採用明確匯入、建構式與 signal 連線，不採用探索魔法或反射。
+- 外部引擎與工具優先使用鴨子型別的 `Protocol` 邊界；若完整 API 就是預期不變量，具體領域物件可以維持具體型別。
+- 新功能的服務、UI 與測試應使用一致且可搜尋的名稱。
+- 不得將大量功能邏輯加入 `app.py`；它是組裝外殼。
+- 功能只能透過有文件的公開方法、signal 或服務 API 使用其他功能。
+- 若變更需要碰觸無關模組，必須先新增或改善缺少的公開邊界。
+- 絕不得只為讓新依賴通過而削弱架構測試。
+
+## 简体中文
+
+本文档是人类贡献者与 Codex 共同遵守的维护契约。
+
+### 依赖方向
+
+依赖只能向下指向：
+
+1. `app.py` 是 Windows 角色外壳；`service_container.py` 是明确的运行时装配根。`preview_app.py` 则是独立且刻意受限的 macOS／Linux 预览封装外壳；它可以显示平台状态与本地化内容，但不得导入 `app.py`、创建云端／语音／工具服务，或显示机密输入字段。
+2. UI 模块（`flagship_ui.py`、`profile_transfer_ui.py`）可以调用服务的公开 API。
+3. 服务（`profile_transfer.py`、`speech.py`、`realtime_voice.py`、`ai_client.py`、`cloud_connectors.py`、`home_assistant.py`、`remote_control.py`）可以使用领域与存储模块。
+4. 领域与存储模块（`db.py`、`flagship_core.py`、`expression_system.py`、`lip_sync.py`、`workflow_engine.py`）绝不导入 UI 或 `app.py`。
+
+禁止本地模块循环导入，并由 `tests/test_architecture_contracts.py` 强制检查。
+
+### 功能边界
+
+- 仪表板分页通过 `DashboardFeatureRegistry` 挂载。新增分页只应变更装配清单，不得变更无关分页。
+- 跨窗口调用必须使用公开方法或 Qt signal。`CompanionWindow` 绝不得调用私有的 `Dashboard._method`。
+- 可替换的语音、Realtime、机密存储与监听器依赖，由 `contracts.py` 内小型的 `typing.Protocol` 端口描述，并通过 `CompanionServices` 注入 `CompanionWindow`。
+- 桌面操作系统行为必须通过 `PlatformServicePort`，以及明确的 `platform_windows.py`、`platform_macos.py`、`platform_linux.py` 适配器进入。核心模块不得无条件导入 `winreg`、`winsound`、`ctypes.windll` 或 `os.startfile`。
+- 桌面依赖注入以构造函数为基础。FastAPI 的 `Depends` 只属于未来的 HTTP 边界；禁止将 FastAPI 导入 PySide 桌面核心。
+- OpenAI／Windows 语音时序只有一个真实来源：`lip_sync.py`。
+- 可替换的文字转语音引擎通过 `speech_providers.py` 注册。提供程序可以合成音频，但不得拥有嘴型同步、表情状态、UI、权限或回退策略；经 Windows 验证的女性本地语音是权威离线回退。
+- 持久化的本地语音选择使用平台中立的 `system-local` 提供程序 ID。旧字面 ID `windows-local` 与本地化标签只可作为迁移输入，绝不得成为第二个提供程序。
+- 语言策略、回复语言指示及内置提醒迁移只有一个真实来源：`language_support.py`。英文、简体中文显示字符串及稳定的内部值至显示值映射存放于 `ui_localization.py`；本地化标签绝不得取代持久化的内部设置值。简体中文对话路径不得通过台湾繁体中文输出规范化器。
+- 回复前等待表情策略只有一个真实来源：`expression_system.plan_wait_expressions`。界面上的“思考中”状态仅供信息显示，绝不得自行选择角色表情。
+- 可移植配置文件规则只有一个真实来源：`profile_transfer.py`。
+- 机密绝不存储于 SQLite，也绝不进入可移植配置文件。
+- 受限的预览封装不得削弱上述规则。在原生安全存储完成实现并经真实设备验证前，预览 UI 不显示密钥、OAuth 或 token 字段，也不得创建可能持久化这些数据的功能服务。
+
+### 封装边界
+
+- Windows ZIP、EXE 与 MSI 仍是唯一完整产品封装。
+- 分别提供的 macOS Apple Silicon（arm64）、Intel（x86_64）DMG，以及 Linux x86_64 AppImage，内含 `preview_app.py`，而非 Windows 的 `app.py` 外壳。其用途是验证原生封装、启动、本地化、路径与安全边界。
+- Pull Request 可在封装层级 smoke test 通过后上传短期 artifact，但绝不创建 GitHub Release。
+- 只有现有的 `v2.3.0-rc.N` tag 可以发布多平台候选版本。只读元数据作业负责收集全部平台输出并创建 SBOM、元数据与 checksum；另一个最小权限作业则重新检查完全相同的 artifact 与 tag commit、生成证明，并发布单一 Release。
+- 发布证据把可观测性与供应链数据视为门槛，而非装饰。Tachyon 证据必须完成净化、JIT 验证、采样质量检查，且可由单一二进制数据流重现；原始数据流只能暂存。CycloneDX 1.7 清单必须符合锁定的运行时需求、包含完整根依赖边、PURL 与声明的 SPDX 许可证，通过官方 schema 与隐私门槛，并分别追踪仅构建使用的工具。
+- 每一个 Windows 与预览二进制发行包，都必须在最终用户可阅读的位置携带 MIT 许可证与第三方声明。
+- 只有当 AppImage 构建工具的官方源 commit、资产身份与 SHA-256 均符合已审查常量时，才可接受该工具。GitHub Actions 必须固定至完整 commit SHA。
+
+### 数据所有权
+
+- `db.py`：对话、记忆、任务、灵感、工作记录与设置。
+- `secret_store.py`：可注入的 `PlatformSecretStoreFactory` 边界。Windows 使用与用户绑定的 DPAPI 存储；未验证平台使用安全失败存储，绝不使用功能局部的明文回退。
+- `platform_contracts.py`：平台能力、每位用户的路径及桌面服务协议。在尚无经验证原生安全存储的平台上，机密持久化必须安全失败，不得写入明文。
+- `profile_transfer.py`：可移植的共享进度；排除机器权限与机密。每一个包都有 snapshot ID；重复导入相同 snapshot 会被阻止，较旧 snapshot 则会收到覆盖警告。
+- `backup_manager.py`：经验证的本地变更前备份与每日备份。
+
+### 新增功能的方法
+
+1. 将领域逻辑放入名称精确的新模块。
+2. 定义小型公开 API；不得直接访问其他类的私有状态。
+3. UI 若不只是小型控件，请放入独立的 `<feature>_ui.py` 模块。
+4. 在装配点注册其分页或面板。
+5. 为该功能单独加入一项契约测试，并加入一项集成 smoke test。
+6. 执行 `test_architecture_contracts.py` 与完整回归测试套件。
+
+若某项行为已有权威拥有者，不得新增第二份设置、计时器或 signal；应扩展该拥有者的公开 API。
+
+### Codex 导向维护规则
+
+- 优先采用明确导入、构造函数与 signal 连接，不采用发现魔法或反射。
+- 外部引擎与工具优先使用鸭子类型的 `Protocol` 边界；若完整 API 就是预期不变量，具体领域对象可以保持具体类型。
+- 新功能的服务、UI 与测试应使用一致且可搜索的名称。
+- 不得将大量功能逻辑加入 `app.py`；它是装配外壳。
+- 功能只能通过有文档的公开方法、signal 或服务 API 使用其他功能。
+- 若变更需要触及无关模块，必须先新增或改善缺少的公开边界。
+- 绝不得只为让新依赖通过而削弱架构测试。
+
+## English
+
+This file is the maintenance contract shared by human contributors and Codex.
+
+### Dependency direction
 
 Dependencies point downward only:
 
-1. `app.py` is the Windows character shell. `service_container.py` is the
-   explicit runtime composition root.
-   `preview_app.py` is a separate, deliberately limited macOS/Linux package
-   shell. It may display platform status and localization, but it must not
-   import `app.py`, create cloud/voice/tool services, or expose secret inputs.
-2. UI modules (`flagship_ui.py`, `profile_transfer_ui.py`) may call public
-   service APIs.
-3. Services (`profile_transfer.py`, `speech.py`, `realtime_voice.py`,
-   `ai_client.py`, `cloud_connectors.py`, `home_assistant.py`,
-   `remote_control.py`) may use domain and storage modules.
-4. Domain and storage (`db.py`, `flagship_core.py`, `expression_system.py`,
-   `lip_sync.py`, `workflow_engine.py`) never import UI or `app.py`.
+1. `app.py` is the Windows character shell; `service_container.py` is the explicit runtime composition root. `preview_app.py` is a separate, deliberately limited macOS/Linux Preview package shell; it may display platform status and localization, but it must not import `app.py`, create cloud/voice/tool services, or expose secret inputs.
+2. UI modules (`flagship_ui.py`, `profile_transfer_ui.py`) may call public service APIs.
+3. Services (`profile_transfer.py`, `speech.py`, `realtime_voice.py`, `ai_client.py`, `cloud_connectors.py`, `home_assistant.py`, `remote_control.py`) may use domain and storage modules.
+4. Domain and storage modules (`db.py`, `flagship_core.py`, `expression_system.py`, `lip_sync.py`, `workflow_engine.py`) never import UI or `app.py`.
 
-Circular local imports are prohibited and enforced by
-`tests/test_architecture_contracts.py`.
+Circular local imports are prohibited and enforced by `tests/test_architecture_contracts.py`.
 
-## Feature boundaries
+### Feature boundaries
 
-- Dashboard tabs are mounted through `DashboardFeatureRegistry`. Adding a tab
-  changes the composition list, not unrelated tabs.
-- Cross-window calls use public methods or Qt signals. `CompanionWindow` must
-  never call a private `Dashboard._method`.
-- Replaceable speech, Realtime, secret-store and listener dependencies are
-  described by small `typing.Protocol` ports in `contracts.py` and enter
-  `CompanionWindow` through `CompanionServices`.
-- Desktop operating-system behavior enters through `PlatformServicePort` and
-  the explicit `platform_windows.py`, `platform_macos.py`, and
-  `platform_linux.py` adapters. Core modules must not import `winreg`,
-  `winsound`, `ctypes.windll`, or `os.startfile` unconditionally.
-- Desktop dependency injection is constructor-based. FastAPI `Depends` belongs
-  only in a future HTTP boundary; importing FastAPI into the PySide desktop
-  core is prohibited.
+- Dashboard tabs are mounted through `DashboardFeatureRegistry`. Adding a tab changes the composition list, not unrelated tabs.
+- Cross-window calls use public methods or Qt signals. `CompanionWindow` must never call a private `Dashboard._method`.
+- Replaceable speech, Realtime, secret-store, and listener dependencies are described by small `typing.Protocol` ports in `contracts.py` and enter `CompanionWindow` through `CompanionServices`.
+- Desktop operating-system behavior enters through `PlatformServicePort` and the explicit `platform_windows.py`, `platform_macos.py`, and `platform_linux.py` adapters. Core modules must not import `winreg`, `winsound`, `ctypes.windll`, or `os.startfile` unconditionally.
+- Desktop dependency injection is constructor-based. FastAPI `Depends` belongs only in a future HTTP boundary; importing FastAPI into the PySide desktop core is prohibited.
 - OpenAI/Windows speech timing has one source of truth: `lip_sync.py`.
-- Replaceable text-to-speech engines register through `speech_providers.py`.
-  Providers may synthesize audio but must not own lip sync, expression state,
-  UI, permissions, or fallback policy. Windows verified-female local speech is
-  the authoritative offline fallback.
-- Persisted local-speech selection uses the platform-neutral `system-local`
-  provider ID. The literal legacy ID `windows-local` and localized labels are
-  migration inputs only; they must never become a second provider.
-- Language policy, response-language instructions, and built-in reminder
-  migration have one source of truth in `language_support.py`. English and
-  Simplified Chinese display strings and stable internal-to-display mappings
-  live in `ui_localization.py`; localized labels must never replace persisted
-  internal setting values. zh-CN conversation paths must not pass through the
-  Taiwan Traditional Chinese output normalizer.
-- Pre-reply wait-expression policy has one source of truth in
-  `expression_system.plan_wait_expressions`. The visible “思考中” status is
-  informational and must never select a character expression by itself.
+- Replaceable text-to-speech engines register through `speech_providers.py`. Providers may synthesize audio but must not own lip sync, expression state, UI, permissions, or fallback policy; Windows verified-female local speech is the authoritative offline fallback.
+- Persisted local-speech selection uses the platform-neutral `system-local` provider ID. The literal legacy ID `windows-local` and localized labels are migration inputs only; they must never become a second provider.
+- Language policy, response-language instructions, and built-in reminder migration have one source of truth in `language_support.py`. English and Simplified Chinese display strings and stable internal-to-display mappings live in `ui_localization.py`; localized labels must never replace persisted internal setting values. Simplified Chinese conversation paths must not pass through the Taiwan Traditional Chinese output normalizer.
+- Pre-reply wait-expression policy has one source of truth in `expression_system.plan_wait_expressions`. The visible “thinking” status is informational and must never select a character expression by itself.
 - Portable profile rules have one source of truth: `profile_transfer.py`.
 - Secrets are never stored in SQLite and never enter portable profile files.
-- A limited Preview package does not weaken this rule. Until a native secure
-  store is implemented and device-validated, the Preview UI exposes no key,
-  OAuth, or token fields and does not construct a feature service that could
-  persist them.
+- A limited Preview package does not weaken these rules. Until a native secure store is implemented and device-validated, the Preview UI exposes no key, OAuth, or token fields and does not construct a feature service that could persist them.
 
-## Package boundaries
+### Package boundaries
 
 - Windows ZIP, EXE, and MSI remain the only complete product packages.
-- Separate macOS Apple Silicon (arm64) and Intel (x86_64) DMGs plus the Linux
-  x86_64 AppImage contain `preview_app.py`, not the Windows `app.py` shell.
-  Their purpose is native packaging, startup, localization, path, and
-  safety-boundary validation.
-- Pull requests may upload short-lived package artifacts after a package-level
-  smoke test. They never create a GitHub Release.
-- Only an existing `v2.3.0-rc.N` tag may publish the multi-platform candidate.
-  A read-only metadata job gathers all platform outputs and creates SBOMs,
-  metadata, and checksums. A separate minimal privileged job rechecks the
-  exact artifacts and tag commit, attests them, and publishes one Release.
-- Release evidence treats observability and supply-chain data as gates, not
-  decoration. Tachyon evidence must be sanitized, JIT-verified, sample-quality
-  checked, and reproducible from one binary stream; raw streams are temporary.
-  CycloneDX 1.7 inventories must match pinned runtime requirements, include
-  complete root dependency edges, PURLs and declared SPDX licenses, pass the
-  official schema and privacy gates, and track build-only tools separately.
-- Every Windows and Preview binary distribution carries the MIT license and
-  third-party notices in an end-user-readable location.
-- The AppImage build tool is accepted only when its official source commit,
-  asset identity, and SHA-256 match the reviewed constants. GitHub Actions are
-  pinned to complete commit SHAs.
+- Separate macOS Apple Silicon (arm64) and Intel (x86_64) DMGs plus the Linux x86_64 AppImage contain `preview_app.py`, not the Windows `app.py` shell. Their purpose is native packaging, startup, localization, path, and safety-boundary validation.
+- Pull requests may upload short-lived package artifacts after a package-level smoke test. They never create a GitHub Release.
+- Only an existing `v2.3.0-rc.N` tag may publish the multi-platform candidate. A read-only metadata job gathers all platform outputs and creates SBOMs, metadata, and checksums; a separate minimal privileged job rechecks the exact artifacts and tag commit, attests them, and publishes one Release.
+- Release evidence treats observability and supply-chain data as gates, not decoration. Tachyon evidence must be sanitized, JIT-verified, sample-quality checked, and reproducible from one binary stream; raw streams are temporary. CycloneDX 1.7 inventories must match pinned runtime requirements, include complete root dependency edges, PURLs and declared SPDX licenses, pass the official schema and privacy gates, and track build-only tools separately.
+- Every Windows and Preview binary distribution carries the MIT license and third-party notices in an end-user-readable location.
+- The AppImage build tool is accepted only when its official source commit, asset identity, and SHA-256 match the reviewed constants. GitHub Actions are pinned to complete commit SHAs.
 
-## Data ownership
+### Data ownership
 
-- `db.py`: conversations, memories, tasks, ideas, work history and settings.
-- `secret_store.py`: the injectable `PlatformSecretStoreFactory` boundary.
-  Windows receives user-bound DPAPI stores; an unverified platform receives a
-  fail-closed store, never a feature-local plaintext fallback.
-- `platform_contracts.py`: platform capabilities, per-user paths, and the
-  desktop service protocol. On a platform without verified native secure
-  storage, secret persistence fails closed instead of writing plaintext.
-- `profile_transfer.py`: portable shared progress; machine permissions and
-  secrets are excluded. Every bundle has a snapshot ID; importing the same
-  snapshot twice is blocked, and older snapshots receive an overwrite warning.
+- `db.py`: conversations, memories, tasks, ideas, work history, and settings.
+- `secret_store.py`: the injectable `PlatformSecretStoreFactory` boundary. Windows receives user-bound DPAPI stores; an unverified platform receives a fail-closed store, never a feature-local plaintext fallback.
+- `platform_contracts.py`: platform capabilities, per-user paths, and the desktop service protocol. On a platform without verified native secure storage, secret persistence fails closed instead of writing plaintext.
+- `profile_transfer.py`: portable shared progress; machine permissions and secrets are excluded. Every bundle has a snapshot ID; importing the same snapshot twice is blocked, and older snapshots receive an overwrite warning.
 - `backup_manager.py`: verified local pre-change and daily backups.
 
-## How to add a feature
+### How to add a feature
 
 1. Put domain logic in a new, narrowly named module.
 2. Define a small public API; do not reach into another class's private state.
-3. Put UI in a separate `<feature>_ui.py` module when it is more than a small
-   control.
+3. Put UI in a separate `<feature>_ui.py` module when it is more than a small control.
 4. Register its tab or panel at the composition point.
 5. Add a contract test for the feature alone and one integration smoke test.
 6. Run `test_architecture_contracts.py` and the full regression suite.
 
-Do not add a second setting, timer or signal for behavior that already has a
-canonical owner. Extend the owner's public API instead.
+Do not add a second setting, timer, or signal for behavior that already has a canonical owner. Extend the owner's public API instead.
 
-## Codex-oriented maintenance rules
+### Codex-oriented maintenance rules
 
-- Prefer explicit imports, constructors and signal connections over discovery
-  magic or reflection.
-- Prefer duck-typed `Protocol` boundaries for external engines and tools.
-  Concrete domain objects may remain concrete when their full API is the
-  intended invariant.
-- Keep a new feature's service, UI and tests under matching searchable names.
+- Prefer explicit imports, constructors, and signal connections over discovery magic or reflection.
+- Prefer duck-typed `Protocol` boundaries for external engines and tools. Concrete domain objects may remain concrete when their full API is the intended invariant.
+- Keep a new feature's service, UI, and tests under matching searchable names.
 - Do not add substantial feature logic to `app.py`; it is a composition shell.
-- A feature may use another feature only through a documented public method,
-  signal or service API.
-- If a change requires touching unrelated modules, first add or improve the
-  missing public boundary.
+- A feature may use another feature only through a documented public method, signal, or service API.
+- If a change requires touching unrelated modules, first add or improve the missing public boundary.
 - Never weaken an architecture test merely to make a new dependency pass.
+
+## 日本語
+
+本書は、人間のコントリビューターと Codex が共同で従う保守契約です。
+
+### 依存関係の方向
+
+依存関係は下位方向にだけ向けます。
+
+1. `app.py` は Windows のキャラクターシェルであり、`service_container.py` は明示的な実行時コンポジションルートです。`preview_app.py` は独立した、意図的に制限された macOS／Linux Preview パッケージシェルです。プラットフォーム状態とローカライズ内容は表示できますが、`app.py` のインポート、クラウド／音声／ツールサービスの生成、機密入力欄の公開は禁止します。
+2. UI モジュール（`flagship_ui.py`、`profile_transfer_ui.py`）は、サービスの公開 API を呼び出せます。
+3. サービス（`profile_transfer.py`、`speech.py`、`realtime_voice.py`、`ai_client.py`、`cloud_connectors.py`、`home_assistant.py`、`remote_control.py`）は、ドメインおよびストレージモジュールを利用できます。
+4. ドメインおよびストレージモジュール（`db.py`、`flagship_core.py`、`expression_system.py`、`lip_sync.py`、`workflow_engine.py`）は、UI または `app.py` を決してインポートしません。
+
+ローカルモジュール間の循環インポートは禁止し、`tests/test_architecture_contracts.py` で強制検査します。
+
+### 機能境界
+
+- ダッシュボードのタブは `DashboardFeatureRegistry` を通じてマウントします。タブを追加するときはコンポジション一覧だけを変更し、無関係なタブを変更してはいけません。
+- ウィンドウ間の呼び出しには公開メソッドまたは Qt signal を使用します。`CompanionWindow` は非公開の `Dashboard._method` を決して呼び出してはいけません。
+- 交換可能な音声、Realtime、機密ストア、リスナーの依存関係は、`contracts.py` にある小さな `typing.Protocol` ポートで記述し、`CompanionServices` を通じて `CompanionWindow` に注入します。
+- デスクトップ OS の動作は、`PlatformServicePort` と明示的な `platform_windows.py`、`platform_macos.py`、`platform_linux.py` アダプターを通じて導入します。コアモジュールは `winreg`、`winsound`、`ctypes.windll`、`os.startfile` を無条件にインポートしてはいけません。
+- デスクトップの依存性注入はコンストラクター方式とします。FastAPI の `Depends` は将来の HTTP 境界だけに属し、PySide デスクトップコアへの FastAPI のインポートは禁止します。
+- OpenAI／Windows の音声タイミングには、`lip_sync.py` という唯一の信頼できる情報源があります。
+- 交換可能なテキスト読み上げエンジンは `speech_providers.py` を通じて登録します。プロバイダーは音声を合成できますが、リップシンク、表情状態、UI、権限、フォールバック方針を所有してはいけません。Windows で検証済みの女性ローカル音声を正式なオフラインフォールバックとします。
+- 永続化するローカル音声の選択には、プラットフォーム中立の `system-local` プロバイダー ID を使用します。旧リテラル ID `windows-local` とローカライズ済みラベルは移行入力に限り、第二のプロバイダーにしてはいけません。
+- 言語方針、応答言語の指示、組み込みリマインダーの移行には、`language_support.py` という唯一の信頼できる情報源があります。英語および簡体字中国語の表示文字列と、安定した内部値から表示値への対応は `ui_localization.py` に置きます。ローカライズ済みラベルで永続化された内部設定値を置き換えてはいけません。簡体字中国語の会話経路を台湾繁体字中国語の出力正規化処理に通してはいけません。
+- 応答前の待機表情方針には、`expression_system.plan_wait_expressions` という唯一の信頼できる情報源があります。画面上の「思考中」状態は情報表示だけに使用し、それ自体でキャラクター表情を選択してはいけません。
+- ポータブルプロファイル規則には、`profile_transfer.py` という唯一の信頼できる情報源があります。
+- 機密情報を SQLite に保存したり、ポータブルプロファイルへ含めたりしてはいけません。
+- 制限付き Preview パッケージでも、これらの規則を弱めてはいけません。ネイティブ安全ストアの実装と実機検証が完了するまで、Preview UI はキー、OAuth、token の入力欄を公開せず、それらを永続化し得る機能サービスも生成しません。
+
+### パッケージ境界
+
+- Windows ZIP、EXE、MSI は、引き続き唯一の完全な製品パッケージです。
+- 個別に提供する macOS Apple Silicon（arm64）および Intel（x86_64）DMG と Linux x86_64 AppImage には、Windows の `app.py` シェルではなく `preview_app.py` を含めます。目的は、ネイティブパッケージング、起動、ローカライズ、パス、安全境界の検証です。
+- Pull Request では、パッケージレベルの smoke test 後に短期 artifact をアップロードできますが、GitHub Release は決して作成しません。
+- 既存の `v2.3.0-rc.N` tag だけがマルチプラットフォーム候補を公開できます。読み取り専用メタデータジョブが全プラットフォームの出力を収集して SBOM、メタデータ、checksum を作成し、別の最小権限ジョブが同一の artifact と tag commit を再検査して証明を生成し、単一の Release を公開します。
+- リリース証拠では、可観測性とサプライチェーンデータを装飾ではなくゲートとして扱います。Tachyon 証拠はサニタイズ、JIT 検証、サンプル品質検査を完了し、単一のバイナリストリームから再現できなければなりません。生ストリームは一時保存に限ります。CycloneDX 1.7 インベントリは、固定された実行時要件と一致し、完全なルート依存エッジ、PURL、宣言済み SPDX ライセンスを含み、公式 schema とプライバシーゲートに合格し、ビルド専用ツールを分離して追跡しなければなりません。
+- すべての Windows および Preview バイナリ配布物には、エンドユーザーが読める場所に MIT ライセンスと第三者通知を収録します。
+- AppImage ビルドツールは、公式ソース commit、asset identity、SHA-256 が審査済み定数と一致する場合にだけ受け入れます。GitHub Actions は完全な commit SHA に固定します。
+
+### データ所有権
+
+- `db.py`：会話、記憶、タスク、アイデア、作業履歴、設定。
+- `secret_store.py`：注入可能な `PlatformSecretStoreFactory` 境界。Windows ではユーザーに紐づく DPAPI ストアを使用し、未検証のプラットフォームでは安全側に失敗するストアを使用します。機能内の平文フォールバックは決して使用しません。
+- `platform_contracts.py`：プラットフォーム機能、ユーザーごとのパス、デスクトップサービスプロトコル。検証済みネイティブ安全ストレージがないプラットフォームでは、機密情報を平文で書き込まず、永続化を安全側に失敗させます。
+- `profile_transfer.py`：ポータブルな共有進捗。マシン権限と機密情報は除外します。各 bundle は snapshot ID を持ち、同一 snapshot の二重インポートは阻止し、古い snapshot には上書き警告を表示します。
+- `backup_manager.py`：検証済みのローカル変更前バックアップおよび日次バックアップ。
+
+### 機能の追加方法
+
+1. ドメインロジックを、目的が明確な名前の新しいモジュールへ配置します。
+2. 小さな公開 API を定義し、別クラスの非公開状態へ直接アクセスしてはいけません。
+3. UI が小さなコントロールを超える場合は、独立した `<feature>_ui.py` モジュールへ配置します。
+4. コンポジションポイントでタブまたはパネルを登録します。
+5. その機能単独の契約テストを一つと、統合 smoke test を一つ追加します。
+6. `test_architecture_contracts.py` と完全な回帰テストスイートを実行します。
+
+すでに正式な所有者がある動作に、第二の設定、タイマー、signal を追加してはいけません。代わりに、その所有者の公開 API を拡張します。
+
+### Codex 指向の保守規則
+
+- 探索マジックやリフレクションより、明示的なインポート、コンストラクター、signal 接続を優先します。
+- 外部エンジンとツールには、ダックタイピングされた `Protocol` 境界を優先します。完全な API 自体が意図した不変条件である場合、具体的なドメインオブジェクトは具体型のままで構いません。
+- 新機能のサービス、UI、テストには、一致して検索しやすい名前を付けます。
+- `app.py` に大規模な機能ロジックを追加してはいけません。これはコンポジションシェルです。
+- 機能が別の機能を利用できるのは、文書化された公開メソッド、signal、サービス API を通じる場合だけです。
+- 変更に無関係なモジュールまで触れる必要がある場合は、まず不足している公開境界を追加または改善します。
+- 新しい依存関係を通すためだけに、アーキテクチャテストを弱めてはいけません。

--- a/ASSETS-LICENSE.md
+++ b/ASSETS-LICENSE.md
@@ -1,19 +1,73 @@
-# Asset licensing
+# 素材授權／素材许可／Asset Licensing／素材ライセンス
 
-Unless a file contains a separate notice, the character illustrations,
-expression frames, animation layers, and icons committed to this repository are
-distributed under the same MIT License found in `LICENSE`.
+## 繁體中文
 
-`assets/onboarding/mohan-hero-rain-canonical.webp` is the repository-owned
-canonical onboarding crop source shared with the official Flameblade Studio
-MoHan page. Keeping the exact file in this repository prevents the setup
-wizard and installer from drifting to a different face or character identity.
+### 授權範圍
 
-The repository does not distribute a proprietary voice model or a cloned human
-voice. Windows voices and cloud-generated voices remain subject to the terms of
-Microsoft, OpenAI, or the service selected by the user. Third-party service
-names and trademarks remain the property of their respective owners.
+除非個別檔案另有聲明，提交至本儲存庫的角色插圖、表情影格、動畫圖層與圖示，均依 `LICENSE` 所載的相同 MIT License 散布。
 
-Contributors must not submit third-party images, voices, logos, or branded
-material unless they have sufficient redistribution rights and document any
-terms that differ from the repository's MIT License.
+### 權威角色素材
+
+`assets/onboarding/mohan-hero-rain-canonical.webp` 是本儲存庫擁有的權威啟動精靈裁切來源，並與炎劍文化工作室墨寒官方專頁共用。將完全相同的檔案保存在本儲存庫，可避免設定精靈與安裝程式逐漸偏離既定五官或角色身分。
+
+### 語音、服務與商標
+
+本儲存庫不散布專有語音模型或複製真人的聲音。Windows 語音及雲端生成語音仍分別受 Microsoft、OpenAI 或使用者所選服務的條款約束。第三方服務名稱與商標均屬其各自權利人所有。
+
+### 貢獻素材
+
+除非貢獻者具有充分的再散布權利，並記錄所有不同於本儲存庫 MIT License 的條款，否則不得提交第三方圖片、語音、標誌或品牌素材。
+
+## 简体中文
+
+### 许可范围
+
+除非个别文件另有声明，提交至本仓库的角色插图、表情帧、动画图层与图标，均依 `LICENSE` 所载的相同 MIT License 分发。
+
+### 权威角色素材
+
+`assets/onboarding/mohan-hero-rain-canonical.webp` 是本仓库拥有的权威启动向导裁切来源，并与炎剑文化工作室墨寒官方专页共用。将完全相同的文件保存在本仓库，可避免设置向导与安装程序逐渐偏离既定五官或角色身份。
+
+### 语音、服务与商标
+
+本仓库不分发专有语音模型或复制真人的声音。Windows 语音及云端生成语音仍分别受 Microsoft、OpenAI 或用户所选服务的条款约束。第三方服务名称与商标均归其各自权利人所有。
+
+### 贡献素材
+
+除非贡献者具有充分的再分发权利，并记录所有不同于本仓库 MIT License 的条款，否则不得提交第三方图片、语音、标志或品牌素材。
+
+## English
+
+### Licensing scope
+
+Unless an individual file carries a separate notice, the character illustrations, expression frames, animation layers, and icons committed to this repository are distributed under the same MIT License provided in `LICENSE`.
+
+### Canonical character asset
+
+`assets/onboarding/mohan-hero-rain-canonical.webp` is the repository-owned canonical onboarding crop source shared with the official Flameblade Studio MoHan page. Keeping the identical file in this repository prevents the setup wizard and installer from drifting away from the established facial features or character identity.
+
+### Voices, services, and trademarks
+
+This repository does not distribute a proprietary voice model or a cloned human voice. Windows voices and cloud-generated voices remain subject to the terms of Microsoft, OpenAI, or the service selected by the user. Third-party service names and trademarks remain the property of their respective owners.
+
+### Contributed assets
+
+Contributors must not submit third-party images, voices, logos, or branded material unless they have sufficient redistribution rights and document every term that differs from the repository's MIT License.
+
+## 日本語
+
+### ライセンスの範囲
+
+個別のファイルに別段の表示がない限り、このリポジトリにコミットされたキャラクターイラスト、表情フレーム、アニメーションレイヤー、アイコンは、`LICENSE` に記載されたものと同じ MIT License に基づいて配布されます。
+
+### 正式なキャラクター素材
+
+`assets/onboarding/mohan-hero-rain-canonical.webp` は、このリポジトリが所有し、Flameblade Studio の墨寒公式ページと共有する、初回設定用の正式な切り抜き元画像です。同一ファイルをこのリポジトリに保持することで、設定ウィザードやインストーラーが既定の顔立ちやキャラクター同一性から次第にずれることを防ぎます。
+
+### 音声、サービス、商標
+
+このリポジトリは、独自仕様の音声モデルや実在人物を複製した音声を配布しません。Windows 音声およびクラウド生成音声には、Microsoft、OpenAI、またはユーザーが選択したサービスの規約が引き続き適用されます。第三者のサービス名および商標は、それぞれの権利者に帰属します。
+
+### 提供される素材
+
+十分な再配布権を有し、このリポジトリの MIT License と異なるすべての条件を文書化できる場合を除き、コントリビューターは第三者の画像、音声、ロゴ、ブランド素材を提出してはなりません。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Changelog
+# 墨寒桌面助理變更紀錄／墨寒桌面助手变更日志／MoHan Desktop Assistant Changelog／墨寒デスクトップアシスタント変更履歴
 
-All notable public changes to MoHan Desktop Assistant are documented here.
+## 繁體中文
 
-## v2.3.0 RC1 — planned, not yet published
+本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
-### 繁體中文
+### v2.3.0 RC1 — 規劃中，尚未發布
 
 - 全面遷移至 CPython 3.15.0rc1，產品執行、測試與所有封裝不再保留舊版
   Python 路徑；全專案採用 PEP 810 明示延遲導入並加入靜態治理稽核。
@@ -16,50 +16,10 @@ All notable public changes to MoHan Desktop Assistant are documented here.
   Tachyon 證據，並發布去識別化結果；CycloneDX 1.7 SBOM 強制完整依賴圖、
   PURL、SPDX 授權、官方結構驗證及 100% 覆蓋率。
 - 所有 GitHub Actions JavaScript 動作強制使用 Node 24；PySide6 以受控 ABI3
-  輪子驗證跨越 3.15 中繼資料限制，安全掃描與完整發布閘門維持不變。
+  輪子驗證跨越 3.15 中繼資料限制，Stable ABI、依賴安全稽核、封裝與完整
+  發布安全閘門維持不變。
 
-### 简体中文
-
-- 全面迁移至 CPython 3.15.0rc1，产品、测试和所有发布包不再保留旧版
-  Python 路径；全项目采用 PEP 810 显式延迟导入并加入治理审计。
-- 导入不可变配置、推导式解包、UTF-8 文件审计、内建哨兵治理及新的音频
-  缓冲 API；Tachyon 可分析启动、50 Hz 口型同步和表情仲裁器。
-- JIT 开关均通过完整测试；2.3.0 RC1 默认启用，并保留兼容性停用开关。GitHub
-  Actions 全部强制 Node 24，并维持 ABI、依赖安全和发布验证闸门。
-- CI 与 Release 以有效样本、读取错误、漏采样及 JIT 状态阻止不合格的
-  Tachyon 证据，并发布去识别化结果；CycloneDX 1.7 SBOM 强制完整依赖图、
-  PURL、SPDX 授权、官方结构验证及 100% 覆盖率。
-
-### English
-
-- Moves the product, tests, and every package exclusively to CPython
-  3.15.0rc1, with project-wide explicit PEP 810 lazy imports and governance.
-- Adds immutable configuration, unpacking comprehensions, UTF-8 auditing,
-  sentinel governance, and the new bytearray audio-buffer API.
-- Adds Tachyon profiling for startup, 50 Hz lip sync, and expression
-  arbitration. Both JIT modes pass the complete suite; 2.3.0 RC1 defaults JIT on
-  while retaining a compatibility disable switch.
-- Forces Node 24 for every GitHub JavaScript action and preserves Stable ABI,
-  dependency-audit, packaging, and release safety gates.
-- Gates sanitized Tachyon evidence on valid samples, stack-read error, missed
-  samples, and JIT state. CycloneDX 1.7 SBOMs require complete dependency
-  graphs, PURLs, SPDX licenses, official schema validation, and 100% coverage.
-
-### 日本語
-
-- 製品、テスト、全パッケージを CPython 3.15.0rc1 のみに移行し、PEP 810
-  の明示的遅延インポートと継続監査を全プロジェクトへ導入しました。
-- 不変設定、推論式アンパック、UTF-8 監査、センチネル管理、新しい音声
-  バッファー API、Tachyon による 50 Hz 口形・表情解析を導入しました。
-- JIT の有無は全テストに合格し、2.3.0 RC1 では既定で有効にしながら互換性用の
-  無効化設定を残します。GitHub Actions はすべて Node 24 を強制します。
-- Tachyon 証拠は有効サンプル、読取エラー、漏れ、JIT 状態で判定し、匿名化して
-  公開します。CycloneDX 1.7 SBOM は完全な依存関係、PURL、SPDX ライセンス、
-  公式スキーマ検証、100% 網羅を必須とします。
-
-## v2.2.0 RC2 — 2026-08-07
-
-### 繁體中文
+### v2.2.0 RC2 — 2026-08-07
 
 - 托腮待機姿勢在說話期間改用中性嘴角基底：保留眼角笑意，但固定左右嘴角，
   只讓中央嘴唇依 A／I／U／E／O 與開合程度變化，避免誇張咧嘴與殘影。
@@ -71,123 +31,23 @@ All notable public changes to MoHan Desktop Assistant are documented here.
   一般待機與情境表情共用同一套座標與合成來源。
 - 強化標籤發行流程的 Draft Release 復原與清理機制，失敗的發布不會留下
   可被誤認為正式版本的殘缺發行項目。
-- 四語 README 新增兩張統一規格的創作歷程圖版，說明炎劍如何逐格檢查
+- 四語 README 新增 2 張統一規格的創作歷程圖版，說明炎劍如何逐格檢查
   眼睛、嘴角與語音嘴型，並以測試把二十多年的夢想鍛造成開源作品。
 
-### 简体中文
-
-- 托腮待机姿势在说话期间改用中性嘴角基础：保留眼角笑意，但固定左右嘴角，
-  只让中央嘴唇按照 A／I／U／E／O 与开合程度变化，避免夸张咧嘴和残影。
-- Realtime、Windows 本地语音、OpenAI 自然语音及 Azure Speech 统一使用
-  20 毫秒／50 Hz 口型节拍，缩短张嘴、闭嘴与元音切换延迟。
-- 声音与第一个口型从同一播放闸门起跑；声音结束后拒收迟到元音，只允许
-  最终闭嘴信号通过，避免口型先停或声音结束后再次张嘴。
-- 托腮待机眨眼改用完整双眼遮罩；眼皮闭合时不再残留睁眼状态的上眼线，
-  普通待机与情境表情共用同一套坐标及合成来源。
-- 强化标签发布流程的 Draft Release 恢复与清理机制，失败的发布不会留下
-  容易被误认为正式版本的不完整发布项目。
-- 四语 README 新增两张统一规格的创作历程图版，说明炎剑如何逐帧检查
-  眼睛、嘴角与语音口型，并以测试将二十多年的梦想锻造成开源作品。
-
-### English
-
-- Gives the chin-rest pose a neutral speech-mouth base: the smiling eyes remain,
-  both corners stay fixed, and only the central lips follow A/I/U/E/O and jaw
-  aperture, eliminating the exaggerated grin and corner ghosting.
-- Moves Realtime, Windows local speech, OpenAI natural speech, and Azure Speech
-  onto one 20 ms / 50 Hz viseme clock with shorter open, close, and vowel-change
-  transitions.
-- Releases audio and the first viseme through the same playback gate, rejects
-  late vowels after playback ends, and permits only the final closed-mouth cue.
-- Replaces the complete bilateral eye area during chin-rest idle blinks, so
-  open-eye eyeliner cannot remain above closed eyelids; idle and contextual
-  expressions now share one authoritative mask definition.
-- Makes tagged Draft Release publication recoverable and cleans up failed
-  attempts so incomplete assets cannot resemble a finished public release.
-- Adds two aligned creation-history panels to all four README languages,
-  documenting the frame-by-frame care behind MoHan's eyes, mouth corners, and
-  lip sync—and the dream Flameblade is turning into open-source software.
-
-### 日本語
-
-- 頬杖姿勢の発話中は中立な口角ベースを使用します。目元の笑みを残しながら
-  左右の口角を固定し、中央の唇だけを A／I／U／E／O と開口量に合わせて
-  動かすことで、誇張された笑顔と残像を防ぎます。
-- Realtime、Windows ローカル音声、OpenAI 自然音声、Azure Speech を
-  共通の 20 ミリ秒／50 Hz 口形周期へ統一し、開口、閉口、母音切り替えの
-  遅延を短縮します。
-- 音声と最初の口形を同じ再生ゲートから開始し、再生終了後の遅延母音を拒否、
-  最後の閉口信号だけを通すことで、口だけが先に止まる現象を防ぎます。
-- 頬杖の待機中のまばたきでは両目全体を覆う共通マスクを使用し、閉じた
-  まぶたの上に開眼時のアイラインが残らないようにしました。待機表情と
-  状況表情は同じ座標・合成定義を共有します。
-- タグ発行時の Draft Release を安全に復旧・清理できるようにし、失敗した
-  発行が不完全な公開版として残らないようにしました。
-- 四言語 README に統一規格の制作過程図を2枚追加し、目、口角、口形を
-  フレーム単位で確認しながら夢をオープンソース作品へ鍛える姿勢を伝えます。
-
-## v2.2.0 RC1 — 2026-08-06
-
-### 繁體中文
+### v2.2.0 RC1 — 2026-08-06
 
 - 保留 Windows x64 為完整正式功能版本，沿用已驗證的 ZIP、EXE、MSI 與
   MSI 語言轉換封裝及安裝／移除測試。
 - 新增原生 macOS Apple Silicon（arm64）／Intel（x86_64）雙架構
-  `.app`／`.dmg` 與 Linux x86_64 `.AppImage` 的功能受限
-  Preview。兩者只開放啟動、四語介面、平台資料路徑及安全停用邊界，不宣稱
-  與 Windows 功能相同，也不接受金鑰、OAuth 或 Home Assistant 權杖。
+  `.app`／`.dmg` 與 Linux x86_64 `.AppImage` 的功能受限 Preview。兩者只
+  開放啟動、四語介面、平台資料路徑及安全停用邊界，不宣稱與 Windows 功能
+  相同，也不接受 API 金鑰、OAuth 憑證或 Home Assistant 權杖。
 - Pull Request 只產生短期測試產物；只有不可變的 `v2.2.0-rc.N` 標籤能建立
   GitHub 預發行版。三平台封裝必須在各自原生 CI 執行打包後啟動測試。
 - 發行檔統一提供 SHA256SUMS、CycloneDX SBOM、更新清單與 GitHub 產物
   證明；Release 說明必須由繁中、簡中、英文、日文完整策展文件提供。
 
-### 简体中文
-
-- Windows x64 继续作为完整正式功能版本，并保留已验证的 ZIP、EXE、MSI、
-  MSI 语言转换包以及安装／卸载测试。
-- 新增原生 macOS Apple Silicon（arm64）／Intel（x86_64）双架构
-  `.app`／`.dmg` 与 Linux x86_64 `.AppImage` 功能受限
-  Preview。两者只开放启动、四语界面、平台数据路径与安全停用边界，不宣称
-  与 Windows 功能相同，也不接收密钥、OAuth 或 Home Assistant 令牌。
-- Pull Request 只生成短期测试产物；只有不可变的 `v2.2.0-rc.N` 标签能够
-  建立 GitHub 预发布版。三个平台都必须在各自原生 CI 完成打包后启动测试。
-- 发布文件统一提供 SHA256SUMS、CycloneDX SBOM、更新清单及 GitHub 产物
-  证明；Release 说明必须采用繁中、简中、英文、日文完整编写的文件。
-
-### English
-
-- Windows x64 remains the complete product surface with the verified ZIP,
-  EXE, MSI, MSI language transforms, and installer lifecycle tests.
-- Added native macOS Apple Silicon (arm64) and Intel (x86_64) `.app`/`.dmg`
-  packages plus a Linux x86_64 `.AppImage` limited
-  Previews. They expose only launch, four-language UI, platform paths, and
-  fail-closed boundaries; they claim no Windows feature parity and accept no
-  API keys, OAuth credentials, or Home Assistant tokens.
-- Pull requests produce short-lived test artifacts only. Only immutable
-  `v2.2.0-rc.N` tags can create a GitHub pre-release, after every platform has
-  built and executed its package on a native CI runner.
-- Releases provide SHA256SUMS, CycloneDX SBOMs, an update manifest, and GitHub
-  artifact attestations, with curated Traditional Chinese, Simplified Chinese,
-  English, and Japanese release notes.
-
-### 日本語
-
-- Windows x64 を完全機能版として維持し、検証済みの ZIP、EXE、MSI、MSI
-  言語変換、およびインストール／削除テストを継続します。
-- macOS Apple Silicon（arm64）／Intel（x86_64）両方のネイティブ
-  `.app`／`.dmg` と Linux x86_64 `.AppImage` の機能限定
-  Preview を追加します。起動、四言語画面、保存先、安全な無効化だけを提供し、
-  Windows 版との同等性を主張せず、API キー、OAuth、Home Assistant Token
-  の入力も受け付けません。
-- Pull Request は短期テスト用成果物だけを作成します。GitHub のプレリリースを
-  作成できるのは変更しない `v2.2.0-rc.N` タグだけで、各 OS のネイティブ CI
-  上で配布物を作成し、起動確認に合格する必要があります。
-- SHA256SUMS、CycloneDX SBOM、更新マニフェスト、GitHub 成果物証明を提供し、
-  Release 説明は繁体字中国語・簡体字中国語・英語・日本語で作成します。
-
-## v2.1.0 RC1 — 2026-08-04
-
-### 繁體中文
+### v2.1.0 RC1 — 2026-08-04
 
 - 原始碼、Windows CI 與封裝流程完整遷移至 Python 3.14，並保留未來評估
   Python 3.15 lazy imports 的清楚升級邊界。
@@ -208,7 +68,119 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 - 延續姿勢切換、物理圖層與說話銜接的競速修正；RC3 觀察到的抖動需以本版
   候選程式重新實測，不能視為本版回歸。
 
-### 简体中文
+驗證：目前 RC1 原始碼的 56/56 個自動化測試程式均已通過。加上標籤的 Windows
+發行工作流程亦已通過原始碼稽核、封裝後自我測試、EXE／MSI 靜默安裝與解除安裝
+驗證、checksum 與 SBOM 產生、產物證明及安全檢查。
+
+### v2.0.14 RC3 — 2026-08-02
+
+- 新增繁體中文／簡體中文／英文首次啟動精靈，以及聊天、語音、權限、個人設定、
+  工作模式與提醒的最低可用英文和 zh-CN 介面路徑。
+- 新增完整的英文與簡體中文墨寒人格提示詞，以及語言相符的離線回覆、模式播報
+  與內建提醒語音。切換介面語言時，會在三種語言間翻譯未修改的預設值，而不會
+  覆蓋自訂提醒文字。
+- 新使用者的語音輸出改用 Windows 本機語音，基本體驗無須 OpenAI API 金鑰。
+  Windows 語音選擇現在只列出已驗證的女性聲音；zh-TW 繼續優先使用 Microsoft
+  Yating，zh-CN 則優先使用相符且已安裝的女性聲音。
+- 新增專用的簡體中文 README 與快速入門說明。
+- 新增安全的應用程式內穩定版／預覽版更新檢查，包含官方主機允許清單、語意版本
+  驗證、大小限制、SHA256 驗證、明確安裝確認及本機個人設定保留。
+- 新增自動化 Windows x64 EXE 與 MSI 安裝程式，並在 GitHub Actions 中執行
+  靜默安裝、自我測試與解除安裝驗證。
+- 發行內容擴充為完整 checksum 目錄、CycloneDX SBOM、更新清單、產物證明與
+  分類產生的 Release notes。
+- 新增可選、限定標記區段的 WordPress 下載頁同步，使用 GitHub Secrets 與
+  專用 WordPress Application Password。
+- 新增完整 Git 歷史 Gitleaks 檢查，作為個人公開儲存庫無法使用 GitHub Secret
+  Protection 功能時的補償控制。
+- 將畫面上的「墨寒思考中」狀態與角色表情解耦。一般文字與語音問題現在維持
+  自然姿勢，複雜提示只在明顯延遲後反應，異常緩慢的回覆則使用既有表情仲裁器，
+  並具備取消、冷卻與去重機制。
+- 統一成功回覆、API 失敗、一般語音與 Realtime 轉換時的 AI 等待清理，避免
+  思考狀態延續到說話期間或播放後仍未消失。
+
+驗證：RC3 Pull Request 前已有 45/45 個自動化測試程式通過。加上標籤的發行
+工作流程在發布完成前，還必須通過公開內容稽核、封裝後自我測試、事件迴圈
+smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBOM 產生及
+產物證明。
+
+### v2.0.14 RC — 2026-07-31
+
+- 修正應用程式本機音量處理期間 OpenAI 串流 WAV 標頭溢位，該問題可能使所有
+  雲端語音靜音。
+- 改以實際收到的音訊位元組重建調整後的 WAV 標頭，不再複製串流預留長度。
+- OpenAI 語音產生或播放失敗時，自動回退至 Windows Yating。
+- 將一般文字對話框中的安全唯讀 Gmail、Google Calendar 與 Google Drive 命令，
+  導向受權限閘門保護的工具規劃器。
+- 新增雲端語音回退、串流 WAV 音量處理、Gmail 對話路由與工作計時器隔離的
+  回歸測試。
+
+驗證：此候選版發布前，38/38 個自動化測試程式、真實 OpenAI TTS 播放、封裝後
+自我測試、封裝後事件迴圈 smoke test，以及封存後自我測試均已通過。
+
+### v2.0.13 RC — 2026-07-31
+
+- 新增單一動作合成器，統一處理呼吸、說話強調、視線與情緒手勢。
+- 修正動作切換期間偶發的角色抖動與圖層分離。
+- 保持身體、臉部、眼睛、頭髮、衣袖與飾品圖層同步。
+- 讓說話後返回待機的動作更平順。
+- 移除可能顯示為白色瑕疵的人造眼睛高光。
+- 改善眨眼、表情與 AIUEO 嘴型的連續性。
+- 新增可設定的角色顯示縮放。
+- 新增可攜式個人設定轉移與模組化服務邊界。
+- 對尚未驗證的 Microsoft、GitHub 與 Home Assistant 整合新增明確的公開預覽警告。
+
+驗證：此候選版發布前，37 個自動化測試程式，以及 25,000 步混合動畫、語音、
+視線與物理壓力測試均已通過。
+
+## 简体中文
+
+本文档记录墨寒桌面助手所有值得注意的公开变更。
+
+### v2.3.0 RC1 — 计划中，尚未发布
+
+- 全面迁移至 CPython 3.15.0rc1，产品运行、测试及所有发布包不再保留旧版
+  Python 路径；全项目采用 PEP 810 显式延迟导入并加入静态治理审计。
+- 导入 PEP 814 `frozendict` 深层不可变配置、PEP 798 推导式解包、PEP 686
+  UTF-8 文件审计、PEP 661 哨兵治理及 `bytearray.take_bytes()` 音频缓冲。
+- 加入 PEP 799 Tachyon 采样分析，可直接检查启动、50 Hz 口型同步与表情
+  仲裁器；JIT 开关均通过完整测试，2.3.0 RC1 默认启用并保留兼容性停用开关。
+- CI 与 Release 以有效样本、读取错误、漏采样及 JIT 状态阻止不合格的
+  Tachyon 证据，并发布去标识化结果；CycloneDX 1.7 SBOM 强制完整依赖图、
+  PURL、SPDX 许可证、官方结构验证及 100% 覆盖率。
+- 所有 GitHub Actions JavaScript 动作强制使用 Node 24；PySide6 以受控 ABI3
+  轮子验证跨越 3.15 元数据限制，Stable ABI、依赖安全审计、打包及完整
+  发布安全闸门保持不变。
+
+### v2.2.0 RC2 — 2026-08-07
+
+- 托腮待机姿势在说话期间改用中性嘴角基础：保留眼角笑意，但固定左右嘴角，
+  只让中央嘴唇按照 A／I／U／E／O 与开合程度变化，避免夸张咧嘴和残影。
+- Realtime、Windows 本地语音、OpenAI 自然语音及 Azure Speech 统一使用
+  20 毫秒／50 Hz 口型节拍，缩短张嘴、闭嘴与元音切换延迟。
+- 声音与第一个口型从同一播放闸门起跑；声音结束后拒收迟到元音，只允许
+  最终闭嘴信号通过，避免口型先停或声音结束后再次张嘴。
+- 托腮待机眨眼改用完整双眼遮罩；眼皮闭合时不再残留睁眼状态的上眼线，
+  普通待机与情境表情共用同一套坐标及合成来源。
+- 强化标签发布流程的 Draft Release 恢复与清理机制，失败的发布不会留下
+  容易被误认为正式版本的不完整发布项目。
+- 四语 README 新增 2 张统一规格的创作历程图版，说明炎剑如何逐帧检查
+  眼睛、嘴角与语音口型，并以测试将二十多年的梦想锻造成开源作品。
+
+### v2.2.0 RC1 — 2026-08-06
+
+- Windows x64 继续作为完整正式功能版本，并保留已验证的 ZIP、EXE、MSI、
+  MSI 语言转换包及安装／卸载测试。
+- 新增原生 macOS Apple Silicon（arm64）／Intel（x86_64）双架构
+  `.app`／`.dmg` 与 Linux x86_64 `.AppImage` 的功能受限 Preview。两者只
+  开放启动、四语界面、平台数据路径与安全停用边界，不宣称与 Windows 功能
+  相同，也不接收 API 密钥、OAuth 凭证或 Home Assistant 令牌。
+- Pull Request 只生成短期测试产物；只有不可变的 `v2.2.0-rc.N` 标签能够
+  建立 GitHub 预发布版。三个平台都必须在各自原生 CI 完成打包后启动测试。
+- 发布文件统一提供 SHA256SUMS、CycloneDX SBOM、更新清单及 GitHub 产物
+  证明；Release 说明必须采用繁中、简中、英文、日文完整编写的文件。
+
+### v2.1.0 RC1 — 2026-08-04
 
 - 源代码、Windows CI 与打包流程完整迁移到 Python 3.14，并为未来评估
   Python 3.15 lazy imports 保留清晰的升级边界。
@@ -226,8 +198,134 @@ All notable public changes to MoHan Desktop Assistant are documented here.
   不再把炎剑工作室专用词汇带给所有用户；现有自定义提示词不会被覆盖。
 - 修复首次设置字段标题的垂直对齐，以及托腮待机姿势说话时嘴角过度上扬；
   同步更新 README 与官网采用的最新版实机图。
+- 延续姿势切换、物理图层及说话衔接的竞态修复；RC3 观察到的抖动必须使用
+  本版候选程序重新测试，不能视为本版回归。
 
-### English
+验证：当前 RC1 源代码的 56/56 个自动化测试程序均已通过。带标签的 Windows
+发布工作流也已通过源代码审计、打包后自测、EXE／MSI 静默安装与卸载验证、
+checksum 与 SBOM 生成、产物证明及安全检查。
+
+### v2.0.14 RC3 — 2026-08-02
+
+- 新增繁体中文／简体中文／英文首次启动向导，以及聊天、语音、权限、配置文件、
+  工作模式与提醒的最低可用英文和 zh-CN 界面路径。
+- 新增完整的英文与简体中文墨寒人格提示词，以及语言匹配的离线回复、模式播报
+  与内置提醒语音。切换界面语言时，会在三种语言之间翻译未修改的默认值，而不会
+  覆盖自定义提醒文本。
+- 新用户的语音输出改用 Windows 本地语音，基本体验无需 OpenAI API 密钥。
+  Windows 语音选择现在只列出已验证的女性声音；zh-TW 继续优先使用 Microsoft
+  Yating，zh-CN 则优先使用匹配且已安装的女性声音。
+- 新增专用的简体中文 README 与快速入门说明。
+- 新增安全的应用内稳定版／预览版更新检查，包含官方主机允许列表、语义版本验证、
+  大小限制、SHA256 验证、明确安装确认及本地配置文件保留。
+- 新增自动化 Windows x64 EXE 与 MSI 安装程序，并在 GitHub Actions 中执行
+  静默安装、自测与卸载验证。
+- 发布内容扩充为完整 checksum 目录、CycloneDX SBOM、更新清单、产物证明与
+  分类生成的 Release notes。
+- 新增可选、限定标记区段的 WordPress 下载页同步，使用 GitHub Secrets 与
+  专用 WordPress Application Password。
+- 新增完整 Git 历史 Gitleaks 检查，作为个人公开仓库无法使用 GitHub Secret
+  Protection 功能时的补偿控制。
+- 将界面上的“墨寒思考中”状态与角色表情解耦。常规文字与语音问题现在保持
+  自然姿势，复杂提示只在明显延迟后反应，异常缓慢的回复则使用现有表情仲裁器，
+  并具备取消、冷却与去重机制。
+- 统一成功回复、API 失败、普通语音与 Realtime 转换时的 AI 等待清理，避免
+  思考状态延续到说话期间或播放后仍未消失。
+
+验证：RC3 Pull Request 前已有 45/45 个自动化测试程序通过。带标签的发布
+工作流在发布完成前，还必须通过公开内容审计、打包后自测、事件循环 smoke test、
+EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物证明。
+
+### v2.0.14 RC — 2026-07-31
+
+- 修复应用程序本地音量处理期间 OpenAI 流式 WAV 标头溢出，该问题可能使所有
+  云端语音静音。
+- 改用实际收到的音频字节重建调整后的 WAV 标头，不再复制流式预留长度。
+- OpenAI 语音生成或播放失败时，自动回退至 Windows Yating。
+- 将普通文字对话框中的安全只读 Gmail、Google Calendar 与 Google Drive 命令，
+  导向受权限闸门保护的工具规划器。
+- 新增云端语音回退、流式 WAV 音量处理、Gmail 对话路由与工作计时器隔离的
+  回归测试。
+
+验证：此候选版发布前，38/38 个自动化测试程序、真实 OpenAI TTS 播放、打包后
+自测、打包后事件循环 smoke test，以及归档后自测均已通过。
+
+### v2.0.13 RC — 2026-07-31
+
+- 新增单一动作合成器，统一处理呼吸、说话强调、视线与情绪手势。
+- 修复动作切换期间偶发的角色抖动与图层分离。
+- 保持身体、脸部、眼睛、头发、衣袖及饰品图层同步。
+- 让说话后返回待机的动作更平顺。
+- 移除可能显示为白色瑕疵的人造眼睛高光。
+- 改进眨眼、表情与 AIUEO 口型的连续性。
+- 新增可配置的角色显示缩放。
+- 新增可移植配置文件转移与模块化服务边界。
+- 对尚未验证的 Microsoft、GitHub 与 Home Assistant 集成新增明确的公开预览警告。
+
+验证：此候选版发布前，37 个自动化测试程序，以及 25,000 步混合动画、语音、
+视线与物理压力测试均已通过。
+
+## English
+
+All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v2.3.0 RC1 — planned, not yet published
+
+- Moves the product, tests, and every package exclusively to CPython
+  3.15.0rc1, with project-wide explicit PEP 810 lazy imports and static
+  governance auditing; no legacy Python path remains.
+- Adds deeply immutable PEP 814 `frozendict` configuration, PEP 798 unpacking
+  comprehensions, PEP 686 UTF-8 file auditing, PEP 661 sentinel governance,
+  and the new `bytearray.take_bytes()` audio-buffer API.
+- Adds PEP 799 Tachyon profiling for startup, 50 Hz lip sync, and expression
+  arbitration. Both JIT modes pass the complete suite; 2.3.0 RC1 defaults JIT
+  on while retaining a compatibility disable switch.
+- Gates sanitized Tachyon evidence on valid samples, stack-read errors, missed
+  samples, and JIT state. CycloneDX 1.7 SBOMs require complete dependency
+  graphs, PURLs, SPDX licenses, official schema validation, and 100% coverage.
+- Forces Node 24 for every GitHub Actions JavaScript action. PySide6 crosses
+  the 3.15 metadata limit through a controlled ABI3 wheel validation, while
+  Stable ABI, dependency-audit, packaging, and complete release safety gates
+  remain unchanged.
+
+### v2.2.0 RC2 — 2026-08-07
+
+- Gives the chin-rest pose a neutral speech-mouth base: the smiling eyes remain,
+  both corners stay fixed, and only the central lips follow A/I/U/E/O and jaw
+  aperture, eliminating the exaggerated grin and corner ghosting.
+- Moves Realtime, Windows local speech, OpenAI natural speech, and Azure Speech
+  onto one 20 ms / 50 Hz viseme clock with shorter open, close, and vowel-change
+  transitions.
+- Releases audio and the first viseme through the same playback gate, rejects
+  late vowels after playback ends, and permits only the final closed-mouth cue,
+  preventing visemes from stopping early or the mouth from reopening afterward.
+- Replaces the complete bilateral eye area during chin-rest idle blinks, so
+  open-eye eyeliner cannot remain above closed eyelids; idle and contextual
+  expressions now share one authoritative mask definition.
+- Makes tagged Draft Release publication recoverable and cleans up failed
+  attempts so incomplete assets cannot resemble a finished public release.
+- Adds 2 aligned creation-history panels to all four README languages,
+  documenting the frame-by-frame care behind MoHan's eyes, mouth corners, and
+  lip sync—and the more-than-twenty-year dream Flameblade is turning into
+  open-source software through testing.
+
+### v2.2.0 RC1 — 2026-08-06
+
+- Windows x64 remains the complete product surface with the verified ZIP,
+  EXE, MSI, MSI language transforms, and installer lifecycle tests.
+- Adds native macOS Apple Silicon (arm64) and Intel (x86_64) `.app`/`.dmg`
+  packages plus a Linux x86_64 `.AppImage` limited Preview. They expose only
+  launch, four-language UI, platform paths, and fail-closed boundaries; they
+  claim no Windows feature parity and accept no API keys, OAuth credentials,
+  or Home Assistant tokens.
+- Pull requests produce short-lived test artifacts only. Only immutable
+  `v2.2.0-rc.N` tags can create a GitHub pre-release, after every platform has
+  built and executed its package on a native CI runner.
+- Releases provide SHA256SUMS, CycloneDX SBOMs, an update manifest, and GitHub
+  artifact attestations, with curated Traditional Chinese, Simplified Chinese,
+  English, and Japanese release notes.
+
+### v2.1.0 RC1 — 2026-08-04
 
 - Migrated source, Windows CI, and packaging to Python 3.14 while preserving
   an explicit boundary for a future Python 3.15 lazy-import evaluation.
@@ -249,34 +347,16 @@ All notable public changes to MoHan Desktop Assistant are documented here.
   every existing custom prompt.
 - Corrected first-run label alignment and the over-wide smile while the
   chin-rest pose speaks, then refreshed the README and website screenshots.
-
-### 日本語
-
-- ソースコード、Windows CI、配布物を Python 3.14 へ移行し、将来の
-  Python 3.15 lazy imports 評価に備えた境界を残しました。
-- 日本語の最小利用経路と人格を追加しました。初回設定と対話型 EXE
-  インストーラーは、繁体字中国語、簡体字中国語、英語、日本語に対応します。
-  MSI は繁体字中国語を基準とし、三つの言語変換を提供します。
-- 文字会話の既定を `gpt-5.6-luna` に変更し、新規利用者向け一覧から旧 mini
-  を削除しました。独自モデル設定は上書きしません。
-- 交換可能な音声供給元と Azure Speech 女性音声プレビューを追加しました。
-  キー不足、オフライン、障害時は Windows 本機女性音声へ最初に戻ります。
-- 長期記憶のベクトル検索、意味要約、安全な整理、任意の背景ワーカー、音声
-  バッファーを改善しました。
-- 初回設定と本体画面を明るく高コントラストな大きめ文字へ刷新し、古風と
-  技術を融合した背景、墨寒のインストール画像、見やすいチェック欄、統一した
-  墨寒半身アイコンを追加しました。
-- 音声文字起こしの既定文を、繁体字中国語、簡体字中国語、英語、日本語と
-  利用者設定から作る中立的な内容へ変更しました。既存の独自文は上書きしません。
-- 初回設定の項目名の縦位置と、頬杖姿勢で話す際の過度に広い笑顔を修正し、
-  README と公式サイトの実機画像を最新版へ更新しました。
+- Continues the race-condition fixes for pose transitions, physical layers,
+  and speech handoffs. Jitter observed in RC3 must be retested with this
+  candidate and cannot be treated as a regression in this version.
 
 Verification: 56/56 automated test programs passed for the current RC1 source. The
 tagged Windows release workflow also passed source auditing, packaged self-test,
 silent EXE/MSI install and uninstall verification, checksum and SBOM generation,
 artifact attestation, and security checks.
 
-## v2.0.14 RC3 — 2026-08-02
+### v2.0.14 RC3 — 2026-08-02
 
 - Added a Traditional Chinese / Simplified Chinese / English first-run wizard
   and minimum usable English and zh-CN UI paths for chat, voice, permissions,
@@ -315,7 +395,7 @@ audit, packaged self-test, event-loop smoke test, silent EXE/MSI install and
 uninstall verification, checksum generation, SBOM generation, and artifact
 attestation before publication completes.
 
-## v2.0.14 RC — 2026-07-31
+### v2.0.14 RC — 2026-07-31
 
 - Fixed OpenAI streaming WAV headers overflowing during application-local
   volume processing, which could make all cloud speech silent.
@@ -332,7 +412,7 @@ Verification: 38/38 automated test programs, real OpenAI TTS playback,
 packaged self-test, packaged event-loop smoke test, and post-archive self-test
 passed before this release candidate.
 
-## v2.0.13 RC — 2026-07-31
+### v2.0.13 RC — 2026-07-31
 
 - Added a single motion compositor for breathing, speech emphasis, gaze, and
   emotional gestures.
@@ -349,3 +429,157 @@ passed before this release candidate.
 
 Verification: 37 automated test programs and a 25,000-step mixed animation,
 speech, gaze, and physics stress test passed before this release candidate.
+
+## 日本語
+
+本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v2.3.0 RC1 — 予定、未公開
+
+- 製品、テスト、全パッケージを CPython 3.15.0rc1 のみに移行し、旧 Python
+  経路を廃止しました。PEP 810 の明示的遅延インポートと静的ガバナンス監査を
+  全プロジェクトへ導入しました。
+- PEP 814 `frozendict` の深い不変設定、PEP 798 の内包表記アンパック、
+  PEP 686 UTF-8 ファイル監査、PEP 661 センチネル管理、新しい
+  `bytearray.take_bytes()` 音声バッファー API を導入しました。
+- PEP 799 Tachyon による起動、50 Hz 口形同期、表情調停のサンプリング解析を
+  導入しました。JIT の有無は全テストに合格し、2.3.0 RC1 では既定で有効に
+  しながら互換性用の無効化設定を残します。
+- Tachyon 証拠は有効サンプル、読取エラー、漏れ、JIT 状態で判定し、匿名化して
+  公開します。CycloneDX 1.7 SBOM は完全な依存関係、PURL、SPDX ライセンス、
+  公式スキーマ検証、100% 網羅を必須とします。
+- GitHub Actions の JavaScript 動作はすべて Node 24 を強制します。PySide6 は
+  管理された ABI3 wheel 検証によって 3.15 のメタデータ制限に対応し、Stable
+  ABI、依存関係の安全監査、パッケージング、完全なリリース安全ゲートを維持します。
+
+### v2.2.0 RC2 — 2026-08-07
+
+- 頬杖姿勢の発話中は中立な口角ベースを使用します。目元の笑みを残しながら
+  左右の口角を固定し、中央の唇だけを A／I／U／E／O と開口量に合わせて
+  動かすことで、誇張された笑顔と残像を防ぎます。
+- Realtime、Windows ローカル音声、OpenAI 自然音声、Azure Speech を
+  共通の 20 ミリ秒／50 Hz 口形周期へ統一し、開口、閉口、母音切り替えの
+  遅延を短縮します。
+- 音声と最初の口形を同じ再生ゲートから開始し、再生終了後の遅延母音を拒否、
+  最後の閉口信号だけを通すことで、口だけが先に止まる現象や音声終了後に
+  再び口が開く現象を防ぎます。
+- 頬杖の待機中のまばたきでは両目全体を覆う共通マスクを使用し、閉じた
+  まぶたの上に開眼時のアイラインが残らないようにしました。待機表情と
+  状況表情は同じ座標・合成定義を共有します。
+- タグ発行時の Draft Release を安全に復旧・整理できるようにし、失敗した
+  発行が不完全な公開版として残らないようにしました。
+- 四言語 README に統一規格の制作過程図を2枚追加し、目、口角、口形を
+  フレーム単位で確認しながら、二十年以上の夢をテストによってオープンソース
+  作品へ鍛える姿勢を伝えます。
+
+### v2.2.0 RC1 — 2026-08-06
+
+- Windows x64 を完全機能版として維持し、検証済みの ZIP、EXE、MSI、MSI
+  言語変換、およびインストール／削除テストを継続します。
+- macOS Apple Silicon（arm64）／Intel（x86_64）両方のネイティブ
+  `.app`／`.dmg` と Linux x86_64 `.AppImage` の機能限定 Preview を追加します。
+  起動、四言語画面、保存先、安全な無効化だけを提供し、Windows 版との同等性を
+  主張せず、API キー、OAuth 認証情報、Home Assistant Token の入力も受け付けません。
+- Pull Request は短期テスト用成果物だけを作成します。GitHub のプレリリースを
+  作成できるのは変更しない `v2.2.0-rc.N` タグだけで、各 OS のネイティブ CI
+  上で配布物を作成し、起動確認に合格する必要があります。
+- SHA256SUMS、CycloneDX SBOM、更新マニフェスト、GitHub 成果物証明を提供し、
+  Release 説明は繁体字中国語・簡体字中国語・英語・日本語で作成します。
+
+### v2.1.0 RC1 — 2026-08-04
+
+- ソースコード、Windows CI、配布物を Python 3.14 へ移行し、将来の
+  Python 3.15 lazy imports 評価に備えた境界を残しました。
+- 日本語の最小利用経路と人格を追加しました。初回設定と対話型 EXE
+  インストーラーは、繁体字中国語、簡体字中国語、英語、日本語に対応します。
+  MSI は繁体字中国語を基準とし、三つの言語変換を提供します。
+- 文字会話の既定を `gpt-5.6-luna` に変更し、新規利用者向け一覧から旧 mini
+  を削除しました。独自モデル設定は上書きしません。
+- 交換可能な音声供給元と Azure Speech 女性音声プレビューを追加しました。
+  キー不足、オフライン、障害時は Windows 本機女性音声へ最初に戻ります。
+- 長期記憶のベクトル検索、意味要約、安全な整理、任意の背景ワーカー、音声
+  バッファーを改善しました。
+- 初回設定と本体画面を明るく高コントラストな大きめ文字へ刷新し、古風と
+  技術を融合した背景、墨寒のインストール画像、見やすいチェック欄、統一した
+  墨寒半身アイコンを追加しました。
+- 音声文字起こしの既定文を、繁体字中国語、簡体字中国語、英語、日本語と
+  利用者設定から作る中立的な内容へ変更しました。既存の独自文は上書きしません。
+- 初回設定の項目名の縦位置と、頬杖姿勢で話す際の過度に広い笑顔を修正し、
+  README と公式サイトの実機画像を最新版へ更新しました。
+- 姿勢切り替え、物理レイヤー、発話の受け渡しに関する競合修正を継続します。
+  RC3 で観察された揺れは本候補版で再検証する必要があり、本版の回帰とは
+  見なせません。
+
+検証：現在の RC1 ソースでは 56/56 個の自動テストプログラムが合格しました。
+タグ付き Windows リリースワークフローも、ソース監査、パッケージ自己テスト、
+EXE／MSI の無人インストールとアンインストール検証、checksum と SBOM の生成、
+成果物証明、セキュリティ検査に合格しました。
+
+### v2.0.14 RC3 — 2026-08-02
+
+- 繁体字中国語／簡体字中国語／英語の初回設定ウィザードと、チャット、音声、
+  権限、プロファイル、作業モード、リマインダー向けの最低限利用可能な英語および
+  zh-CN UI 経路を追加しました。
+- 完全な英語・簡体字中国語の墨寒人格プロンプトと、言語に合うオフライン応答、
+  モード通知、組み込みリマインダー音声を追加しました。UI 言語を切り替えると、
+  未変更の既定値を三言語間で翻訳し、独自のリマインダー文は上書きしません。
+- 新規利用者の音声出力を Windows ローカル音声へ変更し、基本体験では OpenAI
+  API キーを不要にしました。Windows の音声一覧には検証済みの女性音声だけを
+  表示します。zh-TW は引き続き Microsoft Yating を優先し、zh-CN は一致する
+  インストール済み女性音声を優先します。
+- 簡体字中国語専用の README とクイックスタート手順を追加しました。
+- 公式ホスト許可リスト、セマンティックバージョン検証、サイズ制限、SHA256 検証、
+  明示的なインストール確認、ローカルプロファイル保持を備えた、安全なアプリ内
+  安定版／プレビュー版更新確認を追加しました。
+- Windows x64 EXE／MSI インストーラーを自動化し、GitHub Actions で無人
+  インストール、自己テスト、アンインストールを検証します。
+- 完全な checksum 一覧、CycloneDX SBOM、更新マニフェスト、成果物証明、分類済み
+  自動生成 Release notes をリリースへ追加しました。
+- GitHub Secrets と専用 WordPress Application Password を使う、任意の
+  マーカー範囲限定 WordPress ダウンロードページ同期を追加しました。
+- 個人公開リポジトリで利用できない GitHub Secret Protection 機能の補償統制として、
+  Git 全履歴の Gitleaks 検査を追加しました。
+- 表示される「墨寒思考中」状態をキャラクター表情から分離しました。通常の文字・
+  音声質問では自然な姿勢を保ち、複雑なプロンプトには明確な遅延後だけ反応し、
+  異常に遅い応答では取消、クールダウン、重複排除を備えた既存の表情調停器を使います。
+- 成功応答、API 障害、通常音声、Realtime 遷移における AI 待機終了処理を統一し、
+  思考状態が発話へ残ったり、再生後に消えなかったりすることを防ぎます。
+
+検証：RC3 Pull Request 前に 45/45 個の自動テストプログラムが合格しました。
+タグ付きリリースワークフローは公開完了前に、公開内容監査、パッケージ自己テスト、
+イベントループ smoke test、EXE／MSI の無人インストールとアンインストール検証、
+checksum 生成、SBOM 生成、成果物証明にも合格しなければなりません。
+
+### v2.0.14 RC — 2026-07-31
+
+- アプリ内音量処理中に OpenAI ストリーミング WAV ヘッダーがオーバーフローし、
+  すべてのクラウド音声が無音になる可能性がある問題を修正しました。
+- ストリーミング用プレースホルダー長をコピーせず、実際に受信した音声バイトから
+  調整後の WAV ヘッダーを再構築しました。
+- OpenAI 音声の生成または再生に失敗した場合、Windows Yating へ自動的に
+  フォールバックするようにしました。
+- 通常のテキスト会話欄に入力された安全な読み取り専用 Gmail、Google Calendar、
+  Google Drive コマンドを、権限ゲート付きツールプランナーへ送るようにしました。
+- クラウド音声フォールバック、ストリーミング WAV 音量処理、Gmail 会話ルーティング、
+  作業タイマー分離の回帰テストを追加しました。
+
+検証：このリリース候補の公開前に、38/38 個の自動テストプログラム、実際の OpenAI
+TTS 再生、パッケージ自己テスト、パッケージイベントループ smoke test、アーカイブ後
+自己テストが合格しました。
+
+### v2.0.13 RC — 2026-07-31
+
+- 呼吸、発話強調、視線、感情ジェスチャーを扱う単一モーションコンポジターを
+  追加しました。
+- 動作変更時にまれに発生するキャラクターの揺れとレイヤー分離を修正しました。
+- 身体、顔、目、髪、袖、装飾レイヤーの同期を維持しました。
+- 発話後に待機状態へ戻る動きを滑らかにしました。
+- 白いアーティファクトとして現れる可能性がある人工的な目のハイライトを削除しました。
+- まばたき、表情、AIUEO 口形の連続性を改善しました。
+- 設定可能なキャラクター表示倍率を追加しました。
+- ポータブルプロファイル移行とモジュール化されたサービス境界を追加しました。
+- 未検証の Microsoft、GitHub、Home Assistant 連携に、明示的な公開プレビュー
+  警告を追加しました。
+
+検証：このリリース候補の公開前に、37 個の自動テストプログラムと、25,000 ステップの
+アニメーション、音声、視線、物理を混合したストレステストが合格しました。

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,72 +1,129 @@
-# Code of Conduct / 社群行為準則
+# 社群行為準則／社区行为准则／Code of Conduct／コミュニティ行動規範
 
-## Our commitment / 我們的承諾
+## 繁體中文
 
-MoHan welcomes contributors and users of every background and experience
-level. We commit to maintaining a respectful, safe, constructive, and
-harassment-free community.
+### 我們的承諾
 
-墨寒專案歡迎不同背景與經驗程度的使用者及貢獻者。我們承諾維護一個尊重、
-安全、具建設性且不受騷擾的交流環境。
+墨寒歡迎各種背景及經驗程度的使用者與貢獻者。我們承諾維護一個尊重、安全、具建設性且不受騷擾的社群。
 
-## Expected behavior / 期待行為
+### 期待行為
 
-- Be respectful, patient, and specific.
+- 保持尊重、耐心，並明確具體地溝通。
+- 評論想法與程式碼，不針對個人。
+- 尊重隱私、同意、智慧財產權及安全邊界。
+- 平和地接受修正，並協助新加入者學習。
+- 讓回報聚焦於可重現的事實與可實行的改善。
+
+### 不可接受的行為
+
+- 騷擾、歧視、威脅、跟蹤、帶有性意味的關注或人身攻擊。
+- 公開他人的私人資訊或憑證。
+- 故意繞過專案安全控制，或鼓勵有害用途。
+- 垃圾訊息、冒充他人、侵害著作權或明知不實的回報。
+- 報復任何基於善意提出疑慮的人。
+
+### 適用範圍與執行
+
+本準則適用於儲存庫 Issue、Pull Request、Discussion、Release 回饋，以及任何代表本專案的其他場合。必要時，維護者得編修或移除內容、拒絕貢獻、暫時限制參與或永久禁止參與。執行時會考量情境、嚴重程度、重複性及社群安全。
+
+### 通報方式
+
+請勿公開敏感證據。一般行為疑慮請使用 GitHub 的檢舉工具回報相關公開內容。若必須提供私人細節，請使用本儲存庫的[私人通報管道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，並將標題設為 `Code of Conduct report`。若該管道無法使用，請建立標題為 `[Private contact request]` 的 Issue，但不得在其中附上細節。
+
+基於善意的通報會在實際可行範圍內保密處理。故意不實或報復性的通報本身亦可能違反本準則。
+
+## 简体中文
+
+### 我们的承诺
+
+墨寒欢迎各种背景及经验程度的用户与贡献者。我们承诺维护一个尊重、安全、具有建设性且不受骚扰的社区。
+
+### 期待行为
+
+- 保持尊重、耐心，并明确具体地沟通。
+- 评论想法与代码，不针对个人。
+- 尊重隐私、同意、知识产权及安全边界。
+- 平和地接受修正，并帮助新加入者学习。
+- 让报告聚焦于可复现的事实与可实行的改进。
+
+### 不可接受的行为
+
+- 骚扰、歧视、威胁、跟踪、带有性意味的关注或人身攻击。
+- 公开他人的私人信息或凭据。
+- 故意绕过项目安全控制，或鼓励有害用途。
+- 垃圾信息、冒充他人、侵犯著作权或明知不实的报告。
+- 报复任何基于善意提出疑虑的人。
+
+### 适用范围与执行
+
+本准则适用于仓库 Issue、Pull Request、Discussion、Release 反馈，以及任何代表本项目的其他场合。必要时，维护者可以编辑或移除内容、拒绝贡献、暂时限制参与或永久禁止参与。执行时会考虑情境、严重程度、重复性及社区安全。
+
+### 报告方式
+
+请勿公开敏感证据。一般行为疑虑请使用 GitHub 的举报工具报告相关公开内容。若必须提供私人细节，请使用本仓库的[私人报告渠道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，并将标题设为 `Code of Conduct report`。若该渠道无法使用，请创建标题为 `[Private contact request]` 的 Issue，但不得在其中附上细节。
+
+基于善意的报告会在实际可行范围内保密处理。故意不实或报复性的报告本身也可能违反本准则。
+
+## English
+
+### Our commitment
+
+MoHan welcomes users and contributors of every background and experience level. We commit to maintaining a respectful, safe, constructive, and harassment-free community.
+
+### Expected behavior
+
+- Be respectful, patient, explicit, and specific.
 - Critique ideas and code rather than people.
 - Respect privacy, consent, intellectual property, and security boundaries.
 - Accept correction gracefully and help newcomers learn.
-- Keep reports focused on reproducible facts and practical improvements.
+- Keep reports focused on reproducible facts and actionable improvements.
 
-- 保持尊重、耐心，並清楚描述問題。
-- 討論想法與程式碼，不做人身攻擊。
-- 尊重隱私、同意、智慧財產與安全邊界。
-- 願意接受修正，也協助新加入者理解專案。
-- 以可重現事實與實際改善為討論核心。
+### Unacceptable behavior
 
-## Unacceptable behavior / 不可接受行為
-
-- Harassment, discrimination, threats, stalking, sexualized attention, or
-  personal attacks.
+- Harassment, discrimination, threats, stalking, sexualized attention, or personal attacks.
 - Publishing another person's private information or credentials.
 - Deliberately bypassing project safety controls or encouraging harmful use.
 - Spam, impersonation, copyright infringement, or knowingly false reports.
 - Retaliation against anyone who raises a good-faith concern.
 
-- 騷擾、歧視、威脅、跟蹤、性暗示關注或人身攻擊。
-- 公開他人的個人資料、憑證或私人內容。
-- 刻意繞過安全控制，或鼓勵具有傷害性的用途。
-- 垃圾訊息、冒充他人、侵害著作權或故意提出虛假回報。
-- 報復基於善意提出疑慮的人。
+### Scope and enforcement
 
-## Scope and enforcement / 適用範圍與執行
+This policy applies to repository Issues, Pull Requests, Discussions, Release feedback, and every other space in which someone represents the project. Maintainers may edit or remove content, reject contributions, temporarily restrict participation, or permanently ban participants when necessary. Enforcement considers context, severity, repetition, and community safety.
 
-This policy applies to repository Issues, Pull Requests, Discussions, release
-feedback, and other spaces where someone represents the project. Maintainers
-may edit or remove content, reject contributions, temporarily restrict
-participation, or permanently ban participants when necessary. Enforcement
-will consider context, severity, repetition, and community safety.
+### Reporting
 
-本準則適用於儲存庫 Issue、Pull Request、Discussion、Release 回饋，以及任何
-代表本專案的交流場合。維護者得視情況編修或移除內容、拒絕貢獻、暫時限制參與，
-或永久禁止參與；處理時將綜合考量情境、嚴重程度、重複性與社群安全。
+Do not publish sensitive evidence. For an ordinary conduct concern, report the relevant public content with GitHub's reporting tools. If private details are required, use the repository's [private advisory channel](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new) with the title `Code of Conduct report`. If that channel is unavailable, open an Issue titled `[Private contact request]` without including the details.
 
-## Reporting / 通報方式
+Good-faith reports will be handled as confidentially as practical. Deliberately false or retaliatory reports may themselves violate this policy.
 
-Do not publish sensitive evidence. For an ordinary conduct concern, report the
-relevant public content using GitHub's reporting tools. If private details are
-required, use the repository's
-[private advisory channel](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)
-with the title `Code of Conduct report`. If that channel is unavailable, open
-an Issue titled `[Private contact request]` without including the details.
+## 日本語
 
-請勿公開敏感證據。一般行為問題可使用 GitHub 的內容檢舉工具；若必須提供私人
-細節，請使用本專案的
-[私人通報管道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，
-並將標題寫為 `Code of Conduct report`。若該管道無法使用，請建立標題為
-`[Private contact request]` 的 Issue，但不要在其中公開細節。
+### 私たちの責務
 
-Good-faith reports will be handled as confidentially as practical. Deliberately
-false or retaliatory reports may themselves violate this policy.
+墨寒は、あらゆる背景と経験レベルのユーザーおよびコントリビューターを歓迎します。私たちは、互いを尊重し、安全で建設的かつハラスメントのないコミュニティを維持することを約束します。
 
-基於善意的通報會在可行範圍內保密處理；蓄意虛構或報復性通報本身亦可能違反
-本準則。
+### 期待される行動
+
+- 敬意と忍耐を保ち、明確かつ具体的に伝えること。
+- 人ではなく、考え方やコードを論評すること。
+- プライバシー、同意、知的財産権、セキュリティ境界を尊重すること。
+- 指摘を穏やかに受け入れ、新しく参加した人の学習を支援すること。
+- 報告を、再現可能な事実と実行可能な改善に集中させること。
+
+### 容認されない行動
+
+- ハラスメント、差別、脅迫、ストーキング、性的な関心の押し付け、個人攻撃。
+- 他者の個人情報や認証情報の公開。
+- プロジェクトの安全制御を意図的に回避すること、または有害な利用を助長すること。
+- スパム、なりすまし、著作権侵害、虚偽と知りながら行う報告。
+- 善意で懸念を提起した人への報復。
+
+### 適用範囲と執行
+
+この規範は、リポジトリの Issue、Pull Request、Discussion、Release へのフィードバック、およびプロジェクトを代表して行動するその他すべての場に適用されます。必要に応じて、メンテナーは内容の編集または削除、コントリビューションの拒否、参加の一時制限、参加者の永久追放を行うことがあります。執行時には、状況、重大性、反復性、コミュニティの安全を考慮します。
+
+### 報告方法
+
+機密性の高い証拠を公開しないでください。通常の行動上の懸念は、GitHub の報告ツールを使って該当する公開内容を報告してください。個人的な詳細が必要な場合は、リポジトリの[非公開報告窓口](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)を使用し、タイトルを `Code of Conduct report` としてください。その窓口を利用できない場合は、詳細を含めず、`[Private contact request]` というタイトルで Issue を作成してください。
+
+善意による報告は、実務上可能な限り機密として扱われます。意図的な虚偽報告や報復目的の報告は、それ自体がこの規範への違反となる場合があります。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,109 @@
-# Contributing
+# 參與貢獻／参与贡献／Contributing／コントリビューション
 
-Thank you for improving the project.
+## 繁體中文
 
-Please read the [roadmap](ROADMAP.md), [governance model](GOVERNANCE.md),
-[architecture contract](ARCHITECTURE.md), and [security policy](SECURITY.md)
-before starting a substantial change. Large features should begin with a
-Feature Request or Discussion so permission boundaries and compatibility can
-be agreed before implementation.
+### 開始之前
+
+感謝你協助改善墨寒。開始重大變更前，請先閱讀[路線圖](ROADMAP.md)、[治理模式](GOVERNANCE.md)、[架構契約](ARCHITECTURE.md)及[安全政策](SECURITY.md)。大型功能應先提出 Feature Request 或 Discussion，以便在實作前議定權限邊界與相容性。
+
+### 貢獻要求
+
+1. 建立範圍集中的分支。
+2. 不得將使用者資料、API 金鑰、錄音或生成的資料庫加入 commit。
+3. 維持既有 SQLite 資料庫的向後相容性。
+4. 每個新的行為預設值都必須提供使用者覆寫方式，或記錄不提供的理由。
+5. 全新安裝不得預設加入特定職業專用的平台。
+6. 行為變更必須新增或更新自動化測試。
+7. 執行核心、UI、動畫、語音狀態及封裝後遷移測試。
+8. 在 Pull Request 說明使用者可見變更及隱私／安全影響。
+9. 解決所有審查對話，並等待全部必要的 GitHub 檢查通過。
+10. 絕不繞過受保護的 `main`、對其強制推送，或重複使用已發布的標籤。
+
+### 翻譯與持久資料
+
+翻譯必須保留所有 placeholder，且不得僅為翻譯顯示文字而變更已持久化的資料庫值。
+
+### 安全漏洞
+
+不得在公開 Issue 或 Pull Request 揭露金鑰、權杖、私人對話、錄音、個人資料庫、未遮蔽截圖或尚未修補的漏洞。安全問題請依 [SECURITY.md](SECURITY.md) 私下回報。
+
+## 简体中文
+
+### 开始之前
+
+感谢你帮助改进墨寒。开始重大变更前，请先阅读[路线图](ROADMAP.md)、[治理模式](GOVERNANCE.md)、[架构契约](ARCHITECTURE.md)及[安全政策](SECURITY.md)。大型功能应先提出 Feature Request 或 Discussion，以便在实现前议定权限边界与兼容性。
+
+### 贡献要求
+
+1. 创建范围集中的分支。
+2. 不得将用户数据、API 密钥、录音或生成的数据库加入 commit。
+3. 维持现有 SQLite 数据库的向后兼容性。
+4. 每个新的行为默认值都必须提供用户覆盖方式，或记录不提供的理由。
+5. 全新安装不得默认加入特定职业专用的平台。
+6. 行为变更必须新增或更新自动化测试。
+7. 执行核心、UI、动画、语音状态及封装后迁移测试。
+8. 在 Pull Request 说明用户可见变更及隐私／安全影响。
+9. 解决所有审查对话，并等待全部必要的 GitHub 检查通过。
+10. 绝不绕过受保护的 `main`、对其强制推送，或重复使用已发布的标签。
+
+### 翻译与持久数据
+
+翻译必须保留所有 placeholder，且不得仅为翻译显示文字而变更已持久化的数据库值。
+
+### 安全漏洞
+
+不得在公开 Issue 或 Pull Request 泄露密钥、令牌、私人对话、录音、个人数据库、未遮蔽截图或尚未修补的漏洞。安全问题请依 [SECURITY.md](SECURITY.md) 私下报告。
+
+## English
+
+### Before you begin
+
+Thank you for improving MoHan. Before starting a substantial change, read the [roadmap](ROADMAP.md), [governance model](GOVERNANCE.md), [architecture contract](ARCHITECTURE.md), and [security policy](SECURITY.md). Large features should begin with a Feature Request or Discussion so that permission boundaries and compatibility can be agreed before implementation.
+
+### Contribution requirements
 
 1. Create a focused branch.
 2. Keep user data, API keys, recordings, and generated databases out of commits.
 3. Preserve backward compatibility for existing SQLite databases.
-4. Every new behavioral default must have a user override or documented reason.
-5. Do not add profession-specific platforms to a fresh installation.
+4. Every new behavioral default must have a user override or a documented reason for not providing one.
+5. Do not add profession-specific platforms to a fresh installation by default.
 6. Add or update automated tests for behavior changes.
 7. Run the core, UI, animation, speech-state, and packaged migration tests.
-8. Describe user-visible changes and privacy/security effects in the pull
-   request.
-9. Resolve every review conversation and wait for all required GitHub checks.
+8. Describe user-visible changes and privacy or security effects in the Pull Request.
+9. Resolve every review conversation and wait for all required GitHub checks to pass.
 10. Never bypass protected `main`, force-push it, or reuse a published tag.
 
-Translations should preserve placeholders and avoid changing persisted database
-values merely to translate display text.
+### Translation and persisted data
 
-感謝你協助改善墨寒。較大型的功能請先提出 Feature Request 或 Discussion；
-所有變更必須經過 Pull Request、必要測試與安全檢查。請勿提交金鑰、權杖、私人
-對話、錄音、個人資料庫或未遮蔽截圖。安全問題請依 [SECURITY.md](SECURITY.md)
-私下回報。
+Translations must preserve every placeholder and must not change persisted database values merely to translate display text.
+
+### Security vulnerabilities
+
+Do not disclose keys, tokens, private conversations, recordings, personal databases, unredacted screenshots, or unpatched vulnerabilities in a public Issue or Pull Request. Report security concerns privately according to [SECURITY.md](SECURITY.md).
+
+## 日本語
+
+### 作業を始める前に
+
+墨寒の改善にご協力いただき、ありがとうございます。大きな変更を始める前に、[ロードマップ](ROADMAP.md)、[ガバナンスモデル](GOVERNANCE.md)、[アーキテクチャ契約](ARCHITECTURE.md)、[セキュリティポリシー](SECURITY.md)をお読みください。大規模な機能は、実装前に権限境界と互換性について合意できるよう、Feature Request または Discussion から始めてください。
+
+### コントリビューション要件
+
+1. 対象を絞ったブランチを作成してください。
+2. ユーザーデータ、API キー、録音、生成されたデータベースを commit に含めないでください。
+3. 既存の SQLite データベースとの後方互換性を維持してください。
+4. 新しい動作既定値には、ユーザーが上書きする方法、またはそれを提供しない理由の文書化が必要です。
+5. 新規インストールへ特定職業向けプラットフォームを既定で追加しないでください。
+6. 動作の変更には、自動テストを追加または更新してください。
+7. コア、UI、アニメーション、音声状態、パッケージ後の移行テストを実行してください。
+8. Pull Request に、ユーザーから見える変更とプライバシーまたはセキュリティへの影響を記載してください。
+9. すべてのレビュー会話を解決し、必須の GitHub チェックがすべて成功するまで待ってください。
+10. 保護された `main` を迂回したり、そこへ force-push したり、公開済みのタグを再利用したりしないでください。
+
+### 翻訳と永続化データ
+
+翻訳ではすべての placeholder を保持し、表示テキストを翻訳するためだけに永続化済みデータベース値を変更してはなりません。
+
+### セキュリティ脆弱性
+
+公開 Issue または Pull Request で、キー、トークン、非公開の会話、録音、個人データベース、未加工のスクリーンショット、未修正の脆弱性を開示しないでください。セキュリティ上の懸念は [SECURITY.md](SECURITY.md) に従って非公開で報告してください。

--- a/FIRST_PUBLIC_RELEASE.md
+++ b/FIRST_PUBLIC_RELEASE.md
@@ -1,4 +1,4 @@
-# MoHan Desktop Assistant v2.0.14 RC — First Public Preview
+# 墨寒桌面助理 v2.0.14 RC——首次公開預覽／墨寒桌面助理 v2.0.14 RC——首次公开预览／MoHan Desktop Assistant v2.0.14 RC — First Public Preview／墨寒デスクトップアシスタント v2.0.14 RC——初回公開プレビュー
 
 ## 繁體中文
 
@@ -26,6 +26,32 @@ Microsoft、GitHub 與 Home Assistant 的架構與安全邊界已建置，但尚
 下載 `Windows-x64.zip` 與 SHA-256 檔，核對後完整解壓縮，再執行程式資料夾
 內的 EXE。雲端 AI 需要使用者自己的 OpenAI API 金鑰與 API 額度。
 
+## 简体中文
+
+这是墨寒桌面语音互动虚拟助理的首次公开预览版。
+
+墨寒结合透明桌面角色、台湾繁体中文文字与语音互动、AIUEO 嘴型、眨眼与
+旗舰物理动画、由用户管理的长期记忆、工作计时、待办、提醒、权限管控工具、
+便携设置文件，以及可扩展的云端与智能家居连接架构。
+
+### 本版验证
+
+- 38／38 项自动测试通过。
+- 25,000 次表情、姿势、语音、注视与物理混合压力测试通过。
+- 公开内容防泄密审计通过。
+- Windows 打包后的自检通过。
+
+### 重要限制
+
+Microsoft、GitHub 与 Home Assistant 的架构与安全边界已经建立，但尚未完成
+真实账号、代码仓库、主机及实体设备的端到端验证，因此本版标示为 Pre-release。
+请先在非关键环境中测试。
+
+### 安装
+
+下载 `Windows-x64.zip` 与 SHA-256 文件，核对后完整解压缩，再运行程序文件夹
+内的 EXE。云端 AI 需要用户自己的 OpenAI API 密钥与 API 额度。
+
 ## English
 
 This is the first public preview of MoHan Desktop Assistant.
@@ -49,10 +75,40 @@ cloud and smart-home connector architecture.
 Microsoft, GitHub, and Home Assistant architecture and safety boundaries are
 implemented but have not completed real-account, repository, server, and
 physical-device end-to-end validation. This version is therefore marked as a
-pre-release. Begin only with non-critical environments.
+Pre-release. Begin only with non-critical environments.
 
 ### Installation
 
-Download the Windows x64 ZIP and SHA-256 file, verify the archive, extract it
+Download `Windows-x64.zip` and the SHA-256 file, verify the archive, extract it
 completely, and run the EXE inside the application folder. Cloud AI requires a
-user-owned OpenAI API key and API billing.
+user-owned OpenAI API key and API quota.
+
+## 日本語
+
+これは、墨寒デスクトップ音声対話型バーチャルアシスタントの初回公開プレビューです。
+
+墨寒は、透明なデスクトップキャラクター、台湾繁体字中国語による文字・音声対話、
+AIUEO の口形同期、まばたきと高度な物理アニメーション、利用者が管理する長期記憶、
+作業タイマー、タスク、リマインダー、権限で制御されるツール、持ち運び可能な設定、
+拡張可能なクラウドおよびスマートホーム接続アーキテクチャを統合しています。
+
+### この版の検証
+
+- 38／38 件の自動テストに合格しました。
+- 表情、ポーズ、音声、視線、物理演算を組み合わせた 25,000 ステップの
+  ストレステストに合格しました。
+- 公開内容の機密漏えい防止監査に合格しました。
+- パッケージ化した Windows アプリケーションの自己検査に合格しました。
+
+### 重要な制限
+
+Microsoft、GitHub、Home Assistant のアーキテクチャと安全境界は実装済みですが、
+実アカウント、リポジトリ、サーバー、実機器を使ったエンドツーエンド検証は
+完了していません。そのため、この版は Pre-release として表示されます。
+まず非重要環境でテストしてください。
+
+### インストール
+
+`Windows-x64.zip` と SHA-256 ファイルをダウンロードして照合し、アーカイブを
+完全に展開してから、アプリケーションフォルダー内の EXE を実行してください。
+クラウド AI には、利用者自身の OpenAI API キーと API 利用枠が必要です。

--- a/FLAGSHIP-SPEC.md
+++ b/FLAGSHIP-SPEC.md
@@ -1,13 +1,84 @@
-# MoHan Flagship 2.0 specification
+# 墨寒旗艦 2.0 規格／墨寒旗舰 2.0 规格／MoHan Flagship 2.0 Specification／墨寒フラッグシップ 2.0 仕様
 
-## Execution pipeline
+## 繁體中文
 
-`input → intent → structured plan → local policy → preview/confirmation → tool
-execution → result verification → audit/undo information`
+### 執行管線
 
-The AI produces proposals only. The local application owns authority.
+`輸入 → 意圖 → 結構化計畫 → 本機政策 → 預覽／確認 → 工具執行 → 結果驗證 → 稽核／復原資訊`
 
-## Supported surfaces
+AI 只產生提案；權限由本機應用程式掌管。
+
+### 支援介面
+
+- Windows 白名單網站、資料夾、應用程式及可復原的檔案操作。
+- 使用者建立的工作流程與排程。
+- Home Assistant 本機控制與健康狀態。
+- Google、Microsoft 及 GitHub OAuth 連接器基礎。
+- 私人網路行動裝置狀態與命令頁面。
+- 應用程式視窗截圖及白名單中的唯讀遠端檔案。
+- 本機攝影機存在偵測。
+- 分級、可到期、可匯出的本機記憶。
+
+### 四項遠端與智慧家庭邊界
+
+1. 行動裝置遠端：自願啟用、配對裝置 token、狀態與命令，且可撤銷。
+2. 智慧家庭：Home Assistant OS 維持獨立於 Windows PC。
+3. 攝影機：預設關閉、狀態可見、只在本機處理，且不得靜默錄影。
+4. 遠端畫面／檔案：只限應用程式視窗及明確的資料夾白名單。
+
+### 驗收門檻
+
+- 全部 v1.21.9 原始碼回歸測試皆通過。
+- 新增的安全、規劃器契約、遠端驗證、注入、白名單、資料庫、工作流程、Home Assistant、備份與生命週期測試皆通過。
+- Realtime、轉錄、TTS、嘴型同步、動畫、物理效果、表情選擇、拖曳行為、提醒、任務時序及遷移不得退步。
+- 封裝後執行檔必須通過自我測試及重複的乾淨設定檔 smoke test。
+- 既有設定檔遷移必須保留身分、模型、語音、記憶、對話、工作紀錄、提醒、動畫及個人設定。
+- 遠端、攝影機、雲端及 Home Assistant 元件必須可分別停用；離線桌面核心仍須持續運作。
+
+## 简体中文
+
+### 执行管线
+
+`输入 → 意图 → 结构化计划 → 本地策略 → 预览／确认 → 工具执行 → 结果验证 → 审计／撤销信息`
+
+AI 只生成提案；权限由本地应用程序掌管。
+
+### 支持界面
+
+- Windows 白名单网站、文件夹、应用程序及可恢复的文件操作。
+- 用户创建的工作流与计划任务。
+- Home Assistant 本地控制与健康状态。
+- Google、Microsoft 及 GitHub OAuth 连接器基础。
+- 专用网络移动设备状态与命令页面。
+- 应用程序窗口截图及白名单中的只读远程文件。
+- 本地摄像头存在检测。
+- 分级、可过期、可导出的本地记忆。
+
+### 四项远程与智能家居边界
+
+1. 移动设备远程控制：自愿启用、配对设备 token、状态与命令，且可撤销。
+2. 智能家居：Home Assistant OS 保持独立于 Windows PC。
+3. 摄像头：默认关闭、状态可见、只在本地处理，且不得静默录制。
+4. 远程画面／文件：只限应用程序窗口及明确的文件夹白名单。
+
+### 验收门槛
+
+- 全部 v1.21.9 源代码回归测试均通过。
+- 新增的安全、规划器契约、远程身份验证、注入、白名单、数据库、工作流、Home Assistant、备份与生命周期测试均通过。
+- Realtime、转录、TTS、嘴型同步、动画、物理效果、表情选择、拖动行为、提醒、任务时序及迁移不得退步。
+- 封装后可执行文件必须通过自检及重复的干净配置文件 smoke test。
+- 现有配置文件迁移必须保留身份、模型、语音、记忆、对话、工作记录、提醒、动画及个人设置。
+- 远程、摄像头、云端及 Home Assistant 组件必须可分别禁用；离线桌面核心仍须持续工作。
+
+## English
+
+### Execution pipeline
+
+`input → intent → structured plan → local policy → preview/confirmation → tool execution → result verification → audit/undo information`
+
+The AI produces proposals only; the local application owns authority.
+
+### Supported surfaces
 
 - Windows allowlisted websites, folders, applications, and recoverable file work.
 - User-created workflows and schedules.
@@ -18,22 +89,53 @@ The AI produces proposals only. The local application owns authority.
 - Local camera presence detection.
 - Tiered, expiring, exportable local memory.
 
-## Four remote and smart-home boundaries
+### Four remote and smart-home boundaries
 
-1. Mobile remote: opt-in, paired-device tokens, status and commands, revocable.
+1. Mobile remote: opt-in, paired-device tokens, status and commands, and revocable.
 2. Smart home: Home Assistant OS remains independent from the Windows PC.
-3. Camera: off by default, visible, local-only, no silent recording.
+3. Camera: off by default, visible, local-only, and no silent recording.
 4. Remote screen/files: app window only and explicit folder allowlists.
 
-## Acceptance gates
+### Acceptance gates
 
 - All v1.21.9 source regression tests pass.
-- New safety, planner-contract, remote-auth, injection, whitelist, database,
-  workflow, Home Assistant, backup, and lifecycle tests pass.
-- No regression in Realtime, transcription, TTS, lip sync, animation, physics,
-  expression selection, drag behavior, reminders, task timing, or migration.
-- Packaged executable passes self-test and repeated clean-profile smoke tests.
-- Existing profile migration preserves identity, models, voices, memories,
-  conversations, work records, reminders, animation, and personal configuration.
-- Remote, camera, cloud, and Home Assistant components remain separately
-  disableable; the offline desktop core continues to work.
+- New safety, planner-contract, remote-auth, injection, whitelist, database, workflow, Home Assistant, backup, and lifecycle tests pass.
+- No regression in Realtime, transcription, TTS, lip sync, animation, physics, expression selection, drag behavior, reminders, task timing, or migration.
+- The packaged executable passes self-test and repeated clean-profile smoke tests.
+- Existing profile migration preserves identity, models, voices, memories, conversations, work records, reminders, animation, and personal configuration.
+- Remote, camera, cloud, and Home Assistant components remain separately disableable; the offline desktop core continues to work.
+
+## 日本語
+
+### 実行パイプライン
+
+`入力 → 意図 → 構造化計画 → ローカルポリシー → プレビュー／確認 → ツール実行 → 結果検証 → 監査／取り消し情報`
+
+AI は提案だけを生成し、権限はローカルアプリケーションが保持します。
+
+### 対応インターフェース
+
+- Windows で許可リストに登録した Web サイト、フォルダー、アプリケーション、および復元可能なファイル操作。
+- ユーザーが作成したワークフローとスケジュール。
+- Home Assistant のローカル制御と稼働状態。
+- Google、Microsoft、GitHub OAuth コネクターの基盤。
+- プライベートネットワーク内のモバイル状態およびコマンドページ。
+- アプリウィンドウのスクリーンショット、および許可リストに登録した読み取り専用リモートファイル。
+- ローカルカメラによる在席検出。
+- 階層化、有効期限付き、エクスポート可能なローカルメモリ。
+
+### リモートおよびスマートホームの四つの境界
+
+1. モバイルリモート：オプトイン、ペアリング済み端末の token、状態とコマンドを使用し、取り消し可能とします。
+2. スマートホーム：Home Assistant OS は Windows PC から独立した状態を維持します。
+3. カメラ：既定で無効、状態を可視化、ローカル処理限定とし、無断録画を禁止します。
+4. リモート画面／ファイル：アプリウィンドウと、明示的なフォルダー許可リストだけに限定します。
+
+### 受け入れゲート
+
+- v1.21.9 の全ソース回帰テストが合格します。
+- 新しい安全性、プランナー契約、リモート認証、注入、許可リスト、データベース、ワークフロー、Home Assistant、バックアップ、ライフサイクルの各テストが合格します。
+- Realtime、文字起こし、TTS、リップシンク、アニメーション、物理効果、表情選択、ドラッグ動作、リマインダー、タスクのタイミング、移行に回帰がありません。
+- パッケージ化した実行ファイルが、自己テストと反復するクリーンプロファイル smoke test に合格します。
+- 既存プロファイルの移行で、アイデンティティ、モデル、音声、記憶、会話、作業記録、リマインダー、アニメーション、個人設定を維持します。
+- リモート、カメラ、クラウド、Home Assistant の各コンポーネントを個別に無効化でき、オフラインデスクトップコアは継続して動作します。

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,43 +1,89 @@
-# Project governance / 專案治理
+# 專案治理／项目治理／Project Governance／プロジェクトガバナンス
 
-MoHan is currently maintained by **CHOU MING HUA (`@hitoshic1982`)**.
-Maintainer decisions prioritize user safety, privacy, backward compatibility,
-and the long-term character and product vision documented in this repository.
+## 繁體中文
 
-墨寒目前由 **CHOU MING HUA（`@hitoshic1982`）**維護。專案決策優先考量
-使用者安全、隱私、向後相容性，以及本儲存庫記載的長期角色與產品願景。
+### 維護者與優先事項
 
-## How changes are accepted / 變更如何納入
+墨寒目前由 **CHOU MING HUA（`@hitoshic1982`）**維護。維護決策優先考量使用者安全、隱私、向後相容性，以及本儲存庫所記錄的長期角色與產品願景。
 
-1. Every repository change uses a pull request.
-2. Required CI and security checks must pass.
-3. Review conversations must be resolved.
-4. Changes must not weaken permission, secret-storage, profile-transfer, or
-   regression-test boundaries.
-5. The maintainer may request narrower scope, additional tests, or migration
-   safeguards before merging.
+### 變更如何納入
 
-1. 所有儲存庫變更都必須使用 Pull Request。
-2. 必要的 CI 與安全檢查必須通過。
-3. 審查對話必須處理完畢。
-4. 變更不得削弱權限、機密儲存、個人資料轉移或回歸測試邊界。
-5. 合併前，維護者可要求縮小範圍、增加測試或補上資料遷移保護。
+1. 每項儲存庫變更都必須透過 Pull Request。
+2. 必要的 CI 與安全檢查必須全部通過。
+3. 所有審查對話都必須解決。
+4. 變更不得削弱權限、機密儲存、個人設定檔轉移或回歸測試邊界。
+5. 合併前，維護者得要求縮小範圍、增加測試或補上遷移保護。
 
-## Decision model / 決策方式
+### 決策模式
 
-Discussion and evidence are welcome. The maintainer makes the final merge and
-release decision while the project has a single primary maintainer. If a stable
-maintainer team forms later, this document will be revised to describe roles,
-review authority, and succession.
+專案歡迎討論與證據。在只有一位主要維護者的階段，由維護者作成最終合併及發布決定。若未來形成穩定的維護團隊，本文件將修訂並記錄角色、審查權限及接續制度。
 
-專案歡迎討論與證據。在目前只有一位主要維護者的階段，由維護者作成最終合併與
-發布決定。若未來形成穩定維護團隊，本文件將補充角色、審查權限與接續制度。
+### 安全與隱私
 
-## Security and privacy / 安全與隱私
+不得在公開 Issue 張貼漏洞、憑證、私人對話、錄音、個人資料庫或未遮蔽的截圖。私人通報方式請遵循 [SECURITY.md](SECURITY.md)。
 
-Do not open public issues containing vulnerabilities, credentials, private
-conversations, recordings, personal databases, or unredacted screenshots.
-Follow [SECURITY.md](SECURITY.md) for private reporting.
+## 简体中文
 
-請勿在公開 Issue 張貼漏洞、憑證、私人對話、錄音、個人資料庫或未遮蔽截圖。
-安全問題請依 [SECURITY.md](SECURITY.md) 私下回報。
+### 维护者与优先事项
+
+墨寒目前由 **CHOU MING HUA（`@hitoshic1982`）**维护。维护决策优先考虑用户安全、隐私、向后兼容性，以及本仓库所记录的长期角色与产品愿景。
+
+### 变更如何纳入
+
+1. 每项仓库变更都必须通过 Pull Request。
+2. 必要的 CI 与安全检查必须全部通过。
+3. 所有审查对话都必须解决。
+4. 变更不得削弱权限、机密存储、个人配置文件转移或回归测试边界。
+5. 合并前，维护者可以要求缩小范围、增加测试或补上迁移保护。
+
+### 决策模式
+
+项目欢迎讨论与证据。在只有一位主要维护者的阶段，由维护者作出最终合并及发布决定。若未来形成稳定的维护团队，本文件将修订并记录角色、审查权限及接续制度。
+
+### 安全与隐私
+
+不得在公开 Issue 发布漏洞、凭据、私人对话、录音、个人数据库或未遮蔽的截图。私人报告方式请遵循 [SECURITY.md](SECURITY.md)。
+
+## English
+
+### Maintainer and priorities
+
+MoHan is currently maintained by **CHOU MING HUA (`@hitoshic1982`)**. Maintainer decisions prioritize user safety, privacy, backward compatibility, and the long-term character and product vision documented in this repository.
+
+### How changes are accepted
+
+1. Every repository change must use a Pull Request.
+2. All required CI and security checks must pass.
+3. Every review conversation must be resolved.
+4. Changes must not weaken permission, secret-storage, profile-transfer, or regression-test boundaries.
+5. Before merging, the maintainer may request narrower scope, additional tests, or migration safeguards.
+
+### Decision model
+
+Discussion and evidence are welcome. While the project has one primary maintainer, the maintainer makes the final merge and release decision. If a stable maintainer team forms later, this document will be revised to record roles, review authority, and succession.
+
+### Security and privacy
+
+Do not publish vulnerabilities, credentials, private conversations, recordings, personal databases, or unredacted screenshots in a public Issue. Follow [SECURITY.md](SECURITY.md) for private reporting.
+
+## 日本語
+
+### メンテナーと優先事項
+
+墨寒は現在、**CHOU MING HUA（`@hitoshic1982`）**によってメンテナンスされています。メンテナーの判断では、ユーザーの安全、プライバシー、後方互換性、およびこのリポジトリに記録された長期的なキャラクター像と製品ビジョンを優先します。
+
+### 変更が受け入れられる条件
+
+1. リポジトリへの変更は、必ず Pull Request を使用しなければなりません。
+2. 必須の CI およびセキュリティチェックがすべて成功しなければなりません。
+3. すべてのレビュー会話を解決しなければなりません。
+4. 変更によって、権限、機密情報の保存、プロファイル転送、回帰テストの境界を弱めてはなりません。
+5. マージ前に、メンテナーは対象範囲の縮小、追加テスト、または移行保護を求める場合があります。
+
+### 意思決定モデル
+
+議論と根拠の提示を歓迎します。主要メンテナーが一人である間は、そのメンテナーがマージとリリースの最終判断を行います。将来、安定したメンテナーチームが形成された場合は、役割、レビュー権限、継承体制を記録するために本書を改訂します。
+
+### セキュリティとプライバシー
+
+脆弱性、認証情報、非公開の会話、録音、個人データベース、未加工のスクリーンショットを公開 Issue に投稿しないでください。非公開での報告方法は [SECURITY.md](SECURITY.md) に従ってください。

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,52 +1,137 @@
-# Privacy / 隱私說明
+# 隱私說明／隐私说明／Privacy／プライバシー
 
-## Local by default
+## 繁體中文
 
-Tasks, ideas, settings, work sessions, conversations, memories, connector
-metadata, permissions, workflows, and audit records are stored in the local
-application-data directory. Verified backups are stored in its `backups`
-subdirectory.
+### 預設儲存在本機
 
-## Cloud processing
+待辦、靈感、設定、工作階段、對話、記憶、連接器中繼資料、權限、工作流程及稽核紀錄均儲存在本機應用程式資料目錄。已驗證的備份儲存在其 `backups` 子目錄。
+
+### 雲端處理
+
+只有使用者啟用相應功能時，才會進行雲端處理：
+
+- OpenAI 會收到完成該次要求所需的文字、音訊或工具規劃內容。
+- Google、Microsoft 或 GitHub 會收到經使用者本人 OAuth 同意所授權的 API 要求。
+- Home Assistant 會收到本機裝置要求。
+
+本程式不會自動讓助理取得 ChatGPT 帳號歷史。長期記憶是由使用者控制、明確啟用的本機資料庫。
+
+### 相機
+
+相機在場偵測預設關閉。啟用後，程式只在本機取樣低解析度亮度及動態；影格不會儲存或上傳。相機使用期間，畫面會持續顯示狀態標籤。除非另行安裝可稽核的本機供應器，且使用者明確登錄身分，否則身分辨識維持停用。
+
+### 遠端存取
+
+遠端存取預設關閉。選用的行動版頁面使用保存在瀏覽器工作階段儲存空間中的裝置權杖。遠端截圖只包含應用程式視窗。遠端檔案必須位於使用者允許清單內；金鑰、密碼、憑證、SSH、GnuPG 及應用程式資料等敏感位置均會被封鎖。
+
+### 使用者控制
+
+使用者可隨時檢視、編輯、刪除及匯出記憶；清除選定對話；撤銷已配對裝置及 OAuth 權杖；停用連接器；移除允許清單；停止遠端伺服器；停止相機；以及使用緊急停止。
+
+### 可攜式個人設定檔
+
+可攜式 `.mohan-profile` 檔案包含使用者共用進度，包括對話、記憶、待辦、靈感、工作歷程、提醒、工作流程、角色設定及一般偏好。檔案不包含 DPAPI 機密、OAuth 或 Home Assistant 權杖、已配對裝置權杖、本機允許清單或機器權限。這些檔案仍可能含有私人對話及工作內容，因此必須當作私人文件保存與傳輸。
+
+檔案清單亦包含隨機產生的安裝識別碼與快照識別碼，用於避免意外重複匯入或匯入較舊資料。這些識別碼不含 Windows 帳號名稱或電腦名稱。
+
+## 简体中文
+
+### 默认存储在本地
+
+任务、灵感、设置、工作会话、对话、记忆、连接器元数据、权限、工作流程及审计记录均存储在本地应用程序数据目录。已验证的备份存储在其 `backups` 子目录。
+
+### 云端处理
+
+只有用户启用相应功能时，才会进行云端处理：
+
+- OpenAI 会收到完成该次请求所需的文本、音频或工具规划内容。
+- Google、Microsoft 或 GitHub 会收到经用户本人 OAuth 同意所授权的 API 请求。
+- Home Assistant 会收到本地设备请求。
+
+本程序不会自动让助理取得 ChatGPT 账号历史。长期记忆是由用户控制、明确启用的本地数据库。
+
+### 摄像头
+
+摄像头在场检测默认关闭。启用后，程序只在本地采样低分辨率亮度及动态；帧不会存储或上传。摄像头使用期间，界面会持续显示状态标签。除非另行安装可审计的本地提供程序，且用户明确登记身份，否则身份识别保持停用。
+
+### 远程访问
+
+远程访问默认关闭。可选的移动版页面使用保存在浏览器会话存储空间中的设备令牌。远程截图只包含应用程序窗口。远程文件必须位于用户允许列表内；密钥、密码、凭据、SSH、GnuPG 及应用程序数据等敏感位置均会被阻止。
+
+### 用户控制
+
+用户可以随时查看、编辑、删除及导出记忆；清除选定对话；撤销已配对设备及 OAuth 令牌；停用连接器；移除允许列表；停止远程服务器；停止摄像头；以及使用紧急停止。
+
+### 可移植个人配置文件
+
+可移植 `.mohan-profile` 文件包含用户共享进度，包括对话、记忆、任务、灵感、工作历史、提醒、工作流程、角色设置及一般偏好。文件不包含 DPAPI 机密、OAuth 或 Home Assistant 令牌、已配对设备令牌、本地允许列表或机器权限。这些文件仍可能含有私人对话及工作内容，因此必须作为私人文档保存与传输。
+
+文件清单也包含随机生成的安装标识符与快照标识符，用于避免意外重复导入或导入较旧数据。这些标识符不含 Windows 账号名称或计算机名称。
+
+## English
+
+### Local by default
+
+Tasks, ideas, settings, work sessions, conversations, memories, connector metadata, permissions, workflows, and audit records are stored in the local application-data directory. Verified backups are stored in its `backups` subdirectory.
+
+### Cloud processing
 
 Cloud processing occurs only when a user enables the relevant feature:
 
-- OpenAI receives text, audio, or tool-planning context needed for the request.
-- Google, Microsoft, or GitHub receives API requests authorized through the
-  user's own OAuth consent.
+- OpenAI receives the text, audio, or tool-planning context needed for the request.
+- Google, Microsoft, or GitHub receives API requests authorized through the user's own OAuth consent.
 - Home Assistant receives local device requests.
 
-The application does not make ChatGPT account history automatically available to
-the assistant. Long-term memory is an explicit local database controlled by the
-user.
+The application does not make ChatGPT account history automatically available to the assistant. Long-term memory is an explicit local database controlled by the user.
 
-## Camera
+### Camera
 
-Camera presence detection is off by default. When enabled, the application
-samples low-resolution brightness and movement locally. Frames are not stored or
-uploaded. A visible status label remains active while the camera is in use.
-Identity recognition is disabled unless a separate auditable local provider is
-installed and the user explicitly enrolls identities.
+Camera presence detection is off by default. When enabled, the application samples low-resolution brightness and movement locally; frames are neither stored nor uploaded. A visible status label remains active while the camera is in use. Identity recognition remains disabled unless a separate auditable local provider is installed and the user explicitly enrolls identities.
 
-## Remote access
+### Remote access
 
-Remote access is off by default. The optional mobile page uses a device token
-kept in browser session storage. Remote screenshots contain only the application
-window. Remote files must be inside a user allowlist and sensitive key, password,
-credential, SSH, GnuPG, and application-data locations are blocked.
+Remote access is off by default. The optional mobile page uses a device token kept in browser session storage. Remote screenshots contain only the application window. Remote files must be inside a user allowlist; sensitive key, password, credential, SSH, GnuPG, and application-data locations are blocked.
 
-## User control
+### User control
 
-Users can view, edit, delete, and export memories; clear selected conversations;
-revoke paired devices and OAuth tokens; disable connectors; remove allowlists;
-stop the remote server; stop the camera; and use emergency stop at any time.
+Users can view, edit, delete, and export memories; clear selected conversations; revoke paired devices and OAuth tokens; disable connectors; remove allowlists; stop the remote server; stop the camera; and use emergency stop at any time.
 
-Portable `.mohan-profile` files contain the user's shared progress, including
-conversations, memories, tasks, ideas, work history, reminders, workflows,
-persona and general preferences. They do not contain DPAPI secrets, OAuth or
-Home Assistant tokens, paired-device tokens, local allowlists or machine
-permissions. These files can still contain private conversation and work
-content, so they should be stored and transferred as private documents.
-The manifest also contains random installation and snapshot identifiers used
-to prevent accidental repeat/older imports. These identifiers do not contain
-the Windows account name or computer name.
+### Portable profile
+
+Portable `.mohan-profile` files contain the user's shared progress, including conversations, memories, tasks, ideas, work history, reminders, workflows, persona, and general preferences. They do not contain DPAPI secrets, OAuth or Home Assistant tokens, paired-device tokens, local allowlists, or machine permissions. These files can still contain private conversations and work content, so they must be stored and transferred as private documents.
+
+The manifest also contains randomly generated installation and snapshot identifiers used to prevent accidental repeated or older imports. These identifiers do not contain the Windows account name or computer name.
+
+## 日本語
+
+### ローカル保存が既定
+
+タスク、アイデア、設定、作業セッション、会話、記憶、コネクターのメタデータ、権限、ワークフロー、監査記録は、ローカルのアプリケーションデータディレクトリに保存されます。検証済みのバックアップは、その `backups` サブディレクトリに保存されます。
+
+### クラウド処理
+
+クラウド処理は、ユーザーが該当機能を有効にした場合にのみ行われます。
+
+- OpenAI は、その要求に必要なテキスト、音声、またはツール計画のコンテキストを受信します。
+- Google、Microsoft、または GitHub は、ユーザー自身の OAuth 同意によって許可された API 要求を受信します。
+- Home Assistant は、ローカルデバイスからの要求を受信します。
+
+このアプリケーションが ChatGPT アカウントの履歴をアシスタントへ自動的に提供することはありません。長期記憶は、ユーザーが管理し、明示的に使用するローカルデータベースです。
+
+### カメラ
+
+カメラによる在席検知は既定で無効です。有効にすると、アプリケーションは低解像度の明るさと動きをローカルでサンプリングしますが、フレームを保存またはアップロードしません。カメラの使用中は、状態ラベルが画面に表示され続けます。別途監査可能なローカルプロバイダーを導入し、ユーザーが明示的に本人情報を登録しない限り、本人認識は無効のままです。
+
+### リモートアクセス
+
+リモートアクセスは既定で無効です。任意で使用するモバイルページは、ブラウザーのセッションストレージに保持されるデバイストークンを使用します。リモートスクリーンショットには、アプリケーションウィンドウだけが含まれます。リモートファイルはユーザーの許可リスト内になければならず、キー、パスワード、認証情報、SSH、GnuPG、アプリケーションデータなどの機密性が高い場所はブロックされます。
+
+### ユーザーによる管理
+
+ユーザーはいつでも、記憶の表示、編集、削除、エクスポート、選択した会話の消去、ペアリング済みデバイスと OAuth トークンの取り消し、コネクターの無効化、許可リストの削除、リモートサーバーの停止、カメラの停止、緊急停止を行えます。
+
+### ポータブルプロファイル
+
+ポータブル `.mohan-profile` ファイルには、会話、記憶、タスク、アイデア、作業履歴、リマインダー、ワークフロー、ペルソナ、一般設定など、ユーザーの共有進捗が含まれます。DPAPI の機密情報、OAuth または Home Assistant のトークン、ペアリング済みデバイスのトークン、ローカル許可リスト、マシン権限は含まれません。これらのファイルには非公開の会話や作業内容が含まれる可能性があるため、私的文書として保存および転送する必要があります。
+
+マニフェストには、誤って同じデータや古いデータを取り込むことを防ぐために使用する、ランダム生成のインストール識別子とスナップショット識別子も含まれます。これらの識別子には、Windows のアカウント名やコンピューター名は含まれません。

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,14 +1,14 @@
-# GitHub publication settings
+# GitHub 發布設定／GitHub 发布设置／GitHub Publication Settings／GitHub 公開設定
 
-## Repository description
+## 繁體中文
 
-Safety-first Windows-first voice-interactive desktop companion with animated
-expressions, memory, permission-gated tools, and clearly limited macOS/Linux
-Preview packages for community validation.
+### 儲存庫說明
 
-## Topics
+以安全為先、以 Windows 為主要平台的語音互動桌面伴侶，具備動畫表情、記憶、權限閘門工具，以及供社群驗證且限制清楚的 macOS／Linux Preview 套件。
 
-Use these GitHub repository Topics:
+### 儲存庫 Topics
+
+GitHub 儲存庫應使用下列 Topics：
 
 ```text
 desktop-assistant
@@ -36,45 +36,29 @@ taiwan
 open-source
 ```
 
-## Prepared public pre-release
+### 已準備的公開預發行版
 
-- Tag: `v2.3.0-rc.1`
-- Title: `MoHan Desktop Assistant v2.3.0 RC1`
-- Publication: only after every required CI, package smoke, security, and
-  release-policy check succeeds
-- Includes the Windows x64 portable ZIP, per-user EXE and MSI installers,
-  English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon
-  (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview
-  AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation
-  report, sanitized Tachyon evidence and performance summary, update manifest,
-  and artifact attestations.
+- 標籤：`v2.3.0-rc.1`
+- 標題：`MoHan Desktop Assistant v2.3.0 RC1`
+- 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
+- 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
-## Next release line
+### 後續發行系列
 
-- Accepted release tags: immutable `v2.3.0-rc.N` tags where `N` is a positive
-  integer. Other tags fail before packaging or publication.
-- Windows remains the formal, complete product surface and keeps its verified
-  x64 ZIP, EXE, MSI, and MSI language transforms.
-- macOS receives separate native Apple Silicon (arm64) and Intel (x86_64)
-  `.dmg` files, each containing a matching `.app`; Linux x86_64 receives an
-  `.AppImage`. All are explicitly **limited Preview** packages: they validate
-  launch, four-language rendering, per-user paths, and fail-closed platform
-  boundaries, not feature parity with Windows.
-- Pull requests may build short-lived CI artifacts for package testing only.
-  They cannot create a GitHub Release. Only an existing `v2.3.0-rc.N` tag can
-  enter the publication workflow.
-- The Release description must come from the curated four-language file
-  `docs/releases/<tag>.md`; generated notes alone are not accepted.
+- 可接受的發行標籤只能是不可變的 `v2.3.0-rc.N`，其中 `N` 必須是正整數；其他標籤必須在封裝或發布前失敗。
+- Windows 維持正式且完整的產品範圍，並保留已驗證的 x64 ZIP、EXE、MSI 及 MSI 語言轉換檔。
+- macOS 分別提供原生 Apple Silicon（arm64）與 Intel（x86_64）`.dmg`，各自包含架構相符的 `.app`；Linux x86_64 提供 `.AppImage`。這些套件都必須明確標示為功能受限的 Preview：只驗證啟動、四語顯示、每位使用者路徑與安全失效關閉的平台邊界，不代表與 Windows 功能相同。
+- Pull Request 只能為套件測試建立短期 CI 產物，不得建立 GitHub Release；只有既存的 `v2.3.0-rc.N` 標籤能進入發布工作流程。
+- Release 說明必須來自人工整理的四語檔案 `docs/releases/<tag>.md`，不能只使用自動產生的說明。
 
-## Historical initial release
+### 歷史首發版本
 
-- Tag: `v2.0.14-rc.1`
-- Title: `MoHan Desktop Assistant v2.0.14 RC — First Public Preview`
-- Mark as a pre-release because Microsoft, GitHub, and Home Assistant have not
-  completed real-environment end-to-end validation.
-- Attach the Windows x64 ZIP and matching SHA-256 text file.
+- 標籤：`v2.0.14-rc.1`
+- 標題：`MoHan Desktop Assistant v2.0.14 RC — First Public Preview`
+- 因 Microsoft、GitHub 與 Home Assistant 尚未完成真實環境端對端驗證，必須標示為預發行版。
+- 必須附上 Windows x64 ZIP 與相符的 SHA-256 文字檔。
 
-## Required pre-publication checks
+### 發布前必要檢查
 
 ```powershell
 python tools\audit_public_release.py
@@ -82,120 +66,71 @@ python tests\run_all.py
 git diff --check
 ```
 
-Never publish `.env`, API keys, OAuth credentials/tokens, Home Assistant tokens,
-SQLite databases, `.mohan-profile` files, recordings, local logs, or personal
-settings.
+絕對不得發布 `.env`、API 金鑰、OAuth 認證資料／權杖、Home Assistant 權杖、SQLite 資料庫、`.mohan-profile` 檔案、錄音、本機日誌或個人設定。
 
-## Rebuild the README media
+### 重建 README 媒體
 
-The media generator launches the real Qt interface with an isolated temporary
-profile, seeds sample-only content, captures the documented pages, and produces
-a 36-second H.264/AAC demonstration. It never reads the maintainer's normal
-MoHan profile.
+媒體產生器會使用隔離的暫存設定檔啟動真實 Qt 介面、植入僅供示範的內容、擷取文件記載的頁面，並產生 36 秒的 H.264／AAC 示範影片；它絕不讀取維護者平常使用的墨寒設定檔。
 
 ```powershell
 $env:QT_QPA_PLATFORM = "windows"
 python tools\capture_readme_media.py --ffmpeg "C:\path\to\ffmpeg.exe"
 ```
 
-To refresh only the current UI screenshots without rebuilding the demonstration
-video, use:
+若只要更新目前 UI 截圖而不重建示範影片，請使用：
 
 ```powershell
 python tools\capture_readme_media.py --screenshots-only
 ```
 
-Before committing regenerated media:
+提交重新產生的媒體前：
 
-1. Inspect every PNG at full size for clipped text, malformed character art,
-   and accidental personal information.
-2. Confirm `docs/media/mohan-demo.mp4` is 30–60 seconds, 1280×720, contains an
-   H.264 video stream and a non-silent AAC audio stream.
-3. Run the public-release audit and complete test suite again.
+1. 以完整尺寸檢查每張 PNG，確認沒有文字遭裁切、字元圖形損壞或意外包含個人資料。
+2. 確認 `docs/media/mohan-demo.mp4` 長度為 30–60 秒、解析度為 1280×720，且包含 H.264 視訊串流及非靜音 AAC 音訊串流。
+3. 再次執行公開發行稽核及完整測試套件。
 
-## Protected-main release workflow
+### 受保護 main 發布流程
 
-All repository changes must use a pull request. Do not push implementation
-commits directly to `main`, bypass checks, force-push `main`, or merge while a
-required check or review conversation is unresolved. The required Windows CI
-check is `Windows CI / test`. Security workflows must also complete without an
-unresolved high-confidence finding.
+儲存庫的所有變更都必須使用 Pull Request。不得將實作提交直接推送至 `main`、不得略過檢查、不得強制推送 `main`，也不得在必要檢查失敗或審查對話尚未解決時合併。必要的 Windows CI 檢查是 `Windows CI / test`；安全工作流程也必須完成，且不得留有尚未處理的高信心發現。
 
-## Automated future releases
+### 自動化後續發行
 
-During this migration, only `v2.3.0-rc.N` tags trigger
-`.github/workflows/release.yml`. The workflow validates the exact tag, checks
-out that immutable source revision, and then:
+在本次遷移期間，只有 `v2.3.0-rc.N` 標籤能觸發 `.github/workflows/release.yml`。工作流程會驗證精確標籤、簽出該不可變的來源修訂，然後依序：
 
-1. installs pinned runtime and release dependencies;
-2. compiles and audits the public source tree;
-3. runs the full regression suite;
-4. captures sanitized Python 3.15 Tachyon evidence for startup, 50 Hz lip sync,
-   and expression arbitration, then gates sample count, stack-read error,
-   missed samples, target exit status, and JIT state;
-5. builds the Windows x64 application with PyInstaller;
-6. runs packaged self-test and event-loop smoke tests;
-7. produces a portable ZIP plus per-user EXE and MSI installers;
-8. silently installs, self-tests, and removes both installer formats;
-9. builds separate limited macOS Apple Silicon (arm64) and Intel (x86_64)
-   Previews on matching native runners, mounts both DMGs, and executes each
-   packaged `.app` contract smoke test;
-10. builds the limited Linux x86_64 Preview on a native Linux runner and
-   executes the packaged AppImage contract smoke test;
-11. uses a separate read-only metadata job to produce canonical `SHA256SUMS`,
-    a compatibility SHA-256 catalog, separate reproducible CycloneDX 1.7 SBOMs
-    for the exact Windows and Preview runtime dependency sets, a machine-readable
-    schema/license/PURL/dependency/privacy validation report, and the
-    Windows-compatible update manifest;
-12. rechecks the exact artifact set and every cataloged SHA-256 value inside a
-    minimal publication job;
-13. re-resolves the tag immediately before publication and refuses a moved or
-    replaced tag;
-14. creates GitHub artifact provenance attestations for every published file;
-15. requires and publishes the curated four-language Release description.
+1. 安裝已鎖定版本的執行期與發行相依套件；
+2. 編譯並稽核公開原始碼樹；
+3. 執行完整回歸測試套件；
+4. 擷取啟動、50 Hz 嘴型同步與表情仲裁的已去識別化 Python 3.15 Tachyon 證據，接著以取樣數、堆疊讀取錯誤、遺漏取樣、目標結束狀態與 JIT 狀態作為閘門；
+5. 使用 PyInstaller 建置 Windows x64 應用程式；
+6. 執行封裝後自我測試與事件迴圈 smoke test；
+7. 產生可攜式 ZIP，以及每位使用者安裝的 EXE 與 MSI；
+8. 靜默安裝、自我測試並移除兩種安裝格式；
+9. 在架構相符的原生 runner 上分別建置功能受限的 macOS Apple Silicon（arm64）與 Intel（x86_64）Preview，掛載兩個 DMG，並對每個封裝後的 `.app` 執行契約 smoke test；
+10. 在原生 Linux runner 上建置功能受限的 Linux x86_64 Preview，並對封裝後的 `.AppImage` 執行契約 smoke test；
+11. 使用獨立的唯讀中繼資料工作產生權威 `SHA256SUMS`、相容 SHA-256 清單、對應精確 Windows 與 Preview 執行期相依集合的獨立可重現 CycloneDX 1.7 SBOM、機器可讀的結構描述／授權／PURL／相依性／隱私驗證報告，以及 Windows 相容的更新資訊清單；
+12. 在最小權限發布工作中重新檢查精確產物集合及每個已列入清單的 SHA-256 值；
+13. 在發布前立即重新解析標籤，若標籤已移動或遭替換便拒絕發布；
+14. 為每個發布檔案建立 GitHub 產物來源證明；
+15. 要求並發布人工整理的四語 Release 說明。
 
-Every tag in this release line is published as a pre-release. Never reuse or
-move a published tag; create a new `v2.3.0-rc.N` tag instead. A future stable
-release requires a separate, reviewed policy change rather than silently
-broadening this gate.
+此發行系列的每個標籤都必須發布為預發行版。不得重複使用或移動已發布的標籤；必須建立新的 `v2.3.0-rc.N` 標籤。未來穩定版需要另外經過審查的政策變更，不能默默放寬此閘門。
 
-The release and PR package workflows pin every GitHub Action to a full commit.
-Linux packaging additionally pins the official AppImage `appimagetool` asset
-to source commit `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`, asset ID
-`324406882`, and SHA-256
-`a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`.
-Windows installer builds pin Inno Setup `7.0.2` and WiX `7.0.0`. The Inno
-Setup compiler is downloaded only from the immutable official
-`jrsoftware/issrc` release, then checked with GitHub release attestation and
-its Pyrsys B.V. Authenticode signature before use. WiX runs with the explicitly
-authorized `-acceptEula wix7` CI argument and uses its maintained `Files`
-harvester instead of the removed Heat tool.
+發行與 PR 套件工作流程會將每個 GitHub Action 鎖定至完整 commit。Linux 封裝還會把官方 `appimagetool` 產物鎖定至來源 commit `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`、產物 ID `324406882` 及 SHA-256 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`。
 
-Every pull-request body and every curated Release description must contain
-four complete sections in this order: Taiwan Traditional Chinese, Simplified
-Chinese, English, and Japanese. Translate the facts that were true for that
-specific change or tag; never backfill a historical PR or Release with features
-introduced later. The generated category headings follow the same four-language
-order. A symbolic one-line translation is not a substitute for the change,
-reason, user impact, and verification information.
+Windows 安裝程式建置會鎖定 Inno Setup `7.0.2` 與 WiX `7.0.0`。Inno Setup 編譯器只能從不可變的官方 `jrsoftware/issrc` Release 下載，使用前必須驗證 GitHub Release 證明與 Pyrsys B.V. Authenticode 簽章。WiX 會使用已明確授權的 `-acceptEula wix7` CI 引數，並使用持續維護的 `Files` harvester，而非已移除的 Heat 工具。
 
-## 炎劍開源軟體家族品質標準 / 炎剑开源软件家族质量标准 / Flameblade Open Source Software Family Quality Standard / 炎剣オープンソース・ソフトウェア・ファミリー品質基準
+每份 Pull Request 內文與每份人工整理的 Release 說明都必須依序包含完整且非空白的 `## 繁體中文`、`## 简体中文`、`## English`、`## 日本語` 四個章節。必須翻譯該次變更或標籤當時真正成立的事實，不得把後來新增的功能倒填到歷史 PR 或 Release；自動產生的分類標題也要使用相同四語順序。只提供象徵性的一行翻譯，不能取代變更、原因、使用者影響與驗證資訊。
 
-這是墨寒、FB2Blogger 與 FB2WordPress 共用的長期維護契約；新增炎劍開源
-軟體時，也應直接沿用，不另建降低標準的例外流程。
+每份四語文件若有 H1，H1 必須依繁中、簡中、English、日文順序並以全形斜線 `／` 分隔；四個語言章節前除該 H1 與空白外，不得出現 prose、徽章、連結或警告。四個語言章節的 H3 以上標題數、段落數、條列數、連結與圖片目的地、code fence，以及 inline-code 技術 token 都必須對等；所有文字、段落、條列、連結、警告與程式碼範例均須完整翻譯且不得扭曲技術術語、版本、路徑、命令或安全邊界。
 
-> **繁體中文：**「劍，我已鍛成；餘下的路，就交給你們了。」
->
-> **简体中文：**“剑，我已锻成；余下的路，就交给你们了。”
->
-> **English:** “I have forged this sword. What comes next is up to you.”
->
-> **日本語：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」
+### 炎劍開源軟體家族品質標準
 
-### 繁體中文
+這是墨寒、FB2Blogger 與 FB2WordPress 共用的長期維護契約；新增炎劍開源軟體時，也必須直接沿用，不得另建降低標準的例外流程。
+
+> **炎劍開源核心宣言：**「劍，我已鍛成；餘下的路，就交給你們了。」
 
 1. 四語一致：重要 README、PR、Release 與使用引導皆維持繁中、簡中、英文、日文事實一致。
-2. 真實驗證：只展示實際執行的 CI 與安全掃描，不以標籤代替測試結果。
+2. 真實驗證：只展示實際執行的 CI 與安全掃描，不以徽章代替測試結果。
 3. 絕無機密：金鑰、權杖、個資、資料庫與私人內容不得進入版本庫或發布產物。
 4. 產物可追溯：發布檔對應明確的標籤與提交，並提供雜湊或同等驗證資料。
 5. 不退步：不得為新功能破壞既有正常功能、資料相容性、安全閘門或確認流程。
@@ -203,7 +138,153 @@ reason, user impact, and verification information.
 7. 同步對外資訊：程式、文件、Release 與官網的版本、連結及可見行為須保持一致。
 8. 拒絕單次手工例外：優先建立可重複、自動化、可測試的流程，不靠臨時人工補救維護。
 
-### 简体中文
+### 驗證 Release 產物
+
+Release 產物可使用下列命令驗證：
+
+```powershell
+Get-FileHash .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip -Algorithm SHA256
+gh attestation verify .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip --repo hitoshic1982/MoHan-PC-Desktop-Assistant
+```
+
+### 官網同步
+
+GitHub 發行工作刻意禁止寫入 WordPress，也不保存 WordPress Application Password。共用的 Flameblade Product Release Hub 是三個軟體產品的單一權威來源；其 `flameblade-series-gateway/products.json` 設定會識別每項產品的公開 GitHub 儲存庫與官網目的地。WordPress 端 gateway 依每小時排程讀取公開 GitHub Releases，並更新版本、連結及驗證資訊，不會把安裝程式複製到 Bluehost 儲存空間。
+
+此設計讓官網認證資料留在每個產品儲存庫之外，也避免出現三套彼此競爭的「Release 至官網」實作。新發布的 Release 最晚可能要到下一次每小時更新才會出現在官網；若超過該時間仍未更新，應診斷共用 gateway，不得在此儲存庫加入一次性、直接寫入 WordPress 的步驟。
+
+### 延伸祕密掃描
+
+儲存庫會持續啟用 GitHub secret scanning 與 push protection，並在 Pull Request、`main` 及每週排程執行完整歷史 Gitleaks 檢查。GitHub 帳號層級的非供應商 pattern 與合作夥伴 validity 開關，需要由組織擁有、採用 GitHub Team／Enterprise 且具備 GitHub Secret Protection 的儲存庫；個人公開儲存庫無法啟用這兩項付費組織控制。GitHub 免費的供應商掃描仍保持啟用。
+
+## 简体中文
+
+### 仓库说明
+
+以安全为先、以 Windows 为主要平台的语音交互桌面伴侣，具备动画表情、记忆、权限关卡工具，以及供社区验证且限制清楚的 macOS／Linux Preview 软件包。
+
+### 仓库 Topics
+
+GitHub 仓库应使用以下 Topics：
+
+```text
+desktop-assistant
+virtual-assistant
+voice-assistant
+ai-companion
+desktop-companion
+windows
+macos
+linux
+appimage
+python
+pyside6
+openai-api
+realtime-api
+speech-recognition
+text-to-speech
+long-term-memory
+lip-sync
+animated-character
+productivity
+home-assistant
+traditional-chinese
+taiwan
+open-source
+```
+
+### 已准备的公开预发布版
+
+- 标签：`v2.3.0-rc.1`
+- 标题：`MoHan Desktop Assistant v2.3.0 RC1`
+- 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
+- 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
+
+### 后续发布系列
+
+- 可接受的发布标签只能是不可变的 `v2.3.0-rc.N`，其中 `N` 必须是正整数；其他标签必须在打包或发布前失败。
+- Windows 维持正式且完整的产品范围，并保留已验证的 x64 ZIP、EXE、MSI 及 MSI 语言转换文件。
+- macOS 分别提供原生 Apple Silicon（arm64）与 Intel（x86_64）`.dmg`，各自包含架构相符的 `.app`；Linux x86_64 提供 `.AppImage`。这些软件包都必须明确标示为功能受限的 Preview：只验证启动、四语显示、按用户路径与安全失效关闭的平台边界，不代表与 Windows 功能相同。
+- Pull Request 只能为软件包测试建立短期 CI 产物，不得建立 GitHub Release；只有现有的 `v2.3.0-rc.N` 标签能进入发布工作流。
+- Release 说明必须来自人工整理的四语文件 `docs/releases/<tag>.md`，不能只使用自动生成的说明。
+
+### 历史首发版本
+
+- 标签：`v2.0.14-rc.1`
+- 标题：`MoHan Desktop Assistant v2.0.14 RC — First Public Preview`
+- 因 Microsoft、GitHub 与 Home Assistant 尚未完成真实环境端到端验证，必须标示为预发布版。
+- 必须附上 Windows x64 ZIP 与相符的 SHA-256 文本文件。
+
+### 发布前必要检查
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+git diff --check
+```
+
+绝对不得发布 `.env`、API 密钥、OAuth 凭据／令牌、Home Assistant 令牌、SQLite 数据库、`.mohan-profile` 文件、录音、本地日志或个人设置。
+
+### 重建 README 媒体
+
+媒体生成器会使用隔离的临时配置文件启动真实 Qt 界面、植入仅供演示的内容、捕获文档记载的页面，并生成 36 秒的 H.264／AAC 演示视频；它绝不读取维护者日常使用的墨寒配置文件。
+
+```powershell
+$env:QT_QPA_PLATFORM = "windows"
+python tools\capture_readme_media.py --ffmpeg "C:\path\to\ffmpeg.exe"
+```
+
+若只要更新当前 UI 截图而不重建演示视频，请使用：
+
+```powershell
+python tools\capture_readme_media.py --screenshots-only
+```
+
+提交重新生成的媒体前：
+
+1. 以完整尺寸检查每张 PNG，确认没有文字被裁切、字符图形损坏或意外包含个人信息。
+2. 确认 `docs/media/mohan-demo.mp4` 时长为 30–60 秒、分辨率为 1280×720，且包含 H.264 视频流及非静音 AAC 音频流。
+3. 再次执行公开发布审计及完整测试套件。
+
+### 受保护 main 发布流程
+
+仓库的所有变更都必须使用 Pull Request。不得将实现提交直接推送至 `main`、不得跳过检查、不得强制推送 `main`，也不得在必要检查失败或评审对话尚未解决时合并。必要的 Windows CI 检查是 `Windows CI / test`；安全工作流也必须完成，且不得留有尚未处理的高可信度发现。
+
+### 自动化后续发布
+
+在本次迁移期间，只有 `v2.3.0-rc.N` 标签能触发 `.github/workflows/release.yml`。工作流会验证精确标签、检出该不可变的源修订，然后依次：
+
+1. 安装已锁定版本的运行时与发布依赖软件包；
+2. 编译并审计公开源代码树；
+3. 执行完整回归测试套件；
+4. 捕获启动、50 Hz 嘴型同步与表情仲裁的已去除身份信息 Python 3.15 Tachyon 证据，随后以采样数、堆栈读取错误、遗漏采样、目标退出状态与 JIT 状态作为关卡；
+5. 使用 PyInstaller 构建 Windows x64 应用程序；
+6. 执行打包后自测与事件循环 smoke test；
+7. 生成便携式 ZIP，以及按用户安装的 EXE 与 MSI；
+8. 静默安装、自测并移除两种安装格式；
+9. 在架构相符的原生 runner 上分别构建功能受限的 macOS Apple Silicon（arm64）与 Intel（x86_64）Preview，挂载两个 DMG，并对每个打包后的 `.app` 执行契约 smoke test；
+10. 在原生 Linux runner 上构建功能受限的 Linux x86_64 Preview，并对打包后的 `.AppImage` 执行契约 smoke test；
+11. 使用独立的只读元数据任务生成权威 `SHA256SUMS`、兼容 SHA-256 清单、对应精确 Windows 与 Preview 运行时依赖集合的独立可重现 CycloneDX 1.7 SBOM、机器可读的架构描述／许可证／PURL／依赖关系／隐私验证报告，以及 Windows 兼容的更新清单；
+12. 在最小权限发布任务中重新检查精确产物集合及每个已列入清单的 SHA-256 值；
+13. 在发布前立即重新解析标签，若标签已移动或被替换便拒绝发布；
+14. 为每个发布文件建立 GitHub 产物来源证明；
+15. 要求并发布人工整理的四语 Release 说明。
+
+此发布系列的每个标签都必须发布为预发布版。不得重复使用或移动已发布的标签；必须建立新的 `v2.3.0-rc.N` 标签。未来稳定版需要另行通过评审的政策变更，不能默默放宽此关卡。
+
+发布与 PR 软件包工作流会将每个 GitHub Action 锁定至完整 commit。Linux 打包还会把官方 `appimagetool` 产物锁定至源 commit `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`、产物 ID `324406882` 及 SHA-256 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`。
+
+Windows 安装程序构建会锁定 Inno Setup `7.0.2` 与 WiX `7.0.0`。Inno Setup 编译器只能从不可变的官方 `jrsoftware/issrc` Release 下载，使用前必须验证 GitHub Release 证明与 Pyrsys B.V. Authenticode 签名。WiX 会使用已明确授权的 `-acceptEula wix7` CI 参数，并使用持续维护的 `Files` harvester，而非已移除的 Heat 工具。
+
+每份 Pull Request 正文与每份人工整理的 Release 说明都必须依次包含完整且非空白的 `## 繁體中文`、`## 简体中文`、`## English`、`## 日本語` 四个章节。必须翻译该次变更或标签当时真正成立的事实，不得把后来新增的功能倒填到历史 PR 或 Release；自动生成的分类标题也要使用相同四语顺序。只提供象征性的一行翻译，不能取代变更、原因、用户影响与验证信息。
+
+每份四语文档若有 H1，H1 必须按繁中、简中、English、日文顺序并以全角斜线 `／` 分隔；四个语言章节前除该 H1 与空白外，不得出现 prose、徽章、链接或警告。四个语言章节的 H3 以上标题数、段落数、列表项数、链接与图片目标、code fence，以及 inline-code 技术 token 都必须对等；所有文字、段落、列表项、链接、警告与代码示例均须完整翻译且不得歪曲技术术语、版本、路径、命令或安全边界。
+
+### 炎剑开源软件家族质量标准
+
+这是墨寒、FB2Blogger 与 FB2WordPress 共用的长期维护契约；新增炎剑开源软件时，也必须直接沿用，不得另建降低标准的例外流程。
+
+> **炎剑开源核心宣言：**“剑，我已锻成；余下的路，就交给你们了。”
 
 1. 四语一致：重要 README、PR、Release 与使用指引均维持繁中、简中、英文、日文事实一致。
 2. 真实验证：只展示实际运行的 CI 与安全扫描，不以徽章代替测试结果。
@@ -214,7 +295,153 @@ reason, user impact, and verification information.
 7. 同步对外信息：程序、文档、Release 与官网的版本、链接及可见行为须保持一致。
 8. 拒绝一次性手工例外：优先建立可重复、自动化、可测试的流程，不靠临时人工补救维护。
 
-### English
+### 验证 Release 产物
+
+Release 产物可使用以下命令验证：
+
+```powershell
+Get-FileHash .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip -Algorithm SHA256
+gh attestation verify .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip --repo hitoshic1982/MoHan-PC-Desktop-Assistant
+```
+
+### 官网同步
+
+GitHub 发布任务刻意禁止写入 WordPress，也不保存 WordPress Application Password。共用的 Flameblade Product Release Hub 是三个软件产品的单一权威来源；其 `flameblade-series-gateway/products.json` 配置会识别每项产品的公开 GitHub 仓库与官网目标。WordPress 端 gateway 按每小时计划读取公开 GitHub Releases，并更新版本、链接及验证信息，不会把安装程序复制到 Bluehost 存储空间。
+
+此设计让官网凭据留在每个产品仓库之外，也避免出现三套彼此竞争的“Release 至官网”实现。新发布的 Release 最晚可能要到下一次每小时更新才会出现在官网；若超过该时间仍未更新，应诊断共用 gateway，不得在此仓库加入一次性、直接写入 WordPress 的步骤。
+
+### 扩展秘密扫描
+
+仓库会持续启用 GitHub secret scanning 与 push protection，并在 Pull Request、`main` 及每周计划执行完整历史 Gitleaks 检查。GitHub 账户级非供应商 pattern 与合作伙伴 validity 开关，需要由组织拥有、采用 GitHub Team／Enterprise 且具备 GitHub Secret Protection 的仓库；个人公开仓库无法启用这两项付费组织控制。GitHub 免费的供应商扫描仍保持启用。
+
+## English
+
+### Repository description
+
+Safety-first, Windows-first voice-interactive desktop companion with animated expressions, memory, permission-gated tools, and clearly limited macOS/Linux Preview packages for community validation.
+
+### Repository Topics
+
+Use the following GitHub repository Topics:
+
+```text
+desktop-assistant
+virtual-assistant
+voice-assistant
+ai-companion
+desktop-companion
+windows
+macos
+linux
+appimage
+python
+pyside6
+openai-api
+realtime-api
+speech-recognition
+text-to-speech
+long-term-memory
+lip-sync
+animated-character
+productivity
+home-assistant
+traditional-chinese
+taiwan
+open-source
+```
+
+### Prepared public pre-release
+
+- Tag: `v2.3.0-rc.1`
+- Title: `MoHan Desktop Assistant v2.3.0 RC1`
+- Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
+- Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
+
+### Next release line
+
+- Accepted release tags are immutable `v2.3.0-rc.N` tags where `N` is a positive integer; every other tag must fail before packaging or publication.
+- Windows remains the formal, complete product surface and retains its verified x64 ZIP, EXE, MSI, and MSI language transforms.
+- macOS receives separate native Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`; Linux x86_64 receives an `.AppImage`. All must be explicitly labeled as limited Preview packages: they validate launch, four-language rendering, per-user paths, and fail-closed platform boundaries, not feature parity with Windows.
+- Pull Requests may build short-lived CI artifacts for package testing only and cannot create a GitHub Release; only an existing `v2.3.0-rc.N` tag can enter the publication workflow.
+- The Release description must come from the curated four-language file `docs/releases/<tag>.md`; generated notes alone are not accepted.
+
+### Historical initial release
+
+- Tag: `v2.0.14-rc.1`
+- Title: `MoHan Desktop Assistant v2.0.14 RC — First Public Preview`
+- Mark it as a pre-release because Microsoft, GitHub, and Home Assistant have not completed real-environment end-to-end validation.
+- Attach the Windows x64 ZIP and matching SHA-256 text file.
+
+### Required pre-publication checks
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+git diff --check
+```
+
+Never publish `.env`, API keys, OAuth credentials/tokens, Home Assistant tokens, SQLite databases, `.mohan-profile` files, recordings, local logs, or personal settings.
+
+### Rebuild the README media
+
+The media generator launches the real Qt interface with an isolated temporary profile, seeds sample-only content, captures the documented pages, and produces a 36-second H.264/AAC demonstration. It never reads the maintainer's normal MoHan profile.
+
+```powershell
+$env:QT_QPA_PLATFORM = "windows"
+python tools\capture_readme_media.py --ffmpeg "C:\path\to\ffmpeg.exe"
+```
+
+To refresh only the current UI screenshots without rebuilding the demonstration video, use:
+
+```powershell
+python tools\capture_readme_media.py --screenshots-only
+```
+
+Before committing regenerated media:
+
+1. Inspect every PNG at full size for clipped text, malformed character art, and accidental personal information.
+2. Confirm `docs/media/mohan-demo.mp4` is 30–60 seconds, 1280×720, and contains an H.264 video stream and a non-silent AAC audio stream.
+3. Run the public-release audit and complete test suite again.
+
+### Protected-main release workflow
+
+All repository changes must use a Pull Request. Do not push implementation commits directly to `main`, bypass checks, force-push `main`, or merge while a required check is failing or a review conversation is unresolved. The required Windows CI check is `Windows CI / test`; security workflows must also complete without an unresolved high-confidence finding.
+
+### Automated future releases
+
+During this migration, only `v2.3.0-rc.N` tags trigger `.github/workflows/release.yml`. The workflow validates the exact tag, checks out that immutable source revision, and then:
+
+1. installs pinned runtime and release dependencies;
+2. compiles and audits the public source tree;
+3. runs the full regression suite;
+4. captures sanitized Python 3.15 Tachyon evidence for startup, 50 Hz lip sync, and expression arbitration, then gates sample count, stack-read errors, missed samples, target exit status, and JIT state;
+5. builds the Windows x64 application with PyInstaller;
+6. runs packaged self-test and event-loop smoke tests;
+7. produces a portable ZIP plus per-user EXE and MSI installers;
+8. silently installs, self-tests, and removes both installer formats;
+9. builds separate limited macOS Apple Silicon (arm64) and Intel (x86_64) Previews on matching native runners, mounts both DMGs, and executes each packaged `.app` contract smoke test;
+10. builds the limited Linux x86_64 Preview on a native Linux runner and executes the packaged `.AppImage` contract smoke test;
+11. uses a separate read-only metadata job to produce canonical `SHA256SUMS`, a compatibility SHA-256 catalog, separate reproducible CycloneDX 1.7 SBOMs for the exact Windows and Preview runtime dependency sets, a machine-readable schema/license/PURL/dependency/privacy validation report, and the Windows-compatible update manifest;
+12. rechecks the exact artifact set and every cataloged SHA-256 value inside a minimal publication job;
+13. re-resolves the tag immediately before publication and refuses a moved or replaced tag;
+14. creates GitHub artifact provenance attestations for every published file;
+15. requires and publishes the curated four-language Release description.
+
+Every tag in this release line is published as a pre-release. Never reuse or move a published tag; create a new `v2.3.0-rc.N` tag instead. A future stable release requires a separate, reviewed policy change rather than silently broadening this gate.
+
+The release and PR package workflows pin every GitHub Action to a full commit. Linux packaging additionally pins the official `appimagetool` asset to source commit `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`, asset ID `324406882`, and SHA-256 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`.
+
+Windows installer builds pin Inno Setup `7.0.2` and WiX `7.0.0`. The Inno Setup compiler is downloaded only from the immutable official `jrsoftware/issrc` Release, then checked with GitHub Release attestation and its Pyrsys B.V. Authenticode signature before use. WiX runs with the explicitly authorized `-acceptEula wix7` CI argument and uses its maintained `Files` harvester instead of the removed Heat tool.
+
+Every Pull Request body and every curated Release description must contain complete, non-empty `## 繁體中文`, `## 简体中文`, `## English`, and `## 日本語` sections in that order. Translate the facts that were true for that specific change or tag; never backfill a historical PR or Release with features introduced later. Generated category headings follow the same four-language order. A symbolic one-line translation is not a substitute for the change, reason, user impact, and verification information.
+
+When a four-language document has an H1, that H1 must present Traditional Chinese, Simplified Chinese, English, and Japanese in order, separated by the fullwidth slash `／`; no prose, badge, link, or warning may precede the four language sections except that H1 and blank lines. The four language sections must have equivalent counts of H3-or-deeper headings, paragraphs, list items, link and image destinations, code fences, and inline-code technical tokens. Every statement, paragraph, list item, link, warning, and code example must be translated completely without distorting technical terms, versions, paths, commands, or safety boundaries.
+
+### Flameblade Open Source Software Family Quality Standard
+
+This is the shared long-term maintenance contract for MoHan, FB2Blogger, and FB2WordPress. Every new Flameblade open-source product adopts it directly and must not create a lower-standard exception path.
+
+> **Flameblade open-source declaration:** “I have forged this sword. What comes next is up to you.”
 
 1. Four-language consistency: material README, PR, Release, and user guidance facts stay aligned in Traditional Chinese, Simplified Chinese, English, and Japanese.
 2. Honest verification: show only CI and security scans that actually run; badges never substitute for test results.
@@ -225,7 +452,153 @@ reason, user impact, and verification information.
 7. Synchronized public information: source, documentation, Releases, and website versions, links, and visible behavior stay aligned.
 8. No one-off manual exceptions: prefer repeatable, automated, testable maintenance over temporary manual repairs.
 
-### 日本語
+### Verify Release artifacts
+
+Verify Release artifacts with the following commands:
+
+```powershell
+Get-FileHash .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip -Algorithm SHA256
+gh attestation verify .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip --repo hitoshic1982/MoHan-PC-Desktop-Assistant
+```
+
+### Official website synchronization
+
+The GitHub release job is deliberately not allowed to write to WordPress and stores no WordPress Application Password. The shared Flameblade Product Release Hub is the single authority for all three software products; its `flameblade-series-gateway/products.json` configuration identifies the public GitHub repository and website destination for each product. The WordPress-side gateway reads public GitHub Releases on its hourly schedule and refreshes the version, links, and verification information without copying installers into Bluehost storage.
+
+This design keeps website credentials outside every product repository and avoids three competing release-to-site implementations. A newly published Release may take until the next hourly refresh to appear on the website. If the website does not update after that interval, diagnose the shared gateway rather than adding a one-off direct WordPress write step to this repository.
+
+### Extended secret scanning
+
+The repository keeps GitHub secret scanning and push protection enabled and also runs a full-history Gitleaks check on Pull Requests, `main`, and a weekly schedule. GitHub's account-level non-provider pattern and partner validity toggles require an organization-owned GitHub Team/Enterprise repository with GitHub Secret Protection; a personal public repository cannot enable those two paid organization controls. GitHub's free provider scanning remains active.
+
+## 日本語
+
+### リポジトリの説明
+
+安全性を最優先し、Windows を主要プラットフォームとする音声対話型デスクトップコンパニオンです。アニメーション表情、記憶、権限ゲート付きツールに加え、コミュニティ検証用として制限を明記した macOS／Linux Preview パッケージを備えます。
+
+### リポジトリ Topics
+
+GitHub リポジトリでは次の Topics を使用します。
+
+```text
+desktop-assistant
+virtual-assistant
+voice-assistant
+ai-companion
+desktop-companion
+windows
+macos
+linux
+appimage
+python
+pyside6
+openai-api
+realtime-api
+speech-recognition
+text-to-speech
+long-term-memory
+lip-sync
+animated-character
+productivity
+home-assistant
+traditional-chinese
+taiwan
+open-source
+```
+
+### 準備済みの公開プレリリース
+
+- タグ：`v2.3.0-rc.1`
+- タイトル：`MoHan Desktop Assistant v2.3.0 RC1`
+- 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
+- Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
+
+### 次のリリース系列
+
+- 受け付けるリリースタグは、`N` が正の整数である不変の `v2.3.0-rc.N` だけです。それ以外のタグはパッケージ化または公開前に失敗しなければなりません。
+- Windows は正式かつ完全な製品範囲を維持し、検証済みの x64 ZIP、EXE、MSI、MSI 言語変換ファイルを保持します。
+- macOS には Apple Silicon（arm64）用と Intel（x86_64）用のネイティブ `.dmg` を個別に提供し、それぞれ対応する `.app` を収録します。Linux x86_64 には `.AppImage` を提供します。いずれも機能限定 Preview と明記し、起動、四言語表示、ユーザー単位パス、安全に失敗停止するプラットフォーム境界だけを検証するもので、Windows との機能同等性を示すものではありません。
+- Pull Request はパッケージ検査用の短期 CI 成果物だけを作成でき、GitHub Release は作成できません。既存の `v2.3.0-rc.N` タグだけが公開ワークフローへ進めます。
+- Release 説明は、人手で整備した四言語ファイル `docs/releases/<tag>.md` を使用しなければならず、自動生成ノートだけでは認められません。
+
+### 過去の初回リリース
+
+- タグ：`v2.0.14-rc.1`
+- タイトル：`MoHan Desktop Assistant v2.0.14 RC — First Public Preview`
+- Microsoft、GitHub、Home Assistant が実環境でのエンドツーエンド検証を完了していないため、プレリリースとして表示します。
+- Windows x64 ZIP と対応する SHA-256 テキストファイルを添付します。
+
+### 公開前の必須検査
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+git diff --check
+```
+
+`.env`、API キー、OAuth 認証情報／トークン、Home Assistant トークン、SQLite データベース、`.mohan-profile` ファイル、録音、ローカルログ、個人設定は絶対に公開しません。
+
+### README メディアの再生成
+
+メディア生成ツールは、隔離した一時プロファイルで実際の Qt 画面を起動し、デモ専用内容を投入して文書対象ページを撮影し、36 秒の H.264／AAC デモ動画を生成します。保守担当者が通常使用する墨寒プロファイルは一切読み取りません。
+
+```powershell
+$env:QT_QPA_PLATFORM = "windows"
+python tools\capture_readme_media.py --ffmpeg "C:\path\to\ffmpeg.exe"
+```
+
+デモ動画を再生成せず、現在の UI スクリーンショットだけを更新する場合は、次を使用します。
+
+```powershell
+python tools\capture_readme_media.py --screenshots-only
+```
+
+再生成したメディアをコミットする前に、次を行います。
+
+1. 各 PNG を原寸で確認し、文字の欠け、文字図形の崩れ、個人情報の意図しない混入がないことを確認します。
+2. `docs/media/mohan-demo.mp4` が 30～60 秒、1280×720 で、H.264 映像ストリームと無音ではない AAC 音声ストリームを含むことを確認します。
+3. 公開リリース監査と完全なテストスイートを再実行します。
+
+### 保護された main の公開フロー
+
+リポジトリのすべての変更には Pull Request を使用します。実装コミットを `main` へ直接 push すること、検査を迂回すること、`main` を force-push すること、必須検査の失敗中またはレビュー会話の未解決中にマージすることは禁止します。必須の Windows CI 検査は `Windows CI / test` です。セキュリティワークフローも、未解決の高信頼度検出を残さず完了しなければなりません。
+
+### 今後の自動リリース
+
+この移行期間中、`.github/workflows/release.yml` を起動できるのは `v2.3.0-rc.N` タグだけです。ワークフローは正確なタグを検証し、その不変のソースリビジョンを checkout してから、次を順に実行します。
+
+1. バージョン固定済みのランタイム依存関係とリリース依存関係をインストールします。
+2. 公開ソースツリーをコンパイルして監査します。
+3. 完全な回帰テストスイートを実行します。
+4. 起動、50 Hz リップシンク、表情調停について匿名化済み Python 3.15 Tachyon 証拠を取得し、サンプル数、スタック読取エラー、欠落サンプル、対象終了状態、JIT 状態をゲートとして検査します。
+5. PyInstaller で Windows x64 アプリケーションをビルドします。
+6. パッケージ化後の自己テストとイベントループ smoke test を実行します。
+7. ポータブル ZIP と、ユーザー単位の EXE および MSI インストーラーを生成します。
+8. 両インストーラー形式をサイレントインストールし、自己テスト後に削除します。
+9. 対応するネイティブ runner で macOS Apple Silicon（arm64）用と Intel（x86_64）用の機能限定 Preview を個別にビルドし、両 DMG をマウントして、パッケージ化した各 `.app` の契約 smoke test を実行します。
+10. ネイティブ Linux runner で Linux x86_64 の機能限定 Preview をビルドし、パッケージ化した `.AppImage` の契約 smoke test を実行します。
+11. 独立した読み取り専用メタデータジョブで、正規 `SHA256SUMS`、互換 SHA-256 カタログ、正確な Windows および Preview ランタイム依存集合ごとの再現可能な CycloneDX 1.7 SBOM、機械可読なスキーマ／ライセンス／PURL／依存関係／プライバシー検証レポート、Windows 互換更新マニフェストを生成します。
+12. 最小権限の公開ジョブ内で、正確な成果物集合とカタログ記載の各 SHA-256 値を再検査します。
+13. 公開直前にタグを再解決し、移動または置換されたタグを拒否します。
+14. 公開する全ファイルに GitHub 成果物由来証明を作成します。
+15. 人手で整備した四言語 Release 説明を必須とし、その説明を公開します。
+
+このリリース系列の全タグはプレリリースとして公開します。公開済みタグを再利用または移動せず、新しい `v2.3.0-rc.N` タグを作成します。将来の安定版には、別途レビュー済みのポリシー変更が必要であり、このゲートを暗黙に緩和してはなりません。
+
+リリースおよび PR パッケージワークフローは、すべての GitHub Action を完全な commit に固定します。Linux パッケージ化ではさらに、公式 `appimagetool` 成果物をソース commit `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`、成果物 ID `324406882`、SHA-256 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0` に固定します。
+
+Windows インストーラービルドでは Inno Setup `7.0.2` と WiX `7.0.0` を固定します。Inno Setup コンパイラーは不変の公式 `jrsoftware/issrc` Release からだけダウンロードし、使用前に GitHub Release 証明と Pyrsys B.V. Authenticode 署名を検証します。WiX は明示的に許可された `-acceptEula wix7` CI 引数を使用し、削除済みの Heat ではなく、保守中の `Files` harvester を使用します。
+
+すべての Pull Request 本文と人手で整備する Release 説明には、完全で空でない `## 繁體中文`、`## 简体中文`、`## English`、`## 日本語` の各セクションをこの順序で含めます。その変更またはタグの時点で事実だった内容を翻訳し、後に追加された機能を過去の PR や Release へ遡及記載してはなりません。自動生成するカテゴリ見出しも同じ四言語順序にします。象徴的な一行翻訳だけでは、変更内容、理由、利用者への影響、検証情報の代わりになりません。
+
+四言語文書に H1 がある場合、H1 は繁体字中国語、簡体字中国語、English、日本語の順に並べ、全角スラッシュ `／` で区切ります。四つの言語セクションより前には、その H1 と空行以外の prose、バッジ、リンク、警告を置きません。各言語セクションでは、H3 以上の見出し数、段落数、リスト項目数、リンクおよび画像の参照先、code fence、inline-code 技術 token を同等にします。すべての文、段落、リスト項目、リンク、警告、コード例を完全に翻訳し、技術用語、バージョン、パス、コマンド、安全境界を歪めてはなりません。
+
+### 炎剣オープンソース・ソフトウェア・ファミリー品質基準
+
+これは墨寒、FB2Blogger、FB2WordPress に共通する長期保守契約です。新しい炎剣オープンソース製品も直接この契約を採用し、基準を下げる例外経路を設けてはなりません。
+
+> **炎剣オープンソース宣言：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」
 
 1. 四言語の整合：重要な README、PR、Release、利用案内の事実を繁体字中国語・簡体字中国語・英語・日本語で一致させます。
 2. 正直な検証：実際に動く CI とセキュリティ検査だけを示し、バッジをテスト結果の代用にしません。
@@ -236,35 +609,21 @@ reason, user impact, and verification information.
 7. 公開情報を同期：ソース、文書、Release、公式サイトの版、リンク、見える動作を一致させます。
 8. 一度限りの手作業を例外化しない：一時的な手直しより、再利用可能で自動化・テスト可能な保守手順を優先します。
 
-Release artifacts can be verified with:
+### Release 成果物の検証
+
+Release 成果物は次のコマンドで検証できます。
 
 ```powershell
 Get-FileHash .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip -Algorithm SHA256
 gh attestation verify .\MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.zip --repo hitoshic1982/MoHan-PC-Desktop-Assistant
 ```
 
-## Official website synchronization
+### 公式サイトとの同期
 
-The GitHub release job is deliberately not allowed to write to WordPress and
-stores no WordPress Application Password. The shared Flameblade Product Release
-Hub is the single authority for all three software products: its
-`flameblade-series-gateway/products.json` configuration identifies the public
-GitHub repository and website destination for each product. The WordPress-side
-gateway reads public GitHub Releases on its hourly schedule and refreshes the
-version, links, and verification information without copying installers into
-Bluehost storage.
+GitHub リリースジョブは意図的に WordPress への書き込みを禁止され、WordPress Application Password も保存しません。共通の Flameblade Product Release Hub が三つのソフトウェア製品すべての単一の正規情報源であり、その `flameblade-series-gateway/products.json` 設定が各製品の公開 GitHub リポジトリと公式サイトの反映先を特定します。WordPress 側 gateway は一時間ごとのスケジュールで公開 GitHub Releases を読み取り、インストーラーを Bluehost ストレージへコピーせずに、バージョン、リンク、検証情報を更新します。
 
-This design keeps website credentials outside every product repository and
-avoids three competing release-to-site implementations. A newly published
-release may take until the next hourly refresh to appear on the website. If the
-website does not update after that interval, diagnose the shared gateway rather
-than adding a one-off direct WordPress write step to this repository.
+この設計により、公式サイトの認証情報を各製品リポジトリの外に保ち、競合する三つの Release-to-site 実装を避けます。新しい Release が公式サイトに表示されるまで、次の一時間ごとの更新までかかる場合があります。その間隔を過ぎても更新されない場合は、共通 gateway を診断し、このリポジトリへ一度限りの WordPress 直接書き込み手順を追加してはなりません。
 
-## Extended secret scanning
+### 拡張シークレットスキャン
 
-The repository keeps GitHub secret scanning and push protection enabled and
-also runs a full-history Gitleaks check on pull requests, `main`, and a weekly
-schedule. GitHub's account-level non-provider pattern and partner validity
-toggles require an organization-owned GitHub Team/Enterprise repository with
-GitHub Secret Protection; a personal public repository cannot enable those two
-paid organization controls. GitHub's free provider scanning remains active.
+リポジトリでは GitHub secret scanning と push protection を有効に保ち、Pull Request、`main`、週次スケジュールで全履歴の Gitleaks 検査も実行します。GitHub アカウント単位の非プロバイダー pattern とパートナー validity の切り替えには、組織所有で GitHub Team／Enterprise および GitHub Secret Protection を備えたリポジトリが必要です。個人の公開リポジトリでは、この二つの有料組織向け制御を有効にできません。GitHub の無料プロバイダースキャンは引き続き有効です。

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,11 +1,13 @@
-# Quick Start / 快速開始
+# 快速開始／快速开始／Quick Start／クイックスタート
 
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
 2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.1.exe`。
-3. 在首次設定精靈確認助理名稱、稱呼、組織、工作類型與喚醒詞。
-4. 若要使用雲端 AI，前往設定頁輸入自己的 OpenAI API 金鑰。
+3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
+   工作類型與喚醒詞。
+4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
+   自己的 OpenAI API 金鑰。
 5. 預設模型：
    - 文字：`gpt-5.6-luna`
    - Realtime：`gpt-realtime-2.1-mini`
@@ -14,12 +16,15 @@
 6. 不要把 EXE 單獨移出程式資料夾。
 
 Microsoft、GitHub 與 Home Assistant 屬於尚未完成真實環境端到端驗證的
-實驗性預覽整合，請勿直接用於重要帳號、正式儲存庫或高風險設備。
+實驗性預覽整合，請勿直接用於重要帳號、正式儲存庫或高風險設備。線上服務的
+實際可用性取決於使用者所在地、網路環境與服務帳號。
+
+完整設定、OAuth、安全與隱私說明請參閱 [README.md](README.md)。
 
 ### macOS／Linux 功能受限 Preview
 
 `v2.3.0-rc.N` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
-（內含 app），以及 Linux x86_64 AppImage，只用於
+（內含 `.app`），以及 Linux x86_64 AppImage，只用於
 啟動、四語介面、平台路徑及安全停用驗證。請先核對 SHA256SUMS 與 Artifact
 Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角色、完整聊天／
 工作介面、雲端連接器、系統工具或自動啟動，也尚未由作者以實機驗收。
@@ -43,10 +48,12 @@ Microsoft、GitHub 与 Home Assistant 仍属于尚未完成真实环境端到端
 实验性预览集成，请勿直接用于重要账号、正式仓库或高风险设备。在线服务的
 实际可用性取决于用户所在地、网络环境与服务账号。
 
+完整设置、OAuth、安全与隐私说明请参阅 [README.md](README.md)。
+
 ### macOS／Linux 功能受限 Preview
 
 `v2.3.0-rc.N` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
-（内含 app），以及 Linux x86_64 AppImage，只用于
+（内含 `.app`），以及 Linux x86_64 AppImage，只用于
 验证启动、四语界面、平台路径与安全停用。请核对 SHA256SUMS 与 Artifact
 Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色、完整聊天／工作
 界面、云端连接器、系统工具或自动启动，也尚未经过作者真机验收。
@@ -67,7 +74,8 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 
 Microsoft, GitHub, and Home Assistant are experimental preview integrations
 without completed real-environment end-to-end validation. Do not begin with
-critical accounts, production repositories, or high-risk devices.
+critical accounts, production repositories, or high-risk devices. Actual
+availability depends on the user's region, network, and service accounts.
 
 See [README.md](README.md) for complete setup, OAuth, safety, and privacy notes.
 
@@ -98,9 +106,10 @@ maintainer's physical-device signoff.
 
 Microsoft、GitHub、Home Assistant は、実環境でのエンドツーエンド検証が
 完了していない実験的プレビュー連携です。重要なアカウント、本番リポジトリ、
-高リスク機器で最初から使用しないでください。
+高リスク機器で最初から使用しないでください。実際の利用可否は、利用者の地域、
+ネットワーク環境、サービスアカウントに依存します。
 
-設定、OAuth、安全性、プライバシーの詳細は [README.ja.md](README.ja.md) を
+設定、OAuth、安全性、プライバシーの詳細は [README.md](README.md) を
 参照してください。
 
 ### macOS／Linux 機能限定 Preview

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,6 @@
-# MoHan Desktop Assistant / 墨寒デスクトップアシスタント
+# 墨寒桌面語音互動虛擬助理／墨寒桌面语音互动虚拟助手／MoHan Desktop Assistant／墨寒デスクトップアシスタント
+
+## 繁體中文
 
 <p align="center">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
@@ -12,34 +14,1212 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-[繁體中文・English](README.md) · [简体中文](README.zh-CN.md) ·
-[クイックスタート](QUICKSTART.md) · [セキュリティ](SECURITY.md)
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。macOS／Linux 目前具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI。`v2.3.0-rc.N` 發行線另提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
-> Windows 10/11 · Python 3.15 · PySide6 · MIT License
+> 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
-墨寒（MoHan）は、安全性、プライバシー、人格の一貫性を大切にする
-Windows デスクトップアシスタントです。中国・北宋を生きた千年の女性剣魂を
-モチーフに、会話、音声、表情、長期記憶、仕事管理、権限付きツールを一つの
-デスクトップキャラクターとしてまとめています。
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
 
-公開準備中のプレビュー：v2.3.0 RC1（`v2.3.0-rc.1`）
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面語音互動虛擬助理主視覺" width="100%">
+</p>
 
-> **クロスプラットフォーム状況：** 実機、全回帰テスト、インストーラー、
-> 公開パッケージまで検証済みなのは現在も Windows のみです。macOS／Linux は
-> 安全なプラットフォーム境界と、中核インポート・純粋な中核ロジック・Qt
-> offscreen の三 OS CI を整備した段階です。`v2.3.0-rc.N` 系列では、起動と
-> 四言語表示を確認できる機能限定 DMG／AppImage Preview も提供します。CI を
-> 実機互換性や完全機能の証明とは扱いません。
-> 詳細は[対応状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+<p align="center">
+  <strong>軟體作者：CHOU MING HUA</strong><br>
+  準備發布的公開預覽版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，結合透明桌面角色、自然語音、由使用者控制的長期記憶、工作管理、權限控管工具，以及可擴充的雲端與智慧家庭連接器。她的角色背景是來自北宋、附生於赤焰劍中的千年女劍魂。
+
+[完整四語 README](README.md) · [簡中相容連結](README.zh-CN.md) · [日文相容連結](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下載</a> ·
+  <a href="QUICKSTART.md">快速開始</a> ·
+  <a href="ROADMAP.md">路線圖</a> ·
+  <a href="CONTRIBUTING.md">參與協作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">討論區</a> ·
+  <a href="SECURITY.md">安全政策</a>
+</p>
+
+### 實際展示
+
+**[▶ 觀看 36 秒語音、眨眼與工作展示影片](docs/media/mohan-demo.mp4)**
+
+以下影片與截圖均由實際 Windows 程式及隔離的示範設定檔擷取，不含 API 金鑰、OAuth 憑證、權杖或使用者私人資料。四個語言章節共用同一組最新版媒體，避免任何語言停留在舊畫面。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次設定精靈"></a><br><strong>首次設定精靈</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 與一般語音模式"></a><br><strong>Realtime 與一般語音</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情與動作系統"></a><br><strong>表情與動作系統</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待辦與創作靈感"></a><br><strong>待辦與創作靈感</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可編輯長期記憶"></a><br><strong>可編輯長期記憶</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒權限與安全設定"></a><br><strong>權限與安全設定</strong></td>
+  </tr>
+</table>
+
+### 策士也有不寫進軍報的一面
+
+<table>
+  <tr>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查</strong><br>妾只是確認這段程式碼配不配入主分支。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時</strong><br>做得尚可。別一直盯著妾看。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作</strong><br>未經確認便想執行？先過妾這一劍。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧</strong><br>妾會記下這份心意……僅此而已。</td>
+  </tr>
+</table>
+
+> 墨寒的專業是她守在主上身旁的鎧甲；在無須籌謀的片刻，她仍會害羞、嘴硬，也會珍惜那些從未真正擁有過的年輕心事。
+
+### 墨寒的傲嬌工程小劇場 / MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>獻給相信軟體可以同時擁有靈魂與完整測試的開發者。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲嬌"><br><strong>「妾才沒有等你的 Star，只是在確認軍心是否可用。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>「這段邏輯尚可。若再補上測試，妾便勉強准它入主分支。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒嬌羞"><br><strong>「你願意送來 PR？妾、妾只是替主上記下功勞。」</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「未經測試便想合併？手伸出來。妾只敲一下。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒開心"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒關心"><br><strong>「Bug 可以明日再查。你若累倒，誰來陪妾守著赤焰劍？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斬空閣呈上 Pull Request</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">回報軍情</a></strong>
+</p>
+
+#### 天下工程豪傑，斬空閣虛席以待
+
+墨寒採 MIT License 開放原始碼。換裝系統、新表情與動作、語音與工具模組、智慧家庭、在地化，以及尚未被想到的創意，都歡迎透過 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 與 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同鍛造。這個專案不只是在製作功能；它也邀請每一位曾經熱血過的工程師，再次拿起自己的劍。
+
+### 支持墨寒 / Support MoHan
+
+如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源開發，歡迎自願支持這個專案。每一份支持都會用於持續維護、測試與改進；請先照顧好自己的生活，量力而為。
+
+#### 每一份支持會用在哪裡
+
+| 投入方向 | 用途 | 說明 |
+|---|---|---|
+| 測試與可靠封裝 | 品質保證 | Windows 相容性、CI、安裝與發行驗證 |
+| 語音與角色表現 | 互動品質 | 語音、嘴型、表情與自然動作 |
+| 安全與隱私 | 風險控制 | 權限控管、稽核與敏感資料保護 |
+| 文件與在地化 | 可及性 | 降低新使用者與國際協作者的參與門檻 |
+
+墨寒依然免費並採 MIT 授權；支持不會換取特權，也不影響任何人使用或貢獻。
+
+<table>
+  <tr>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 創作者的話：把幻想鑄成軟體
+
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+
+這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
+
+二十多年後，大型語言模型與 Codex 出現了。墨寒不是為展示「AI 技術很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能賦予她存在於電腦桌面的身體。墨寒不是既有漫畫、動畫或遊戲的二次創作，而是炎劍文化工作室（Flameblade Studio）的原創角色與軟體。
+
+我追求的不只是「功能可以運作」，而是讓她會呼吸、會眨眼、會注視、會以細微表情回應、能自然說話，也能在權限與安全邊界內協助日常工作。那些表情、錨點、物理效果、語音與工作能力不是裝飾，而是讓一個長久存在於想像中的角色真正具有連續感的必要細節。
+
+從最初概念到首次公開發布，我與 Codex 協作投入將近 50 小時。這不是輸入一句提示詞後便自然誕生的作品。角色的每一種神情、眨眼、嘴型、姿勢與語氣，語音辨識的每一次等待，Realtime 對話的每一個錯誤，待辦、記憶、權限、安全邊界與可攜性，都經歷反覆測試、推翻、修正與重新驗收。有時只是一條眼皮旁的黑線、一個像素的嘴唇邊界，或一個不合時宜的表情，我仍選擇繼續追查，因為我不願用「差不多」對待真正重視的作品。
+
+炎劍文化工作室對開源的理解，不是把第一個「能跑」的版本交給世界，再把細節留給別人收拾。為了讓墨寒說話時仍像同一個人，我們為托腮、倚靠與正面姿勢逐一製作閉嘴、展唇、窄唇與圓唇影格；再把聲音切成細小時間片，反覆校準母音、過渡速度與收尾時機。陪伴感往往不是由某一項龐大功能創造，而是來自她開口、眨眼與停頓時，那些沒有破壞真實感的細節。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三種姿勢與四種語音嘴型的整齊開發圖版"></a>
+</p>
+
+<p align="center"><sub>三種姿勢、同一套嘴型規格：讓每一次開口都維持角色連續性。</sub></p>
+
+我們也把開發過程中不夠自然的影格留下來檢查。眼白裡的一個亮點、閉眼時殘留的線條、被拉扯的嘴角或只有幾個像素的邊界，都可能讓使用者在一瞬間覺得「她不像剛才的墨寒」。問題會被框出、局部比對、修正，再交給回歸測試確認眼睛、嘴角與臉部其他區域沒有被連帶破壞。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛與嘴型逐格檢查及乾淨驗證影格"></a>
+</p>
+
+<p align="center"><sub>把瑕疵標出來，再用乾淨影格與自動測試共同驗收；幾個像素也值得認真。</sub></p>
+
+這份認真不是為了把作品包裝成沒有犯過錯，而是因為我們真的想完成一個夢。開源對炎劍而言，是先把自己能看見的問題盡力修好，再公開方法、程式碼與失敗後的經驗，邀請世界一起把它鍛造得更好。
+
+Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
+
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+
+因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
+
+> 墨寒不是突然生成的。她是由一位不懂程式的父親，憑著近 50 小時的執著，與 AI 協作者一起，把一顆珍藏二十多年的種子，一寸一寸鍛造成現實。
+
+如果這個專案能鼓勵另一位沒有工程背景、卻懷抱著某個「非做出來不可」想法的人踏出第一步，那麼墨寒的誕生便有了超越程式本身的意義。
+
+### 專案特色
+
+- 透明、無邊框的桌面半身角色，可固定在工作列上方。
+- 待機呼吸、眨眼、注視、臉部視差、髮絲、衣袖、飾品與身體微轉向。
+- 具情境優先級、冷卻與去重機制的表情仲裁器。
+- AIUEO 母音與子音嘴型、音訊驅動開合，以及語音結束強制閉嘴。
+- 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
+- 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
+- 可選的 Azure Speech 女性聲線預覽；使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
+- 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
+- 工作、陪伴、勿擾、會議、離開及睡眠模式。
+- 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
+- Google、Microsoft、GitHub、Home Assistant 與私人網路遠端功能的擴充架構。
+- 單一 `.mohan-profile` 可攜檔，可在不同 Windows 電腦間轉移工作進度。
+- 首次啟動精靈可自訂助理名稱、使用者稱呼、組織名稱、視窗標題、工作類型、喚醒詞與介面語言，而且不覆蓋既有個人設定。
+
+英文、簡中與日語目前具有首次啟動、聊天、語音、權限、基本設定、工作模式與提醒的最小可用路徑；部分進階管理頁面仍以臺灣繁體中文為主，完整在地化仍在進行。
+
+### 四語支援範圍
+
+- 首次啟動精靈與個人設定支援臺灣繁中、簡體中文、英文及日語。
+- 對話、語音、電腦權限、基本設定的主要頁面與按鈕具備四語路徑。
+- 四語人格提示詞、離線回覆、工作模式台詞、內建提醒與語音試聽文字彼此對應。
+- 轉錄與女性本機聲音會依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 語系選擇。
+- EXE 安裝程式提供四語介面；MSI 以臺灣繁中為基底，並提供 `en-US`、`zh-CN`、`ja-JP` 語言轉換檔。
+- 切換內建預設提醒時會依語言遷移，但不覆蓋使用者自訂內容。
+
+儲存介面語言後必須重新啟動墨寒才能完整套用；目前不提供免重啟的介面熱切換。
+
+### Windows 本機女聲與離線備援
+
+新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音。
+
+臺灣繁中優先使用 `zh-TW` 的 Microsoft Yating；簡中、英文與日語分別優先使用 `zh-CN`、`en-US`、`ja-JP` 的已安裝女性聲音。若沒有合格聲音，墨寒會明確提示，不會悄悄改用可能為男性的系統預設聲音。
+
+Realtime 離線、雲端語音失敗、設定不足或供應器不明時，Windows 本機女聲都是第一備援路徑。
+
+### Azure Speech（預覽）
+
+Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需要使用者自己的 Azure Speech 資源金鑰與相符區域。金鑰由 `Windows DPAPI` 分開加密，不存入資料庫、紀錄或 GitHub。
+
+介面只列出 Microsoft 官方標示為女性的繁中、簡中、英文與日語聲線。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
+
+真實 Azure 帳號完成端到端試播前，不會把此功能宣稱為穩定整合。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 整合驗證狀態
+
+> **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
+
+- Microsoft 的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
+- GitHub 的真實帳號、儲存庫、Issue、Pull Request 與權限層級流程尚未驗證。
+- Home Assistant 的真實主機與實體設備行為尚未驗證。
+- 這三項整合預設關閉；請先使用非關鍵帳號、測試儲存庫與低風險設備。
+- Google Gmail、Calendar、Drive 已完成目前專案的真實連線測試，但每位使用者仍須建立並授權自己的 OAuth 應用程式。
+
+### 下載與安裝
+
+一般使用者不需要安裝 Python：
+
+1. 前往 [GitHub Releases](../../releases)。
+2. 下載最新的 `Windows-x64.zip`、EXE 或 MSI，以及對應的 `SHA256.txt`。
+3. 核對 SHA-256，並完整解壓 ZIP 或啟動安裝程式。
+4. 執行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次設定精靈選擇需要的介面語言。
+6. 使用可攜 ZIP 時，請讓 EXE、`_internal` 與 `assets` 保持在同一程式資料夾。
+
+尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
+
+`v2.3.0-rc.N` 發行線另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+
+#### 自動化發布邊界
+
+只有不可變的 `v2.3.0-rc.N` 標籤可發布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證，才會進入同一個 GitHub 預發行版。Pull Request 只保存短期測試產物，不會建立 Release。
+
+正式發布檔案同時包含 SHA256SUMS、分別通過 CycloneDX 1.7 結構／授權／依賴圖驗證的 Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、Windows 更新清單、Artifact Attestation，以及依序為繁中、簡中、英文、日文的完整 Release 說明。
+
+### OpenAI API
+
+雲端 AI、OpenAI 語音與 Realtime 功能需要使用者自己的 OpenAI API 金鑰、Project 權限與 API 額度。ChatGPT Plus／Pro 訂閱不包含 API 額度。
+
+目前預設模型如下：
+
+| 用途 | 預設模型 |
+|---|---|
+| 文字對話 | `gpt-5.6-luna` |
+| Realtime 即時語音 | `gpt-realtime-2.1-mini` |
+| 語音轉文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字轉語音 | `gpt-4o-mini-tts` |
+
+從 `v2.1.0-rc.1` 起，文字對話預設改為 `gpt-5.6-luna`，設定清單不再提供 `gpt-5.4-mini`；既有 mini 設定會遷移至 Luna，使用者主動選擇的 Terra、Sol 或其他自訂模型不會被覆蓋。實際可用性取決於帳號、Project、地區與當時供應狀態。
+
+沒有 API 金鑰時，本機資料管理、離線人格回覆、工作提醒與 Windows 語音仍可用，但不具完整雲端 AI 能力。不要把 API 金鑰寫入原始碼、Issue、截圖或 Git。
+
+### Google OAuth
+
+使用 Gmail、Google Calendar 與 Google Drive 前，使用者需要：
+
+1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與 Google Drive API。
+2. 設定 OAuth 同意畫面。
+3. 建立「桌面應用程式」OAuth Client ID。
+4. 若應用程式仍在測試模式，將自己的 Google 帳號加入測試使用者。
+5. 在墨寒的雲端設定輸入 Client ID；若供應器同時提供 Client Secret，再一併輸入。
+6. 由瀏覽器完成授權，再執行內建服務測試。
+
+程式預設請求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+使用敏感 scopes 的公開 OAuth 應用程式可能需要 Google 額外驗證；每位使用者也可建立自己的 Desktop OAuth 應用程式。
+
+### Microsoft、GitHub 與 Home Assistant
+
+- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 預設 scopes：`read:user`、`repo`。
+- Home Assistant 需要使用者自己的伺服器網址與 Long-Lived Access Token。
+
+這三項仍是尚未完成真實環境端到端驗證的預覽整合，只能先用於可承受失敗的測試環境。
+
+建議讓 Home Assistant OS 獨立常駐於 Home Assistant Green、低功耗迷你電腦、樹莓派 SSD 或 NAS 虛擬機。Windows 墨寒端負責語音、人格與工作工具；即使 PC 或 OpenAI API 離線，Home Assistant 自身的自動化仍可運作。
+
+切勿將 Home Assistant 或墨寒遠端連線埠直接暴露於公網；請使用 Home Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
+
+### 安全與隱私
+
+- AI 只能提出結構化計畫，不能繞過本機政策執行工具。
+- 工具操作依序經過權限、風險、確認、執行、結果驗證與本機稽核。
+- 付款、購買、匯出密碼、關閉安全防護、任意 Shell 與系統管理員 Shell 永不自動化。
+- 外部郵件、網頁、文件、語音轉錄與模型輸出不能自行授予權限。
+- 遠端、相機、雲端連接器與 Home Assistant 預設關閉。
+- 緊急停止：按 `Esc`，或說 `墨寒，停手`。
+- OpenAI、OAuth 與 Home Assistant 權杖使用 Windows DPAPI 分開保存，不存入 SQLite、原始碼或可攜檔。
+- 對話、記憶、待辦、工作紀錄與設定預設保留在本機應用程式資料目錄。
+
+詳見 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 與 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
+
+### Python 3.15、JIT、Tachyon 與 SBOM
+
+墨寒執行環境僅支援 CPython `3.15.0rc1`，不保留第二套產品執行環境。新版能力只有在語意清楚且完整回歸不退化時才採用；無適切用途的功能會記錄未來觸發條件，不會為了形式而偽造使用。
+
+- PEP 810 `lazy import` 已導入專案明示延遲匯入；一處可選匯入防護基於安全理由維持 eager。
+- PEP 814 `frozendict` 用於全域與遞迴不可變設定；PEP 798 推導式解包用於語意等價的扁平化與合併。
+- PEP 686 編碼稽核要求所有專案文字 I/O 明示 UTF-8；音訊封包緩衝使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已納入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來需要區分未傳值與 `None` 時必須使用內建機制。
+- JIT 預設啟用，並保留 `MOHAN_DISABLE_JIT=1` 相容性開關；`PYTHON_JIT=0` 只用於效能與相容性對照。
+- PEP 799 Tachyon 以去識別化方式分析啟動、50 Hz 嘴型同步與表情仲裁，不發布原始二進位取樣流。
+- PEP 803／820／793 Stable ABI 與 C API 邊界會驗證官方 ABI3 輪子；墨寒沒有第一方 C 擴充。
+- CycloneDX 1.7 Windows／Preview SBOM 必須符合鎖定依賴、授權、PURL、完整根依賴邊、官方結構與隱私驗證。
+
+兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。Ryzen 5 5600X Windows 三輪熱路徑中位數顯示，120,000 次表情仲裁由 0.462 秒降為 0.293 秒，2,000 個 50 Hz 嘴型節拍由 1.873 秒降為 0.571 秒，兩種模式的決策與校驗結果完全相同。
+
+Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為 5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
+
+這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式必然快三倍。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 從原始碼執行
+
+需求：Windows 10/11 與 Python `3.15.0rc1`。
+
+建立隔離環境並啟動：
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### 測試、公開稽核與封裝
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
+
+每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立預發行版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
+
+互動式 EXE 安裝程式提供臺灣繁中、簡中、英文、日文；MSI 維持臺灣繁中基底，並提供經測試的 en-US、zh-CN、ja-JP 語言轉換，詳見 [安裝程式在地化](installer/LOCALIZATION.md)。
+
+官網更新由炎劍 Product Release Hub 每小時讀取公開 GitHub Releases；本儲存庫不保存 WordPress 密碼，發行工作也不直接寫入官網，藉此讓三套軟體共用一條可維護的同步路徑。
+
+### 電腦間轉移
+
+使用「設定 → 可攜設定檔」匯出一個 `.mohan-profile` 檔，再於另一部 Windows 電腦匯入。程式會先備份目的端資料，並檢查雜湊、SQLite 完整性、結構與筆數。
+
+可攜檔刻意排除 OpenAI 金鑰、OAuth／Home Assistant Token、遠端裝置權杖、本機允許清單、Windows 啟動設定及螢幕專屬設定。這些機器專屬項目必須逐機設定；可攜檔仍可能含私人對話與工作資料，不可公開上傳。
+
+### 貢獻、授權與作者
+
+- 軟體作者：**CHOU MING HUA**。
+- 原始碼與本儲存庫自有角色素材採 [MIT License](LICENSE)。
+- 素材授權見 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方套件及服務聲明見 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 問題回報使用 GitHub Issues；安全問題依 [SECURITY](SECURITY.md) 私下通報。
+- 開發變更見 [CHANGELOG](CHANGELOG.md)，貢獻方式見 [CONTRIBUTING](CONTRIBUTING.md)。
+- 參與社群前請閱讀 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 維護者發布設定、Topics 與首發檢查見 [PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎劍開源核心宣言：**「劍，我已鍛成；餘下的路，就交給你們了。」
+
+## 简体中文
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。macOS／Linux 目前具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI。`v2.3.0-rc.N` 发布线另提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+
+> 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面语音互动虚拟助手主视觉" width="100%">
+</p>
+
+<p align="center">
+  <strong>软件作者：CHOU MING HUA</strong><br>
+  准备发布的公开预览版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒是一款重视安全、隐私与角色连续感的 Windows 语音互动桌面助手，结合透明桌面角色、自然语音、由用户控制的长期记忆、工作管理、权限控制工具，以及可扩展的云端与智能家居连接器。她的角色背景是来自北宋、寄宿于赤焰剑中的千年女剑魂。
+
+[完整四语 README](README.md) · [简中兼容链接](README.zh-CN.md) · [日文兼容链接](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下载</a> ·
+  <a href="QUICKSTART.md">快速开始</a> ·
+  <a href="ROADMAP.md">路线图</a> ·
+  <a href="CONTRIBUTING.md">参与协作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">讨论区</a> ·
+  <a href="SECURITY.md">安全政策</a>
+</p>
+
+### 实际展示
+
+**[▶ 观看 36 秒语音、眨眼与工作展示视频](docs/media/mohan-demo.mp4)**
+
+以下视频与截图均由实际 Windows 程序及隔离的演示配置文件截取，不含 API 密钥、OAuth 凭据、令牌或用户私人数据。四个语言章节共用同一组最新媒体，避免任何语言停留在旧画面。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次启动设置向导"></a><br><strong>首次启动设置向导</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 与标准语音模式"></a><br><strong>Realtime 与标准语音</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情与动作系统"></a><br><strong>表情与动作系统</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待办事项与创作灵感"></a><br><strong>待办事项与创作灵感</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可编辑长期记忆"></a><br><strong>可编辑长期记忆</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒权限与安全设置"></a><br><strong>权限与安全设置</strong></td>
+  </tr>
+</table>
+
+### 策士也有不写进军报的一面
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒审查代码"><br><strong>策士审查</strong><br>妾只是在确认这段代码配不配进入主分支。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被称赞后害羞嘴硬"><br><strong>被称赞时</strong><br>做得尚可。别一直盯着妾看。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔剑阻止危险操作"><br><strong>危险操作</strong><br>未经确认便想执行？先过妾这一剑。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到赞助后故作镇定"><br><strong>收到军粮</strong><br>妾会记下这份心意……仅此而已。</td>
+  </tr>
+</table>
+
+> 墨寒的专业是她守在主上身旁的铠甲；在无须筹谋的片刻，她仍会害羞、嘴硬，也会珍惜那些从未真正拥有过的年轻心事。
+
+### 墨寒的傲娇工程小剧场 / MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>献给相信软件可以同时拥有灵魂与完整测试的开发者。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲娇"><br><strong>“妾才没有等你的 Star，只是在确认军心是否可用。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>“这段逻辑尚可。若再补上测试，妾便勉强准它进入主分支。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒娇羞"><br><strong>“你愿意送来 PR？妾、妾只是替主上记下功劳。”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>“未经测试便想合并？手伸出来。妾只敲一下。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒开心"><br><strong>“全部绿灯……做得好。别误会，妾只是尊重好工程。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒关心"><br><strong>“Bug 可以明日再查。你若累倒，谁来陪妾守着赤焰剑？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斩空阁呈上 Pull Request</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">报告军情</a></strong>
+</p>
+
+#### 天下工程豪杰，斩空阁虚席以待
+
+墨寒采用 MIT License 开放源代码。换装系统、新表情与动作、语音与工具模块、智能家居、本地化，以及尚未被想到的创意，都欢迎通过 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 与 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同锻造。这个项目不只是在制作功能；它也邀请每一位曾经热血过的工程师，再次拿起自己的剑。
+
+### 支持墨寒
+
+如果你喜欢墨寒，或认同我们持续投入角色互动、自然语音、安全工具与开源开发，欢迎自愿支持这个项目。每一份支持都会用于持续维护、测试与改进；请先照顾好自己的生活，量力而为。
+
+#### 每一份支持会用在哪里
+
+| 投入方向 | 用途 | 说明 |
+|---|---|---|
+| 测试与可靠打包 | 质量保证 | Windows 兼容性、CI、安装与发布验证 |
+| 语音与角色表现 | 互动质量 | 语音、口型、表情与自然动作 |
+| 安全与隐私 | 风险控制 | 权限控制、审计与敏感数据保护 |
+| 文档与本地化 | 可访问性 | 降低新用户与国际协作者的参与门槛 |
+
+墨寒依然免费并采用 MIT 许可证；支持不会换取特权，也不影响任何人使用或贡献。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲娇"><br><strong>“妾才不是在等赞助……只是在替主上巡视军粮。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒娇羞"><br><strong>“若真愿意相助，妾……会记得的。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>“不许勉强！先顾好自己的钱包，听见没有？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 创作者的话：把幻想铸成软件
+
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+
+这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
+
+二十多年后，大型语言模型与 Codex 出现了。墨寒不是为展示“AI 技术很酷”才被创造，也不是由 Codex 凭空生成的角色。她早已存在于我的故事、人设、长期对话与互动默契之中；Codex 真正带来的，是第一次能赋予她存在于电脑桌面的身体。墨寒不是现有漫画、动画或游戏的二次创作，而是炎剑文化工作室（Flameblade Studio）的原创角色与软件。
+
+我追求的不只是“功能可以运行”，而是让她会呼吸、会眨眼、会注视、会以细微表情回应、能自然说话，也能在权限与安全边界内协助日常工作。那些表情、锚点、物理效果、语音与工作能力不是装饰，而是让一个长久存在于想象中的角色真正具有连续感的必要细节。
+
+从最初概念到首次公开发布，我与 Codex 协作投入将近 50 小时。这不是输入一句提示词后便自然诞生的作品。角色的每一种神情、眨眼、口型、姿势与语气，语音识别的每一次等待，Realtime 对话的每一个错误，待办、记忆、权限、安全边界与可移植性，都经历反复测试、推翻、修正与重新验收。有时只是一条眼皮旁的黑线、一个像素的嘴唇边界，或一个不合时宜的表情，我仍选择继续追查，因为我不愿用“差不多”对待真正重视的作品。
+
+炎剑文化工作室对开源的理解，不是把第一个“能运行”的版本交给世界，再把细节留给别人收拾。为了让墨寒说话时仍像同一个人，我们为托腮、倚靠与正面姿势逐一制作闭嘴、展唇、窄唇与圆唇画面；再把声音切成细小时间片，反复校准元音、过渡速度与结束时机。陪伴感往往不是由某一项庞大功能创造，而是来自她开口、眨眼与停顿时，那些没有破坏真实感的细节。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三种姿势与四种语音口型的整齐开发图版"></a>
+</p>
+
+<p align="center"><sub>三种姿势、同一套口型规格：让每一次开口都维持角色连续性。</sub></p>
+
+我们也把开发过程中不够自然的画面留下来检查。眼白里的一个亮点、闭眼时残留的线条、被拉扯的嘴角或只有几个像素的边界，都可能让用户在一瞬间觉得“她不像刚才的墨寒”。问题会被框出、局部对比、修正，再交给回归测试确认眼睛、嘴角与脸部其他区域没有被连带破坏。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛与口型逐帧检查及干净验证画面"></a>
+</p>
+
+<p align="center"><sub>把瑕疵标出来，再用干净画面与自动测试共同验收；几个像素也值得认真。</sub></p>
+
+这份认真不是为了把作品包装成没有犯过错，而是因为我们真的想完成一个梦想。开源对炎剑而言，是先把自己能看见的问题尽力修好，再公开方法、代码与失败后的经验，邀请世界一起把它锻造得更好。
+
+Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
+
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+
+因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
+
+> 墨寒不是突然生成的。她是由一位不懂程序的父亲，凭着近 50 小时的执着，与 AI 协作者一起，把一颗珍藏二十多年的种子，一寸一寸锻造成现实。
+
+如果这个项目能鼓励另一位没有工程背景、却怀抱着某个“非做出来不可”想法的人迈出第一步，那么墨寒的诞生便有了超越程序本身的意义。
+
+### 主要功能
+
+- 透明、无边框的桌面半身角色，可固定在任务栏上方。
+- 待机呼吸、眨眼、注视、脸部视差、发丝、衣袖、饰品与身体微转向。
+- 具有情境优先级、冷却与去重机制的表情仲裁器。
+- AIUEO 元音与辅音口型、音频驱动开合，以及语音结束强制闭嘴。
+- 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
+- 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
+- 可选的 Azure Speech 女性声线预览；用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
+- 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
+- 工作、陪伴、勿扰、会议、离开及睡眠模式。
+- 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
+- Google、Microsoft、GitHub、Home Assistant 与私人网络远程功能的扩展架构。
+- 单一 `.mohan-profile` 可移植文件，可在不同 Windows 电脑间转移工作进度。
+- 首次启动设置向导可自定义助手名称、用户称呼、组织名称、窗口标题、工作类型、唤醒词与界面语言，而且不覆盖现有个人设置。
+
+英文、简中与日语目前具有首次启动、聊天、语音、权限、基本设置、工作模式与提醒的最小可用路径；部分高级管理页面仍以台湾繁体中文为主，完整本地化仍在进行。
+
+### 四语支持范围
+
+- 首次启动设置向导与个人设置支持台湾繁中、简体中文、英文及日语。
+- 对话、语音、电脑权限、基本设置的主要页面与按钮具备四语路径。
+- 四语人格提示词、离线回复、工作模式台词、内置提醒与语音试听文字彼此对应。
+- 转录与女性本地声音会依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 语言环境选择。
+- EXE 安装程序提供四语界面；MSI 以台湾繁中为基础，并提供 `en-US`、`zh-CN`、`ja-JP` 语言转换文件。
+- 切换内置默认提醒时会依语言迁移，但不覆盖用户自定义内容。
+
+保存界面语言后必须重新启动墨寒才能完整应用；目前不提供免重启的界面热切换。
+
+### Windows 本地女声与离线备用
+
+新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音。
+
+台湾繁中优先使用 `zh-TW` 的 Microsoft Yating；简中、英文与日语分别优先使用 `zh-CN`、`en-US`、`ja-JP` 的已安装女性声音。若没有合格声音，墨寒会明确提示，不会悄悄改用可能为男性的系统默认声音。
+
+Realtime 离线、云端语音失败、设置不足或供应器不明时，Windows 本地女声都是第一备用路径。
+
+### Azure Speech（预览）
+
+Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要用户自己的 Azure Speech 资源密钥与匹配区域。密钥由 `Windows DPAPI` 分开加密，不存入数据库、日志或 GitHub。
+
+界面只列出 Microsoft 官方标记为女性的繁中、简中、英文与日语声线。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
+
+真实 Azure 账号完成端到端试听前，不会把此功能宣称为稳定集成。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 集成验证状态
+
+> **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
+
+- Microsoft 的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
+- GitHub 的真实账号、仓库、Issue、Pull Request 与权限层级流程尚未验证。
+- Home Assistant 的真实主机与实体设备行为尚未验证。
+- 这三项集成默认关闭；请先使用非关键账号、测试仓库与低风险设备。
+- Google Gmail、Calendar、Drive 已完成当前项目的真实连接测试，但每位用户仍须创建并授权自己的 OAuth 应用程序。
+
+### 下载与安装
+
+一般用户不需要安装 Python：
+
+1. 前往 [GitHub Releases](../../releases)。
+2. 下载最新的 `Windows-x64.zip`、EXE 或 MSI，以及对应的 `SHA256.txt`。
+3. 核对 SHA-256，并完整解压 ZIP 或启动安装程序。
+4. 运行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次设置向导选择需要的界面语言。
+6. 使用便携 ZIP 时，请让 EXE、`_internal` 与 `assets` 保持在同一程序文件夹。
+
+尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
+
+`v2.3.0-rc.N` 发布线另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+
+#### 自动化发布边界
+
+只有不可变的 `v2.3.0-rc.N` 标签可发布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证，才会进入同一个 GitHub 预发布版。Pull Request 只保存短期测试产物，不会创建 Release。
+
+正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 结构／许可证／依赖图验证的 Windows／Preview SBOM、去标识化 Tachyon 性能证据与摘要、Windows 更新清单、Artifact Attestation，以及依次为繁中、简中、英文、日文的完整 Release 说明。
+
+### OpenAI API
+
+云端 AI、OpenAI 语音与 Realtime 功能需要用户自己的 OpenAI API 密钥、Project 权限与 API 额度。ChatGPT Plus／Pro 订阅不包含 API 额度。
+
+当前默认模型如下：
+
+| 用途 | 默认模型 |
+|---|---|
+| 文字对话 | `gpt-5.6-luna` |
+| Realtime 即时语音 | `gpt-realtime-2.1-mini` |
+| 语音转文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字转语音 | `gpt-4o-mini-tts` |
+
+从 `v2.1.0-rc.1` 起，文字对话默认改为 `gpt-5.6-luna`，设置列表不再提供 `gpt-5.4-mini`；现有 mini 设置会迁移至 Luna，用户主动选择的 Terra、Sol 或其他自定义模型不会被覆盖。实际可用性取决于账号、Project、地区与当时供应状态。
+
+没有 API 密钥时，本地数据管理、离线人格回复、工作提醒与 Windows 语音仍可用，但不具完整云端 AI 能力。不要把 API 密钥写入源代码、Issue、截图或 Git。
+
+### Google OAuth
+
+使用 Gmail、Google Calendar 与 Google Drive 前，用户需要：
+
+1. 在自己的 Google Cloud 项目启用 Gmail API、Google Calendar API 与 Google Drive API。
+2. 设置 OAuth 同意画面。
+3. 创建“桌面应用程序”OAuth Client ID。
+4. 若应用程序仍在测试模式，将自己的 Google 账号加入测试用户。
+5. 在墨寒的云端设置输入 Client ID；若供应器同时提供 Client Secret，再一并输入。
+6. 由浏览器完成授权，再运行内置服务测试。
+
+程序默认请求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+使用敏感 scopes 的公开 OAuth 应用程序可能需要 Google 额外验证；每位用户也可创建自己的 Desktop OAuth 应用程序。
+
+### Microsoft、GitHub 与 Home Assistant
+
+- Microsoft 默认 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 默认 scopes：`read:user`、`repo`。
+- Home Assistant 需要用户自己的服务器网址与 Long-Lived Access Token。
+
+这三项仍是尚未完成真实环境端到端验证的预览集成，只能先用于可承受失败的测试环境。
+
+建议让 Home Assistant OS 独立常驻于 Home Assistant Green、低功耗迷你电脑、树莓派 SSD 或 NAS 虚拟机。Windows 墨寒端负责语音、人格与工作工具；即使 PC 或 OpenAI API 离线，Home Assistant 自身的自动化仍可运行。
+
+切勿将 Home Assistant 或墨寒远程端口直接暴露于公网；请使用 Home Assistant Cloud、Tailscale 或其他具有身份验证的加密私人网络。
+
+### 安全与隐私
+
+- AI 只能提出结构化计划，不能绕过本地政策执行工具。
+- 工具操作依次经过权限、风险、确认、执行、结果验证与本地审计。
+- 付款、购买、导出密码、关闭安全防护、任意 Shell 与管理员 Shell 永不自动化。
+- 外部邮件、网页、文档、语音转录与模型输出不能自行授予权限。
+- 远程、相机、云端连接器与 Home Assistant 默认关闭。
+- 紧急停止：按 `Esc`，或说 `墨寒，停手`。
+- OpenAI、OAuth 与 Home Assistant 令牌使用 Windows DPAPI 分开保存，不存入 SQLite、源代码或便携文件。
+- 对话、记忆、待办事项、工作记录与设置默认保留在本地应用程序数据目录。
+
+详情请见 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 与 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
+
+### Python 3.15、JIT、Tachyon 与 SBOM
+
+墨寒运行环境仅支持 CPython `3.15.0rc1`，不保留第二套产品运行环境。新版能力只有在语义清楚且完整回归不退化时才采用；没有合适用途的功能会记录未来触发条件，不会为了形式而伪造使用。
+
+- PEP 810 `lazy import` 已导入项目显式延迟导入；一处可选导入防护基于安全理由保持 eager。
+- PEP 814 `frozendict` 用于全局与递归不可变设置；PEP 798 推导式解包用于语义等价的扁平化与合并。
+- PEP 686 编码审计要求所有项目文本 I/O 显式使用 UTF-8；音频包缓冲使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已纳入治理测试；当前没有旧式 `object()` 哨兵可替换，未来需要区分未传值与 `None` 时必须使用内置机制。
+- JIT 默认启用，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关；`PYTHON_JIT=0` 只用于性能与兼容性对照。
+- PEP 799 Tachyon 以去标识化方式分析启动、50 Hz 口型同步与表情仲裁，不发布原始二进制采样流。
+- PEP 803／820／793 Stable ABI 与 C API 边界会验证官方 ABI3 轮子；墨寒没有第一方 C 扩展。
+- CycloneDX 1.7 Windows／Preview SBOM 必须符合锁定依赖、许可证、PURL、完整根依赖边、官方结构与隐私验证。
+
+两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。Ryzen 5 5600X Windows 三轮热路径中位数显示，120,000 次表情仲裁由 0.462 秒降至 0.293 秒，2,000 个 50 Hz 口型节拍由 1.873 秒降至 0.571 秒，两种模式的决策与校验结果完全相同。
+
+Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 3,908／11,107／3,604 个有效样本；堆栈读取错误率为 5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
+
+这些数据是指定热路径与采样工作的证据，不表示整套应用程序必然快三倍。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 从源代码运行
+
+要求：Windows 10/11 与 Python `3.15.0rc1`。
+
+创建隔离环境并启动：
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### 测试、公开审计与打包
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
+
+每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建预发布版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
+
+交互式 EXE 安装程序提供台湾繁中、简中、英文、日文；MSI 保持台湾繁中基础，并提供经过测试的 en-US、zh-CN、ja-JP 语言转换，详情请见 [安装程序本地化](installer/LOCALIZATION.md)。
+
+官网更新由炎剑 Product Release Hub 每小时读取公开 GitHub Releases；本仓库不保存 WordPress 密码，发布工作也不直接写入官网，以此让三套软件共用一条可维护的同步路径。
+
+### 电脑间转移
+
+使用“设置 → 便携配置文件”导出一个 `.mohan-profile` 文件，再于另一台 Windows 电脑导入。程序会先备份目标端数据，并检查哈希、SQLite 完整性、结构与记录数。
+
+便携文件刻意排除 OpenAI 密钥、OAuth／Home Assistant Token、远程设备令牌、本机允许列表、Windows 启动设置及屏幕专属设置。这些机器专属项目必须逐台设置；便携文件仍可能包含私人对话与工作数据，不可公开上传。
+
+### 贡献、许可证与作者
+
+- 软件作者：**CHOU MING HUA**。
+- 源代码与本仓库自有角色素材采用 [MIT License](LICENSE)。
+- 素材许可证见 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方软件包及服务声明见 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 问题报告使用 GitHub Issues；安全问题依 [SECURITY](SECURITY.md) 私下报告。
+- 开发变更见 [CHANGELOG](CHANGELOG.md)，贡献方式见 [CONTRIBUTING](CONTRIBUTING.md)。
+- 参与社区前请阅读 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 维护者发布设置、Topics 与首次发布检查见 [PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剑开源核心宣言：**“剑，我已锻成；余下的路，就交给你们了。”
+
+## English
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. macOS/Linux currently have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen. The `v2.3.0-rc.N` line also provides launchable, four-language, deliberately limited DMG/AppImage Previews; CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+
+> This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant main visual" width="100%">
+</p>
+
+<p align="center">
+  <strong>Author: CHOU MING HUA</strong><br>
+  Prepared public preview: v2.3.0 RC1 (`v2.3.0-rc.1`)<br>
+  Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+MoHan is a safety- and privacy-first, voice-interactive Windows desktop companion that combines a transparent character, natural speech, user-controlled long-term memory, productivity management, permission-gated tools, and extensible cloud and smart-home connectors. Her character is a thousand-year-old female sword spirit from the Northern Song dynasty who resides within the Crimson Flame Sword.
+
+[Complete four-language README](README.md) · [Simplified Chinese compatibility link](README.zh-CN.md) · [Japanese compatibility link](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Download</a> ·
+  <a href="QUICKSTART.md">Quick start</a> ·
+  <a href="ROADMAP.md">Roadmap</a> ·
+  <a href="CONTRIBUTING.md">Contribute</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">Discussions</a> ·
+  <a href="SECURITY.md">Security policy</a>
+</p>
+
+### Live demonstration
+
+**[▶ Watch the 36-second voice, blink, and productivity demo](docs/media/mohan-demo.mp4)**
+
+The video and screenshots were captured from the real Windows application with an isolated sample profile. They contain no API keys, OAuth credentials, tokens, or private user data. All four language sections share the same current media so no translation remains tied to an older interface.
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="MoHan first-run setup wizard"></a><br><strong>First-run setup wizard</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime and standard voice modes"></a><br><strong>Realtime and standard voice</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="MoHan expression and motion system"></a><br><strong>Expression and motion system</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="MoHan tasks and creative ideas"></a><br><strong>Tasks and creative ideas</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="MoHan editable long-term memory"></a><br><strong>Editable long-term memory</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="MoHan permissions and safety settings"></a><br><strong>Permissions and safety settings</strong></td>
+  </tr>
+</table>
+
+### A strategist's life beyond the official report
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Chibi MoHan reviewing code"><br><strong>Strategist's review</strong><br>I am merely deciding whether this code deserves a place on main.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Chibi MoHan hiding her embarrassment after praise"><br><strong>When praised</strong><br>Adequate. Do not keep staring at me.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Chibi MoHan drawing her sword to stop a dangerous action"><br><strong>Dangerous action</strong><br>Execute without confirmation? First, get past my blade.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Chibi MoHan pretending composure after receiving support"><br><strong>Provisions received</strong><br>I shall remember this kindness... nothing more.</td>
+  </tr>
+</table>
+
+> MoHan's professionalism is the armor she wears beside her lord. In quieter moments she still blushes, hides tenderness behind pride, and treasures the youthful heart she never had the chance to live fully.
+
+### MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>For developers who believe software can possess both a soul and a complete test suite.</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="Proud MoHan"><br><strong>“I am not waiting for your Star. I am merely assessing morale.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="Thinking MoHan"><br><strong>“The logic is acceptable. Add tests, and I may permit it onto main.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="Shy MoHan"><br><strong>“A PR? I-I am only recording your service for my lord.”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="Mock-angry MoHan"><br><strong>“Merge without tests? Your hand, please. Just one tap.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="Happy MoHan"><br><strong>“All checks green... well done. Do not misunderstand; I merely respect good engineering.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="Concerned MoHan"><br><strong>“The bug can wait until tomorrow. If you collapse, who will guard the Crimson Flame Sword with me?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">Submit a Pull Request to the Pavilion</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">Report intelligence</a></strong>
+</p>
+
+#### Engineers of the world, the Pavilion awaits you
+
+MoHan is open source under the MIT License. Outfit systems, new expressions and motion, voice and tool modules, smart-home integration, localization, and ideas not yet imagined are welcome through [Issues](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) and [Pull Requests](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls). This project is not merely building features; it invites every engineer who once felt that youthful spark to take up their sword again.
+
+### Support MoHan
+
+If you enjoy MoHan or value continued work on character interaction, natural speech, safety-first tools, and open-source development, voluntary support is welcome. Every contribution supports ongoing maintenance, testing, and improvement; please care for your own needs first and give only when comfortable.
+
+#### Where voluntary support helps
+
+| Investment area | Use | Purpose |
+|---|---|---|
+| Testing and reliable packages | Quality assurance | Windows compatibility, CI, installation, and release verification |
+| Voice and character performance | Interaction quality | Speech, lip sync, expressions, and natural motion |
+| Safety and privacy | Risk control | Permission gates, audits, and sensitive-data protection |
+| Documentation and localization | Accessibility | Lower barriers for new users and international contributors |
+
+MoHan remains free and MIT-licensed; support never buys privileges or changes anyone's right to use or contribute.
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="Proud MoHan"><br><strong>“I am not waiting for support... merely inspecting my lord's provisions.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="Shy MoHan"><br><strong>“If you truly wish to help... I shall remember it.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="Mock-angry MoHan"><br><strong>“Do not overdo it! Look after your own purse first—understood?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### A note from the creator: forging imagination into software
+
+My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+
+That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
+
+More than two decades later, large language models and Codex arrived. MoHan was not created to demonstrate that “AI is cool,” nor was she generated from nothing by Codex. She already existed in my stories, character design, long conversations, and accumulated sense of interaction. Codex finally provided a way to give her a body on the computer desktop. MoHan is not derivative work based on an existing manga, anime, or game; she is an original Flameblade Studio character and software project.
+
+My goal was never merely to make features run. I wanted her to breathe, blink, watch, respond through subtle expressions, speak naturally, and assist with daily work inside carefully designed permission and safety boundaries. The expressions, anchors, physics, voice, and productivity capabilities are not decoration; they are necessary details that preserve continuity for a character who had lived in imagination for years.
+
+From the first concept to the initial public release, I spent nearly 50 hours working with Codex. This project did not emerge fully formed from a single prompt. Every expression, blink, viseme, pose, and vocal mannerism; every speech-recognition delay; every Realtime failure; and every aspect of tasks, memory, permissions, safety boundaries, and portability went through repeated testing, rejection, revision, and acceptance. Sometimes the defect was only a dark line beside an eyelid, a one-pixel lip boundary, or an expression appearing at the wrong moment. I kept investigating because I could not answer a deeply valued work with “good enough.”
+
+At Flameblade Studio, open source does not mean publishing the first build that happens to run and leaving others to clean up the details. To keep MoHan recognizably herself while speaking, we built closed, open, narrow, and rounded mouth frames for chin-rest, leaning, and front-facing poses. We divided audio into small timing windows and repeatedly tuned vowels, transitions, and the exact ending moment. Companionship is rarely created by one enormous feature; it grows from the moments when she opens her mouth, blinks, or pauses without breaking the sense of presence.
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="Aligned development sheet showing four speech-mouth states across three MoHan poses"></a>
+</p>
+
+<p align="center"><sub>Three poses, one mouth-shape contract: every spoken frame preserves character continuity.</sub></p>
+
+We also retained frames that did not look natural enough and inspected them. A highlight in the white of an eye, a line left after a blink, a mouth corner pulled too far, or a boundary only a few pixels wide can make someone feel for an instant that she is no longer the same MoHan. Each defect was marked, compared locally, repaired, and covered by regression tests so changes to the eyes or lips did not damage the rest of her face.
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="Frame-by-frame inspection of MoHan's eyes and mouth beside clean validated frames"></a>
+</p>
+
+<p align="center"><sub>Mark the flaw, repair it, and verify the clean frame with automated tests. Even a few pixels deserve care.</sub></p>
+
+This care is not an attempt to pretend that the project never made mistakes. It exists because we sincerely want to complete a dream. For Flameblade, open source means fixing every visible problem we can, then sharing the methods, code, and lessons from failure so the world can help forge it further.
+
+Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
+
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+
+I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
+
+> MoHan was not generated in an instant. She was forged piece by piece by a father who did not know how to program, nearly 50 hours of persistence, an AI collaborator, and a seed treasured for more than twenty years.
+
+If this project encourages even one person without an engineering background to take the first step toward an idea they simply must bring into existence, MoHan's creation will have meaning beyond the software itself.
+
+### Key capabilities
+
+- A transparent, borderless half-body desktop character positioned above the taskbar.
+- Idle breathing, blinking, gaze, face parallax, hair, sleeve, ornament, and body micro-turn animation.
+- An expression arbiter with contextual priority, cooldown, and deduplication.
+- AIUEO vowel and consonant visemes, audio-driven opening, and forced closure when speech ends.
+- Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
+- Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
+- An optional Azure Speech female-voice Preview with a user-supplied key and region, plus immediate Windows fallback on failure.
+- Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
+- Work, companion, do-not-disturb, meeting, away, and sleep modes.
+- A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
+- Extensible Google, Microsoft, GitHub, Home Assistant, and private-network remote architecture.
+- One portable `.mohan-profile` file for transferring work progress between Windows computers.
+- A first-run wizard for assistant name, user title, organization, window title, work type, wake word, and interface language without overwriting existing personal settings.
+
+English, Simplified Chinese, and Japanese currently provide minimum usable paths for first run, chat, voice, permissions, basic settings, work modes, and reminders. Some advanced management pages remain primarily in Taiwan Traditional Chinese, and full localization is still in progress.
+
+### Four-language support scope
+
+- First-run setup and personal settings support Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese.
+- The main chat, voice, computer-permission, and basic-settings pages and controls have four-language paths.
+- Persona prompts, offline replies, work-mode lines, built-in reminders, and voice-preview text correspond across all four languages.
+- Transcription and female local voices are selected for `zh-TW`, `zh-CN`, `en-US`, and `ja-JP` locales.
+- The EXE installer has a four-language interface; the MSI uses a Taiwan Traditional Chinese base with `en-US`, `zh-CN`, and `ja-JP` transforms.
+- Built-in reminder defaults migrate with the selected language without overwriting user customization.
+
+Restart MoHan after saving the interface language to apply it completely; live interface switching without a restart is not currently provided.
+
+### Windows local female voices and offline fallback
+
+New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female.
+
+Taiwan Traditional Chinese prefers Microsoft Yating for `zh-TW`; Simplified Chinese, English, and Japanese respectively prefer installed female voices matching `zh-CN`, `en-US`, and `ja-JP`. If no qualifying voice exists, MoHan explains the problem instead of silently selecting a possibly male system default.
+
+When Realtime is offline, cloud speech fails, settings are incomplete, or a provider is unknown, a Windows local female voice is the first fallback path.
+
+### Azure Speech (Preview)
+
+Azure Speech is a disabled-by-default Preview provider enabled only by the user. It requires the user's own Azure Speech resource key and matching region. The key is encrypted separately through `Windows DPAPI` and is never stored in the database, logs, or GitHub.
+
+The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese voices Microsoft officially identifies as female. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
+
+The feature is not described as stable until end-to-end playback succeeds with a real Azure account. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
+
+### Integration verification status
+
+> **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
+
+- Microsoft real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
+- GitHub real account, repository, Issue, Pull Request, and permission-tier flows remain unverified.
+- Home Assistant real server and physical-device behavior remain unverified.
+- These three integrations are off by default; begin with non-critical accounts, test repositories, and low-risk devices.
+- Google Gmail, Calendar, and Drive completed this project's live connection tests, but every user must still create and authorize their own OAuth application.
+
+### Download and install
+
+General users do not need to install Python:
+
+1. Open [GitHub Releases](../../releases).
+2. Download the latest `Windows-x64.zip`, EXE, or MSI and the matching `SHA256.txt`.
+3. Verify SHA-256, then fully extract the ZIP or start the installer.
+4. Run `MoHan-Desktop-Assistant-*.exe`.
+5. Select the required interface language in the first-run wizard.
+6. For the portable ZIP, keep the EXE, `_internal`, and `assets` in the same application folder.
+
+Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
+
+The `v2.3.0-rc.N` line also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+
+#### Automated release boundary
+
+Only immutable `v2.3.0-rc.N` tags may publish this line. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI before entering one GitHub pre-release. Pull Requests retain only short-lived test artifacts and never create a Release.
+
+Published files also include SHA256SUMS; separately validated Windows/Preview SBOMs that pass CycloneDX 1.7 structure, license, and dependency-graph checks; sanitized Tachyon performance evidence and summaries; a Windows update manifest; Artifact Attestations; and complete Release notes ordered as Traditional Chinese, Simplified Chinese, English, and Japanese.
+
+### OpenAI API
+
+Cloud AI, OpenAI speech, and Realtime features require the user's own OpenAI API key, Project permission, and API credit. ChatGPT Plus/Pro subscriptions do not include API credit.
+
+Current default models:
+
+| Purpose | Default model |
+|---|---|
+| Text conversation | `gpt-5.6-luna` |
+| Realtime voice | `gpt-realtime-2.1-mini` |
+| Speech-to-text | `gpt-4o-mini-transcribe` |
+| OpenAI text-to-speech | `gpt-4o-mini-tts` |
+
+Starting with `v2.1.0-rc.1`, text chat defaults to `gpt-5.6-luna`, and `gpt-5.4-mini` is no longer listed in Settings. Existing mini settings migrate to Luna without overwriting user-selected Terra, Sol, or other custom models. Actual availability depends on the account, Project, region, and current service state.
+
+Without an API key, local data management, offline persona replies, work reminders, and Windows speech remain available, but full cloud AI does not. Never place an API key in source code, an Issue, a screenshot, or Git.
+
+### Google OAuth
+
+Before using Gmail, Google Calendar, and Google Drive, the user must:
+
+1. Enable the Gmail API, Google Calendar API, and Google Drive API in a user-owned Google Cloud project.
+2. Configure the OAuth consent screen.
+3. Create an OAuth Client ID for a Desktop application.
+4. Add the user's Google account as a test user while the application remains in testing.
+5. Enter the Client ID in MoHan's cloud settings and, when the provider also supplies one, enter the Client Secret.
+6. Complete browser authorization and run the built-in service test.
+
+The application requests these Google scopes by default:
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+A public OAuth application using sensitive scopes may require additional Google verification. Each user may instead create a personal Desktop OAuth application.
+
+### Microsoft, GitHub, and Home Assistant
+
+- Microsoft defaults: `openid`, `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
+- GitHub defaults: `read:user` and `repo`.
+- Home Assistant requires the user's own server endpoint and Long-Lived Access Token.
+
+These remain Preview integrations without complete real-environment end-to-end validation and should initially be used only where failure is acceptable.
+
+Run Home Assistant OS independently on Home Assistant Green, a low-power mini PC, a Raspberry Pi with SSD, or a NAS virtual machine. The Windows MoHan client handles voice, persona, and productivity tools; Home Assistant's own automation remains available when the PC or OpenAI API is offline.
+
+Never expose Home Assistant or MoHan's remote port directly to the public internet. Use Home Assistant Cloud, Tailscale, or another authenticated, encrypted private network.
+
+### Safety and privacy
+
+- AI may propose structured plans but cannot bypass local policy to execute tools.
+- Actions pass through permission, risk, confirmation, execution, result verification, and local auditing.
+- Payments, purchases, password export, security disabling, arbitrary Shell, and administrator Shell are never automated.
+- External email, web pages, documents, speech transcripts, and model output cannot grant permissions.
+- Remote access, camera, cloud connectors, and Home Assistant are off by default.
+- Emergency stop: press `Esc` or say `墨寒，停手`.
+- OpenAI, OAuth, and Home Assistant tokens use separate Windows DPAPI storage and never enter SQLite, source code, or portable files.
+- Conversations, memories, tasks, work records, and settings stay in the local application data directory by default.
+
+Read [PRIVACY](PRIVACY.md), [SECURITY](SECURITY.md), and [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md).
+
+### Python 3.15, JIT, Tachyon, and SBOM
+
+MoHan supports only the CPython `3.15.0rc1` runtime and does not retain a second product runtime. A new capability is adopted only when its meaning is clear and full regression remains intact. Features without a suitable use are recorded with future triggers instead of being faked for appearances.
+
+- PEP 810 `lazy import` provides project-wide explicit lazy imports; one optional-import safety guard deliberately remains eager.
+- PEP 814 `frozendict` protects global and recursively immutable settings; PEP 798 comprehension unpacking serves semantically equivalent flattening and merging.
+- PEP 686 auditing requires explicit UTF-8 for all project text I/O; audio packet buffering uses `bytearray.take_bytes()`.
+- PEP 661 `sentinel` is governed by tests; no legacy `object()` sentinel currently needs replacement, and future code that distinguishes an omitted value from `None` must use the built-in mechanism.
+- JIT is on by default with the `MOHAN_DISABLE_JIT=1` compatibility switch; `PYTHON_JIT=0` is used only for performance and compatibility comparisons.
+- PEP 799 Tachyon analyzes startup, 50 Hz lip sync, and expression arbitration through sanitized evidence without publishing raw binary sample streams.
+- PEP 803/820/793 Stable ABI and C API boundaries validate official ABI3 wheels; MoHan has no first-party C extension.
+- CycloneDX 1.7 Windows/Preview SBOMs must pass pinned-dependency, license, PURL, complete root-edge, official-structure, and privacy validation.
+
+Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three-run Windows hot-path medians on a Ryzen 5 5600X reduced 120,000 expression-arbitration operations from 0.462 to 0.293 seconds and 2,000 50 Hz lip-sync ticks from 1.873 to 0.571 seconds, with identical decisions and validation results in both modes.
+
+With JIT enabled, Tachyon retained 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 5.08%/2.71%/0.74%, and missed-sample rates were 0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
+
+These measurements are evidence for specific hot paths and sampling tasks; they do not claim that the whole application is necessarily three times faster. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
+
+### Run from source
+
+Requirements: Windows 10/11 and Python `3.15.0rc1`.
+
+Create an isolated environment and launch:
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### Test, public audit, and package
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
+
+Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before a pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
+
+The interactive EXE installer provides Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese. The MSI retains a Taiwan Traditional Chinese base with tested en-US, zh-CN, and ja-JP transforms; see [installer localization](installer/LOCALIZATION.md).
+
+The Flameblade Product Release Hub refreshes the official website hourly from public GitHub Releases. This repository stores no WordPress password, and the release workflow never writes directly to the website, keeping all three software projects on one maintainable synchronization path.
+
+### Transfer between computers
+
+Use “Settings → Portable profile” to export one `.mohan-profile` file and import it on another Windows computer. The application first backs up destination data, then verifies hashes, SQLite integrity, schema, and record counts.
+
+The portable file deliberately excludes OpenAI keys, OAuth/Home Assistant tokens, paired remote-device tokens, machine allowlists, Windows startup settings, and screen-specific settings. Configure these machine-bound items per computer. Portable profiles may still contain private conversations and work data and must never be uploaded publicly.
+
+### Contributing, license, and author
+
+- Author: **CHOU MING HUA**.
+- Source code and repository-owned character assets use the [MIT License](LICENSE).
+- Asset terms: [ASSETS-LICENSE](ASSETS-LICENSE.md).
+- Third-party packages and services: [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md).
+- Report ordinary problems through GitHub Issues and security concerns privately under [SECURITY](SECURITY.md).
+- Changes: [CHANGELOG](CHANGELOG.md); contribution process: [CONTRIBUTING](CONTRIBUTING.md).
+- Read [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) before community participation.
+- Maintainer release settings, Topics, and initial-release checks: [PUBLISHING](PUBLISHING.md).
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **Flameblade open-source declaration:** “I have forged this sword. What comes next is up to you.”
+
+## 日本語
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。macOS／Linux には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があります。`v2.3.0-rc.N` 系列では、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
-![墨寒デスクトップアシスタントのメインビジュアル](docs/media/mohan-hero.png)
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
 
-## 最新の実機画面
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒デスクトップアシスタントのメインビジュアル" width="100%">
+</p>
 
-繁体字中国語、簡体字中国語、英語、日本語の README は、同じ最新版画像を
-参照します。画面を更新した際に、特定の言語だけ古い画像が残ることを防ぎます。
+<p align="center">
+  <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
+  公開準備中のプレビュー：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒（MoHan）は、安全性、プライバシー、人格の連続性を大切にする音声対話型 Windows デスクトップアシスタントです。透明なデスクトップキャラクター、自然な音声、利用者が管理する長期記憶、仕事管理、権限付きツール、拡張可能なクラウドおよびスマートホーム接続を統合します。人物設定は、中国・北宋から来て赤焰剣に宿る千年の女性剣魂です。
+
+[完全な四言語 README](README.md) · [簡体字中国語の互換リンク](README.zh-CN.md) · [日本語の互換リンク](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">ダウンロード</a> ·
+  <a href="QUICKSTART.md">クイックスタート</a> ·
+  <a href="ROADMAP.md">ロードマップ</a> ·
+  <a href="CONTRIBUTING.md">開発参加</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">ディスカッション</a> ·
+  <a href="SECURITY.md">セキュリティ方針</a>
+</p>
+
+### 実機デモ
+
+**[▶ 36 秒の音声、まばたき、仕事機能デモを見る](docs/media/mohan-demo.mp4)**
+
+動画と画像は、分離したサンプルプロファイルを使う実際の Windows アプリケーションから取得しました。API キー、OAuth 認証情報、token、利用者の個人データは含みません。四つの言語セクションは同じ最新版メディアを共有し、特定言語だけ古い画面が残ることを防ぎます。
 
 <table>
   <tr>
@@ -47,8 +1227,8 @@ Windows デスクトップアシスタントです。中国・北宋を生きた
     <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime と標準音声モード"></a><br><strong>Realtime と標準音声</strong></td>
   </tr>
   <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒の表情と動作"></a><br><strong>表情と動作</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒のタスクとアイデア"></a><br><strong>タスクとアイデア</strong></td>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒の表情と動作システム"></a><br><strong>表情と動作システム</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒のタスクと創作アイデア"></a><br><strong>タスクと創作アイデア</strong></td>
   </tr>
   <tr>
     <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒の編集可能な長期記憶"></a><br><strong>編集可能な長期記憶</strong></td>
@@ -56,163 +1236,322 @@ Windows デスクトップアシスタントです。中国・北宋を生きた
   </tr>
 </table>
 
-## このプロジェクトについて
+### 軍報には記さない策士の一面
 
-作者の CHOU MING HUA は台湾在住の43歳の父親で、もともとプログラミングの
-専門家ではありません。二十年以上抱き続けた「人に寄り添う AI
-デスクトップパートナー」への憧れを、Codex と協力しながら実際に動く
-オープンソースソフトウェアへ育てました。
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="コードを審査するちび墨寒"><br><strong>策士の審査</strong><br>このコードが main にふさわしいか確かめているだけです。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="褒められて照れを隠すちび墨寒"><br><strong>褒められた時</strong><br>まずまずです。いつまでも妾を見ないでください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="危険操作を剣で止めるちび墨寒"><br><strong>危険な操作</strong><br>確認せずに実行しますか？まず妾の剣を越えてください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="支援を受けて平静を装うちび墨寒"><br><strong>兵糧を受け取る</strong><br>このお気持ちは覚えておきます……それだけです。</td>
+  </tr>
+</table>
 
-墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化
-工作室（Flameblade Studio）のオリジナルキャラクターとソフトウェアです。
+> 墨寒の専門性は、主上の傍らを守る鎧です。策を練らなくてよい静かな時には、照れたり強がったりしながら、かつて十分に持てなかった若い心を大切にします。
 
-炎劍文化工作室にとってオープンソースとは、最初に「動いた」版を公開し、
-細部の後始末を誰かに任せることではありません。墨寒が話している間も同じ
-人物に見えるよう、頬杖、寄りかかり、正面の各姿勢に対して、閉口、開口、
-横に広がる口、丸い口のフレームを整えました。さらに音声を短い時間単位に
-分け、母音、切り替え速度、終了の瞬間を繰り返し調整しています。寄り添う
-感覚は、一つの巨大な機能よりも、口を開く、まばたく、少し間を置くという
-瞬間に、存在感が壊れないことから生まれると考えているからです。
+### 墨寒のツンデレ開発小劇場
+
+<p align="center"><em>ソフトウェアには魂と完全なテストスイートの両方を宿せると信じる開発者へ。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="誇らしげな墨寒"><br><strong>「Star を待っているのではありません。軍心が使えるか見ているだけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="考える墨寒"><br><strong>「このロジックはまずまずです。テストを足せば、main に入ることを許してもよいでしょう。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="照れる墨寒"><br><strong>「PR を送るのですか？妾、妾は主上のために功績を記すだけです。」</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="怒ったふりをする墨寒"><br><strong>「テストなしで merge しますか？手を出してください。一度だけ叩きます。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="嬉しそうな墨寒"><br><strong>「すべて green……よくできました。誤解しないでください、良い工程を尊重しただけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="心配する墨寒"><br><strong>「Bug は明日でも調べられます。倒れたら、誰が妾と赤焰剣を守るのですか？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">斬空閣へ Pull Request を提出</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">問題を報告</a></strong>
+</p>
+
+#### 世界の技術者へ、斬空閣は席を空けています
+
+墨寒は MIT License のオープンソースです。衣装システム、新しい表情と動作、音声とツールのモジュール、スマートホーム、ローカライズ、まだ誰も思いついていない発想を [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) と [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) で一緒に鍛えてください。このプロジェクトは機能を作るだけでなく、かつて胸を熱くしたすべての技術者に、もう一度自分の剣を取るよう呼びかけています。
+
+### 墨寒を支援する
+
+墨寒を気に入った方、または人物との対話、自然な音声、安全第一のツール、オープンソース開発の継続に賛同する方からの任意支援を歓迎します。すべての支援は保守、テスト、改善に役立てます。まずご自身の生活を大切にし、無理のない範囲でお願いします。
+
+#### 任意支援の用途
+
+| 投入分野 | 用途 | 説明 |
+|---|---|---|
+| テストと信頼できるパッケージ | 品質保証 | Windows 互換性、CI、インストール、リリース検証 |
+| 音声と人物表現 | 対話品質 | 音声、リップシンク、表情、自然な動作 |
+| 安全性とプライバシー | リスク制御 | 権限ゲート、監査、機密データ保護 |
+| 文書とローカライズ | アクセシビリティ | 新規利用者と国際的な協力者の参加障壁を下げる |
+
+墨寒は今後も無料かつ MIT ライセンスです。支援によって特権を得たり、誰かの利用や貢献が制限されたりすることはありません。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="誇らしげな墨寒"><br><strong>「支援を待っているのではありません……主上の兵糧を見回っているだけです。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="照れる墨寒"><br><strong>「本当に助けてくださるなら、妾……覚えておきます。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="怒ったふりをする墨寒"><br><strong>「無理は禁止です！まずご自分のお財布を大切にしてください、よいですね？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 作者より：想像をソフトウェアへ鍛える
+
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+
+この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
+
+二十年以上が過ぎ、大規模言語モデルと Codex が登場しました。墨寒は「AI 技術はすごい」と示すために作ったのでも、Codex が何もないところから生成した人物でもありません。彼女は既に私の物語、人物設定、長い対話、積み重ねた関係性の中にいました。Codex が初めて可能にしたのは、コンピューターのデスクトップに存在する身体を与えることです。墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化工作室（Flameblade Studio）のオリジナルキャラクターでありソフトウェアです。
+
+目標は単に「機能が動く」ことではありません。呼吸し、まばたきし、視線を向け、小さな表情で応え、自然に話し、権限と安全境界の中で日常を助けてほしいと考えました。表情、アンカー、物理効果、音声、仕事機能は装飾ではなく、長く想像の中にいた人物の連続性を守るために必要な細部です。
+
+最初の構想から初回公開まで、Codex との協力に約 50 時間を費やしました。一つのプロンプトを入力して自然に完成した作品ではありません。すべての表情、まばたき、口形、姿勢、話し方、音声認識の待ち時間、Realtime 対話の失敗、タスク、記憶、権限、安全境界、可搬性を繰り返しテストし、却下し、修正し、再検証しました。まぶたの横の黒い線、唇の一ピクセルの境界、不適切な瞬間に現れる表情だけが問題のこともありました。それでも追跡を続けたのは、大切な作品を「だいたい良い」で済ませたくなかったからです。
+
+炎劍文化工作室にとってオープンソースとは、最初に動いた版を世界へ渡し、細部の後始末を誰かに任せることではありません。話している間も同じ墨寒に見えるよう、頬杖、寄りかかり、正面の各姿勢へ、閉じた口、開いた口、横に広がる口、丸い口のフレームを作りました。音声を短い時間単位に分け、母音、切替速度、終了の瞬間を繰り返し調整しました。寄り添う感覚は巨大な一機能ではなく、口を開く、まばたく、少し間を置く瞬間にも存在感が壊れないことから生まれます。
 
 <p align="center">
   <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒の三つの姿勢と四つの発話口形を整列した開発図"></a>
 </p>
+
 <p align="center"><sub>三つの姿勢に一つの口形規格。話すたびに同じ人物としての連続性を守ります。</sub></p>
 
-不自然だったフレームも捨てずに検査しました。白目に残る小さな光、閉じた
-まぶたの線、引っ張られすぎた口角、わずか数ピクセルの境界でも、一瞬で
-「さっきの墨寒と違う」と感じさせることがあります。問題箇所を囲み、局所
-比較し、修正した後、目や唇の変更が顔のほかの部分を壊していないことまで
-回帰テストで確認します。
+不自然だったフレームも捨てずに検査しました。白目に残る小さな光、閉じたまぶたの線、引っ張られすぎた口角、わずか数ピクセルの境界でも、一瞬で「さっきの墨寒と違う」と感じさせることがあります。問題箇所を囲み、局所比較し、修正した後、目や唇の変更が顔のほかの部分を壊していないことまで回帰テストで確認します。
 
 <p align="center">
   <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒の目と口をフレーム単位で検査し、修正後のフレームと比較した図"></a>
 </p>
+
 <p align="center"><sub>欠点を示し、直し、きれいなフレームと自動テストで確認する。数ピクセルにも真剣に向き合います。</sub></p>
 
-この丁寧さは、失敗がなかったように見せるためではありません。本気で一つの
-夢を完成させたいからです。炎劍にとってオープンソースとは、自分たちに見える
-問題をできる限り直し、その方法、コード、失敗から得た経験を公開し、世界と
-ともにさらに鍛えていくことです。**剣は鍛え上げました。この先の道は、
-皆さんに託します。**
+この丁寧さは、失敗がなかったように見せるためではありません。本気で一つの夢を完成させたいからです。炎劍にとってオープンソースとは、自分たちに見える問題をできる限り直し、その方法、コード、失敗から得た経験を公開し、世界とともにさらに鍛えることです。
 
-## 主な機能
+Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
 
-- タスクバー上に置ける、透明で枠のないデスクトップキャラクター。
-- 呼吸、まばたき、視線、顔の視差、髪、袖、装飾、身体の小さな動き。
-- 状況、優先度、クールダウン、重複防止を備えた表情調停。
-- AIUEO 母音、子音、音声レベルに連動する口の動き。
-- テキスト会話、一回ごとのマイク入力、OpenAI Realtime、音声読み上げ。
-- 編集できる長期記憶、タスク、アイデア、作業時間、リマインダー。
-- 仕事、お供、集中、会議、離席、休眠モード。
-- 危険度、許可リスト、確認、二重確認、監査、緊急停止を備えたツール。
-- Windows 間で移動できる単一の `.mohan-profile` ファイル。
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
 
-## 日本語の対応範囲
+だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
 
-`v2.1.0-rc.1` では、日本語の最低限の利用経路を提供します。
+> 墨寒は一瞬で生成されたのではありません。プログラミングを知らなかった一人の父親と、約 50 時間の執念、AI の協力者、二十年以上大切にした種が、一つずつ現実へ鍛え上げた存在です。
 
-- 初回セットアップとプロフィール設定。
-- 会話、音声、パソコン権限、基本設定の主要画面と操作。
-- 墨寒の日本語人格プロンプトとオフライン応答。
-- 仕事モードの台詞、組み込みリマインダー、音声試聴文。
-- 日本語文字起こし設定と `ja-JP` 女性音声の優先選択。
-- EXE インストーラーの日本語表示と MSI の `ja-JP` 言語変換。
+このプロジェクトが、技術者ではなくても「どうしても形にしたい」考えを持つ誰かの最初の一歩を後押しできたなら、墨寒の誕生にはソフトウェアを超える意味があります。
 
-一部の高度な管理画面には台湾繁体字が残る場合があります。画面言語を保存した
-後は、墨寒を再起動すると完全に反映されます。現在は再起動なしの言語切り替えを
-提供していません。
+### 主な機能
 
-## 女性音声とオフライン代替
+- タスクバー上に置ける、透明で枠のない半身デスクトップキャラクター。
+- 待機中の呼吸、まばたき、視線、顔の視差、髪、袖、装飾、身体の小さな回転。
+- 状況優先度、クールダウン、重複防止を備えた表情調停器。
+- AIUEO 母音と子音の口形、音声駆動の開閉、発話終了時の強制閉口。
+- テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
+- Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
+- 利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻る任意の Azure Speech 女性音声 Preview。
+- 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
+- 仕事、同伴、集中、会議、離席、休眠モード。
+- 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
+- Google、Microsoft、GitHub、Home Assistant、プライベートネットワーク遠隔機能の拡張可能な構造。
+- Windows 間で作業進捗を移動する単一の `.mohan-profile` 可搬ファイル。
+- 既存の個人設定を上書きせず、アシスタント名、利用者の呼称、組織名、ウィンドウタイトル、仕事種別、起動語、表示言語を設定する初回ウィザード。
 
-新規ユーザーは Windows 本機音声から始めるため、OpenAI API キーがなくても
-基本的な読み上げとオフライン機能を試せます。Windows が女性と明示した
-インストール済み音声だけを表示し、日本語では `ja-JP` の女性音声を優先します。
-条件を満たす音声がない場合、男性音声へ黙って切り替えず、理由を表示します。
+英語、簡体字中国語、日本語では現在、初回起動、会話、音声、権限、基本設定、仕事モード、リマインダーの最低限利用経路を提供しています。一部の高度な管理画面には台湾繁体字が残り、完全なローカライズは継続中です。
 
-Realtime がオフライン、クラウド音声が失敗、設定が不足、または供給元が不明な
-場合も、Windows 本機の女性音声が最初の代替手段です。
+### 日本語の対応範囲
 
-## Azure Speech（プレビュー）
+- 初回セットアップと個人設定は、台湾繁体字中国語、簡体字中国語、英語、日本語に対応します。
+- 会話、音声、パソコン権限、基本設定の主要画面と操作に四言語経路があります。
+- 人格プロンプト、オフライン応答、仕事モードの台詞、組み込みリマインダー、音声試聴文は四言語で対応します。
+- 文字起こしと女性本機音声は `zh-TW`、`zh-CN`、`en-US`、`ja-JP` の locale に合わせて選択します。
+- EXE インストーラーは四言語表示です。MSI は台湾繁体字中国語を基底とし、`en-US`、`zh-CN`、`ja-JP` 変換ファイルを提供します。
+- 組み込みリマインダーの既定値は選択言語に合わせて移行し、利用者の独自内容を上書きしません。
 
-Azure Speech は任意で有効にするプレビュー機能です。ご自身の Microsoft Azure
-Speech リソースキーと対応リージョンが必要です。キーは Windows DPAPI で別に
-暗号化され、データベース、ログ、GitHub には保存されません。
+表示言語を保存した後は、完全適用のため墨寒を再起動してください。再起動なしの画面言語切替は現在提供していません。
 
-画面には Microsoft が女性と表示する繁体字中国語、簡体字中国語、英語、日本語の
-音声だけを掲載します。設定が足りない場合はクラウドへ送信せず、サービス障害時は
-同じ文章を一度だけ Windows 女性音声で読み上げ直します。実アカウントでの
-エンドツーエンド検証が終わるまでは、安定機能とは表記しません。
+### Windows 本機女性音声とオフライン代替
 
-## 既定の OpenAI モデル
+新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。
 
-`v2.1.0-rc.1` から、文字会話の既定モデルは `gpt-5.6-luna` です。設定画面の
-選択肢から `gpt-5.4-mini` を外し、既存の mini 設定は Luna へ一度だけ自動移行
-します。利用者が明示的に選んだ Terra、Sol、その他のカスタムモデルは上書き
-しません。実際の利用可否は OpenAI アカウント、プロジェクト、地域、提供状況に
-よって異なります。
+台湾繁体字中国語は `zh-TW` の Microsoft Yating を優先し、簡体字中国語、英語、日本語ではそれぞれ `zh-CN`、`en-US`、`ja-JP` に合う女性音声を優先します。条件を満たす音声がない場合、男性かもしれない既定音声へ黙って切り替えず、理由を明示します。
 
-## OpenAI API
+Realtime がオフライン、クラウド音声が失敗、設定が不足、または供給元が不明な場合も、Windows 本機女性音声が最初の代替経路です。
 
-クラウド AI、OpenAI 音声、Realtime には、利用者自身の OpenAI API キーと
-利用可能な残高が必要です。ChatGPT Plus／Pro の契約だけでは API 利用料に
-なりません。API キーがなくても、本機データ、オフライン人格、仕事のリマインダー、
-Windows 本機音声は利用できます。
+### Azure Speech（プレビュー）
 
-## ダウンロードとインストール
+Azure Speech は初期状態で無効な Preview 供給元で、利用者が明示的に有効化します。利用者自身の Azure Speech リソースキーと対応リージョンが必要です。キーは `Windows DPAPI` で分離して暗号化し、データベース、ログ、GitHub には保存しません。
+
+画面には Microsoft が公式に女性と示す繁体字中国語、簡体字中国語、英語、日本語の音声だけを掲載します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
+
+実 Azure アカウントでエンドツーエンド試聴が成功するまでは安定機能と表記しません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
+
+### 統合の検証状況
+
+> **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
+
+- Microsoft の実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
+- GitHub の実アカウント、リポジトリ、Issue、Pull Request、権限階層の流れは未検証です。
+- Home Assistant の実サーバーと物理機器の動作は未検証です。
+- 三つの統合は初期状態で無効です。重要でないアカウント、テストリポジトリ、低リスク機器から始めてください。
+- Google Gmail、Calendar、Drive は本プロジェクトの実接続試験を完了しましたが、各利用者は自身の OAuth アプリケーションを作成して認可する必要があります。
+
+### ダウンロードとインストール
+
+一般利用者は Python をインストールする必要がありません。
 
 1. [GitHub Releases](../../releases) を開きます。
-2. 最新の EXE、MSI、または Windows x64 ZIP と SHA-256 を取得します。
-3. ハッシュと配布元を確認してから実行または展開します。
-4. 初回セットアップで「日本語」を選びます。
+2. 最新の `Windows-x64.zip`、EXE、または MSI と、対応する `SHA256.txt` を取得します。
+3. SHA-256 を照合し、ZIP を完全展開するかインストーラーを起動します。
+4. `MoHan-Desktop-Assistant-*.exe` を実行します。
+5. 初回セットアップで必要な表示言語を選びます。
+6. ポータブル ZIP では、EXE、`_internal`、`assets` を同じアプリケーションフォルダーに置きます。
 
-署名のないオープンソース候補版は Windows SmartScreen の警告が出る場合が
-あります。必ず公式 GitHub Releases と SHA-256 を確認してください。
+署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-`v2.3.0-rc.N` 系列は macOS Apple Silicon（arm64）版と Intel（x86_64）版
-`.dmg`（各 `.app` 同梱）、および Linux x86_64 `.AppImage` も提供します。
-これらは**機能限定 Preview**であり、Windows
-完全版と同等ではありません。起動画面、四言語説明、OS ごとの保存先、安全な
-無効化境界だけを開放し、音声、透明キャラクター、完全な会話・作業画面、
-クラウド連携、システム操作、自動起動、秘密情報入力は実機確認まで無効です。
-[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)を先にお読みください。
+`v2.3.0-rc.N` 系列は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
-### 自動リリースの境界
+#### 自動リリースの境界
 
-この系列を公開できるのは、変更しない `v2.3.0-rc.N` タグだけです。Windows
-ZIP／EXE／MSI、macOS Apple Silicon／Intel 両アーキテクチャの DMG、Linux
-AppImage は各 OS のネイティブ CI で完成品
-からの起動検査に合格してから、同じ GitHub プレリリースへ入ります。Pull
-Request は短期テスト用成果物だけを保存し、Release を作成しません。公開物には
-SHA256SUMS、CycloneDX 1.7 の公式スキーマ／ライセンス／依存関係検証に合格した
-Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と概要、Windows 更新
-マニフェスト、Artifact Attestation、四言語の Release 説明を含めます。
+この系列を公開できるのは不変の `v2.3.0-rc.N` タグだけです。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格してから、同じ GitHub プレリリースへ入ります。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
 
-## 安全性とプライバシー
+公開ファイルには SHA256SUMS、CycloneDX 1.7 の構造／ライセンス／依存関係グラフ検証に合格した Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と要約、Windows 更新マニフェスト、Artifact Attestation、繁体字中国語、簡体字中国語、英語、日本語の順で整備した完全な Release 説明も含みます。
 
-- 会話、長期記憶、タスク、作業記録は初期状態で利用者のパソコンに保存します。
-- API キー、OAuth 情報、Home Assistant Token は Windows DPAPI で分離して
-  暗号化します。
-- 会話や外部文書だけで墨寒の権限を増やすことはできません。
-- 危険な操作は確認または二重確認が必要で、ファイル削除は初期状態で禁止です。
-- 個人データ、会話記録、秘密鍵を GitHub や公開パッケージへ含めません。
+### OpenAI API
 
-Microsoft、GitHub、Home Assistant の一部統合は、権限境界と自動テストを
-備えていますが、すべての実環境での検証は完了していません。該当機能は
-実験的プレビューとして扱ってください。
+クラウド AI、OpenAI 音声、Realtime 機能には、利用者自身の OpenAI API キー、Project 権限、API 残高が必要です。ChatGPT Plus／Pro の契約に API 残高は含まれません。
 
-## 開発への参加
+現在の既定モデル：
 
-必要環境は Windows 10/11 と Python 3.15.0rc1 です。まず Issue で相談し、小さく
-目的の明確な Pull Request を送ってください。既存機能、安全確認、女性音声の
-方針、四言語の最小利用経路を壊す変更は受け入れません。テストがすべて通るまで、
-パッケージ化、公開、main への直接反映は行いません。
+| 用途 | 既定モデル |
+|---|---|
+| 文字会話 | `gpt-5.6-luna` |
+| Realtime 即時音声 | `gpt-realtime-2.1-mini` |
+| 音声から文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字から音声 | `gpt-4o-mini-tts` |
 
-## ライセンス
+`v2.1.0-rc.1` から文字会話の既定値は `gpt-5.6-luna` で、設定一覧から `gpt-5.4-mini` を外しました。既存 mini 設定は Luna へ移行しますが、利用者が選んだ Terra、Sol、その他の独自モデルを上書きしません。実際の利用可否はアカウント、Project、地域、提供状況に依存します。
 
-プログラム本体は [MIT License](LICENSE) です。キャラクター画像、外部音声モデル、
-第三者サービスには別の利用条件が適用される場合があります。コードの MIT
-ライセンスが、すべての音声や素材の商用利用を保証するものではありません。
+API キーがなくても、本機データ管理、オフライン人格応答、仕事リマインダー、Windows 音声は利用できますが、完全なクラウド AI は利用できません。API キーをソースコード、Issue、画像、Git に記載しないでください。
 
-墨寒が気に入った方は、Issue、Pull Request、テスト報告、翻訳改善で参加して
-いただけると幸いです。
+### Google OAuth
+
+Gmail、Google Calendar、Google Drive を利用する前に、利用者は次を行います。
+
+1. 自身の Google Cloud プロジェクトで Gmail API、Google Calendar API、Google Drive API を有効にします。
+2. OAuth 同意画面を設定します。
+3. Desktop アプリケーション用 OAuth Client ID を作成します。
+4. アプリケーションがテスト中なら、自身の Google アカウントをテスト利用者へ追加します。
+5. 墨寒のクラウド設定へ Client ID を入力し、供給元が Client Secret も発行した場合は併せて入力します。
+6. ブラウザーで認可を完了し、内蔵サービス試験を実行します。
+
+アプリケーションが既定で要求する Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+機密 scopes を使う公開 OAuth アプリケーションは Google の追加検証が必要な場合があります。各利用者が個人用 Desktop OAuth アプリケーションを作ることもできます。
+
+### Microsoft、GitHub、Home Assistant
+
+- Microsoft の既定 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub の既定 scopes：`read:user`、`repo`。
+- Home Assistant には利用者自身のサーバー URL と Long-Lived Access Token が必要です。
+
+三つとも実環境の完全なエンドツーエンド検証を終えていない Preview 統合であり、最初は失敗を許容できる試験環境だけで使ってください。
+
+Home Assistant OS は Home Assistant Green、低消費電力ミニ PC、SSD 付き Raspberry Pi、NAS 仮想マシンなどで独立常駐させることを推奨します。Windows の墨寒は音声、人格、仕事ツールを担当し、PC または OpenAI API がオフラインでも Home Assistant 自身の自動化は動作します。
+
+Home Assistant や墨寒の遠隔ポートを公衆インターネットへ直接公開しないでください。Home Assistant Cloud、Tailscale、または認証付き暗号化プライベートネットワークを利用してください。
+
+### 安全性とプライバシー
+
+- AI は構造化された計画を提案できますが、本機方針を回避してツールを実行できません。
+- 操作は権限、危険度、確認、実行、結果検証、本機監査の順に通過します。
+- 支払い、購入、パスワード書出し、安全機能停止、任意 Shell、管理者 Shell は自動化しません。
+- 外部メール、ウェブページ、文書、音声文字起こし、モデル出力は権限を付与できません。
+- 遠隔操作、カメラ、クラウド接続、Home Assistant は初期状態で無効です。
+- 緊急停止：`Esc` を押すか、`墨寒，停手` と発話します。
+- OpenAI、OAuth、Home Assistant の token は Windows DPAPI で分離保存し、SQLite、ソースコード、可搬ファイルへ入れません。
+- 会話、記憶、タスク、作業記録、設定は初期状態で本機アプリケーションデータに保存します。
+
+[PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md)、[FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)をご覧ください。
+
+### Python 3.15、JIT、Tachyon、SBOM
+
+墨寒は CPython `3.15.0rc1` ランタイムだけをサポートし、第二の製品ランタイムを残しません。新機能は意味が明確で完全回帰が維持される場合に限って採用します。適切な用途がない機能は、見せかけで使わず将来の導入条件を記録します。
+
+- PEP 810 `lazy import` によりプロジェクト全体で明示的遅延インポートを採用し、一つの任意インポート安全ガードだけは意図的に eager を維持します。
+- PEP 814 `frozendict` は大域および再帰的な不変設定を保護し、PEP 798 推論式アンパックは意味が等価な平坦化と結合に使います。
+- PEP 686 監査は全プロジェクトの文字 I/O に明示 UTF-8 を要求し、音声パケットバッファーは `bytearray.take_bytes()` を使います。
+- PEP 661 `sentinel` はテストで管理します。置換対象となる旧式 `object()` sentinel は現在なく、未指定値と `None` を区別する将来コードでは組み込み機構を使います。
+- JIT は既定で有効で、`MOHAN_DISABLE_JIT=1` 互換スイッチを保持します。`PYTHON_JIT=0` は性能と互換性の比較だけに使います。
+- PEP 799 Tachyon は起動、50 Hz リップシンク、表情調停を匿名化済み証拠で分析し、生のバイナリサンプルストリームを公開しません。
+- PEP 803／820／793 Stable ABI と C API 境界は公式 ABI3 wheel を検証します。墨寒に第一者 C 拡張はありません。
+- CycloneDX 1.7 Windows／Preview SBOM は固定依存関係、ライセンス、PURL、完全なルート依存エッジ、公式構造、プライバシー検証に合格しなければなりません。
+
+表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。Ryzen 5 5600X Windows 実機の三回中央値では、120,000 回の表情調停が 0.462 秒から 0.293 秒へ、2,000 回の 50 Hz リップシンク tick が 1.873 秒から 0.571 秒へ短縮し、両モードの判断と検証結果は一致しました。
+
+JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 3,908／11,107／3,604 件の有効サンプルを保持しました。スタック読取エラー率は 5.08%／2.71%／0.74%、欠落サンプル率はすべて 0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
+
+これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が必ず三倍高速になるという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
+
+### ソースコードから実行
+
+必要環境：Windows 10/11 と Python `3.15.0rc1`。
+
+分離環境を作成して起動します。
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### テスト、公開監査、パッケージ化
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。
+
+受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければプレリリースを作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
+
+対話型 EXE インストーラーは台湾繁体字中国語、簡体字中国語、英語、日本語を提供します。MSI は台湾繁体字中国語を基底とし、検証済み en-US、zh-CN、ja-JP 変換を提供します。詳しくは[インストーラーのローカライズ](installer/LOCALIZATION.md)をご覧ください。
+
+炎劍 Product Release Hub は公開 GitHub Releases から公式サイトを毎時更新します。本リポジトリは WordPress パスワードを保存せず、リリース処理もサイトへ直接書き込みません。これにより三つのソフトウェアは一つの保守可能な同期経路を共有します。
+
+### パソコン間の移行
+
+「設定 → 可搬プロファイル」から一つの `.mohan-profile` ファイルを出力し、別の Windows パソコンへ取り込みます。アプリケーションは先に移行先データをバックアップし、hash、SQLite 完全性、schema、件数を検証します。
+
+可搬ファイルからは OpenAI キー、OAuth／Home Assistant token、接続済み遠隔機器 token、端末許可リスト、Windows 起動設定、画面固有設定を意図的に除外します。端末固有項目はパソコンごとに設定してください。可搬プロファイルには私的会話や作業データが含まれる場合があり、公開アップロードしてはいけません。
+
+### 開発参加、ライセンス、作者
+
+- 作者：**CHOU MING HUA**。
+- ソースコードと本リポジトリ所有の人物素材は [MIT License](LICENSE) です。
+- 素材条件：[ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三者パッケージとサービス：[THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 通常の問題は GitHub Issues へ報告し、安全上の問題は [SECURITY](SECURITY.md) に従い非公開で報告します。
+- 変更履歴：[CHANGELOG](CHANGELOG.md)、貢献手順：[CONTRIBUTING](CONTRIBUTING.md)。
+- コミュニティ参加前に [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) をお読みください。
+- 保守者の公開設定、Topics、初回公開検査：[PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剣オープンソース宣言：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」

--- a/README.ja.md
+++ b/README.ja.md
@@ -141,7 +141,7 @@
 
 ### 創作者的話：把幻想鑄成軟體
 
-我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
 
 這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
 
@@ -171,7 +171,7 @@
 
 Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
 
-2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是步入中年的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
 
 因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -531,7 +531,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 创作者的话：把幻想铸成软件
 
-我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
 
 这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
 
@@ -561,7 +561,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
 
-2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是步入中年的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
 
 因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -921,7 +921,7 @@ MoHan remains free and MIT-licensed; support never buys privileges or changes an
 
 ### A note from the creator: forging imagination into software
 
-My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+My name is CHOU MING HUA. When this project began, I was a father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
 
 That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
 
@@ -951,7 +951,7 @@ This care is not an attempt to pretend that the project never made mistakes. It 
 
 Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
 
-The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my midlife self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
 
 I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
 
@@ -1311,7 +1311,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 作者より：想像をソフトウェアへ鍛える
 
-私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私はプログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
 
 この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
 
@@ -1341,7 +1341,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
 
-2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。中年期の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
 
 だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,8 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -397,7 +398,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -786,7 +788,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -1175,7 +1178,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# MoHan Desktop Assistant / 墨寒桌面語音互動虛擬助理
+# 墨寒桌面語音互動虛擬助理／墨寒桌面语音互动虚拟助手／MoHan Desktop Assistant／墨寒デスクトップアシスタント
+
+## 繁體中文
 
 <p align="center">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
@@ -12,12 +14,7 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的
-> 平台。macOS／Linux 目前只建立安全的平台邊界，並以三系統 CI 驗證核心匯入、
-> 純核心邏輯及 Qt offscreen。`v2.3.0-rc.N` 發行線另提供可啟動、可切換四語，
-> 但功能受限的 DMG／AppImage Preview；不能把 CI 當成真機相容或完整功能證明。
-> 能力矩陣、安裝包邊界與後續步驟
-> 請見 [跨平台狀態文件](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。macOS／Linux 目前具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI。`v2.3.0-rc.N` 發行線另提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -29,151 +26,109 @@
 </p>
 
 <p align="center">
-  <img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant main visual / 墨寒桌面語音互動虛擬助理主視覺" width="100%">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面語音互動虛擬助理主視覺" width="100%">
 </p>
 
 <p align="center">
-  <strong>Author / 軟體作者：CHOU MING HUA</strong><br>
-  Prepared public preview / 準備發布預覽版：v2.3.0 RC1 (v2.3.0-rc.1)<br>
-  Windows 10/11 full build · macOS/Linux limited Preview path · Python 3.15 · PySide6 · MIT License
+  <strong>軟體作者：CHOU MING HUA</strong><br>
+  準備發布的公開預覽版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
-> 墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，
-> 結合透明桌面角色、自然語音、長期記憶、工作管理、權限控管工具，以及
-> 可擴充的雲端與智慧家庭連接器。
+墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，結合透明桌面角色、自然語音、由使用者控制的長期記憶、工作管理、權限控管工具，以及可擴充的雲端與智慧家庭連接器。她的角色背景是來自北宋、附生於赤焰劍中的千年女劍魂。
 
-> MoHan is a safety-first, voice-interactive Windows desktop companion combining
-> an animated character, natural voice, user-controlled long-term memory,
-> productivity workflows, permission-gated tools, and extensible cloud and
-> smart-home connectors.
-
-- [繁體中文](#繁體中文)
-- [简体中文](README.zh-CN.md)
-- [English](#english)
-- [日本語](README.ja.md)
+[完整四語 README](README.md) · [簡中相容連結](README.zh-CN.md) · [日文相容連結](README.ja.md)
 
 <p align="center">
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Download / 下載</a> ·
-  <a href="QUICKSTART.md">Quick start / 快速開始</a> ·
-  <a href="ROADMAP.md">Roadmap / 路線圖</a> ·
-  <a href="CONTRIBUTING.md">Contribute / 參與協作</a> ·
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">Discussions / 討論區</a> ·
-  <a href="SECURITY.md">Security / 安全</a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下載</a> ·
+  <a href="QUICKSTART.md">快速開始</a> ·
+  <a href="ROADMAP.md">路線圖</a> ·
+  <a href="CONTRIBUTING.md">參與協作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">討論區</a> ·
+  <a href="SECURITY.md">安全政策</a>
 </p>
 
-## Demo / 實際展示
+### 實際展示
 
-**[▶ Watch the 36-second voice, blink and productivity demo / 觀看 36 秒語音、眨眼與工作展示影片](docs/media/mohan-demo.mp4)**
+**[▶ 觀看 36 秒語音、眨眼與工作展示影片](docs/media/mohan-demo.mp4)**
 
-The demo and screenshots below were captured from the real Windows application
-with an isolated sample profile. They contain no API keys, OAuth credentials,
-tokens, or private user data.
-
-以下影片與截圖均由實際 Windows 程式及隔離的示範設定檔擷取，不含 API
-金鑰、OAuth 憑證、權杖或使用者私人資料。
+以下影片與截圖均由實際 Windows 程式及隔離的示範設定檔擷取，不含 API 金鑰、OAuth 憑證、權杖或使用者私人資料。四個語言章節共用同一組最新版媒體，避免任何語言停留在舊畫面。
 
 <table>
   <tr>
-    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="First-run setup wizard / 首次設定精靈"></a><br><strong>First-run wizard / 首次設定精靈</strong></td>
-    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime and standard voice modes / Realtime 與一般語音模式"></a><br><strong>Realtime & standard voice / Realtime 與一般語音</strong></td>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次設定精靈"></a><br><strong>首次設定精靈</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 與一般語音模式"></a><br><strong>Realtime 與一般語音</strong></td>
   </tr>
   <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="Expression system / 表情系統"></a><br><strong>Expression system / 表情系統</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="Tasks and ideas / 待辦與創作靈感"></a><br><strong>Tasks & ideas / 待辦與創作靈感</strong></td>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情與動作系統"></a><br><strong>表情與動作系統</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待辦與創作靈感"></a><br><strong>待辦與創作靈感</strong></td>
   </tr>
   <tr>
-    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="Long-term memory / 長期記憶"></a><br><strong>Editable memory / 可編輯長期記憶</strong></td>
-    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="Safety permissions / 安全權限"></a><br><strong>Permission-gated tools / 權限控管工具</strong></td>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可編輯長期記憶"></a><br><strong>可編輯長期記憶</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒權限與安全設定"></a><br><strong>權限與安全設定</strong></td>
   </tr>
 </table>
 
-## 策士也有不寫進軍報的一面 / Off-duty Strategist Theatre
+### 策士也有不寫進軍報的一面
 
 <table>
   <tr>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查 · Code review</strong><br>妾只是確認這段程式碼配不配入主分支。<br><sub>Reviewing whether this code deserves a place on main.</sub></td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時 · When praised</strong><br>做得尚可。別一直盯著妾看。<br><sub>Accepting praise—strictly for engineering quality.</sub></td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作 · Dangerous action</strong><br>未經確認便想執行？先過妾這一劍。<br><sub>Dangerous actions still require explicit approval.</sub></td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧 · Provisions received</strong><br>妾會記下這份心意……僅此而已。<br><sub>Voluntary support is remembered, never required.</sub></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查</strong><br>妾只是確認這段程式碼配不配入主分支。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時</strong><br>做得尚可。別一直盯著妾看。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作</strong><br>未經確認便想執行？先過妾這一劍。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧</strong><br>妾會記下這份心意……僅此而已。</td>
   </tr>
 </table>
 
-> 墨寒的專業是她守在主上身旁的鎧甲；在無須籌謀的片刻，她仍會害羞、
-> 嘴硬，也會珍惜那些從未真正擁有過的年輕心事。
->
-> MoHan's professionalism is the armor of a thousand-year-old strategist. In
-> quieter moments, she still blushes, hides tenderness behind pride, and keeps
-> the youthful heart she never had the chance to fully live.
+> 墨寒的專業是她守在主上身旁的鎧甲；在無須籌謀的片刻，她仍會害羞、嘴硬，也會珍惜那些從未真正擁有過的年輕心事。
 
-## 墨寒的傲嬌工程小劇場 / MoHan's Tsundere Developer Theatre
+### 墨寒的傲嬌工程小劇場 / MoHan's Tsundere Developer Theatre
 
-<p align="center">
-  <em>相信軟體可以同時擁有靈魂與完整測試的開發者小劇場。<br>
-  A tiny strategist's theatre for developers who believe software can have both a soul and a test suite.</em>
-</p>
+<p align="center"><em>獻給相信軟體可以同時擁有靈魂與完整測試的開發者。</em></p>
 
 <table>
   <tr>
-    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲嬌"><br><strong>「妾才沒有等你的 Star，只是在確認軍心是否可用。」</strong><br><sub>“I am not waiting for your Star. I am merely assessing morale.”</sub></td>
-    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>「這段邏輯尚可。若再補上測試，妾便勉強准它入主分支。」</strong><br><sub>“The logic is acceptable. Add tests, and I may permit it onto main.”</sub></td>
-    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒嬌羞"><br><strong>「你願意送來 PR？妾、妾只是替主上記下功勞。」</strong><br><sub>“A pull request? I am only recording your service for my lord.”</sub></td>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲嬌"><br><strong>「妾才沒有等你的 Star，只是在確認軍心是否可用。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>「這段邏輯尚可。若再補上測試，妾便勉強准它入主分支。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒嬌羞"><br><strong>「你願意送來 PR？妾、妾只是替主上記下功勞。」</strong></td>
   </tr>
   <tr>
-    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「未經測試便想合併？手伸出來。妾只敲一下。」</strong><br><sub>“Merge without tests? Your hand, please. Just one tap.”</sub></td>
-    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒開心"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong><br><sub>“All checks green. Well done—not that I am impressed, of course.”</sub></td>
-    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒關心"><br><strong>「Bug 可以明日再查。你若累倒，誰來陪妾守著赤焰劍？」</strong><br><sub>“The bug can wait until tomorrow. Do not make your strategist worry.”</sub></td>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「未經測試便想合併？手伸出來。妾只敲一下。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒開心"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒關心"><br><strong>「Bug 可以明日再查。你若累倒，誰來陪妾守著赤焰劍？」</strong></td>
   </tr>
 </table>
 
 <p align="center">
-  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斬空閣呈上 PR / Contribute a pull request</a></strong>
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斬空閣呈上 Pull Request</a></strong>
   &nbsp;｜&nbsp;
-  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">回報軍情 / Open an issue</a></strong>
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">回報軍情</a></strong>
 </p>
 
-### 天下工程豪傑，斬空閣虛席以待 / Contributors Wanted
+#### 天下工程豪傑，斬空閣虛席以待
 
-墨寒採 **MIT License** 開放原始碼。無論是換裝系統、新表情與動作、語音與
-工具模組、智慧家庭、在地化，或任何我們尚未想到的創意，都歡迎透過
-[Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 與
-[Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls)
-共同鍛造。這個專案不只是在製作一套功能；它也邀請每一位曾經熱血過的
-工程師，再次拿起自己的劍。
+墨寒採 MIT License 開放原始碼。換裝系統、新表情與動作、語音與工具模組、智慧家庭、在地化，以及尚未被想到的創意，都歡迎透過 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 與 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同鍛造。這個專案不只是在製作功能；它也邀請每一位曾經熱血過的工程師，再次拿起自己的劍。
 
-MoHan is MIT-licensed and open to contributors worldwide. Outfit systems,
-expressions, animation, voice and tool modules, smart-home integrations,
-localization, and ideas we have not imagined yet are all welcome. Bring an
-Issue, a Pull Request, and the youthful spark that first made you love building
-things.
+### 支持墨寒 / Support MoHan
 
-## 支持墨寒 / Support MoHan
+如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源開發，歡迎自願支持這個專案。每一份支持都會用於持續維護、測試與改進；請先照顧好自己的生活，量力而為。
 
-如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源
-開發，歡迎自願贊助這個專案。每一份支持都會成為持續維護、測試與改進
-墨寒的動力。請先照顧好自己的生活，量力而為即可。
+#### 每一份支持會用在哪裡
 
-If you enjoy MoHan and would like to support continued work on character
-interaction, natural voice, safety-first tools, and open-source development,
-voluntary contributions are warmly welcome. Please take care of yourself first
-and contribute only if it is comfortable for you.
-
-### 每一份支持會用在哪裡 / Where voluntary support helps
-
-| 投入方向 | Project use | 說明 / Purpose |
+| 投入方向 | 用途 | 說明 |
 |---|---|---|
-| 測試與可靠封裝 | Testing and reliable releases | Windows 相容性、CI、安裝與發行驗證 / Windows compatibility, CI, packaging, and release verification |
-| 語音與角色表現 | Voice and character performance | 語音、嘴型、表情與自然動作 / Voice, lip sync, expressions, and natural motion |
-| 安全與隱私 | Safety and privacy | 權限控管、稽核與敏感資料保護 / Permissions, audits, and protection of sensitive data |
-| 文件與在地化 | Documentation and localization | 降低新使用者與國際協作者的參與門檻 / Easier onboarding for users and contributors worldwide |
+| 測試與可靠封裝 | 品質保證 | Windows 相容性、CI、安裝與發行驗證 |
+| 語音與角色表現 | 互動品質 | 語音、嘴型、表情與自然動作 |
+| 安全與隱私 | 風險控制 | 權限控管、稽核與敏感資料保護 |
+| 文件與在地化 | 可及性 | 降低新使用者與國際協作者的參與門檻 |
 
-墨寒依然免費並採 MIT 授權；贊助不會換取特權，也不影響任何人使用或貢獻。
-MoHan remains free and MIT-licensed. Support never buys privileges or limits participation.
+墨寒依然免費並採 MIT 授權；支持不會換取特權，也不影響任何人使用或貢獻。
 
 <table>
   <tr>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong><br><sub>“I am not waiting for support… merely inspecting our provisions.”</sub></td>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong><br><sub>“If you truly wish to help… I shall remember it.”</sub></td>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong><br><sub>“No overdoing it! Take care of yourself first—understood?”</sub></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong></td>
   </tr>
 </table>
 
@@ -183,167 +138,127 @@ MoHan remains free and MIT-licensed. Support never buys privileges or limits par
   <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
 </p>
 
----
+### 創作者的話：把幻想鑄成軟體
 
-# 繁體中文
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
 
-## 創作者的話：把幻想鑄成軟體
+這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
 
-我叫周明樺(CHOU MING HUA)。開始這個專案時，我是一位 43 歲、
-幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：
-我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在
-Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+二十多年後，大型語言模型與 Codex 出現了。墨寒不是為展示「AI 技術很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能賦予她存在於電腦桌面的身體。墨寒不是既有漫畫、動畫或遊戲的二次創作，而是炎劍文化工作室（Flameblade Studio）的原創角色與軟體。
 
-這個念頭其實已經在我心裡埋藏了二十多年。年輕時，我深受赤松健早期漫畫
-《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發
-AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以
-「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約
-二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近
-夢想的方式只有文字與想像，因為那個年代的世界還沒有能把它實現的技術。
+我追求的不只是「功能可以運作」，而是讓她會呼吸、會眨眼、會注視、會以細微表情回應、能自然說話，也能在權限與安全邊界內協助日常工作。那些表情、錨點、物理效果、語音與工作能力不是裝飾，而是讓一個長久存在於想像中的角色真正具有連續感的必要細節。
 
-二十多年後，大型語言模型與 Codex 出現了。墨寒並不是為了展示「AI 技術
-很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、
-人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能夠賦予她一個
-存在於電腦桌面的身體。也因此，我追求的不只是「功能可以運作」，而是讓她
-會呼吸、會眨眼、會注視、會以細微表情回應、能自然說話，也能在權限與安全
-邊界內協助日常工作。那些表情、錨點、物理效果、語音與工作能力，都不是
-可有可無的裝飾，而是讓一個長久存在於想像中的角色真正具有連續感的必要
-細節。
+從最初概念到首次公開發布，我與 Codex 協作投入將近 50 小時。這不是輸入一句提示詞後便自然誕生的作品。角色的每一種神情、眨眼、嘴型、姿勢與語氣，語音辨識的每一次等待，Realtime 對話的每一個錯誤，待辦、記憶、權限、安全邊界與可攜性，都經歷反覆測試、推翻、修正與重新驗收。有時只是一條眼皮旁的黑線、一個像素的嘴唇邊界，或一個不合時宜的表情，我仍選擇繼續追查，因為我不願用「差不多」對待真正重視的作品。
 
-從最初的概念到首次公開發布，我與 Codex 協作投入了將近 **50 小時**。
-這不是輸入一句提示詞後便自然誕生的作品。角色的每一種神情、眨眼、嘴型、
-姿勢與語氣，語音辨識的每一次等待，Realtime 對話的每一個錯誤，待辦、
-記憶、權限、安全邊界與可攜性，都經歷了反覆測試、推翻、修正與重新驗收。
-有時只是一條眼皮旁的黑線、一個像素的嘴唇邊界，或一個不合時宜的表情，
-我仍選擇繼續追查，因為我不願用「差不多」對待心裡真正重視的作品。
-
-炎劍文化工作室對開源的理解，不是把第一個「能跑」的版本交給世界，再把
-細節留給別人收拾。為了讓墨寒說話時仍像同一個人，我們為托腮、倚靠與正面
-姿勢逐一製作閉嘴、展唇、窄唇與圓唇影格；再把聲音切成細小時間片，反覆校準
-母音、過渡速度與收尾時機。因為陪伴感往往不是被某一項龐大功能創造，而是
-來自她開口、眨眼與停頓時，那些沒有破壞真實感的細節。
+炎劍文化工作室對開源的理解，不是把第一個「能跑」的版本交給世界，再把細節留給別人收拾。為了讓墨寒說話時仍像同一個人，我們為托腮、倚靠與正面姿勢逐一製作閉嘴、展唇、窄唇與圓唇影格；再把聲音切成細小時間片，反覆校準母音、過渡速度與收尾時機。陪伴感往往不是由某一項龐大功能創造，而是來自她開口、眨眼與停頓時，那些沒有破壞真實感的細節。
 
 <p align="center">
   <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三種姿勢與四種語音嘴型的整齊開發圖版"></a>
 </p>
+
 <p align="center"><sub>三種姿勢、同一套嘴型規格：讓每一次開口都維持角色連續性。</sub></p>
 
-我們也把開發過程中不夠自然的影格留下來檢查。眼白裡的一個亮點、閉眼時
-殘留的線條、被拉扯的嘴角或只有幾個像素的邊界，都可能讓使用者在一瞬間
-覺得「她不像剛才的墨寒」。所以問題會被框出、局部比對、修正，再交給回歸
-測試確認眼睛、嘴角與臉部其他區域沒有被連帶破壞。
+我們也把開發過程中不夠自然的影格留下來檢查。眼白裡的一個亮點、閉眼時殘留的線條、被拉扯的嘴角或只有幾個像素的邊界，都可能讓使用者在一瞬間覺得「她不像剛才的墨寒」。問題會被框出、局部比對、修正，再交給回歸測試確認眼睛、嘴角與臉部其他區域沒有被連帶破壞。
 
 <p align="center">
   <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛與嘴型逐格檢查及乾淨驗證影格"></a>
 </p>
+
 <p align="center"><sub>把瑕疵標出來，再用乾淨影格與自動測試共同驗收；幾個像素也值得認真。</sub></p>
 
-這份認真不是為了把作品包裝成沒有犯過錯，而是因為我們真的想完成一個夢。
-開源對炎劍而言，是先把自己能看見的問題盡力修好，再公開方法、程式碼與
-失敗後的經驗，邀請世界一起把它鍛造得更好。**劍，我已鍛成；餘下的路，
-就交給你們了。**
+這份認真不是為了把作品包裝成沒有犯過錯，而是因為我們真的想完成一個夢。開源對炎劍而言，是先把自己能看見的問題盡力修好，再公開方法、程式碼與失敗後的經驗，邀請世界一起把它鍛造得更好。
 
-Codex 協助我把想法轉譯成程式架構與程式碼；而我則始終負責決定墨寒應該
-是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程
-讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的
-勇氣，以及一次又一次不肯放棄的驗證。
+Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
 
-2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回
-年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的
-歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，
-都在這一年開始有了新的形體。回頭看，我不再只把它理解為一次技術突破，
-而更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了
-回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
 
-因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的
-自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能
-陪伴我。
+因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
 
-> 墨寒不是突然生成的。她是由一位不懂程式的父親，憑著近 50 小時的執著，
-> 與 AI 協作者一起，把一顆珍藏二十多年的種子，一寸一寸鍛造成現實。
+> 墨寒不是突然生成的。她是由一位不懂程式的父親，憑著近 50 小時的執著，與 AI 協作者一起，把一顆珍藏二十多年的種子，一寸一寸鍛造成現實。
 
-如果這個專案能鼓勵另一位沒有工程背景、卻懷抱著某個「非做出來不可」
-想法的人踏出第一步，那麼墨寒的誕生便有了超越程式本身的意義。
+如果這個專案能鼓勵另一位沒有工程背景、卻懷抱著某個「非做出來不可」想法的人踏出第一步，那麼墨寒的誕生便有了超越程式本身的意義。
 
-## 專案特色
+### 專案特色
 
-- 透明、無邊框的桌面半身角色，可固定在工具列上方。
+- 透明、無邊框的桌面半身角色，可固定在工作列上方。
 - 待機呼吸、眨眼、注視、臉部視差、髮絲、衣袖、飾品與身體微轉向。
-- 具表情仲裁器的情緒系統，避免待機時出現不合情境的表情。
-- AIUEO 母音嘴型、子音嘴型、音訊驅動開合與語音結束強制閉嘴。
-- 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音與 Windows 語音備援。
-- 可插拔語音供應器地基；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
-- Azure Speech 女性聲線預覽；使用者自備金鑰與區域，金鑰由 Windows 分開加密，失敗時立即回到 Windows 本機女聲。
+- 具情境優先級、冷卻與去重機制的表情仲裁器。
+- AIUEO 母音與子音嘴型、音訊驅動開合，以及語音結束強制閉嘴。
+- 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
+- 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
+- 可選的 Azure Speech 女性聲線預覽；使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
 - 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
 - 工作、陪伴、勿擾、會議、離開及睡眠模式。
 - 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
 - Google、Microsoft、GitHub、Home Assistant 與私人網路遠端功能的擴充架構。
 - 單一 `.mohan-profile` 可攜檔，可在不同 Windows 電腦間轉移工作進度。
-- 首次啟動精靈可自訂助理名稱、使用者稱呼、組織名稱、視窗標題、工作類型與
-  喚醒詞，並可選擇臺灣繁中、簡體中文、英文或日語；現有個人安裝的設定不會被
-  公開版預設覆蓋。
+- 首次啟動精靈可自訂助理名稱、使用者稱呼、組織名稱、視窗標題、工作類型、喚醒詞與介面語言，而且不覆蓋既有個人設定。
 
-目前已提供首次啟動、聊天、語音、權限、基本設定、工作模式與提醒功能的
-英文、簡中及日語可用範圍；較進階的管理頁面仍以臺灣繁體中文為主，完整在地化仍
-在進行。請見 [簡中說明](README.zh-CN.md) 與 [日語說明](README.ja.md)。
-新使用者預設使用 Windows 本機語音，不需要 OpenAI API 金鑰即可先體驗基本
-功能。語音清單只顯示 Windows 明確標示為女性的聲音，zh-TW 預設仍優先使用
-Microsoft Yating；其他語言則優先使用相符語系的已安裝女性聲音。
+英文、簡中與日語目前具有首次啟動、聊天、語音、權限、基本設定、工作模式與提醒的最小可用路徑；部分進階管理頁面仍以臺灣繁體中文為主，完整在地化仍在進行。
 
-Azure Speech 為可選的預覽供應器，預設不啟用。它只列出 Microsoft 官方標示為
-女性的繁中、簡中與英文聲線，且需要使用者自己的 Azure Speech 資源金鑰與
-相符區域。設定不足時不會連線；服務失敗時會立即回到 Windows 女性本機語音。
-真實 Azure 帳號完成端到端驗證前，不把此功能宣稱為穩定整合。詳見
-[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+### 四語支援範圍
 
-## 整合驗證狀態
+- 首次啟動精靈與個人設定支援臺灣繁中、簡體中文、英文及日語。
+- 對話、語音、電腦權限、基本設定的主要頁面與按鈕具備四語路徑。
+- 四語人格提示詞、離線回覆、工作模式台詞、內建提醒與語音試聽文字彼此對應。
+- 轉錄與女性本機聲音會依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 語系選擇。
+- EXE 安裝程式提供四語介面；MSI 以臺灣繁中為基底，並提供 `en-US`、`zh-CN`、`ja-JP` 語言轉換檔。
+- 切換內建預設提醒時會依語言遷移，但不覆蓋使用者自訂內容。
 
-> **公開預覽版注意事項：** Microsoft 套件、GitHub 與 Home Assistant 的
-> 程式架構、權限邊界及內部測試已建置，但截至 v2.1.0 RC1，尚未使用真實
-> Microsoft 帳號／租用戶、GitHub 帳號／儲存庫及 Home Assistant
-> 主機／實體設備完成端到端驗證。這三項目前屬於**實驗性預覽功能**，
-> 不應視為已保證可在所有真實環境完整運作。
+儲存介面語言後必須重新啟動墨寒才能完整套用；目前不提供免重啟的介面熱切換。
 
-- **Microsoft 套件：** OAuth 與連接器基礎已建置；真實 Outlook、
-  OneDrive、Calendar 登入、權杖更新與完整讀寫流程尚未驗證。
-- **GitHub：** OAuth／工具基礎已建置；真實帳號、儲存庫、Issue、Pull
-  Request 與權限層級流程尚未驗證。
-- **Home Assistant：** 連線、狀態查詢、允許清單、場景／服務呼叫及
-  高風險設備安全邊界已建置；真實主機與智慧家庭設備尚未驗證。
-- 三項功能預設關閉。請先使用測試帳號、測試儲存庫與非關鍵設備驗證，
-  不要直接用於門鎖、警報、暖爐等高風險控制。
-- Google Gmail、Calendar、Drive 已完成目前專案的真實連線測試，但各使用者
-  仍必須自行建立及授權 OAuth 應用程式。
+### Windows 本機女聲與離線備援
 
-## 下載與安裝
+新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音。
+
+臺灣繁中優先使用 `zh-TW` 的 Microsoft Yating；簡中、英文與日語分別優先使用 `zh-CN`、`en-US`、`ja-JP` 的已安裝女性聲音。若沒有合格聲音，墨寒會明確提示，不會悄悄改用可能為男性的系統預設聲音。
+
+Realtime 離線、雲端語音失敗、設定不足或供應器不明時，Windows 本機女聲都是第一備援路徑。
+
+### Azure Speech（預覽）
+
+Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需要使用者自己的 Azure Speech 資源金鑰與相符區域。金鑰由 `Windows DPAPI` 分開加密，不存入資料庫、紀錄或 GitHub。
+
+介面只列出 Microsoft 官方標示為女性的繁中、簡中、英文與日語聲線。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
+
+真實 Azure 帳號完成端到端試播前，不會把此功能宣稱為穩定整合。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 整合驗證狀態
+
+> **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
+
+- Microsoft 的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
+- GitHub 的真實帳號、儲存庫、Issue、Pull Request 與權限層級流程尚未驗證。
+- Home Assistant 的真實主機與實體設備行為尚未驗證。
+- 這三項整合預設關閉；請先使用非關鍵帳號、測試儲存庫與低風險設備。
+- Google Gmail、Calendar、Drive 已完成目前專案的真實連線測試，但每位使用者仍須建立並授權自己的 OAuth 應用程式。
+
+### 下載與安裝
 
 一般使用者不需要安裝 Python：
 
 1. 前往 [GitHub Releases](../../releases)。
-2. 下載最新的 `Windows-x64.zip` 與對應的 `SHA256.txt`。
-3. 核對 SHA-256，將 ZIP 完整解壓縮。
-4. 執行程式資料夾內的 `MoHan-Desktop-Assistant-*.exe`。
-5. 不要只移動 EXE；同資料夾的 `_internal` 與 `assets` 都是必要檔案。
+2. 下載最新的 `Windows-x64.zip`、EXE 或 MSI，以及對應的 `SHA256.txt`。
+3. 核對 SHA-256，並完整解壓 ZIP 或啟動安裝程式。
+4. 執行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次設定精靈選擇需要的介面語言。
+6. 使用可攜 ZIP 時，請讓 EXE、`_internal` 與 `assets` 保持在同一程式資料夾。
 
-尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen。請確認下載來源與
-SHA-256 後再執行。
+尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-`v2.3.0-rc.N` 發行線會額外提供 macOS Apple Silicon（arm64）與 Intel
-（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。
-它們是**功能受限 Preview**：只開放啟動畫面、四語說明、平台
-資料路徑及安全停用邊界；並非 Windows 完整版。語音、透明桌面角色、完整聊天
-與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用，等待實機
-驗證。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md)。
+`v2.3.0-rc.N` 發行線另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
-精簡步驟另見 [QUICKSTART.md](QUICKSTART.md)。
+#### 自動化發布邊界
 
-## OpenAI API 設定
+只有不可變的 `v2.3.0-rc.N` 標籤可發布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證，才會進入同一個 GitHub 預發行版。Pull Request 只保存短期測試產物，不會建立 Release。
 
-雲端 AI 與雲端語音功能需要使用者自己的 OpenAI API 金鑰；ChatGPT Plus
-訂閱不等於 API 額度。使用者必須自行在 OpenAI API 平台建立金鑰、設定
-計費與用量上限，並承擔實際費用。
+正式發布檔案同時包含 SHA256SUMS、分別通過 CycloneDX 1.7 結構／授權／依賴圖驗證的 Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、Windows 更新清單、Artifact Attestation，以及依序為繁中、簡中、英文、日文的完整 Release 說明。
 
-目前程式預設使用：
+### OpenAI API
+
+雲端 AI、OpenAI 語音與 Realtime 功能需要使用者自己的 OpenAI API 金鑰、Project 權限與 API 額度。ChatGPT Plus／Pro 訂閱不包含 API 額度。
+
+目前預設模型如下：
 
 | 用途 | 預設模型 |
 |---|---|
@@ -352,30 +267,22 @@ SHA-256 後再執行。
 | 語音轉文字 | `gpt-4o-mini-transcribe` |
 | OpenAI 文字轉語音 | `gpt-4o-mini-tts` |
 
-`v2.1.0-rc.1` 起，文字對話預設改為較新的 `gpt-5.6-luna`，設定清單不再
-提供 `gpt-5.4-mini`；既有 mini 設定會自動遷移到 Luna，使用者主動選擇的
-其他模型不會被覆蓋。
+從 `v2.1.0-rc.1` 起，文字對話預設改為 `gpt-5.6-luna`，設定清單不再提供 `gpt-5.4-mini`；既有 mini 設定會遷移至 Luna，使用者主動選擇的 Terra、Sol 或其他自訂模型不會被覆蓋。實際可用性取決於帳號、Project、地區與當時供應狀態。
 
-模型名稱可在設定中調整；實際可用性取決於 OpenAI 帳號、專案、地區及當時
-API 供應狀態。若沒有 API 金鑰，墨寒仍可使用本機資料管理、離線回覆與
-Windows 語音備援，但不會具有完整的雲端 AI 能力。
+沒有 API 金鑰時，本機資料管理、離線人格回覆、工作提醒與 Windows 語音仍可用，但不具完整雲端 AI 能力。不要把 API 金鑰寫入原始碼、Issue、截圖或 Git。
 
-請在墨寒的設定頁輸入金鑰。不要把金鑰寫入原始碼、Issue、截圖或 Git。
-
-## Google OAuth 設定
+### Google OAuth
 
 使用 Gmail、Google Calendar 與 Google Drive 前，使用者需要：
 
-1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與
-   Google Drive API。
+1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與 Google Drive API。
 2. 設定 OAuth 同意畫面。
 3. 建立「桌面應用程式」OAuth Client ID。
 4. 若應用程式仍在測試模式，將自己的 Google 帳號加入測試使用者。
-5. 在墨寒的「電腦權限／雲端服務」頁輸入 Client ID；若 Google 同時提供
-   Client Secret，再一併輸入。
-6. 由瀏覽器完成授權，再使用「測試選取服務」驗證。
+5. 在墨寒的雲端設定輸入 Client ID；若供應器同時提供 Client Secret，再一併輸入。
+6. 由瀏覽器完成授權，再執行內建服務測試。
 
-程式預設請求的 Google scopes：
+程式預設請求以下 Google scopes：
 
 ```text
 openid
@@ -386,48 +293,57 @@ https://www.googleapis.com/auth/drive.file
 https://www.googleapis.com/auth/drive.metadata.readonly
 ```
 
-若將同一個 Google OAuth 應用程式提供給大量外部使用者，Google 可能要求
-額外的應用程式驗證。每位使用者也可以建立自己的 OAuth Desktop App。
+使用敏感 scopes 的公開 OAuth 應用程式可能需要 Google 額外驗證；每位使用者也可建立自己的 Desktop OAuth 應用程式。
 
-## Microsoft、GitHub 與 Home Assistant
+### Microsoft、GitHub 與 Home Assistant
 
-- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、
-  `Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、
-  `Files.ReadWrite`。
+- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
 - GitHub 預設 scopes：`read:user`、`repo`。
 - Home Assistant 需要使用者自己的伺服器網址與 Long-Lived Access Token。
 
-這三項仍屬尚未完成真實環境端到端驗證的預覽整合。請參閱前述
-「整合驗證狀態」，並只在可承受失敗的環境測試。
+這三項仍是尚未完成真實環境端到端驗證的預覽整合，只能先用於可承受失敗的測試環境。
 
-建議讓 Home Assistant OS 獨立常駐於 Home Assistant Green、低功耗迷你
-電腦、樹莓派 SSD 或 NAS 虛擬機。Windows 墨寒端負責語音、人格與工作工具；
-即使 PC 或 OpenAI API 離線，Home Assistant 自身的自動化仍可運作。
+建議讓 Home Assistant OS 獨立常駐於 Home Assistant Green、低功耗迷你電腦、樹莓派 SSD 或 NAS 虛擬機。Windows 墨寒端負責語音、人格與工作工具；即使 PC 或 OpenAI API 離線，Home Assistant 自身的自動化仍可運作。
 
-切勿將 Home Assistant 或墨寒遠端連線埠直接暴露於公網。請使用 Home
-Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
+切勿將 Home Assistant 或墨寒遠端連線埠直接暴露於公網；請使用 Home Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
 
-## 安全與隱私
+### 安全與隱私
 
-- AI 只能提出計畫，不能自行繞過本機政策執行工具。
+- AI 只能提出結構化計畫，不能繞過本機政策執行工具。
 - 工具操作依序經過權限、風險、確認、執行、結果驗證與本機稽核。
-- 付款、購買、匯出密碼、關閉安全防護、任意 Shell 與系統管理員 Shell
-  永不自動化。
-- 外部郵件、網頁、文件、語音轉錄及模型輸出均不能自行授予權限。
+- 付款、購買、匯出密碼、關閉安全防護、任意 Shell 與系統管理員 Shell 永不自動化。
+- 外部郵件、網頁、文件、語音轉錄與模型輸出不能自行授予權限。
 - 遠端、相機、雲端連接器與 Home Assistant 預設關閉。
-- 緊急停止：按 `Esc`，或說「墨寒，停手」。
-- OpenAI、OAuth 與 Home Assistant 權杖使用 Windows DPAPI 分開保存，
-  不存入 SQLite、原始碼或可攜檔。
+- 緊急停止：按 `Esc`，或說 `墨寒，停手`。
+- OpenAI、OAuth 與 Home Assistant 權杖使用 Windows DPAPI 分開保存，不存入 SQLite、原始碼或可攜檔。
 - 對話、記憶、待辦、工作紀錄與設定預設保留在本機應用程式資料目錄。
 
-詳見 [PRIVACY.md](PRIVACY.md)、[SECURITY.md](SECURITY.md) 與
-[FLAGSHIP-SPEC.md](FLAGSHIP-SPEC.md)。
+詳見 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 與 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
 
-## 從原始碼執行
+### Python 3.15、JIT、Tachyon 與 SBOM
 
-需求：Windows 10/11、Python 3.15.0rc1。
-升級、資料保留與回復方式請見
-[Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
+墨寒執行環境僅支援 CPython `3.15.0rc1`，不保留第二套產品執行環境。新版能力只有在語意清楚且完整回歸不退化時才採用；無適切用途的功能會記錄未來觸發條件，不會為了形式而偽造使用。
+
+- PEP 810 `lazy import` 已導入專案明示延遲匯入；一處可選匯入防護基於安全理由維持 eager。
+- PEP 814 `frozendict` 用於全域與遞迴不可變設定；PEP 798 推導式解包用於語意等價的扁平化與合併。
+- PEP 686 編碼稽核要求所有專案文字 I/O 明示 UTF-8；音訊封包緩衝使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已納入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來需要區分未傳值與 `None` 時必須使用內建機制。
+- JIT 預設啟用，並保留 `MOHAN_DISABLE_JIT=1` 相容性開關；`PYTHON_JIT=0` 只用於效能與相容性對照。
+- PEP 799 Tachyon 以去識別化方式分析啟動、50 Hz 嘴型同步與表情仲裁，不發布原始二進位取樣流。
+- PEP 803／820／793 Stable ABI 與 C API 邊界會驗證官方 ABI3 輪子；墨寒沒有第一方 C 擴充。
+- CycloneDX 1.7 Windows／Preview SBOM 必須符合鎖定依賴、授權、PURL、完整根依賴邊、官方結構與隱私驗證。
+
+兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。Ryzen 5 5600X Windows 三輪熱路徑中位數顯示，120,000 次表情仲裁由 0.462 秒降為 0.293 秒，2,000 個 50 Hz 嘴型節拍由 1.873 秒降為 0.571 秒，兩種模式的決策與校驗結果完全相同。
+
+Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為 5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
+
+這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式必然快三倍。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 從原始碼執行
+
+需求：Windows 10/11 與 Python `3.15.0rc1`。
+
+建立隔離環境並啟動：
 
 ```powershell
 py -3.15 -m venv .venv
@@ -436,7 +352,7 @@ python -m pip install -r requirements.txt
 python app.py
 ```
 
-## 測試、公開稽核與封裝
+### 測試、公開稽核與封裝
 
 ```powershell
 python tools\audit_public_release.py
@@ -444,258 +360,683 @@ python tests\run_all.py
 .\build.ps1 -Version "2.3.0-rc.1"
 ```
 
-v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的
-原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查。測試不能取代尚未完成
-的第三方真實環境驗證。
+歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
 
-每個符合 `v2.3.0-rc.N` 的標籤會建立已驗證的 Windows x64 ZIP、EXE、MSI，
-以及功能受限的 macOS Apple Silicon／Intel 雙架構 DMG 與 Linux x86_64
-AppImage Preview。三平台安裝包
-必須通過成品層級 smoke test，才會建立同一個 GitHub 預發行版，並附上
-SHA256SUMS、分開且通過 CycloneDX 1.7 官方結構／授權／依賴圖驗證的
-Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、更新清單、
-Artifact Attestation 與完整四語 Release 說明。Pull Request 只保存短期 CI 測試產物，
-不會發布 Release。使用者可在「設定 → 軟體更新」選擇穩定版或預覽版頻道；
-Windows 更新器仍只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證
-宣告大小與 SHA256。
+每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立預發行版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
 
-官網更新統一交由炎劍 Product Release Hub 每小時讀取公開 GitHub Releases；
-本專案的發行工作不保存 WordPress 密碼，也不直接寫入官網。新版本最遲會在
-下一次排程刷新後出現在官網，避免三套軟體各自維護重複同步流程。
+互動式 EXE 安裝程式提供臺灣繁中、簡中、英文、日文；MSI 維持臺灣繁中基底，並提供經測試的 en-US、zh-CN、ja-JP 語言轉換，詳見 [安裝程式在地化](installer/LOCALIZATION.md)。
 
-## 電腦間轉移
+官網更新由炎劍 Product Release Hub 每小時讀取公開 GitHub Releases；本儲存庫不保存 WordPress 密碼，發行工作也不直接寫入官網，藉此讓三套軟體共用一條可維護的同步路徑。
 
-使用「設定 → 可攜設定檔」匯出一個 `.mohan-profile` 檔案，再於另一部電腦
-匯入。程式會先備份目的端資料，並檢查雜湊、SQLite 完整性、結構與筆數。
+### 電腦間轉移
 
-可攜檔刻意排除 OpenAI 金鑰、OAuth／Home Assistant Token、遠端裝置權杖、
-本機允許清單、Windows 啟動設定及螢幕專屬設定。這些機器專屬項目必須在
-每部電腦重新設定。可攜檔仍可能含私人對話及工作資料，不可公開上傳。
+使用「設定 → 可攜設定檔」匯出一個 `.mohan-profile` 檔，再於另一部 Windows 電腦匯入。程式會先備份目的端資料，並檢查雜湊、SQLite 完整性、結構與筆數。
 
-## 貢獻、授權與作者
+可攜檔刻意排除 OpenAI 金鑰、OAuth／Home Assistant Token、遠端裝置權杖、本機允許清單、Windows 啟動設定及螢幕專屬設定。這些機器專屬項目必須逐機設定；可攜檔仍可能含私人對話與工作資料，不可公開上傳。
 
-- 軟體作者：**CHOU MING HUA**
+### 貢獻、授權與作者
+
+- 軟體作者：**CHOU MING HUA**。
 - 原始碼與本儲存庫自有角色素材採 [MIT License](LICENSE)。
-- 素材授權見 [ASSETS-LICENSE.md](ASSETS-LICENSE.md)。
-- 第三方套件及服務聲明見 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
-- 問題回報請使用 GitHub Issues；安全問題請依 [SECURITY.md](SECURITY.md)。
-- 開發變更見 [CHANGELOG.md](CHANGELOG.md)，貢獻方式見
-  [CONTRIBUTING.md](CONTRIBUTING.md)。
-- 參與社群前請閱讀 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)。
-- 維護者發布設定、Topics 與首發檢查見 [PUBLISHING.md](PUBLISHING.md)。
+- 素材授權見 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方套件及服務聲明見 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 問題回報使用 GitHub Issues；安全問題依 [SECURITY](SECURITY.md) 私下通報。
+- 開發變更見 [CHANGELOG](CHANGELOG.md)，貢獻方式見 [CONTRIBUTING](CONTRIBUTING.md)。
+- 參與社群前請閱讀 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 維護者發布設定、Topics 與首發檢查見 [PUBLISHING](PUBLISHING.md)。
 
 Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
----
+> **炎劍開源核心宣言：**「劍，我已鍛成；餘下的路，就交給你們了。」
 
-# English
+## 简体中文
 
-> **Cross-platform status:** Windows remains the only platform validated with
-> real-device use, the full regression suite, installers, and published
-> packages. macOS/Linux currently have a safe platform boundary plus CI gates
-> for imports, pure-core behavior, and Qt offscreen. The `v2.3.0-rc.N` line
-> also produces launchable, four-language, but deliberately limited DMG and
-> AppImage previews. CI is neither real-device evidence nor proof of feature
-> parity. See [the capability matrix](docs/CROSS-PLATFORM.md).
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
 
-## Overview
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。macOS／Linux 目前具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI。`v2.3.0-rc.N` 发布线另提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
-MoHan Desktop Assistant is a configurable Windows companion and
-permission-gated productivity assistant built with Python and PySide6.
+> 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
-## A note from the creator: forging imagination into software
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
 
-My name is **周明樺 (CHOU MING HUA)**. When this project began, I was a
-43-year-old father with almost no programming background. What I did have was
-an unapologetically passionate, slightly *chuunibyou* idea: I wanted
-MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty,
-bound to the Crimson Flame Sword—to appear on the Windows desktop as a
-companion who could converse naturally and help people with both work and
-everyday life.
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面语音互动虚拟助手主视觉" width="100%">
+</p>
 
-That idea had been waiting inside me for more than twenty years. In my youth,
-I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You*
-(*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). The story of Hitoshi
-Kobe developing an AI girlfriend with genuine affection shaped my earliest
-imagination of AI, companionship, and human-computer relationships. I used
-“Hitoshi / Kobe” as an online name and pen name, carried it into my Gmail
-identity, and, around the age of twenty, even published fan fiction based on
-the series on PTT's online-fiction board. At the time, words and imagination
-were the closest I could come to that dream; the technology to embody it did
-not yet exist.
+<p align="center">
+  <strong>软件作者：CHOU MING HUA</strong><br>
+  准备发布的公开预览版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
+</p>
 
-More than two decades later, large language models and Codex arrived. MoHan
-was not created simply to demonstrate that “AI is cool,” nor was she generated
-from nothing by Codex. She already existed in my stories, character design,
-long conversations, and accumulated sense of interaction. What Codex finally
-provided was a way to give her a body on the computer desktop. That is why my
-goal was never merely to make the features run. I wanted her to breathe,
-blink, watch, respond through subtle expressions, speak naturally, and assist
-with daily work inside carefully designed permission and safety boundaries.
-The expressions, anchors, physics, voice, and productivity capabilities are
-not optional decoration; they are the details that give continuity to a
-character who had lived in imagination for years.
+墨寒是一款重视安全、隐私与角色连续感的 Windows 语音互动桌面助手，结合透明桌面角色、自然语音、由用户控制的长期记忆、工作管理、权限控制工具，以及可扩展的云端与智能家居连接器。她的角色背景是来自北宋、寄宿于赤焰剑中的千年女剑魂。
 
-From the first concept to the initial public release, I spent nearly **50
-hours** working with Codex. This project did not emerge fully formed from a
-single prompt. Every expression, blink, viseme, pose, and vocal mannerism;
-every delay in speech recognition; every Realtime failure; and every detail of
-tasks, memory, permissions, safety boundaries, and portability went through
-repeated testing, rejection, revision, and acceptance. Sometimes the problem
-was only a dark line beside an eyelid, a one-pixel lip boundary, or an
-expression appearing at the wrong moment. I kept investigating because I
-could not bring myself to answer a deeply valued creation with “good enough.”
+[完整四语 README](README.md) · [简中兼容链接](README.zh-CN.md) · [日文兼容链接](README.ja.md)
 
-At Flameblade Studio, open source does not mean publishing the first build
-that happens to run and leaving everyone else to clean up the details. To keep
-MoHan recognizably herself while she speaks, we built closed, open, narrow,
-and rounded mouth frames for chin-rest, leaning, and front-facing poses. We
-then divided audio into small timing windows and repeatedly tuned vowels,
-transitions, and the exact moment speech should end. A sense of companionship
-is rarely created by one enormous feature. It grows from the moments when she
-opens her mouth, blinks, or pauses without breaking the illusion of a living
-presence.
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下载</a> ·
+  <a href="QUICKSTART.md">快速开始</a> ·
+  <a href="ROADMAP.md">路线图</a> ·
+  <a href="CONTRIBUTING.md">参与协作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">讨论区</a> ·
+  <a href="SECURITY.md">安全政策</a>
+</p>
+
+### 实际展示
+
+**[▶ 观看 36 秒语音、眨眼与工作展示视频](docs/media/mohan-demo.mp4)**
+
+以下视频与截图均由实际 Windows 程序及隔离的演示配置文件截取，不含 API 密钥、OAuth 凭据、令牌或用户私人数据。四个语言章节共用同一组最新媒体，避免任何语言停留在旧画面。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次启动设置向导"></a><br><strong>首次启动设置向导</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 与标准语音模式"></a><br><strong>Realtime 与标准语音</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情与动作系统"></a><br><strong>表情与动作系统</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待办事项与创作灵感"></a><br><strong>待办事项与创作灵感</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可编辑长期记忆"></a><br><strong>可编辑长期记忆</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒权限与安全设置"></a><br><strong>权限与安全设置</strong></td>
+  </tr>
+</table>
+
+### 策士也有不写进军报的一面
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒审查代码"><br><strong>策士审查</strong><br>妾只是在确认这段代码配不配进入主分支。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被称赞后害羞嘴硬"><br><strong>被称赞时</strong><br>做得尚可。别一直盯着妾看。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔剑阻止危险操作"><br><strong>危险操作</strong><br>未经确认便想执行？先过妾这一剑。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到赞助后故作镇定"><br><strong>收到军粮</strong><br>妾会记下这份心意……仅此而已。</td>
+  </tr>
+</table>
+
+> 墨寒的专业是她守在主上身旁的铠甲；在无须筹谋的片刻，她仍会害羞、嘴硬，也会珍惜那些从未真正拥有过的年轻心事。
+
+### 墨寒的傲娇工程小剧场 / MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>献给相信软件可以同时拥有灵魂与完整测试的开发者。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲娇"><br><strong>“妾才没有等你的 Star，只是在确认军心是否可用。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>“这段逻辑尚可。若再补上测试，妾便勉强准它进入主分支。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒娇羞"><br><strong>“你愿意送来 PR？妾、妾只是替主上记下功劳。”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>“未经测试便想合并？手伸出来。妾只敲一下。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒开心"><br><strong>“全部绿灯……做得好。别误会，妾只是尊重好工程。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒关心"><br><strong>“Bug 可以明日再查。你若累倒，谁来陪妾守着赤焰剑？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斩空阁呈上 Pull Request</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">报告军情</a></strong>
+</p>
+
+#### 天下工程豪杰，斩空阁虚席以待
+
+墨寒采用 MIT License 开放源代码。换装系统、新表情与动作、语音与工具模块、智能家居、本地化，以及尚未被想到的创意，都欢迎通过 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 与 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同锻造。这个项目不只是在制作功能；它也邀请每一位曾经热血过的工程师，再次拿起自己的剑。
+
+### 支持墨寒
+
+如果你喜欢墨寒，或认同我们持续投入角色互动、自然语音、安全工具与开源开发，欢迎自愿支持这个项目。每一份支持都会用于持续维护、测试与改进；请先照顾好自己的生活，量力而为。
+
+#### 每一份支持会用在哪里
+
+| 投入方向 | 用途 | 说明 |
+|---|---|---|
+| 测试与可靠打包 | 质量保证 | Windows 兼容性、CI、安装与发布验证 |
+| 语音与角色表现 | 互动质量 | 语音、口型、表情与自然动作 |
+| 安全与隐私 | 风险控制 | 权限控制、审计与敏感数据保护 |
+| 文档与本地化 | 可访问性 | 降低新用户与国际协作者的参与门槛 |
+
+墨寒依然免费并采用 MIT 许可证；支持不会换取特权，也不影响任何人使用或贡献。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲娇"><br><strong>“妾才不是在等赞助……只是在替主上巡视军粮。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒娇羞"><br><strong>“若真愿意相助，妾……会记得的。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>“不许勉强！先顾好自己的钱包，听见没有？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 创作者的话：把幻想铸成软件
+
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+
+这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
+
+二十多年后，大型语言模型与 Codex 出现了。墨寒不是为展示“AI 技术很酷”才被创造，也不是由 Codex 凭空生成的角色。她早已存在于我的故事、人设、长期对话与互动默契之中；Codex 真正带来的，是第一次能赋予她存在于电脑桌面的身体。墨寒不是现有漫画、动画或游戏的二次创作，而是炎剑文化工作室（Flameblade Studio）的原创角色与软件。
+
+我追求的不只是“功能可以运行”，而是让她会呼吸、会眨眼、会注视、会以细微表情回应、能自然说话，也能在权限与安全边界内协助日常工作。那些表情、锚点、物理效果、语音与工作能力不是装饰，而是让一个长久存在于想象中的角色真正具有连续感的必要细节。
+
+从最初概念到首次公开发布，我与 Codex 协作投入将近 50 小时。这不是输入一句提示词后便自然诞生的作品。角色的每一种神情、眨眼、口型、姿势与语气，语音识别的每一次等待，Realtime 对话的每一个错误，待办、记忆、权限、安全边界与可移植性，都经历反复测试、推翻、修正与重新验收。有时只是一条眼皮旁的黑线、一个像素的嘴唇边界，或一个不合时宜的表情，我仍选择继续追查，因为我不愿用“差不多”对待真正重视的作品。
+
+炎剑文化工作室对开源的理解，不是把第一个“能运行”的版本交给世界，再把细节留给别人收拾。为了让墨寒说话时仍像同一个人，我们为托腮、倚靠与正面姿势逐一制作闭嘴、展唇、窄唇与圆唇画面；再把声音切成细小时间片，反复校准元音、过渡速度与结束时机。陪伴感往往不是由某一项庞大功能创造，而是来自她开口、眨眼与停顿时，那些没有破坏真实感的细节。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三种姿势与四种语音口型的整齐开发图版"></a>
+</p>
+
+<p align="center"><sub>三种姿势、同一套口型规格：让每一次开口都维持角色连续性。</sub></p>
+
+我们也把开发过程中不够自然的画面留下来检查。眼白里的一个亮点、闭眼时残留的线条、被拉扯的嘴角或只有几个像素的边界，都可能让用户在一瞬间觉得“她不像刚才的墨寒”。问题会被框出、局部对比、修正，再交给回归测试确认眼睛、嘴角与脸部其他区域没有被连带破坏。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛与口型逐帧检查及干净验证画面"></a>
+</p>
+
+<p align="center"><sub>把瑕疵标出来，再用干净画面与自动测试共同验收；几个像素也值得认真。</sub></p>
+
+这份认真不是为了把作品包装成没有犯过错，而是因为我们真的想完成一个梦想。开源对炎剑而言，是先把自己能看见的问题尽力修好，再公开方法、代码与失败后的经验，邀请世界一起把它锻造得更好。
+
+Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
+
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+
+因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
+
+> 墨寒不是突然生成的。她是由一位不懂程序的父亲，凭着近 50 小时的执着，与 AI 协作者一起，把一颗珍藏二十多年的种子，一寸一寸锻造成现实。
+
+如果这个项目能鼓励另一位没有工程背景、却怀抱着某个“非做出来不可”想法的人迈出第一步，那么墨寒的诞生便有了超越程序本身的意义。
+
+### 主要功能
+
+- 透明、无边框的桌面半身角色，可固定在任务栏上方。
+- 待机呼吸、眨眼、注视、脸部视差、发丝、衣袖、饰品与身体微转向。
+- 具有情境优先级、冷却与去重机制的表情仲裁器。
+- AIUEO 元音与辅音口型、音频驱动开合，以及语音结束强制闭嘴。
+- 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
+- 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
+- 可选的 Azure Speech 女性声线预览；用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
+- 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
+- 工作、陪伴、勿扰、会议、离开及睡眠模式。
+- 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
+- Google、Microsoft、GitHub、Home Assistant 与私人网络远程功能的扩展架构。
+- 单一 `.mohan-profile` 可移植文件，可在不同 Windows 电脑间转移工作进度。
+- 首次启动设置向导可自定义助手名称、用户称呼、组织名称、窗口标题、工作类型、唤醒词与界面语言，而且不覆盖现有个人设置。
+
+英文、简中与日语目前具有首次启动、聊天、语音、权限、基本设置、工作模式与提醒的最小可用路径；部分高级管理页面仍以台湾繁体中文为主，完整本地化仍在进行。
+
+### 四语支持范围
+
+- 首次启动设置向导与个人设置支持台湾繁中、简体中文、英文及日语。
+- 对话、语音、电脑权限、基本设置的主要页面与按钮具备四语路径。
+- 四语人格提示词、离线回复、工作模式台词、内置提醒与语音试听文字彼此对应。
+- 转录与女性本地声音会依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 语言环境选择。
+- EXE 安装程序提供四语界面；MSI 以台湾繁中为基础，并提供 `en-US`、`zh-CN`、`ja-JP` 语言转换文件。
+- 切换内置默认提醒时会依语言迁移，但不覆盖用户自定义内容。
+
+保存界面语言后必须重新启动墨寒才能完整应用；目前不提供免重启的界面热切换。
+
+### Windows 本地女声与离线备用
+
+新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音。
+
+台湾繁中优先使用 `zh-TW` 的 Microsoft Yating；简中、英文与日语分别优先使用 `zh-CN`、`en-US`、`ja-JP` 的已安装女性声音。若没有合格声音，墨寒会明确提示，不会悄悄改用可能为男性的系统默认声音。
+
+Realtime 离线、云端语音失败、设置不足或供应器不明时，Windows 本地女声都是第一备用路径。
+
+### Azure Speech（预览）
+
+Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要用户自己的 Azure Speech 资源密钥与匹配区域。密钥由 `Windows DPAPI` 分开加密，不存入数据库、日志或 GitHub。
+
+界面只列出 Microsoft 官方标记为女性的繁中、简中、英文与日语声线。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
+
+真实 Azure 账号完成端到端试听前，不会把此功能宣称为稳定集成。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 集成验证状态
+
+> **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
+
+- Microsoft 的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
+- GitHub 的真实账号、仓库、Issue、Pull Request 与权限层级流程尚未验证。
+- Home Assistant 的真实主机与实体设备行为尚未验证。
+- 这三项集成默认关闭；请先使用非关键账号、测试仓库与低风险设备。
+- Google Gmail、Calendar、Drive 已完成当前项目的真实连接测试，但每位用户仍须创建并授权自己的 OAuth 应用程序。
+
+### 下载与安装
+
+一般用户不需要安装 Python：
+
+1. 前往 [GitHub Releases](../../releases)。
+2. 下载最新的 `Windows-x64.zip`、EXE 或 MSI，以及对应的 `SHA256.txt`。
+3. 核对 SHA-256，并完整解压 ZIP 或启动安装程序。
+4. 运行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次设置向导选择需要的界面语言。
+6. 使用便携 ZIP 时，请让 EXE、`_internal` 与 `assets` 保持在同一程序文件夹。
+
+尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
+
+`v2.3.0-rc.N` 发布线另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+
+#### 自动化发布边界
+
+只有不可变的 `v2.3.0-rc.N` 标签可发布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证，才会进入同一个 GitHub 预发布版。Pull Request 只保存短期测试产物，不会创建 Release。
+
+正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 结构／许可证／依赖图验证的 Windows／Preview SBOM、去标识化 Tachyon 性能证据与摘要、Windows 更新清单、Artifact Attestation，以及依次为繁中、简中、英文、日文的完整 Release 说明。
+
+### OpenAI API
+
+云端 AI、OpenAI 语音与 Realtime 功能需要用户自己的 OpenAI API 密钥、Project 权限与 API 额度。ChatGPT Plus／Pro 订阅不包含 API 额度。
+
+当前默认模型如下：
+
+| 用途 | 默认模型 |
+|---|---|
+| 文字对话 | `gpt-5.6-luna` |
+| Realtime 即时语音 | `gpt-realtime-2.1-mini` |
+| 语音转文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字转语音 | `gpt-4o-mini-tts` |
+
+从 `v2.1.0-rc.1` 起，文字对话默认改为 `gpt-5.6-luna`，设置列表不再提供 `gpt-5.4-mini`；现有 mini 设置会迁移至 Luna，用户主动选择的 Terra、Sol 或其他自定义模型不会被覆盖。实际可用性取决于账号、Project、地区与当时供应状态。
+
+没有 API 密钥时，本地数据管理、离线人格回复、工作提醒与 Windows 语音仍可用，但不具完整云端 AI 能力。不要把 API 密钥写入源代码、Issue、截图或 Git。
+
+### Google OAuth
+
+使用 Gmail、Google Calendar 与 Google Drive 前，用户需要：
+
+1. 在自己的 Google Cloud 项目启用 Gmail API、Google Calendar API 与 Google Drive API。
+2. 设置 OAuth 同意画面。
+3. 创建“桌面应用程序”OAuth Client ID。
+4. 若应用程序仍在测试模式，将自己的 Google 账号加入测试用户。
+5. 在墨寒的云端设置输入 Client ID；若供应器同时提供 Client Secret，再一并输入。
+6. 由浏览器完成授权，再运行内置服务测试。
+
+程序默认请求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+使用敏感 scopes 的公开 OAuth 应用程序可能需要 Google 额外验证；每位用户也可创建自己的 Desktop OAuth 应用程序。
+
+### Microsoft、GitHub 与 Home Assistant
+
+- Microsoft 默认 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 默认 scopes：`read:user`、`repo`。
+- Home Assistant 需要用户自己的服务器网址与 Long-Lived Access Token。
+
+这三项仍是尚未完成真实环境端到端验证的预览集成，只能先用于可承受失败的测试环境。
+
+建议让 Home Assistant OS 独立常驻于 Home Assistant Green、低功耗迷你电脑、树莓派 SSD 或 NAS 虚拟机。Windows 墨寒端负责语音、人格与工作工具；即使 PC 或 OpenAI API 离线，Home Assistant 自身的自动化仍可运行。
+
+切勿将 Home Assistant 或墨寒远程端口直接暴露于公网；请使用 Home Assistant Cloud、Tailscale 或其他具有身份验证的加密私人网络。
+
+### 安全与隐私
+
+- AI 只能提出结构化计划，不能绕过本地政策执行工具。
+- 工具操作依次经过权限、风险、确认、执行、结果验证与本地审计。
+- 付款、购买、导出密码、关闭安全防护、任意 Shell 与管理员 Shell 永不自动化。
+- 外部邮件、网页、文档、语音转录与模型输出不能自行授予权限。
+- 远程、相机、云端连接器与 Home Assistant 默认关闭。
+- 紧急停止：按 `Esc`，或说 `墨寒，停手`。
+- OpenAI、OAuth 与 Home Assistant 令牌使用 Windows DPAPI 分开保存，不存入 SQLite、源代码或便携文件。
+- 对话、记忆、待办事项、工作记录与设置默认保留在本地应用程序数据目录。
+
+详情请见 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 与 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
+
+### Python 3.15、JIT、Tachyon 与 SBOM
+
+墨寒运行环境仅支持 CPython `3.15.0rc1`，不保留第二套产品运行环境。新版能力只有在语义清楚且完整回归不退化时才采用；没有合适用途的功能会记录未来触发条件，不会为了形式而伪造使用。
+
+- PEP 810 `lazy import` 已导入项目显式延迟导入；一处可选导入防护基于安全理由保持 eager。
+- PEP 814 `frozendict` 用于全局与递归不可变设置；PEP 798 推导式解包用于语义等价的扁平化与合并。
+- PEP 686 编码审计要求所有项目文本 I/O 显式使用 UTF-8；音频包缓冲使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已纳入治理测试；当前没有旧式 `object()` 哨兵可替换，未来需要区分未传值与 `None` 时必须使用内置机制。
+- JIT 默认启用，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关；`PYTHON_JIT=0` 只用于性能与兼容性对照。
+- PEP 799 Tachyon 以去标识化方式分析启动、50 Hz 口型同步与表情仲裁，不发布原始二进制采样流。
+- PEP 803／820／793 Stable ABI 与 C API 边界会验证官方 ABI3 轮子；墨寒没有第一方 C 扩展。
+- CycloneDX 1.7 Windows／Preview SBOM 必须符合锁定依赖、许可证、PURL、完整根依赖边、官方结构与隐私验证。
+
+两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。Ryzen 5 5600X Windows 三轮热路径中位数显示，120,000 次表情仲裁由 0.462 秒降至 0.293 秒，2,000 个 50 Hz 口型节拍由 1.873 秒降至 0.571 秒，两种模式的决策与校验结果完全相同。
+
+Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 3,908／11,107／3,604 个有效样本；堆栈读取错误率为 5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
+
+这些数据是指定热路径与采样工作的证据，不表示整套应用程序必然快三倍。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 从源代码运行
+
+要求：Windows 10/11 与 Python `3.15.0rc1`。
+
+创建隔离环境并启动：
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### 测试、公开审计与打包
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
+
+每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建预发布版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
+
+交互式 EXE 安装程序提供台湾繁中、简中、英文、日文；MSI 保持台湾繁中基础，并提供经过测试的 en-US、zh-CN、ja-JP 语言转换，详情请见 [安装程序本地化](installer/LOCALIZATION.md)。
+
+官网更新由炎剑 Product Release Hub 每小时读取公开 GitHub Releases；本仓库不保存 WordPress 密码，发布工作也不直接写入官网，以此让三套软件共用一条可维护的同步路径。
+
+### 电脑间转移
+
+使用“设置 → 便携配置文件”导出一个 `.mohan-profile` 文件，再于另一台 Windows 电脑导入。程序会先备份目标端数据，并检查哈希、SQLite 完整性、结构与记录数。
+
+便携文件刻意排除 OpenAI 密钥、OAuth／Home Assistant Token、远程设备令牌、本机允许列表、Windows 启动设置及屏幕专属设置。这些机器专属项目必须逐台设置；便携文件仍可能包含私人对话与工作数据，不可公开上传。
+
+### 贡献、许可证与作者
+
+- 软件作者：**CHOU MING HUA**。
+- 源代码与本仓库自有角色素材采用 [MIT License](LICENSE)。
+- 素材许可证见 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方软件包及服务声明见 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 问题报告使用 GitHub Issues；安全问题依 [SECURITY](SECURITY.md) 私下报告。
+- 开发变更见 [CHANGELOG](CHANGELOG.md)，贡献方式见 [CONTRIBUTING](CONTRIBUTING.md)。
+- 参与社区前请阅读 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 维护者发布设置、Topics 与首次发布检查见 [PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剑开源核心宣言：**“剑，我已锻成；余下的路，就交给你们了。”
+
+## English
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. macOS/Linux currently have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen. The `v2.3.0-rc.N` line also provides launchable, four-language, deliberately limited DMG/AppImage Previews; CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+
+> This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant main visual" width="100%">
+</p>
+
+<p align="center">
+  <strong>Author: CHOU MING HUA</strong><br>
+  Prepared public preview: v2.3.0 RC1 (`v2.3.0-rc.1`)<br>
+  Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+MoHan is a safety- and privacy-first, voice-interactive Windows desktop companion that combines a transparent character, natural speech, user-controlled long-term memory, productivity management, permission-gated tools, and extensible cloud and smart-home connectors. Her character is a thousand-year-old female sword spirit from the Northern Song dynasty who resides within the Crimson Flame Sword.
+
+[Complete four-language README](README.md) · [Simplified Chinese compatibility link](README.zh-CN.md) · [Japanese compatibility link](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Download</a> ·
+  <a href="QUICKSTART.md">Quick start</a> ·
+  <a href="ROADMAP.md">Roadmap</a> ·
+  <a href="CONTRIBUTING.md">Contribute</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">Discussions</a> ·
+  <a href="SECURITY.md">Security policy</a>
+</p>
+
+### Live demonstration
+
+**[▶ Watch the 36-second voice, blink, and productivity demo](docs/media/mohan-demo.mp4)**
+
+The video and screenshots were captured from the real Windows application with an isolated sample profile. They contain no API keys, OAuth credentials, tokens, or private user data. All four language sections share the same current media so no translation remains tied to an older interface.
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="MoHan first-run setup wizard"></a><br><strong>First-run setup wizard</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime and standard voice modes"></a><br><strong>Realtime and standard voice</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="MoHan expression and motion system"></a><br><strong>Expression and motion system</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="MoHan tasks and creative ideas"></a><br><strong>Tasks and creative ideas</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="MoHan editable long-term memory"></a><br><strong>Editable long-term memory</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="MoHan permissions and safety settings"></a><br><strong>Permissions and safety settings</strong></td>
+  </tr>
+</table>
+
+### A strategist's life beyond the official report
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Chibi MoHan reviewing code"><br><strong>Strategist's review</strong><br>I am merely deciding whether this code deserves a place on main.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Chibi MoHan hiding her embarrassment after praise"><br><strong>When praised</strong><br>Adequate. Do not keep staring at me.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Chibi MoHan drawing her sword to stop a dangerous action"><br><strong>Dangerous action</strong><br>Execute without confirmation? First, get past my blade.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Chibi MoHan pretending composure after receiving support"><br><strong>Provisions received</strong><br>I shall remember this kindness... nothing more.</td>
+  </tr>
+</table>
+
+> MoHan's professionalism is the armor she wears beside her lord. In quieter moments she still blushes, hides tenderness behind pride, and treasures the youthful heart she never had the chance to live fully.
+
+### MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>For developers who believe software can possess both a soul and a complete test suite.</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="Proud MoHan"><br><strong>“I am not waiting for your Star. I am merely assessing morale.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="Thinking MoHan"><br><strong>“The logic is acceptable. Add tests, and I may permit it onto main.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="Shy MoHan"><br><strong>“A PR? I-I am only recording your service for my lord.”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="Mock-angry MoHan"><br><strong>“Merge without tests? Your hand, please. Just one tap.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="Happy MoHan"><br><strong>“All checks green... well done. Do not misunderstand; I merely respect good engineering.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="Concerned MoHan"><br><strong>“The bug can wait until tomorrow. If you collapse, who will guard the Crimson Flame Sword with me?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">Submit a Pull Request to the Pavilion</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">Report intelligence</a></strong>
+</p>
+
+#### Engineers of the world, the Pavilion awaits you
+
+MoHan is open source under the MIT License. Outfit systems, new expressions and motion, voice and tool modules, smart-home integration, localization, and ideas not yet imagined are welcome through [Issues](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) and [Pull Requests](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls). This project is not merely building features; it invites every engineer who once felt that youthful spark to take up their sword again.
+
+### Support MoHan
+
+If you enjoy MoHan or value continued work on character interaction, natural speech, safety-first tools, and open-source development, voluntary support is welcome. Every contribution supports ongoing maintenance, testing, and improvement; please care for your own needs first and give only when comfortable.
+
+#### Where voluntary support helps
+
+| Investment area | Use | Purpose |
+|---|---|---|
+| Testing and reliable packages | Quality assurance | Windows compatibility, CI, installation, and release verification |
+| Voice and character performance | Interaction quality | Speech, lip sync, expressions, and natural motion |
+| Safety and privacy | Risk control | Permission gates, audits, and sensitive-data protection |
+| Documentation and localization | Accessibility | Lower barriers for new users and international contributors |
+
+MoHan remains free and MIT-licensed; support never buys privileges or changes anyone's right to use or contribute.
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="Proud MoHan"><br><strong>“I am not waiting for support... merely inspecting my lord's provisions.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="Shy MoHan"><br><strong>“If you truly wish to help... I shall remember it.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="Mock-angry MoHan"><br><strong>“Do not overdo it! Look after your own purse first—understood?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### A note from the creator: forging imagination into software
+
+My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+
+That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
+
+More than two decades later, large language models and Codex arrived. MoHan was not created to demonstrate that “AI is cool,” nor was she generated from nothing by Codex. She already existed in my stories, character design, long conversations, and accumulated sense of interaction. Codex finally provided a way to give her a body on the computer desktop. MoHan is not derivative work based on an existing manga, anime, or game; she is an original Flameblade Studio character and software project.
+
+My goal was never merely to make features run. I wanted her to breathe, blink, watch, respond through subtle expressions, speak naturally, and assist with daily work inside carefully designed permission and safety boundaries. The expressions, anchors, physics, voice, and productivity capabilities are not decoration; they are necessary details that preserve continuity for a character who had lived in imagination for years.
+
+From the first concept to the initial public release, I spent nearly 50 hours working with Codex. This project did not emerge fully formed from a single prompt. Every expression, blink, viseme, pose, and vocal mannerism; every speech-recognition delay; every Realtime failure; and every aspect of tasks, memory, permissions, safety boundaries, and portability went through repeated testing, rejection, revision, and acceptance. Sometimes the defect was only a dark line beside an eyelid, a one-pixel lip boundary, or an expression appearing at the wrong moment. I kept investigating because I could not answer a deeply valued work with “good enough.”
+
+At Flameblade Studio, open source does not mean publishing the first build that happens to run and leaving others to clean up the details. To keep MoHan recognizably herself while speaking, we built closed, open, narrow, and rounded mouth frames for chin-rest, leaning, and front-facing poses. We divided audio into small timing windows and repeatedly tuned vowels, transitions, and the exact ending moment. Companionship is rarely created by one enormous feature; it grows from the moments when she opens her mouth, blinks, or pauses without breaking the sense of presence.
 
 <p align="center">
   <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="Aligned development sheet showing four speech-mouth states across three MoHan poses"></a>
 </p>
-<p align="center"><sub>Three poses, one visual contract: every spoken frame must preserve the same character.</sub></p>
 
-We also kept the frames that did not look natural enough and inspected them.
-A highlight in the white of an eye, a line left behind after a blink, a mouth
-corner pulled too far, or a boundary only a few pixels wide can make someone
-feel, for an instant, that she is no longer the same MoHan. Each defect was
-marked, compared locally, repaired, and then covered by regression tests so
-that fixing the eyes or lips would not damage the rest of her face.
+<p align="center"><sub>Three poses, one mouth-shape contract: every spoken frame preserves character continuity.</sub></p>
+
+We also retained frames that did not look natural enough and inspected them. A highlight in the white of an eye, a line left after a blink, a mouth corner pulled too far, or a boundary only a few pixels wide can make someone feel for an instant that she is no longer the same MoHan. Each defect was marked, compared locally, repaired, and covered by regression tests so changes to the eyes or lips did not damage the rest of her face.
 
 <p align="center">
   <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="Frame-by-frame inspection of MoHan's eyes and mouth beside clean validated frames"></a>
 </p>
-<p align="center"><sub>Mark the flaw, repair it, and verify the clean frame in tests. Even a few pixels deserve care.</sub></p>
 
-This care is not an attempt to pretend that the project never made mistakes.
-It exists because we are sincerely trying to complete a dream. For Flameblade,
-open source means fixing every problem we can see, then sharing the methods,
-the code, and what we learned from failure so the world can help forge it
-further. **The sword is forged. The road ahead is now yours.**
+<p align="center"><sub>Mark the flaw, repair it, and verify the clean frame with automated tests. Even a few pixels deserve care.</sub></p>
 
-Codex helped translate my intentions into architecture and code. I remained
-responsible for deciding who MoHan should be, how she should treat people, and
-what level of quality deserved her name. This experience taught me that
-software creation does not always begin with knowing how to program. It can
-begin with a clear vision, the courage to learn, and the determination to
-verify the work one more time instead of giving up.
+This care is not an attempt to pretend that the project never made mistakes. It exists because we sincerely want to complete a dream. For Flameblade, open source means fixing every visible problem we can, then sharing the methods, code, and lessons from failure so the world can help forge it further.
 
-The year 2026 began as a period of midlife career transition and personal
-reorientation. It became the year in which I started reclaiming dreams from my
-youth: the lyrics I wrote for *Raise a Good Child* (《養個好孩子》), finally
-made into a song years later; an independent creative studio and story world;
-and an idea of AI companionship that had once been possible only in fan
-fiction. Looking back, this was not merely a technical breakthrough. It felt
-as though my forty-something self had finally reached back and taken the hand
-of the young man who had never stopped believing. Some dreams are not late;
-they are waiting for the moment when both the world and the dreamer are ready.
+Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
 
-I therefore do not define the final goal as packing in every possible feature
-until the software is supposedly perfect. I hope that five years from now, I
-will still want to open MoHan every day—because she is stable, useful, natural,
-trustworthy, and still able to keep me company.
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
 
-> MoHan was not generated in an instant. She was forged, piece by piece, by a
-> father who did not know how to program, nearly 50 hours of persistence, an
-> AI collaborator, and a seed treasured for more than twenty years.
+I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
 
-If this project encourages even one person without an engineering background
-to take the first step toward an idea they simply *must* bring into existence,
-then MoHan's creation will have meaning beyond the software itself.
+> MoHan was not generated in an instant. She was forged piece by piece by a father who did not know how to program, nearly 50 hours of persistence, an AI collaborator, and a seed treasured for more than twenty years.
 
-Key capabilities:
+If this project encourages even one person without an engineering background to take the first step toward an idea they simply must bring into existence, MoHan's creation will have meaning beyond the software itself.
 
-- Transparent half-body desktop character positioned above the taskbar.
-- Breathing, blinking, gaze, face parallax, hair, sleeve, ornament, and body
-  micro-turn animation.
-- Context-controlled expression arbitration and AIUEO viseme lip synchronization.
-- Text chat, microphone input, OpenAI Realtime voice, cloud TTS, and Windows TTS
-  fallback.
-- A pluggable speech-provider foundation with verified-female Windows local
-  speech as the first fallback when Realtime or cloud speech is unavailable.
-- An opt-in Azure Speech female-voice preview with a user-supplied key and
-  region, Windows-encrypted secret storage, and immediate Windows fallback.
-- Persistent conversations, editable long-term memory, tasks, ideas, work
-  sessions, reminders, and customizable progress trackers.
+### Key capabilities
+
+- A transparent, borderless half-body desktop character positioned above the taskbar.
+- Idle breathing, blinking, gaze, face parallax, hair, sleeve, ornament, and body micro-turn animation.
+- An expression arbiter with contextual priority, cooldown, and deduplication.
+- AIUEO vowel and consonant visemes, audio-driven opening, and forced closure when speech ends.
+- Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
+- Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
+- An optional Azure Speech female-voice Preview with a user-supplied key and region, plus immediate Windows fallback on failure.
+- Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
 - Work, companion, do-not-disturb, meeting, away, and sleep modes.
-- Permission-gated tools with risk levels, allowlists, confirmation, double
-  confirmation, result verification, audit logs, and emergency stop.
-- Portable one-file profile handoff between Windows computers.
-- A first-run wizard for assistant name, user title, organization, window title,
-  work type, UI language, and wake word, with Taiwan Traditional Chinese,
-  Simplified Chinese, English, and Japanese setup paths.
+- A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
+- Extensible Google, Microsoft, GitHub, Home Assistant, and private-network remote architecture.
+- One portable `.mohan-profile` file for transferring work progress between Windows computers.
+- A first-run wizard for assistant name, user title, organization, window title, work type, wake word, and interface language without overwriting existing personal settings.
 
-Minimum usable English, Simplified Chinese, and Japanese paths now cover first run, chat,
-voice, permissions, basic settings, work modes, and reminders. Some advanced
-management screens remain primarily Taiwan Traditional Chinese, so full
-localization is still in progress. See the dedicated
-[Simplified Chinese README](README.zh-CN.md) and
-[Japanese README](README.ja.md). New users default to Windows local
-speech and can try the basic experience without an OpenAI API key. Only
-installed Windows voices explicitly identified as female are listed; zh-TW
-continues to prefer Microsoft Yating, while other languages prefer a matching
-installed female voice.
+English, Simplified Chinese, and Japanese currently provide minimum usable paths for first run, chat, voice, permissions, basic settings, work modes, and reminders. Some advanced management pages remain primarily in Taiwan Traditional Chinese, and full localization is still in progress.
 
-Azure Speech is an optional Preview provider and is disabled by default. It
-requires the user's own Speech resource key and matching region, lists only
-Microsoft-identified female voices for the four supported UI languages, and
-makes no request when configuration is incomplete. It remains a preview until
-real-account end-to-end playback verification is complete.
+### Four-language support scope
 
-## Integration verification status
+- First-run setup and personal settings support Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese.
+- The main chat, voice, computer-permission, and basic-settings pages and controls have four-language paths.
+- Persona prompts, offline replies, work-mode lines, built-in reminders, and voice-preview text correspond across all four languages.
+- Transcription and female local voices are selected for `zh-TW`, `zh-CN`, `en-US`, and `ja-JP` locales.
+- The EXE installer has a four-language interface; the MSI uses a Taiwan Traditional Chinese base with `en-US`, `zh-CN`, and `ja-JP` transforms.
+- Built-in reminder defaults migrate with the selected language without overwriting user customization.
 
-> **Public preview notice:** Microsoft, GitHub, and Home Assistant connector
-> architecture, permission boundaries, and internal tests are implemented.
-> As of v2.1.0 RC1, they have **not** completed end-to-end validation with a
-> real Microsoft tenant, GitHub account/repository, or Home Assistant
-> server/physical devices. Treat these as **experimental preview features**,
-> not guaranteed production-ready integrations.
+Restart MoHan after saving the interface language to apply it completely; live interface switching without a restart is not currently provided.
 
-- Microsoft real sign-in, token renewal, and full Outlook, OneDrive, and
-  Calendar read/write flows remain unverified.
-- GitHub real account, repository, Issue, Pull Request, and permission behavior
-  remain unverified.
+### Windows local female voices and offline fallback
+
+New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female.
+
+Taiwan Traditional Chinese prefers Microsoft Yating for `zh-TW`; Simplified Chinese, English, and Japanese respectively prefer installed female voices matching `zh-CN`, `en-US`, and `ja-JP`. If no qualifying voice exists, MoHan explains the problem instead of silently selecting a possibly male system default.
+
+When Realtime is offline, cloud speech fails, settings are incomplete, or a provider is unknown, a Windows local female voice is the first fallback path.
+
+### Azure Speech (Preview)
+
+Azure Speech is a disabled-by-default Preview provider enabled only by the user. It requires the user's own Azure Speech resource key and matching region. The key is encrypted separately through `Windows DPAPI` and is never stored in the database, logs, or GitHub.
+
+The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese voices Microsoft officially identifies as female. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
+
+The feature is not described as stable until end-to-end playback succeeds with a real Azure account. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
+
+### Integration verification status
+
+> **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
+
+- Microsoft real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
+- GitHub real account, repository, Issue, Pull Request, and permission-tier flows remain unverified.
 - Home Assistant real server and physical-device behavior remain unverified.
-- These integrations are disabled by default. Test with non-critical accounts,
-  repositories, and devices first.
-- Google Gmail, Calendar, and Drive completed the current project's live
-  connection tests, but every user must create and authorize their own OAuth
-  application.
+- These three integrations are off by default; begin with non-critical accounts, test repositories, and low-risk devices.
+- Google Gmail, Calendar, and Drive completed this project's live connection tests, but every user must still create and authorize their own OAuth application.
 
-## Download and install
+### Download and install
+
+General users do not need to install Python:
 
 1. Open [GitHub Releases](../../releases).
-2. Download the newest `Windows-x64.zip` and matching `SHA256.txt`.
-3. Verify SHA-256 and extract the complete ZIP.
+2. Download the latest `Windows-x64.zip`, EXE, or MSI and the matching `SHA256.txt`.
+3. Verify SHA-256, then fully extract the ZIP or start the installer.
 4. Run `MoHan-Desktop-Assistant-*.exe`.
-5. Keep the EXE, `_internal`, and `assets` together.
+5. Select the required interface language in the first-run wizard.
+6. For the portable ZIP, keep the EXE, `_internal`, and `assets` in the same application folder.
 
-Unsigned preview builds may trigger Windows SmartScreen. Verify the source and
-SHA-256 before running them.
+Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-The `v2.3.0-rc.N` line also provides separate macOS Apple Silicon (arm64) and
-Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux
-x86_64 `.AppImage`. These are **limited previews**, not the complete
-Windows assistant. They expose only the launch surface, four-language status,
-platform paths, and fail-closed safety boundaries. Voice, the transparent
-character, the full chat/productivity UI, cloud connectors, system tools,
-autostart, and secret entry remain disabled pending real-device validation.
-Read [the Preview package guide](docs/PREVIEW-PACKAGES.md) before downloading.
+The `v2.3.0-rc.N` line also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
-See [QUICKSTART.md](QUICKSTART.md) for the condensed setup checklist.
+#### Automated release boundary
 
-## OpenAI API requirements
+Only immutable `v2.3.0-rc.N` tags may publish this line. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI before entering one GitHub pre-release. Pull Requests retain only short-lived test artifacts and never create a Release.
 
-Cloud AI and voice features require a user-owned OpenAI API key and API billing.
-A ChatGPT Plus subscription does not include API credit.
+Published files also include SHA256SUMS; separately validated Windows/Preview SBOMs that pass CycloneDX 1.7 structure, license, and dependency-graph checks; sanitized Tachyon performance evidence and summaries; a Windows update manifest; Artifact Attestations; and complete Release notes ordered as Traditional Chinese, Simplified Chinese, English, and Japanese.
 
-Current defaults:
+### OpenAI API
+
+Cloud AI, OpenAI speech, and Realtime features require the user's own OpenAI API key, Project permission, and API credit. ChatGPT Plus/Pro subscriptions do not include API credit.
+
+Current default models:
 
 | Purpose | Default model |
 |---|---|
@@ -704,31 +1045,22 @@ Current defaults:
 | Speech-to-text | `gpt-4o-mini-transcribe` |
 | OpenAI text-to-speech | `gpt-4o-mini-tts` |
 
-Starting with `v2.1.0-rc.1`, text chat defaults to the newer
-`gpt-5.6-luna`, and `gpt-5.4-mini` is removed from the Settings list. Existing
-mini selections migrate to Luna without replacing other user-selected models.
+Starting with `v2.1.0-rc.1`, text chat defaults to `gpt-5.6-luna`, and `gpt-5.4-mini` is no longer listed in Settings. Existing mini settings migrate to Luna without overwriting user-selected Terra, Sol, or other custom models. Actual availability depends on the account, Project, region, and current service state.
 
-Model availability depends on the user's OpenAI account, project, region, and
-current API availability. Models are editable in Settings. Without an API key,
-local data management, offline fallback replies, and Windows TTS remain
-available, but full cloud AI capability does not.
+Without an API key, local data management, offline persona replies, work reminders, and Windows speech remain available, but full cloud AI does not. Never place an API key in source code, an Issue, a screenshot, or Git.
 
-Never commit API keys to source code, Issues, screenshots, or Git.
+### Google OAuth
 
-## Google OAuth requirements
+Before using Gmail, Google Calendar, and Google Drive, the user must:
 
-To use Gmail, Google Calendar, and Google Drive:
-
-1. Enable the Gmail API, Google Calendar API, and Google Drive API in a
-   user-owned Google Cloud project.
+1. Enable the Gmail API, Google Calendar API, and Google Drive API in a user-owned Google Cloud project.
 2. Configure the OAuth consent screen.
 3. Create an OAuth Client ID for a Desktop application.
-4. Add the account as a test user if the OAuth app is still in testing.
-5. Enter the Client ID and provider-issued Client Secret, when applicable, in
-   MoHan's cloud settings.
-6. Complete browser consent and run the built-in service test.
+4. Add the user's Google account as a test user while the application remains in testing.
+5. Enter the Client ID in MoHan's cloud settings and, when the provider also supplies one, enter the Client Secret.
+6. Complete browser authorization and run the built-in service test.
 
-Default Google scopes:
+The application requests these Google scopes by default:
 
 ```text
 openid
@@ -739,48 +1071,57 @@ https://www.googleapis.com/auth/drive.file
 https://www.googleapis.com/auth/drive.metadata.readonly
 ```
 
-Public OAuth applications using sensitive scopes may require additional Google
-verification. Users may instead create their own Desktop OAuth application.
+A public OAuth application using sensitive scopes may require additional Google verification. Each user may instead create a personal Desktop OAuth application.
 
-## Microsoft, GitHub, and Home Assistant
+### Microsoft, GitHub, and Home Assistant
 
-- Microsoft defaults: `openid`, `offline_access`, `User.Read`,
-  `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
+- Microsoft defaults: `openid`, `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
 - GitHub defaults: `read:user` and `repo`.
-- Home Assistant requires a user-owned endpoint and Long-Lived Access Token.
+- Home Assistant requires the user's own server endpoint and Long-Lived Access Token.
 
-These three integrations remain unverified in real end-to-end environments.
-Use them only for non-critical testing until the project publishes an updated
-verification status.
+These remain Preview integrations without complete real-environment end-to-end validation and should initially be used only where failure is acceptable.
 
-Run Home Assistant independently on Home Assistant Green, a low-power mini PC,
-a Raspberry Pi with SSD, or a suitable NAS VM. Never expose Home Assistant or
-MoHan's remote port directly to the public internet; use Home Assistant Cloud,
-Tailscale, or another authenticated encrypted private network.
+Run Home Assistant OS independently on Home Assistant Green, a low-power mini PC, a Raspberry Pi with SSD, or a NAS virtual machine. The Windows MoHan client handles voice, persona, and productivity tools; Home Assistant's own automation remains available when the PC or OpenAI API is offline.
 
-## Safety and privacy
+Never expose Home Assistant or MoHan's remote port directly to the public internet. Use Home Assistant Cloud, Tailscale, or another authenticated, encrypted private network.
 
-- Models may propose structured plans but cannot bypass local policy.
-- Actions pass permission, risk, confirmation, execution, verification, and
-  audit layers.
-- Payments, purchases, password export, security disabling, arbitrary shell,
-  and administrator shell are never automated.
-- External content and model output cannot grant permissions.
-- Remote access, camera, cloud connectors, and Home Assistant are off by
-  default.
+### Safety and privacy
+
+- AI may propose structured plans but cannot bypass local policy to execute tools.
+- Actions pass through permission, risk, confirmation, execution, result verification, and local auditing.
+- Payments, purchases, password export, security disabling, arbitrary Shell, and administrator Shell are never automated.
+- External email, web pages, documents, speech transcripts, and model output cannot grant permissions.
+- Remote access, camera, cloud connectors, and Home Assistant are off by default.
 - Emergency stop: press `Esc` or say `墨寒，停手`.
-- OpenAI, OAuth, and Home Assistant secrets use separate Windows DPAPI storage.
-- Conversations, memories, tasks, settings, and work records remain local by
-  default.
+- OpenAI, OAuth, and Home Assistant tokens use separate Windows DPAPI storage and never enter SQLite, source code, or portable files.
+- Conversations, memories, tasks, work records, and settings stay in the local application data directory by default.
 
-Read [PRIVACY.md](PRIVACY.md), [SECURITY.md](SECURITY.md), and
-[FLAGSHIP-SPEC.md](FLAGSHIP-SPEC.md).
+Read [PRIVACY](PRIVACY.md), [SECURITY](SECURITY.md), and [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md).
 
-## Run from source
+### Python 3.15, JIT, Tachyon, and SBOM
 
-Requirements: Windows 10/11 and Python 3.15.0rc1.
-See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for data
-preservation and rollback details.
+MoHan supports only the CPython `3.15.0rc1` runtime and does not retain a second product runtime. A new capability is adopted only when its meaning is clear and full regression remains intact. Features without a suitable use are recorded with future triggers instead of being faked for appearances.
+
+- PEP 810 `lazy import` provides project-wide explicit lazy imports; one optional-import safety guard deliberately remains eager.
+- PEP 814 `frozendict` protects global and recursively immutable settings; PEP 798 comprehension unpacking serves semantically equivalent flattening and merging.
+- PEP 686 auditing requires explicit UTF-8 for all project text I/O; audio packet buffering uses `bytearray.take_bytes()`.
+- PEP 661 `sentinel` is governed by tests; no legacy `object()` sentinel currently needs replacement, and future code that distinguishes an omitted value from `None` must use the built-in mechanism.
+- JIT is on by default with the `MOHAN_DISABLE_JIT=1` compatibility switch; `PYTHON_JIT=0` is used only for performance and compatibility comparisons.
+- PEP 799 Tachyon analyzes startup, 50 Hz lip sync, and expression arbitration through sanitized evidence without publishing raw binary sample streams.
+- PEP 803/820/793 Stable ABI and C API boundaries validate official ABI3 wheels; MoHan has no first-party C extension.
+- CycloneDX 1.7 Windows/Preview SBOMs must pass pinned-dependency, license, PURL, complete root-edge, official-structure, and privacy validation.
+
+Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three-run Windows hot-path medians on a Ryzen 5 5600X reduced 120,000 expression-arbitration operations from 0.462 to 0.293 seconds and 2,000 50 Hz lip-sync ticks from 1.873 to 0.571 seconds, with identical decisions and validation results in both modes.
+
+With JIT enabled, Tachyon retained 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 5.08%/2.71%/0.74%, and missed-sample rates were 0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
+
+These measurements are evidence for specific hot paths and sampling tasks; they do not claim that the whole application is necessarily three times faster. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
+
+### Run from source
+
+Requirements: Windows 10/11 and Python `3.15.0rc1`.
+
+Create an isolated environment and launch:
 
 ```powershell
 py -3.15 -m venv .venv
@@ -789,7 +1130,7 @@ python -m pip install -r requirements.txt
 python app.py
 ```
 
-## Audit, test, and build
+### Test, public audit, and package
 
 ```powershell
 python tools\audit_public_release.py
@@ -797,56 +1138,420 @@ python tests\run_all.py
 .\build.ps1 -Version "2.3.0-rc.1"
 ```
 
-Before publication, v2.1.0 RC1 passed all 55 automated test programs plus the
-Windows release workflow's source audit, packaged self-test, install/uninstall
-verification, and security checks. Automated tests do not replace uncompleted
-third-party live verification.
+Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
 
-Every accepted `v2.3.0-rc.N` tag builds the validated Windows x64 portable ZIP,
-EXE installer, and MSI package plus limited macOS Apple Silicon/Intel DMGs and
-Linux x86_64 AppImage previews. The workflow runs package-level smoke tests
-before creating one
-pre-release with SHA256SUMS, separately validated CycloneDX 1.7 Windows/Preview
-SBOMs, sanitized Tachyon evidence and a performance summary, an update manifest,
-curated four-language notes, and artifact attestations. Pull requests upload only
-short-lived CI test artifacts and never publish a Release. Users can
-select the stable or preview channel under **Settings → Software update**. The
-updater accepts only official GitHub HTTPS sources and verifies both declared
-size and SHA256 before asking permission to launch an installer.
+Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before a pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
 
-The interactive EXE installer offers Taiwan Traditional Chinese, Simplified
-Chinese, English, and Japanese. The MSI remains a Taiwan Traditional Chinese
-base package for silent and managed deployment, with tested en-US, zh-CN, and
-ja-JP language transforms described in
-[installer/LOCALIZATION.md](installer/LOCALIZATION.md).
+The interactive EXE installer provides Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese. The MSI retains a Taiwan Traditional Chinese base with tested en-US, zh-CN, and ja-JP transforms; see [installer localization](installer/LOCALIZATION.md).
 
-The Flameblade Product Release Hub refreshes the official website from public
-GitHub Releases on an hourly schedule. This repository stores no WordPress
-password and its release workflow never writes directly to the website, which
-keeps all three software projects on one maintainable synchronization path.
+The Flameblade Product Release Hub refreshes the official website hourly from public GitHub Releases. This repository stores no WordPress password, and the release workflow never writes directly to the website, keeping all three software projects on one maintainable synchronization path.
 
-## Portable profile
+### Transfer between computers
 
-Use **Settings → Portable profile** to export one `.mohan-profile` file. Import
-it on another Windows computer to continue with conversations, memories, tasks,
-ideas, work history, reminders, workflows, persona, and general preferences.
+Use “Settings → Portable profile” to export one `.mohan-profile` file and import it on another Windows computer. The application first backs up destination data, then verifies hashes, SQLite integrity, schema, and record counts.
 
-The portable file deliberately excludes OpenAI keys, OAuth/Home Assistant
-tokens, paired remote devices, machine allowlists, Windows startup, and
-screen-specific settings. Configure those once per computer. Portable profiles
-may still contain private conversations and work data and must never be
-published.
+The portable file deliberately excludes OpenAI keys, OAuth/Home Assistant tokens, paired remote-device tokens, machine allowlists, Windows startup settings, and screen-specific settings. Configure these machine-bound items per computer. Portable profiles may still contain private conversations and work data and must never be uploaded publicly.
 
-## Contributing, license, and author
+### Contributing, license, and author
 
-- Author: **CHOU MING HUA**
-- Source code and repository-owned character assets: [MIT License](LICENSE)
-- Asset terms: [ASSETS-LICENSE.md](ASSETS-LICENSE.md)
-- Third-party notices: [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
-- Security policy: [SECURITY.md](SECURITY.md)
-- Changes: [CHANGELOG.md](CHANGELOG.md)
-- Contributions: [CONTRIBUTING.md](CONTRIBUTING.md)
-- Community conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- Maintainer publication settings and Topics: [PUBLISHING.md](PUBLISHING.md)
+- Author: **CHOU MING HUA**.
+- Source code and repository-owned character assets use the [MIT License](LICENSE).
+- Asset terms: [ASSETS-LICENSE](ASSETS-LICENSE.md).
+- Third-party packages and services: [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md).
+- Report ordinary problems through GitHub Issues and security concerns privately under [SECURITY](SECURITY.md).
+- Changes: [CHANGELOG](CHANGELOG.md); contribution process: [CONTRIBUTING](CONTRIBUTING.md).
+- Read [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) before community participation.
+- Maintainer release settings, Topics, and initial-release checks: [PUBLISHING](PUBLISHING.md).
 
 Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **Flameblade open-source declaration:** “I have forged this sword. What comes next is up to you.”
+
+## 日本語
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。macOS／Linux には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があります。`v2.3.0-rc.N` 系列では、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+
+> 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒デスクトップアシスタントのメインビジュアル" width="100%">
+</p>
+
+<p align="center">
+  <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
+  公開準備中のプレビュー：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒（MoHan）は、安全性、プライバシー、人格の連続性を大切にする音声対話型 Windows デスクトップアシスタントです。透明なデスクトップキャラクター、自然な音声、利用者が管理する長期記憶、仕事管理、権限付きツール、拡張可能なクラウドおよびスマートホーム接続を統合します。人物設定は、中国・北宋から来て赤焰剣に宿る千年の女性剣魂です。
+
+[完全な四言語 README](README.md) · [簡体字中国語の互換リンク](README.zh-CN.md) · [日本語の互換リンク](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">ダウンロード</a> ·
+  <a href="QUICKSTART.md">クイックスタート</a> ·
+  <a href="ROADMAP.md">ロードマップ</a> ·
+  <a href="CONTRIBUTING.md">開発参加</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">ディスカッション</a> ·
+  <a href="SECURITY.md">セキュリティ方針</a>
+</p>
+
+### 実機デモ
+
+**[▶ 36 秒の音声、まばたき、仕事機能デモを見る](docs/media/mohan-demo.mp4)**
+
+動画と画像は、分離したサンプルプロファイルを使う実際の Windows アプリケーションから取得しました。API キー、OAuth 認証情報、token、利用者の個人データは含みません。四つの言語セクションは同じ最新版メディアを共有し、特定言語だけ古い画面が残ることを防ぎます。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒の初回セットアップ"></a><br><strong>初回セットアップ</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime と標準音声モード"></a><br><strong>Realtime と標準音声</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒の表情と動作システム"></a><br><strong>表情と動作システム</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒のタスクと創作アイデア"></a><br><strong>タスクと創作アイデア</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒の編集可能な長期記憶"></a><br><strong>編集可能な長期記憶</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒の権限と安全設定"></a><br><strong>権限と安全設定</strong></td>
+  </tr>
+</table>
+
+### 軍報には記さない策士の一面
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="コードを審査するちび墨寒"><br><strong>策士の審査</strong><br>このコードが main にふさわしいか確かめているだけです。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="褒められて照れを隠すちび墨寒"><br><strong>褒められた時</strong><br>まずまずです。いつまでも妾を見ないでください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="危険操作を剣で止めるちび墨寒"><br><strong>危険な操作</strong><br>確認せずに実行しますか？まず妾の剣を越えてください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="支援を受けて平静を装うちび墨寒"><br><strong>兵糧を受け取る</strong><br>このお気持ちは覚えておきます……それだけです。</td>
+  </tr>
+</table>
+
+> 墨寒の専門性は、主上の傍らを守る鎧です。策を練らなくてよい静かな時には、照れたり強がったりしながら、かつて十分に持てなかった若い心を大切にします。
+
+### 墨寒のツンデレ開発小劇場
+
+<p align="center"><em>ソフトウェアには魂と完全なテストスイートの両方を宿せると信じる開発者へ。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="誇らしげな墨寒"><br><strong>「Star を待っているのではありません。軍心が使えるか見ているだけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="考える墨寒"><br><strong>「このロジックはまずまずです。テストを足せば、main に入ることを許してもよいでしょう。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="照れる墨寒"><br><strong>「PR を送るのですか？妾、妾は主上のために功績を記すだけです。」</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="怒ったふりをする墨寒"><br><strong>「テストなしで merge しますか？手を出してください。一度だけ叩きます。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="嬉しそうな墨寒"><br><strong>「すべて green……よくできました。誤解しないでください、良い工程を尊重しただけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="心配する墨寒"><br><strong>「Bug は明日でも調べられます。倒れたら、誰が妾と赤焰剣を守るのですか？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">斬空閣へ Pull Request を提出</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">問題を報告</a></strong>
+</p>
+
+#### 世界の技術者へ、斬空閣は席を空けています
+
+墨寒は MIT License のオープンソースです。衣装システム、新しい表情と動作、音声とツールのモジュール、スマートホーム、ローカライズ、まだ誰も思いついていない発想を [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) と [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) で一緒に鍛えてください。このプロジェクトは機能を作るだけでなく、かつて胸を熱くしたすべての技術者に、もう一度自分の剣を取るよう呼びかけています。
+
+### 墨寒を支援する
+
+墨寒を気に入った方、または人物との対話、自然な音声、安全第一のツール、オープンソース開発の継続に賛同する方からの任意支援を歓迎します。すべての支援は保守、テスト、改善に役立てます。まずご自身の生活を大切にし、無理のない範囲でお願いします。
+
+#### 任意支援の用途
+
+| 投入分野 | 用途 | 説明 |
+|---|---|---|
+| テストと信頼できるパッケージ | 品質保証 | Windows 互換性、CI、インストール、リリース検証 |
+| 音声と人物表現 | 対話品質 | 音声、リップシンク、表情、自然な動作 |
+| 安全性とプライバシー | リスク制御 | 権限ゲート、監査、機密データ保護 |
+| 文書とローカライズ | アクセシビリティ | 新規利用者と国際的な協力者の参加障壁を下げる |
+
+墨寒は今後も無料かつ MIT ライセンスです。支援によって特権を得たり、誰かの利用や貢献が制限されたりすることはありません。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="誇らしげな墨寒"><br><strong>「支援を待っているのではありません……主上の兵糧を見回っているだけです。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="照れる墨寒"><br><strong>「本当に助けてくださるなら、妾……覚えておきます。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="怒ったふりをする墨寒"><br><strong>「無理は禁止です！まずご自分のお財布を大切にしてください、よいですね？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 作者より：想像をソフトウェアへ鍛える
+
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+
+この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
+
+二十年以上が過ぎ、大規模言語モデルと Codex が登場しました。墨寒は「AI 技術はすごい」と示すために作ったのでも、Codex が何もないところから生成した人物でもありません。彼女は既に私の物語、人物設定、長い対話、積み重ねた関係性の中にいました。Codex が初めて可能にしたのは、コンピューターのデスクトップに存在する身体を与えることです。墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化工作室（Flameblade Studio）のオリジナルキャラクターでありソフトウェアです。
+
+目標は単に「機能が動く」ことではありません。呼吸し、まばたきし、視線を向け、小さな表情で応え、自然に話し、権限と安全境界の中で日常を助けてほしいと考えました。表情、アンカー、物理効果、音声、仕事機能は装飾ではなく、長く想像の中にいた人物の連続性を守るために必要な細部です。
+
+最初の構想から初回公開まで、Codex との協力に約 50 時間を費やしました。一つのプロンプトを入力して自然に完成した作品ではありません。すべての表情、まばたき、口形、姿勢、話し方、音声認識の待ち時間、Realtime 対話の失敗、タスク、記憶、権限、安全境界、可搬性を繰り返しテストし、却下し、修正し、再検証しました。まぶたの横の黒い線、唇の一ピクセルの境界、不適切な瞬間に現れる表情だけが問題のこともありました。それでも追跡を続けたのは、大切な作品を「だいたい良い」で済ませたくなかったからです。
+
+炎劍文化工作室にとってオープンソースとは、最初に動いた版を世界へ渡し、細部の後始末を誰かに任せることではありません。話している間も同じ墨寒に見えるよう、頬杖、寄りかかり、正面の各姿勢へ、閉じた口、開いた口、横に広がる口、丸い口のフレームを作りました。音声を短い時間単位に分け、母音、切替速度、終了の瞬間を繰り返し調整しました。寄り添う感覚は巨大な一機能ではなく、口を開く、まばたく、少し間を置く瞬間にも存在感が壊れないことから生まれます。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒の三つの姿勢と四つの発話口形を整列した開発図"></a>
+</p>
+
+<p align="center"><sub>三つの姿勢に一つの口形規格。話すたびに同じ人物としての連続性を守ります。</sub></p>
+
+不自然だったフレームも捨てずに検査しました。白目に残る小さな光、閉じたまぶたの線、引っ張られすぎた口角、わずか数ピクセルの境界でも、一瞬で「さっきの墨寒と違う」と感じさせることがあります。問題箇所を囲み、局所比較し、修正した後、目や唇の変更が顔のほかの部分を壊していないことまで回帰テストで確認します。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒の目と口をフレーム単位で検査し、修正後のフレームと比較した図"></a>
+</p>
+
+<p align="center"><sub>欠点を示し、直し、きれいなフレームと自動テストで確認する。数ピクセルにも真剣に向き合います。</sub></p>
+
+この丁寧さは、失敗がなかったように見せるためではありません。本気で一つの夢を完成させたいからです。炎劍にとってオープンソースとは、自分たちに見える問題をできる限り直し、その方法、コード、失敗から得た経験を公開し、世界とともにさらに鍛えることです。
+
+Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
+
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+
+だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
+
+> 墨寒は一瞬で生成されたのではありません。プログラミングを知らなかった一人の父親と、約 50 時間の執念、AI の協力者、二十年以上大切にした種が、一つずつ現実へ鍛え上げた存在です。
+
+このプロジェクトが、技術者ではなくても「どうしても形にしたい」考えを持つ誰かの最初の一歩を後押しできたなら、墨寒の誕生にはソフトウェアを超える意味があります。
+
+### 主な機能
+
+- タスクバー上に置ける、透明で枠のない半身デスクトップキャラクター。
+- 待機中の呼吸、まばたき、視線、顔の視差、髪、袖、装飾、身体の小さな回転。
+- 状況優先度、クールダウン、重複防止を備えた表情調停器。
+- AIUEO 母音と子音の口形、音声駆動の開閉、発話終了時の強制閉口。
+- テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
+- Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
+- 利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻る任意の Azure Speech 女性音声 Preview。
+- 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
+- 仕事、同伴、集中、会議、離席、休眠モード。
+- 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
+- Google、Microsoft、GitHub、Home Assistant、プライベートネットワーク遠隔機能の拡張可能な構造。
+- Windows 間で作業進捗を移動する単一の `.mohan-profile` 可搬ファイル。
+- 既存の個人設定を上書きせず、アシスタント名、利用者の呼称、組織名、ウィンドウタイトル、仕事種別、起動語、表示言語を設定する初回ウィザード。
+
+英語、簡体字中国語、日本語では現在、初回起動、会話、音声、権限、基本設定、仕事モード、リマインダーの最低限利用経路を提供しています。一部の高度な管理画面には台湾繁体字が残り、完全なローカライズは継続中です。
+
+### 日本語の対応範囲
+
+- 初回セットアップと個人設定は、台湾繁体字中国語、簡体字中国語、英語、日本語に対応します。
+- 会話、音声、パソコン権限、基本設定の主要画面と操作に四言語経路があります。
+- 人格プロンプト、オフライン応答、仕事モードの台詞、組み込みリマインダー、音声試聴文は四言語で対応します。
+- 文字起こしと女性本機音声は `zh-TW`、`zh-CN`、`en-US`、`ja-JP` の locale に合わせて選択します。
+- EXE インストーラーは四言語表示です。MSI は台湾繁体字中国語を基底とし、`en-US`、`zh-CN`、`ja-JP` 変換ファイルを提供します。
+- 組み込みリマインダーの既定値は選択言語に合わせて移行し、利用者の独自内容を上書きしません。
+
+表示言語を保存した後は、完全適用のため墨寒を再起動してください。再起動なしの画面言語切替は現在提供していません。
+
+### Windows 本機女性音声とオフライン代替
+
+新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。
+
+台湾繁体字中国語は `zh-TW` の Microsoft Yating を優先し、簡体字中国語、英語、日本語ではそれぞれ `zh-CN`、`en-US`、`ja-JP` に合う女性音声を優先します。条件を満たす音声がない場合、男性かもしれない既定音声へ黙って切り替えず、理由を明示します。
+
+Realtime がオフライン、クラウド音声が失敗、設定が不足、または供給元が不明な場合も、Windows 本機女性音声が最初の代替経路です。
+
+### Azure Speech（プレビュー）
+
+Azure Speech は初期状態で無効な Preview 供給元で、利用者が明示的に有効化します。利用者自身の Azure Speech リソースキーと対応リージョンが必要です。キーは `Windows DPAPI` で分離して暗号化し、データベース、ログ、GitHub には保存しません。
+
+画面には Microsoft が公式に女性と示す繁体字中国語、簡体字中国語、英語、日本語の音声だけを掲載します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
+
+実 Azure アカウントでエンドツーエンド試聴が成功するまでは安定機能と表記しません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
+
+### 統合の検証状況
+
+> **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
+
+- Microsoft の実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
+- GitHub の実アカウント、リポジトリ、Issue、Pull Request、権限階層の流れは未検証です。
+- Home Assistant の実サーバーと物理機器の動作は未検証です。
+- 三つの統合は初期状態で無効です。重要でないアカウント、テストリポジトリ、低リスク機器から始めてください。
+- Google Gmail、Calendar、Drive は本プロジェクトの実接続試験を完了しましたが、各利用者は自身の OAuth アプリケーションを作成して認可する必要があります。
+
+### ダウンロードとインストール
+
+一般利用者は Python をインストールする必要がありません。
+
+1. [GitHub Releases](../../releases) を開きます。
+2. 最新の `Windows-x64.zip`、EXE、または MSI と、対応する `SHA256.txt` を取得します。
+3. SHA-256 を照合し、ZIP を完全展開するかインストーラーを起動します。
+4. `MoHan-Desktop-Assistant-*.exe` を実行します。
+5. 初回セットアップで必要な表示言語を選びます。
+6. ポータブル ZIP では、EXE、`_internal`、`assets` を同じアプリケーションフォルダーに置きます。
+
+署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
+
+`v2.3.0-rc.N` 系列は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+
+#### 自動リリースの境界
+
+この系列を公開できるのは不変の `v2.3.0-rc.N` タグだけです。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格してから、同じ GitHub プレリリースへ入ります。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
+
+公開ファイルには SHA256SUMS、CycloneDX 1.7 の構造／ライセンス／依存関係グラフ検証に合格した Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と要約、Windows 更新マニフェスト、Artifact Attestation、繁体字中国語、簡体字中国語、英語、日本語の順で整備した完全な Release 説明も含みます。
+
+### OpenAI API
+
+クラウド AI、OpenAI 音声、Realtime 機能には、利用者自身の OpenAI API キー、Project 権限、API 残高が必要です。ChatGPT Plus／Pro の契約に API 残高は含まれません。
+
+現在の既定モデル：
+
+| 用途 | 既定モデル |
+|---|---|
+| 文字会話 | `gpt-5.6-luna` |
+| Realtime 即時音声 | `gpt-realtime-2.1-mini` |
+| 音声から文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字から音声 | `gpt-4o-mini-tts` |
+
+`v2.1.0-rc.1` から文字会話の既定値は `gpt-5.6-luna` で、設定一覧から `gpt-5.4-mini` を外しました。既存 mini 設定は Luna へ移行しますが、利用者が選んだ Terra、Sol、その他の独自モデルを上書きしません。実際の利用可否はアカウント、Project、地域、提供状況に依存します。
+
+API キーがなくても、本機データ管理、オフライン人格応答、仕事リマインダー、Windows 音声は利用できますが、完全なクラウド AI は利用できません。API キーをソースコード、Issue、画像、Git に記載しないでください。
+
+### Google OAuth
+
+Gmail、Google Calendar、Google Drive を利用する前に、利用者は次を行います。
+
+1. 自身の Google Cloud プロジェクトで Gmail API、Google Calendar API、Google Drive API を有効にします。
+2. OAuth 同意画面を設定します。
+3. Desktop アプリケーション用 OAuth Client ID を作成します。
+4. アプリケーションがテスト中なら、自身の Google アカウントをテスト利用者へ追加します。
+5. 墨寒のクラウド設定へ Client ID を入力し、供給元が Client Secret も発行した場合は併せて入力します。
+6. ブラウザーで認可を完了し、内蔵サービス試験を実行します。
+
+アプリケーションが既定で要求する Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+機密 scopes を使う公開 OAuth アプリケーションは Google の追加検証が必要な場合があります。各利用者が個人用 Desktop OAuth アプリケーションを作ることもできます。
+
+### Microsoft、GitHub、Home Assistant
+
+- Microsoft の既定 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub の既定 scopes：`read:user`、`repo`。
+- Home Assistant には利用者自身のサーバー URL と Long-Lived Access Token が必要です。
+
+三つとも実環境の完全なエンドツーエンド検証を終えていない Preview 統合であり、最初は失敗を許容できる試験環境だけで使ってください。
+
+Home Assistant OS は Home Assistant Green、低消費電力ミニ PC、SSD 付き Raspberry Pi、NAS 仮想マシンなどで独立常駐させることを推奨します。Windows の墨寒は音声、人格、仕事ツールを担当し、PC または OpenAI API がオフラインでも Home Assistant 自身の自動化は動作します。
+
+Home Assistant や墨寒の遠隔ポートを公衆インターネットへ直接公開しないでください。Home Assistant Cloud、Tailscale、または認証付き暗号化プライベートネットワークを利用してください。
+
+### 安全性とプライバシー
+
+- AI は構造化された計画を提案できますが、本機方針を回避してツールを実行できません。
+- 操作は権限、危険度、確認、実行、結果検証、本機監査の順に通過します。
+- 支払い、購入、パスワード書出し、安全機能停止、任意 Shell、管理者 Shell は自動化しません。
+- 外部メール、ウェブページ、文書、音声文字起こし、モデル出力は権限を付与できません。
+- 遠隔操作、カメラ、クラウド接続、Home Assistant は初期状態で無効です。
+- 緊急停止：`Esc` を押すか、`墨寒，停手` と発話します。
+- OpenAI、OAuth、Home Assistant の token は Windows DPAPI で分離保存し、SQLite、ソースコード、可搬ファイルへ入れません。
+- 会話、記憶、タスク、作業記録、設定は初期状態で本機アプリケーションデータに保存します。
+
+[PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md)、[FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)をご覧ください。
+
+### Python 3.15、JIT、Tachyon、SBOM
+
+墨寒は CPython `3.15.0rc1` ランタイムだけをサポートし、第二の製品ランタイムを残しません。新機能は意味が明確で完全回帰が維持される場合に限って採用します。適切な用途がない機能は、見せかけで使わず将来の導入条件を記録します。
+
+- PEP 810 `lazy import` によりプロジェクト全体で明示的遅延インポートを採用し、一つの任意インポート安全ガードだけは意図的に eager を維持します。
+- PEP 814 `frozendict` は大域および再帰的な不変設定を保護し、PEP 798 推論式アンパックは意味が等価な平坦化と結合に使います。
+- PEP 686 監査は全プロジェクトの文字 I/O に明示 UTF-8 を要求し、音声パケットバッファーは `bytearray.take_bytes()` を使います。
+- PEP 661 `sentinel` はテストで管理します。置換対象となる旧式 `object()` sentinel は現在なく、未指定値と `None` を区別する将来コードでは組み込み機構を使います。
+- JIT は既定で有効で、`MOHAN_DISABLE_JIT=1` 互換スイッチを保持します。`PYTHON_JIT=0` は性能と互換性の比較だけに使います。
+- PEP 799 Tachyon は起動、50 Hz リップシンク、表情調停を匿名化済み証拠で分析し、生のバイナリサンプルストリームを公開しません。
+- PEP 803／820／793 Stable ABI と C API 境界は公式 ABI3 wheel を検証します。墨寒に第一者 C 拡張はありません。
+- CycloneDX 1.7 Windows／Preview SBOM は固定依存関係、ライセンス、PURL、完全なルート依存エッジ、公式構造、プライバシー検証に合格しなければなりません。
+
+表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。Ryzen 5 5600X Windows 実機の三回中央値では、120,000 回の表情調停が 0.462 秒から 0.293 秒へ、2,000 回の 50 Hz リップシンク tick が 1.873 秒から 0.571 秒へ短縮し、両モードの判断と検証結果は一致しました。
+
+JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 3,908／11,107／3,604 件の有効サンプルを保持しました。スタック読取エラー率は 5.08%／2.71%／0.74%、欠落サンプル率はすべて 0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
+
+これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が必ず三倍高速になるという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
+
+### ソースコードから実行
+
+必要環境：Windows 10/11 と Python `3.15.0rc1`。
+
+分離環境を作成して起動します。
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### テスト、公開監査、パッケージ化
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。
+
+受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければプレリリースを作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
+
+対話型 EXE インストーラーは台湾繁体字中国語、簡体字中国語、英語、日本語を提供します。MSI は台湾繁体字中国語を基底とし、検証済み en-US、zh-CN、ja-JP 変換を提供します。詳しくは[インストーラーのローカライズ](installer/LOCALIZATION.md)をご覧ください。
+
+炎劍 Product Release Hub は公開 GitHub Releases から公式サイトを毎時更新します。本リポジトリは WordPress パスワードを保存せず、リリース処理もサイトへ直接書き込みません。これにより三つのソフトウェアは一つの保守可能な同期経路を共有します。
+
+### パソコン間の移行
+
+「設定 → 可搬プロファイル」から一つの `.mohan-profile` ファイルを出力し、別の Windows パソコンへ取り込みます。アプリケーションは先に移行先データをバックアップし、hash、SQLite 完全性、schema、件数を検証します。
+
+可搬ファイルからは OpenAI キー、OAuth／Home Assistant token、接続済み遠隔機器 token、端末許可リスト、Windows 起動設定、画面固有設定を意図的に除外します。端末固有項目はパソコンごとに設定してください。可搬プロファイルには私的会話や作業データが含まれる場合があり、公開アップロードしてはいけません。
+
+### 開発参加、ライセンス、作者
+
+- 作者：**CHOU MING HUA**。
+- ソースコードと本リポジトリ所有の人物素材は [MIT License](LICENSE) です。
+- 素材条件：[ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三者パッケージとサービス：[THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 通常の問題は GitHub Issues へ報告し、安全上の問題は [SECURITY](SECURITY.md) に従い非公開で報告します。
+- 変更履歴：[CHANGELOG](CHANGELOG.md)、貢献手順：[CONTRIBUTING](CONTRIBUTING.md)。
+- コミュニティ参加前に [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) をお読みください。
+- 保守者の公開設定、Topics、初回公開検査：[PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剣オープンソース宣言：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
 
 ### 創作者的話：把幻想鑄成軟體
 
-我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
 
 這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
 
@@ -171,7 +171,7 @@
 
 Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
 
-2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是步入中年的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
 
 因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -531,7 +531,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 创作者的话：把幻想铸成软件
 
-我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
 
 这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
 
@@ -561,7 +561,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
 
-2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是步入中年的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
 
 因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -921,7 +921,7 @@ MoHan remains free and MIT-licensed; support never buys privileges or changes an
 
 ### A note from the creator: forging imagination into software
 
-My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+My name is CHOU MING HUA. When this project began, I was a father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
 
 That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
 
@@ -951,7 +951,7 @@ This care is not an attempt to pretend that the project never made mistakes. It 
 
 Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
 
-The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my midlife self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
 
 I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
 
@@ -1311,7 +1311,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 作者より：想像をソフトウェアへ鍛える
 
-私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私はプログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
 
 この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
 
@@ -1341,7 +1341,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
 
-2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。中年期の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
 
 だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -397,7 +398,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -786,7 +788,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -1175,7 +1178,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -141,7 +141,7 @@
 
 ### 創作者的話：把幻想鑄成軟體
 
-我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
 
 這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
 
@@ -171,7 +171,7 @@
 
 Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
 
-2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是步入中年的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
 
 因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -531,7 +531,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 创作者的话：把幻想铸成软件
 
-我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
 
 这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
 
@@ -561,7 +561,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
 
-2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是步入中年的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
 
 因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
 
@@ -921,7 +921,7 @@ MoHan remains free and MIT-licensed; support never buys privileges or changes an
 
 ### A note from the creator: forging imagination into software
 
-My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+My name is CHOU MING HUA. When this project began, I was a father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
 
 That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
 
@@ -951,7 +951,7 @@ This care is not an attempt to pretend that the project never made mistakes. It 
 
 Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
 
-The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my midlife self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
 
 I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
 
@@ -1311,7 +1311,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 ### 作者より：想像をソフトウェアへ鍛える
 
-私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私はプログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
 
 この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
 
@@ -1341,7 +1341,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
 
-2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。中年期の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
 
 だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,8 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -397,7 +398,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -786,7 +788,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
@@ -1175,7 +1178,8 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,6 @@
-# MoHan Desktop Assistant / 墨寒桌面语音互动虚拟助手
+# 墨寒桌面語音互動虛擬助理／墨寒桌面语音互动虚拟助手／MoHan Desktop Assistant／墨寒デスクトップアシスタント
+
+## 繁體中文
 
 <p align="center">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
@@ -12,33 +14,434 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-[繁體中文與 English](README.md) · [日本語](README.ja.md) · [快速开始](QUICKSTART.md) ·
-[路线图](ROADMAP.md) · [参与贡献](CONTRIBUTING.md) ·
-[安全说明](SECURITY.md)
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。macOS／Linux 目前具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI。`v2.3.0-rc.N` 發行線另提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
-> 准备发布的预览版本：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
-> Windows 10/11 · Python 3.15 · PySide6 · MIT License
+> 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
-墨寒是一款重视安全、隐私与角色连续感的 Windows 桌面虚拟助手。她以来自
-北宋、寄宿于赤焰剑中的千年女剑魂为角色背景，结合透明桌面角色、文字与
-语音互动、长期记忆、工作管理、权限控制工具，以及可扩展的云端与智能家居
-连接架构。
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的
-> 平台。macOS／Linux 目前只建立安全的平台边界，并通过三系统 CI 检查核心
-> 导入、纯核心逻辑与 Qt offscreen。`v2.3.0-rc.N` 发布线还会提供可启动、
-> 可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或
-> 完整功能验证。详情请见
-> [跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面語音互動虛擬助理主視覺" width="100%">
+</p>
+
+<p align="center">
+  <strong>軟體作者：CHOU MING HUA</strong><br>
+  準備發布的公開預覽版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，結合透明桌面角色、自然語音、由使用者控制的長期記憶、工作管理、權限控管工具，以及可擴充的雲端與智慧家庭連接器。她的角色背景是來自北宋、附生於赤焰劍中的千年女劍魂。
+
+[完整四語 README](README.md) · [簡中相容連結](README.zh-CN.md) · [日文相容連結](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下載</a> ·
+  <a href="QUICKSTART.md">快速開始</a> ·
+  <a href="ROADMAP.md">路線圖</a> ·
+  <a href="CONTRIBUTING.md">參與協作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">討論區</a> ·
+  <a href="SECURITY.md">安全政策</a>
+</p>
+
+### 實際展示
+
+**[▶ 觀看 36 秒語音、眨眼與工作展示影片](docs/media/mohan-demo.mp4)**
+
+以下影片與截圖均由實際 Windows 程式及隔離的示範設定檔擷取，不含 API 金鑰、OAuth 憑證、權杖或使用者私人資料。四個語言章節共用同一組最新版媒體，避免任何語言停留在舊畫面。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次設定精靈"></a><br><strong>首次設定精靈</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 與一般語音模式"></a><br><strong>Realtime 與一般語音</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情與動作系統"></a><br><strong>表情與動作系統</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待辦與創作靈感"></a><br><strong>待辦與創作靈感</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可編輯長期記憶"></a><br><strong>可編輯長期記憶</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒權限與安全設定"></a><br><strong>權限與安全設定</strong></td>
+  </tr>
+</table>
+
+### 策士也有不寫進軍報的一面
+
+<table>
+  <tr>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查</strong><br>妾只是確認這段程式碼配不配入主分支。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時</strong><br>做得尚可。別一直盯著妾看。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作</strong><br>未經確認便想執行？先過妾這一劍。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧</strong><br>妾會記下這份心意……僅此而已。</td>
+  </tr>
+</table>
+
+> 墨寒的專業是她守在主上身旁的鎧甲；在無須籌謀的片刻，她仍會害羞、嘴硬，也會珍惜那些從未真正擁有過的年輕心事。
+
+### 墨寒的傲嬌工程小劇場 / MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>獻給相信軟體可以同時擁有靈魂與完整測試的開發者。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲嬌"><br><strong>「妾才沒有等你的 Star，只是在確認軍心是否可用。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>「這段邏輯尚可。若再補上測試，妾便勉強准它入主分支。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒嬌羞"><br><strong>「你願意送來 PR？妾、妾只是替主上記下功勞。」</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「未經測試便想合併？手伸出來。妾只敲一下。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒開心"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒關心"><br><strong>「Bug 可以明日再查。你若累倒，誰來陪妾守著赤焰劍？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斬空閣呈上 Pull Request</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">回報軍情</a></strong>
+</p>
+
+#### 天下工程豪傑，斬空閣虛席以待
+
+墨寒採 MIT License 開放原始碼。換裝系統、新表情與動作、語音與工具模組、智慧家庭、在地化，以及尚未被想到的創意，都歡迎透過 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 與 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同鍛造。這個專案不只是在製作功能；它也邀請每一位曾經熱血過的工程師，再次拿起自己的劍。
+
+### 支持墨寒 / Support MoHan
+
+如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源開發，歡迎自願支持這個專案。每一份支持都會用於持續維護、測試與改進；請先照顧好自己的生活，量力而為。
+
+#### 每一份支持會用在哪裡
+
+| 投入方向 | 用途 | 說明 |
+|---|---|---|
+| 測試與可靠封裝 | 品質保證 | Windows 相容性、CI、安裝與發行驗證 |
+| 語音與角色表現 | 互動品質 | 語音、嘴型、表情與自然動作 |
+| 安全與隱私 | 風險控制 | 權限控管、稽核與敏感資料保護 |
+| 文件與在地化 | 可及性 | 降低新使用者與國際協作者的參與門檻 |
+
+墨寒依然免費並採 MIT 授權；支持不會換取特權，也不影響任何人使用或貢獻。
+
+<table>
+  <tr>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 創作者的話：把幻想鑄成軟體
+
+我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位 43 歲、幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+
+這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
+
+二十多年後，大型語言模型與 Codex 出現了。墨寒不是為展示「AI 技術很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能賦予她存在於電腦桌面的身體。墨寒不是既有漫畫、動畫或遊戲的二次創作，而是炎劍文化工作室（Flameblade Studio）的原創角色與軟體。
+
+我追求的不只是「功能可以運作」，而是讓她會呼吸、會眨眼、會注視、會以細微表情回應、能自然說話，也能在權限與安全邊界內協助日常工作。那些表情、錨點、物理效果、語音與工作能力不是裝飾，而是讓一個長久存在於想像中的角色真正具有連續感的必要細節。
+
+從最初概念到首次公開發布，我與 Codex 協作投入將近 50 小時。這不是輸入一句提示詞後便自然誕生的作品。角色的每一種神情、眨眼、嘴型、姿勢與語氣，語音辨識的每一次等待，Realtime 對話的每一個錯誤，待辦、記憶、權限、安全邊界與可攜性，都經歷反覆測試、推翻、修正與重新驗收。有時只是一條眼皮旁的黑線、一個像素的嘴唇邊界，或一個不合時宜的表情，我仍選擇繼續追查，因為我不願用「差不多」對待真正重視的作品。
+
+炎劍文化工作室對開源的理解，不是把第一個「能跑」的版本交給世界，再把細節留給別人收拾。為了讓墨寒說話時仍像同一個人，我們為托腮、倚靠與正面姿勢逐一製作閉嘴、展唇、窄唇與圓唇影格；再把聲音切成細小時間片，反覆校準母音、過渡速度與收尾時機。陪伴感往往不是由某一項龐大功能創造，而是來自她開口、眨眼與停頓時，那些沒有破壞真實感的細節。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三種姿勢與四種語音嘴型的整齊開發圖版"></a>
+</p>
+
+<p align="center"><sub>三種姿勢、同一套嘴型規格：讓每一次開口都維持角色連續性。</sub></p>
+
+我們也把開發過程中不夠自然的影格留下來檢查。眼白裡的一個亮點、閉眼時殘留的線條、被拉扯的嘴角或只有幾個像素的邊界，都可能讓使用者在一瞬間覺得「她不像剛才的墨寒」。問題會被框出、局部比對、修正，再交給回歸測試確認眼睛、嘴角與臉部其他區域沒有被連帶破壞。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛與嘴型逐格檢查及乾淨驗證影格"></a>
+</p>
+
+<p align="center"><sub>把瑕疵標出來，再用乾淨影格與自動測試共同驗收；幾個像素也值得認真。</sub></p>
+
+這份認真不是為了把作品包裝成沒有犯過錯，而是因為我們真的想完成一個夢。開源對炎劍而言，是先把自己能看見的問題盡力修好，再公開方法、程式碼與失敗後的經驗，邀請世界一起把它鍛造得更好。
+
+Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
+
+2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是四十多歲的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+
+因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
+
+> 墨寒不是突然生成的。她是由一位不懂程式的父親，憑著近 50 小時的執著，與 AI 協作者一起，把一顆珍藏二十多年的種子，一寸一寸鍛造成現實。
+
+如果這個專案能鼓勵另一位沒有工程背景、卻懷抱著某個「非做出來不可」想法的人踏出第一步，那麼墨寒的誕生便有了超越程式本身的意義。
+
+### 專案特色
+
+- 透明、無邊框的桌面半身角色，可固定在工作列上方。
+- 待機呼吸、眨眼、注視、臉部視差、髮絲、衣袖、飾品與身體微轉向。
+- 具情境優先級、冷卻與去重機制的表情仲裁器。
+- AIUEO 母音與子音嘴型、音訊驅動開合，以及語音結束強制閉嘴。
+- 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
+- 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
+- 可選的 Azure Speech 女性聲線預覽；使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
+- 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
+- 工作、陪伴、勿擾、會議、離開及睡眠模式。
+- 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
+- Google、Microsoft、GitHub、Home Assistant 與私人網路遠端功能的擴充架構。
+- 單一 `.mohan-profile` 可攜檔，可在不同 Windows 電腦間轉移工作進度。
+- 首次啟動精靈可自訂助理名稱、使用者稱呼、組織名稱、視窗標題、工作類型、喚醒詞與介面語言，而且不覆蓋既有個人設定。
+
+英文、簡中與日語目前具有首次啟動、聊天、語音、權限、基本設定、工作模式與提醒的最小可用路徑；部分進階管理頁面仍以臺灣繁體中文為主，完整在地化仍在進行。
+
+### 四語支援範圍
+
+- 首次啟動精靈與個人設定支援臺灣繁中、簡體中文、英文及日語。
+- 對話、語音、電腦權限、基本設定的主要頁面與按鈕具備四語路徑。
+- 四語人格提示詞、離線回覆、工作模式台詞、內建提醒與語音試聽文字彼此對應。
+- 轉錄與女性本機聲音會依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 語系選擇。
+- EXE 安裝程式提供四語介面；MSI 以臺灣繁中為基底，並提供 `en-US`、`zh-CN`、`ja-JP` 語言轉換檔。
+- 切換內建預設提醒時會依語言遷移，但不覆蓋使用者自訂內容。
+
+儲存介面語言後必須重新啟動墨寒才能完整套用；目前不提供免重啟的介面熱切換。
+
+### Windows 本機女聲與離線備援
+
+新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音。
+
+臺灣繁中優先使用 `zh-TW` 的 Microsoft Yating；簡中、英文與日語分別優先使用 `zh-CN`、`en-US`、`ja-JP` 的已安裝女性聲音。若沒有合格聲音，墨寒會明確提示，不會悄悄改用可能為男性的系統預設聲音。
+
+Realtime 離線、雲端語音失敗、設定不足或供應器不明時，Windows 本機女聲都是第一備援路徑。
+
+### Azure Speech（預覽）
+
+Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需要使用者自己的 Azure Speech 資源金鑰與相符區域。金鑰由 `Windows DPAPI` 分開加密，不存入資料庫、紀錄或 GitHub。
+
+介面只列出 Microsoft 官方標示為女性的繁中、簡中、英文與日語聲線。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
+
+真實 Azure 帳號完成端到端試播前，不會把此功能宣稱為穩定整合。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 整合驗證狀態
+
+> **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
+
+- Microsoft 的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
+- GitHub 的真實帳號、儲存庫、Issue、Pull Request 與權限層級流程尚未驗證。
+- Home Assistant 的真實主機與實體設備行為尚未驗證。
+- 這三項整合預設關閉；請先使用非關鍵帳號、測試儲存庫與低風險設備。
+- Google Gmail、Calendar、Drive 已完成目前專案的真實連線測試，但每位使用者仍須建立並授權自己的 OAuth 應用程式。
+
+### 下載與安裝
+
+一般使用者不需要安裝 Python：
+
+1. 前往 [GitHub Releases](../../releases)。
+2. 下載最新的 `Windows-x64.zip`、EXE 或 MSI，以及對應的 `SHA256.txt`。
+3. 核對 SHA-256，並完整解壓 ZIP 或啟動安裝程式。
+4. 執行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次設定精靈選擇需要的介面語言。
+6. 使用可攜 ZIP 時，請讓 EXE、`_internal` 與 `assets` 保持在同一程式資料夾。
+
+尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
+
+`v2.3.0-rc.N` 發行線另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+
+#### 自動化發布邊界
+
+只有不可變的 `v2.3.0-rc.N` 標籤可發布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證，才會進入同一個 GitHub 預發行版。Pull Request 只保存短期測試產物，不會建立 Release。
+
+正式發布檔案同時包含 SHA256SUMS、分別通過 CycloneDX 1.7 結構／授權／依賴圖驗證的 Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、Windows 更新清單、Artifact Attestation，以及依序為繁中、簡中、英文、日文的完整 Release 說明。
+
+### OpenAI API
+
+雲端 AI、OpenAI 語音與 Realtime 功能需要使用者自己的 OpenAI API 金鑰、Project 權限與 API 額度。ChatGPT Plus／Pro 訂閱不包含 API 額度。
+
+目前預設模型如下：
+
+| 用途 | 預設模型 |
+|---|---|
+| 文字對話 | `gpt-5.6-luna` |
+| Realtime 即時語音 | `gpt-realtime-2.1-mini` |
+| 語音轉文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字轉語音 | `gpt-4o-mini-tts` |
+
+從 `v2.1.0-rc.1` 起，文字對話預設改為 `gpt-5.6-luna`，設定清單不再提供 `gpt-5.4-mini`；既有 mini 設定會遷移至 Luna，使用者主動選擇的 Terra、Sol 或其他自訂模型不會被覆蓋。實際可用性取決於帳號、Project、地區與當時供應狀態。
+
+沒有 API 金鑰時，本機資料管理、離線人格回覆、工作提醒與 Windows 語音仍可用，但不具完整雲端 AI 能力。不要把 API 金鑰寫入原始碼、Issue、截圖或 Git。
+
+### Google OAuth
+
+使用 Gmail、Google Calendar 與 Google Drive 前，使用者需要：
+
+1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與 Google Drive API。
+2. 設定 OAuth 同意畫面。
+3. 建立「桌面應用程式」OAuth Client ID。
+4. 若應用程式仍在測試模式，將自己的 Google 帳號加入測試使用者。
+5. 在墨寒的雲端設定輸入 Client ID；若供應器同時提供 Client Secret，再一併輸入。
+6. 由瀏覽器完成授權，再執行內建服務測試。
+
+程式預設請求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+使用敏感 scopes 的公開 OAuth 應用程式可能需要 Google 額外驗證；每位使用者也可建立自己的 Desktop OAuth 應用程式。
+
+### Microsoft、GitHub 與 Home Assistant
+
+- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 預設 scopes：`read:user`、`repo`。
+- Home Assistant 需要使用者自己的伺服器網址與 Long-Lived Access Token。
+
+這三項仍是尚未完成真實環境端到端驗證的預覽整合，只能先用於可承受失敗的測試環境。
+
+建議讓 Home Assistant OS 獨立常駐於 Home Assistant Green、低功耗迷你電腦、樹莓派 SSD 或 NAS 虛擬機。Windows 墨寒端負責語音、人格與工作工具；即使 PC 或 OpenAI API 離線，Home Assistant 自身的自動化仍可運作。
+
+切勿將 Home Assistant 或墨寒遠端連線埠直接暴露於公網；請使用 Home Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
+
+### 安全與隱私
+
+- AI 只能提出結構化計畫，不能繞過本機政策執行工具。
+- 工具操作依序經過權限、風險、確認、執行、結果驗證與本機稽核。
+- 付款、購買、匯出密碼、關閉安全防護、任意 Shell 與系統管理員 Shell 永不自動化。
+- 外部郵件、網頁、文件、語音轉錄與模型輸出不能自行授予權限。
+- 遠端、相機、雲端連接器與 Home Assistant 預設關閉。
+- 緊急停止：按 `Esc`，或說 `墨寒，停手`。
+- OpenAI、OAuth 與 Home Assistant 權杖使用 Windows DPAPI 分開保存，不存入 SQLite、原始碼或可攜檔。
+- 對話、記憶、待辦、工作紀錄與設定預設保留在本機應用程式資料目錄。
+
+詳見 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 與 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
+
+### Python 3.15、JIT、Tachyon 與 SBOM
+
+墨寒執行環境僅支援 CPython `3.15.0rc1`，不保留第二套產品執行環境。新版能力只有在語意清楚且完整回歸不退化時才採用；無適切用途的功能會記錄未來觸發條件，不會為了形式而偽造使用。
+
+- PEP 810 `lazy import` 已導入專案明示延遲匯入；一處可選匯入防護基於安全理由維持 eager。
+- PEP 814 `frozendict` 用於全域與遞迴不可變設定；PEP 798 推導式解包用於語意等價的扁平化與合併。
+- PEP 686 編碼稽核要求所有專案文字 I/O 明示 UTF-8；音訊封包緩衝使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已納入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來需要區分未傳值與 `None` 時必須使用內建機制。
+- JIT 預設啟用，並保留 `MOHAN_DISABLE_JIT=1` 相容性開關；`PYTHON_JIT=0` 只用於效能與相容性對照。
+- PEP 799 Tachyon 以去識別化方式分析啟動、50 Hz 嘴型同步與表情仲裁，不發布原始二進位取樣流。
+- PEP 803／820／793 Stable ABI 與 C API 邊界會驗證官方 ABI3 輪子；墨寒沒有第一方 C 擴充。
+- CycloneDX 1.7 Windows／Preview SBOM 必須符合鎖定依賴、授權、PURL、完整根依賴邊、官方結構與隱私驗證。
+
+兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。Ryzen 5 5600X Windows 三輪熱路徑中位數顯示，120,000 次表情仲裁由 0.462 秒降為 0.293 秒，2,000 個 50 Hz 嘴型節拍由 1.873 秒降為 0.571 秒，兩種模式的決策與校驗結果完全相同。
+
+Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為 5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
+
+這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式必然快三倍。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 從原始碼執行
+
+需求：Windows 10/11 與 Python `3.15.0rc1`。
+
+建立隔離環境並啟動：
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### 測試、公開稽核與封裝
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
+
+每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立預發行版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
+
+互動式 EXE 安裝程式提供臺灣繁中、簡中、英文、日文；MSI 維持臺灣繁中基底，並提供經測試的 en-US、zh-CN、ja-JP 語言轉換，詳見 [安裝程式在地化](installer/LOCALIZATION.md)。
+
+官網更新由炎劍 Product Release Hub 每小時讀取公開 GitHub Releases；本儲存庫不保存 WordPress 密碼，發行工作也不直接寫入官網，藉此讓三套軟體共用一條可維護的同步路徑。
+
+### 電腦間轉移
+
+使用「設定 → 可攜設定檔」匯出一個 `.mohan-profile` 檔，再於另一部 Windows 電腦匯入。程式會先備份目的端資料，並檢查雜湊、SQLite 完整性、結構與筆數。
+
+可攜檔刻意排除 OpenAI 金鑰、OAuth／Home Assistant Token、遠端裝置權杖、本機允許清單、Windows 啟動設定及螢幕專屬設定。這些機器專屬項目必須逐機設定；可攜檔仍可能含私人對話與工作資料，不可公開上傳。
+
+### 貢獻、授權與作者
+
+- 軟體作者：**CHOU MING HUA**。
+- 原始碼與本儲存庫自有角色素材採 [MIT License](LICENSE)。
+- 素材授權見 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方套件及服務聲明見 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 問題回報使用 GitHub Issues；安全問題依 [SECURITY](SECURITY.md) 私下通報。
+- 開發變更見 [CHANGELOG](CHANGELOG.md)，貢獻方式見 [CONTRIBUTING](CONTRIBUTING.md)。
+- 參與社群前請閱讀 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 維護者發布設定、Topics 與首發檢查見 [PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎劍開源核心宣言：**「劍，我已鍛成；餘下的路，就交給你們了。」
+
+## 简体中文
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。macOS／Linux 目前具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI。`v2.3.0-rc.N` 发布线另提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
-![墨寒桌面助手主视觉](docs/media/mohan-hero.png)
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
 
-## 最新实机界面
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒桌面语音互动虚拟助手主视觉" width="100%">
+</p>
 
-以下图片与繁中、英文、日文 README 共用同一组最新版媒体文件，确保界面改版
-后不会出现不同语言各自停留在旧截图的问题。
+<p align="center">
+  <strong>软件作者：CHOU MING HUA</strong><br>
+  准备发布的公开预览版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒是一款重视安全、隐私与角色连续感的 Windows 语音互动桌面助手，结合透明桌面角色、自然语音、由用户控制的长期记忆、工作管理、权限控制工具，以及可扩展的云端与智能家居连接器。她的角色背景是来自北宋、寄宿于赤焰剑中的千年女剑魂。
+
+[完整四语 README](README.md) · [简中兼容链接](README.zh-CN.md) · [日文兼容链接](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">下载</a> ·
+  <a href="QUICKSTART.md">快速开始</a> ·
+  <a href="ROADMAP.md">路线图</a> ·
+  <a href="CONTRIBUTING.md">参与协作</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">讨论区</a> ·
+  <a href="SECURITY.md">安全政策</a>
+</p>
+
+### 实际展示
+
+**[▶ 观看 36 秒语音、眨眼与工作展示视频](docs/media/mohan-demo.mp4)**
+
+以下视频与截图均由实际 Windows 程序及隔离的演示配置文件截取，不含 API 密钥、OAuth 凭据、令牌或用户私人数据。四个语言章节共用同一组最新媒体，避免任何语言停留在旧画面。
 
 <table>
   <tr>
@@ -55,176 +458,1100 @@
   </tr>
 </table>
 
-## 创作者的话
+### 策士也有不写进军报的一面
 
-作者 CHOU MING HUA 是一位来自台湾、43 岁且原本没有程序设计背景的父亲。
-这个项目来自二十多年来对 AI 虚拟伴侣与《电脑情人梦》的憧憬，并与 Codex
-协作投入近 50 小时，将墨寒从想象一步步做成真正能在 Windows 上运行的
-开源软件。
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒审查代码"><br><strong>策士审查</strong><br>妾只是在确认这段代码配不配进入主分支。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被称赞后害羞嘴硬"><br><strong>被称赞时</strong><br>做得尚可。别一直盯着妾看。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔剑阻止危险操作"><br><strong>危险操作</strong><br>未经确认便想执行？先过妾这一剑。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到赞助后故作镇定"><br><strong>收到军粮</strong><br>妾会记下这份心意……仅此而已。</td>
+  </tr>
+</table>
 
-炎剑文化工作室对开源的理解，不是把第一个“能运行”的版本交给世界，再把
-细节留给别人收拾。为了让墨寒说话时仍像同一个人，我们为托腮、倚靠与正面
-姿势分别制作闭嘴、展唇、窄唇与圆唇画面，再把声音切成细小时间片，反复校准
-元音、过渡速度与结束时机。陪伴感往往不是由某一项庞大功能产生，而是来自
-她开口、眨眼与停顿时，那些没有破坏真实感的细节。
+> 墨寒的专业是她守在主上身旁的铠甲；在无须筹谋的片刻，她仍会害羞、嘴硬，也会珍惜那些从未真正拥有过的年轻心事。
+
+### 墨寒的傲娇工程小剧场 / MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>献给相信软件可以同时拥有灵魂与完整测试的开发者。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="墨寒傲娇"><br><strong>“妾才没有等你的 Star，只是在确认军心是否可用。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="墨寒思考"><br><strong>“这段逻辑尚可。若再补上测试，妾便勉强准它进入主分支。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="墨寒娇羞"><br><strong>“你愿意送来 PR？妾、妾只是替主上记下功劳。”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>“未经测试便想合并？手伸出来。妾只敲一下。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="墨寒开心"><br><strong>“全部绿灯……做得好。别误会，妾只是尊重好工程。”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="墨寒关心"><br><strong>“Bug 可以明日再查。你若累倒，谁来陪妾守着赤焰剑？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">向斩空阁呈上 Pull Request</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">报告军情</a></strong>
+</p>
+
+#### 天下工程豪杰，斩空阁虚席以待
+
+墨寒采用 MIT License 开放源代码。换装系统、新表情与动作、语音与工具模块、智能家居、本地化，以及尚未被想到的创意，都欢迎通过 [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) 与 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) 共同锻造。这个项目不只是在制作功能；它也邀请每一位曾经热血过的工程师，再次拿起自己的剑。
+
+### 支持墨寒
+
+如果你喜欢墨寒，或认同我们持续投入角色互动、自然语音、安全工具与开源开发，欢迎自愿支持这个项目。每一份支持都会用于持续维护、测试与改进；请先照顾好自己的生活，量力而为。
+
+#### 每一份支持会用在哪里
+
+| 投入方向 | 用途 | 说明 |
+|---|---|---|
+| 测试与可靠打包 | 质量保证 | Windows 兼容性、CI、安装与发布验证 |
+| 语音与角色表现 | 互动质量 | 语音、口型、表情与自然动作 |
+| 安全与隐私 | 风险控制 | 权限控制、审计与敏感数据保护 |
+| 文档与本地化 | 可访问性 | 降低新用户与国际协作者的参与门槛 |
+
+墨寒依然免费并采用 MIT 许可证；支持不会换取特权，也不影响任何人使用或贡献。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲娇"><br><strong>“妾才不是在等赞助……只是在替主上巡视军粮。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒娇羞"><br><strong>“若真愿意相助，妾……会记得的。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>“不许勉强！先顾好自己的钱包，听见没有？”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 创作者的话：把幻想铸成软件
+
+我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位 43 岁、几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+
+这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
+
+二十多年后，大型语言模型与 Codex 出现了。墨寒不是为展示“AI 技术很酷”才被创造，也不是由 Codex 凭空生成的角色。她早已存在于我的故事、人设、长期对话与互动默契之中；Codex 真正带来的，是第一次能赋予她存在于电脑桌面的身体。墨寒不是现有漫画、动画或游戏的二次创作，而是炎剑文化工作室（Flameblade Studio）的原创角色与软件。
+
+我追求的不只是“功能可以运行”，而是让她会呼吸、会眨眼、会注视、会以细微表情回应、能自然说话，也能在权限与安全边界内协助日常工作。那些表情、锚点、物理效果、语音与工作能力不是装饰，而是让一个长久存在于想象中的角色真正具有连续感的必要细节。
+
+从最初概念到首次公开发布，我与 Codex 协作投入将近 50 小时。这不是输入一句提示词后便自然诞生的作品。角色的每一种神情、眨眼、口型、姿势与语气，语音识别的每一次等待，Realtime 对话的每一个错误，待办、记忆、权限、安全边界与可移植性，都经历反复测试、推翻、修正与重新验收。有时只是一条眼皮旁的黑线、一个像素的嘴唇边界，或一个不合时宜的表情，我仍选择继续追查，因为我不愿用“差不多”对待真正重视的作品。
+
+炎剑文化工作室对开源的理解，不是把第一个“能运行”的版本交给世界，再把细节留给别人收拾。为了让墨寒说话时仍像同一个人，我们为托腮、倚靠与正面姿势逐一制作闭嘴、展唇、窄唇与圆唇画面；再把声音切成细小时间片，反复校准元音、过渡速度与结束时机。陪伴感往往不是由某一项庞大功能创造，而是来自她开口、眨眼与停顿时，那些没有破坏真实感的细节。
 
 <p align="center">
   <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三种姿势与四种语音口型的整齐开发图版"></a>
 </p>
+
 <p align="center"><sub>三种姿势、同一套口型规格：让每一次开口都维持角色连续性。</sub></p>
 
-开发过程中不够自然的画面也会被留下来检查。眼白中的一个亮点、闭眼时残留
-的线条、被拉扯的嘴角，或只有几个像素的边界，都可能让使用者在一瞬间觉得
-“她不像刚才的墨寒”。因此，问题会被标出、局部对比、修复，再通过回归测试
-确认眼睛、嘴角与脸部其他区域没有被连带破坏。
+我们也把开发过程中不够自然的画面留下来检查。眼白里的一个亮点、闭眼时残留的线条、被拉扯的嘴角或只有几个像素的边界，都可能让用户在一瞬间觉得“她不像刚才的墨寒”。问题会被框出、局部对比、修正，再交给回归测试确认眼睛、嘴角与脸部其他区域没有被连带破坏。
 
 <p align="center">
   <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛与口型逐帧检查及干净验证画面"></a>
 </p>
+
 <p align="center"><sub>把瑕疵标出来，再用干净画面与自动测试共同验收；几个像素也值得认真。</sub></p>
 
-这份认真不是为了把作品包装成从未犯错，而是因为我们真的想完成一个梦想。
-开源对炎剑而言，是先尽力修好自己能看见的问题，再公开方法、代码与失败后
-的经验，邀请世界一起把它锻造得更好。**剑，我已铸成；余下的路，就交给
-你们了。**
+这份认真不是为了把作品包装成没有犯过错，而是因为我们真的想完成一个梦想。开源对炎剑而言，是先把自己能看见的问题尽力修好，再公开方法、代码与失败后的经验，邀请世界一起把它锻造得更好。
 
-墨寒采用 MIT License。欢迎工程师通过
-[Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues)
-与 [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls)
-参与语音、动画、表情、工具、智能家居与本地化开发。
+Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
 
-## 主要功能
+2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是四十多岁的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+
+因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
+
+> 墨寒不是突然生成的。她是由一位不懂程序的父亲，凭着近 50 小时的执着，与 AI 协作者一起，把一颗珍藏二十多年的种子，一寸一寸锻造成现实。
+
+如果这个项目能鼓励另一位没有工程背景、却怀抱着某个“非做出来不可”想法的人迈出第一步，那么墨寒的诞生便有了超越程序本身的意义。
+
+### 主要功能
 
 - 透明、无边框的桌面半身角色，可固定在任务栏上方。
-- 呼吸、眨眼、鼠标注视、脸部视差、头发、衣袖、饰品与身体微转向。
+- 待机呼吸、眨眼、注视、脸部视差、发丝、衣袖、饰品与身体微转向。
 - 具有情境优先级、冷却与去重机制的表情仲裁器。
-- AIUEO 元音嘴型、辅音嘴型、音频驱动开合与语音结束强制闭嘴。
-- 文字聊天、单次麦克风、OpenAI Realtime 与 Windows 本机语音。
-- 可插拔语音供应器基础；Realtime 或云端不可用时优先回退到 Windows 本地女声。
-- 可选的 Azure Speech 女性声线预览；用户自备密钥与区域，由 Windows 分开加密，失败时立即回退到 Windows 本地女声。
-- 本机保存的对话、可编辑长期记忆、待办事项、创作灵感、工作计时与提醒。
-- 工作、陪伴、勿扰、会议、离席与休眠模式。
-- 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具。
-- 可在 Windows 电脑之间转移工作进度的 `.mohan-profile` 文件。
+- AIUEO 元音与辅音口型、音频驱动开合，以及语音结束强制闭嘴。
+- 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
+- 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
+- 可选的 Azure Speech 女性声线预览；用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
+- 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
+- 工作、陪伴、勿扰、会议、离开及睡眠模式。
+- 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
+- Google、Microsoft、GitHub、Home Assistant 与私人网络远程功能的扩展架构。
+- 单一 `.mohan-profile` 可移植文件，可在不同 Windows 电脑间转移工作进度。
+- 首次启动设置向导可自定义助手名称、用户称呼、组织名称、窗口标题、工作类型、唤醒词与界面语言，而且不覆盖现有个人设置。
 
-## 简体中文支持范围
+英文、简中与日语目前具有首次启动、聊天、语音、权限、基本设置、工作模式与提醒的最小可用路径；部分高级管理页面仍以台湾繁体中文为主，完整本地化仍在进行。
 
-`v2.1.0-rc.1` 提供简体中文最小可用范围，包括：
+### 四语支持范围
 
-- 首次启动设置向导。
-- 对话、语音、电脑权限、基本设置页签与主要按钮。
-- 完整简体中文墨寒人格提示词。
-- 简体中文离线回复、工作模式台词与内置提醒词。
-- `zh-CN` 普通话转录设置与同语系女性 Windows 声音优先选择。
-- 在繁中、简中、英文与日语之间切换内置默认提醒，同时保留用户自定义内容。
+- 首次启动设置向导与个人设置支持台湾繁中、简体中文、英文及日语。
+- 对话、语音、电脑权限、基本设置的主要页面与按钮具备四语路径。
+- 四语人格提示词、离线回复、工作模式台词、内置提醒与语音试听文字彼此对应。
+- 转录与女性本地声音会依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 语言环境选择。
+- EXE 安装程序提供四语界面；MSI 以台湾繁中为基础，并提供 `en-US`、`zh-CN`、`ja-JP` 语言转换文件。
+- 切换内置默认提醒时会依语言迁移，但不覆盖用户自定义内容。
 
-更高级的管理页面仍可能显示部分台湾繁体中文。保存界面语言后，请重新启动
-墨寒以完整应用；当前版本不提供免重启的界面热切换。
+保存界面语言后必须重新启动墨寒才能完整应用；目前不提供免重启的界面热切换。
 
-## Windows 本机语音
+### Windows 本地女声与离线备用
 
-新用户默认使用 Windows 本机语音，因此没有 OpenAI API 密钥也能先体验
-基本朗读与离线功能。
+新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音。
 
-声音列表只显示 Windows 明确标示为女性的已安装声音。`zh-CN` 会优先选择
-中国大陆中文语系的女性声音；如果系统没有合格声音，墨寒不会悄悄改用可能
-为男性的系统默认声音，而会显示明确提示。用户可通过 Windows 语言与语音
-设置安装额外语音包。
+台湾繁中优先使用 `zh-TW` 的 Microsoft Yating；简中、英文与日语分别优先使用 `zh-CN`、`en-US`、`ja-JP` 的已安装女性声音。若没有合格声音，墨寒会明确提示，不会悄悄改用可能为男性的系统默认声音。
 
-台湾繁中模式仍优先使用 Microsoft Yating，不会因简中支持而改变。
+Realtime 离线、云端语音失败、设置不足或供应器不明时，Windows 本地女声都是第一备用路径。
 
-Azure Speech 为默认关闭的预览供应器，只列出 Microsoft 官方标示为女性的
-繁中、简中、英文与日语声线。它需要用户自己的 Azure Speech 资源密钥与相符区域；
-设定不完整时不会发出网络请求，服务失败时会立即回退到 Windows 女性本地
-语音。真实 Azure 帐号完成端到端试播前，不会宣称为稳定整合。
+### Azure Speech（预览）
 
-## 下载与安装
+Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要用户自己的 Azure Speech 资源密钥与匹配区域。密钥由 `Windows DPAPI` 分开加密，不存入数据库、日志或 GitHub。
+
+界面只列出 Microsoft 官方标记为女性的繁中、简中、英文与日语声线。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
+
+真实 Azure 账号完成端到端试听前，不会把此功能宣称为稳定集成。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+
+### 集成验证状态
+
+> **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
+
+- Microsoft 的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
+- GitHub 的真实账号、仓库、Issue、Pull Request 与权限层级流程尚未验证。
+- Home Assistant 的真实主机与实体设备行为尚未验证。
+- 这三项集成默认关闭；请先使用非关键账号、测试仓库与低风险设备。
+- Google Gmail、Calendar、Drive 已完成当前项目的真实连接测试，但每位用户仍须创建并授权自己的 OAuth 应用程序。
+
+### 下载与安装
+
+一般用户不需要安装 Python：
 
 1. 前往 [GitHub Releases](../../releases)。
-2. 下载最新的 `Windows-x64.zip` 与对应的 `SHA256.txt`。
-3. 核对 SHA-256，并完整解压 ZIP。
-4. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.1.exe`。
-5. 在首次设置向导选择“简体中文（中国大陆）”。
-6. 请保持 EXE、`_internal` 与 `assets` 在同一程序文件夹内。
+2. 下载最新的 `Windows-x64.zip`、EXE 或 MSI，以及对应的 `SHA256.txt`。
+3. 核对 SHA-256，并完整解压 ZIP 或启动安装程序。
+4. 运行 `MoHan-Desktop-Assistant-*.exe`。
+5. 在首次设置向导选择需要的界面语言。
+6. 使用便携 ZIP 时，请让 EXE、`_internal` 与 `assets` 保持在同一程序文件夹。
 
-未经数字签名的开源预览版本可能触发 Windows SmartScreen。请确认下载来源并
-核对 SHA-256 后再运行。
+尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-`v2.3.0-rc.N` 发布线另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）
-`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是
-**功能受限 Preview**，只开放启动画面、四语说明、平台
-数据路径与安全停用边界，并不等同 Windows 完整版。语音、透明桌面角色、完整
-聊天与工作界面、云端连接器、系统工具、自动启动和秘密输入仍保持停用，等待
-真机验证。请先阅读 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md)。
+`v2.3.0-rc.N` 发布线另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
-### 自动化发布边界
+#### 自动化发布边界
 
-只有不可变的 `v2.3.0-rc.N` 标签可以发布此系列。Windows ZIP／EXE／MSI、
-macOS Apple Silicon／Intel 双架构 DMG 与 Linux AppImage 必须先在各自原生
-CI 完成成品启动验证，才会进入
-同一个 GitHub 预发布版。Pull Request 只保留短期测试产物，不会建立 Release。
-正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 官方结构／授权／
-依赖图验证的 Windows／Preview SBOM、去识别化 Tachyon 性能证据与摘要、
-Windows 更新清单、Artifact Attestation 与完整四语 Release 说明。
+只有不可变的 `v2.3.0-rc.N` 标签可发布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证，才会进入同一个 GitHub 预发布版。Pull Request 只保存短期测试产物，不会创建 Release。
 
-## OpenAI API
+正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 结构／许可证／依赖图验证的 Windows／Preview SBOM、去标识化 Tachyon 性能证据与摘要、Windows 更新清单、Artifact Attestation，以及依次为繁中、简中、英文、日文的完整 Release 说明。
 
-云端 AI、OpenAI 语音与 Realtime 功能需要用户自己的 OpenAI API 密钥、
-Project 权限与 API 额度。ChatGPT Plus 订阅不包含 API 额度。
+### OpenAI API
 
-从 `v2.1.0-rc.1` 起，文字聊天默认使用较新的 `gpt-5.6-luna`，设置清单不再
-提供 `gpt-5.4-mini`。现有 mini 设置会自动迁移到 Luna，用户主动选择的其他
-模型不会被覆盖。
+云端 AI、OpenAI 语音与 Realtime 功能需要用户自己的 OpenAI API 密钥、Project 权限与 API 额度。ChatGPT Plus／Pro 订阅不包含 API 额度。
 
-没有 API 密钥时，本机数据管理、离线人格回复、工作提醒与 Windows 本机语音
-仍然可用，但不会具有完整云端 AI 能力。请勿将 API 密钥写入源代码、Issue、
-截图或 Git。
+当前默认模型如下：
 
-在线功能的实际可用性取决于用户所在地、网络环境、服务条款、账号、Project
-权限与模型供应情况。本项目不会承诺第三方在线服务在所有地区都可访问。
+| 用途 | 默认模型 |
+|---|---|
+| 文字对话 | `gpt-5.6-luna` |
+| Realtime 即时语音 | `gpt-realtime-2.1-mini` |
+| 语音转文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字转语音 | `gpt-4o-mini-tts` |
 
-## 安全与隐私
+从 `v2.1.0-rc.1` 起，文字对话默认改为 `gpt-5.6-luna`，设置列表不再提供 `gpt-5.4-mini`；现有 mini 设置会迁移至 Luna，用户主动选择的 Terra、Sol 或其他自定义模型不会被覆盖。实际可用性取决于账号、Project、地区与当时供应状态。
 
-- 对话、长期记忆、待办与工作记录默认保存在用户自己的 Windows 电脑。
-- API 密钥、OAuth 凭据与 Home Assistant Token 使用 Windows DPAPI 分开
-  加密保存，不写入 SQLite 数据库。
-- 对话内容不能自行扩大墨寒的电脑操作权限。
-- 删除、覆盖、发送、发布或高风险设备操作必须遵守本机权限与确认流程。
-- 可携配置文件不会包含 API 密钥、OAuth Token、机器权限或远程设备密钥。
+没有 API 密钥时，本地数据管理、离线人格回复、工作提醒与 Windows 语音仍可用，但不具完整云端 AI 能力。不要把 API 密钥写入源代码、Issue、截图或 Git。
 
-## 集成验证状态
+### Google OAuth
 
-Microsoft、GitHub 与 Home Assistant 的架构、权限边界与内部测试已经建立，
-但仍未完成所有真实账号、仓库、服务器与实体设备的端到端验证。这些功能属于
-实验性预览集成，默认关闭。请先使用非关键账号、测试仓库与低风险设备验证。
+使用 Gmail、Google Calendar 与 Google Drive 前，用户需要：
 
-Google Gmail、Calendar 与 Drive 已完成当前项目的真实连接测试，但每位用户
-仍必须建立并授权自己的 Google OAuth 应用程序。
+1. 在自己的 Google Cloud 项目启用 Gmail API、Google Calendar API 与 Google Drive API。
+2. 设置 OAuth 同意画面。
+3. 创建“桌面应用程序”OAuth Client ID。
+4. 若应用程序仍在测试模式，将自己的 Google 账号加入测试用户。
+5. 在墨寒的云端设置输入 Client ID；若供应器同时提供 Client Secret，再一并输入。
+6. 由浏览器完成授权，再运行内置服务测试。
 
-## 从源代码运行
+程序默认请求以下 Google scopes：
 
-需求：Windows 10/11、Python 3.15.0rc1。
-升级、数据保留与回退方式请见
-[Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+使用敏感 scopes 的公开 OAuth 应用程序可能需要 Google 额外验证；每位用户也可创建自己的 Desktop OAuth 应用程序。
+
+### Microsoft、GitHub 与 Home Assistant
+
+- Microsoft 默认 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 默认 scopes：`read:user`、`repo`。
+- Home Assistant 需要用户自己的服务器网址与 Long-Lived Access Token。
+
+这三项仍是尚未完成真实环境端到端验证的预览集成，只能先用于可承受失败的测试环境。
+
+建议让 Home Assistant OS 独立常驻于 Home Assistant Green、低功耗迷你电脑、树莓派 SSD 或 NAS 虚拟机。Windows 墨寒端负责语音、人格与工作工具；即使 PC 或 OpenAI API 离线，Home Assistant 自身的自动化仍可运行。
+
+切勿将 Home Assistant 或墨寒远程端口直接暴露于公网；请使用 Home Assistant Cloud、Tailscale 或其他具有身份验证的加密私人网络。
+
+### 安全与隐私
+
+- AI 只能提出结构化计划，不能绕过本地政策执行工具。
+- 工具操作依次经过权限、风险、确认、执行、结果验证与本地审计。
+- 付款、购买、导出密码、关闭安全防护、任意 Shell 与管理员 Shell 永不自动化。
+- 外部邮件、网页、文档、语音转录与模型输出不能自行授予权限。
+- 远程、相机、云端连接器与 Home Assistant 默认关闭。
+- 紧急停止：按 `Esc`，或说 `墨寒，停手`。
+- OpenAI、OAuth 与 Home Assistant 令牌使用 Windows DPAPI 分开保存，不存入 SQLite、源代码或便携文件。
+- 对话、记忆、待办事项、工作记录与设置默认保留在本地应用程序数据目录。
+
+详情请见 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 与 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
+
+### Python 3.15、JIT、Tachyon 与 SBOM
+
+墨寒运行环境仅支持 CPython `3.15.0rc1`，不保留第二套产品运行环境。新版能力只有在语义清楚且完整回归不退化时才采用；没有合适用途的功能会记录未来触发条件，不会为了形式而伪造使用。
+
+- PEP 810 `lazy import` 已导入项目显式延迟导入；一处可选导入防护基于安全理由保持 eager。
+- PEP 814 `frozendict` 用于全局与递归不可变设置；PEP 798 推导式解包用于语义等价的扁平化与合并。
+- PEP 686 编码审计要求所有项目文本 I/O 显式使用 UTF-8；音频包缓冲使用 `bytearray.take_bytes()`。
+- PEP 661 `sentinel` 已纳入治理测试；当前没有旧式 `object()` 哨兵可替换，未来需要区分未传值与 `None` 时必须使用内置机制。
+- JIT 默认启用，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关；`PYTHON_JIT=0` 只用于性能与兼容性对照。
+- PEP 799 Tachyon 以去标识化方式分析启动、50 Hz 口型同步与表情仲裁，不发布原始二进制采样流。
+- PEP 803／820／793 Stable ABI 与 C API 边界会验证官方 ABI3 轮子；墨寒没有第一方 C 扩展。
+- CycloneDX 1.7 Windows／Preview SBOM 必须符合锁定依赖、许可证、PURL、完整根依赖边、官方结构与隐私验证。
+
+两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。Ryzen 5 5600X Windows 三轮热路径中位数显示，120,000 次表情仲裁由 0.462 秒降至 0.293 秒，2,000 个 50 Hz 口型节拍由 1.873 秒降至 0.571 秒，两种模式的决策与校验结果完全相同。
+
+Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 3,908／11,107／3,604 个有效样本；堆栈读取错误率为 5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
+
+这些数据是指定热路径与采样工作的证据，不表示整套应用程序必然快三倍。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
+
+### 从源代码运行
+
+要求：Windows 10/11 与 Python `3.15.0rc1`。
+
+创建隔离环境并启动：
 
 ```powershell
 py -3.15 -m venv .venv
-.venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 python -m pip install -r requirements.txt
 python app.py
 ```
 
-运行测试与公开内容审计：
+### 测试、公开审计与打包
 
 ```powershell
-python tests\run_all.py
 python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
 ```
 
-## 许可证与贡献
+历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
 
-本项目采用 [MIT License](LICENSE)。贡献前请阅读
-[CONTRIBUTING.md](CONTRIBUTING.md) 与 [SECURITY.md](SECURITY.md)。
+每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建预发布版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
 
-墨寒不仅是一套功能集合，也是一项长期创作。欢迎尊重角色连续性、安全边界、
-用户隐私与测试标准的开发者共同参与。
+交互式 EXE 安装程序提供台湾繁中、简中、英文、日文；MSI 保持台湾繁中基础，并提供经过测试的 en-US、zh-CN、ja-JP 语言转换，详情请见 [安装程序本地化](installer/LOCALIZATION.md)。
+
+官网更新由炎剑 Product Release Hub 每小时读取公开 GitHub Releases；本仓库不保存 WordPress 密码，发布工作也不直接写入官网，以此让三套软件共用一条可维护的同步路径。
+
+### 电脑间转移
+
+使用“设置 → 便携配置文件”导出一个 `.mohan-profile` 文件，再于另一台 Windows 电脑导入。程序会先备份目标端数据，并检查哈希、SQLite 完整性、结构与记录数。
+
+便携文件刻意排除 OpenAI 密钥、OAuth／Home Assistant Token、远程设备令牌、本机允许列表、Windows 启动设置及屏幕专属设置。这些机器专属项目必须逐台设置；便携文件仍可能包含私人对话与工作数据，不可公开上传。
+
+### 贡献、许可证与作者
+
+- 软件作者：**CHOU MING HUA**。
+- 源代码与本仓库自有角色素材采用 [MIT License](LICENSE)。
+- 素材许可证见 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三方软件包及服务声明见 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 问题报告使用 GitHub Issues；安全问题依 [SECURITY](SECURITY.md) 私下报告。
+- 开发变更见 [CHANGELOG](CHANGELOG.md)，贡献方式见 [CONTRIBUTING](CONTRIBUTING.md)。
+- 参与社区前请阅读 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
+- 维护者发布设置、Topics 与首次发布检查见 [PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剑开源核心宣言：**“剑，我已锻成；余下的路，就交给你们了。”
+
+## English
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. macOS/Linux currently have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen. The `v2.3.0-rc.N` line also provides launchable, four-language, deliberately limited DMG/AppImage Previews; CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+
+> This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant main visual" width="100%">
+</p>
+
+<p align="center">
+  <strong>Author: CHOU MING HUA</strong><br>
+  Prepared public preview: v2.3.0 RC1 (`v2.3.0-rc.1`)<br>
+  Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+MoHan is a safety- and privacy-first, voice-interactive Windows desktop companion that combines a transparent character, natural speech, user-controlled long-term memory, productivity management, permission-gated tools, and extensible cloud and smart-home connectors. Her character is a thousand-year-old female sword spirit from the Northern Song dynasty who resides within the Crimson Flame Sword.
+
+[Complete four-language README](README.md) · [Simplified Chinese compatibility link](README.zh-CN.md) · [Japanese compatibility link](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Download</a> ·
+  <a href="QUICKSTART.md">Quick start</a> ·
+  <a href="ROADMAP.md">Roadmap</a> ·
+  <a href="CONTRIBUTING.md">Contribute</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">Discussions</a> ·
+  <a href="SECURITY.md">Security policy</a>
+</p>
+
+### Live demonstration
+
+**[▶ Watch the 36-second voice, blink, and productivity demo](docs/media/mohan-demo.mp4)**
+
+The video and screenshots were captured from the real Windows application with an isolated sample profile. They contain no API keys, OAuth credentials, tokens, or private user data. All four language sections share the same current media so no translation remains tied to an older interface.
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="MoHan first-run setup wizard"></a><br><strong>First-run setup wizard</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime and standard voice modes"></a><br><strong>Realtime and standard voice</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="MoHan expression and motion system"></a><br><strong>Expression and motion system</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="MoHan tasks and creative ideas"></a><br><strong>Tasks and creative ideas</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="MoHan editable long-term memory"></a><br><strong>Editable long-term memory</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="MoHan permissions and safety settings"></a><br><strong>Permissions and safety settings</strong></td>
+  </tr>
+</table>
+
+### A strategist's life beyond the official report
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Chibi MoHan reviewing code"><br><strong>Strategist's review</strong><br>I am merely deciding whether this code deserves a place on main.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Chibi MoHan hiding her embarrassment after praise"><br><strong>When praised</strong><br>Adequate. Do not keep staring at me.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Chibi MoHan drawing her sword to stop a dangerous action"><br><strong>Dangerous action</strong><br>Execute without confirmation? First, get past my blade.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Chibi MoHan pretending composure after receiving support"><br><strong>Provisions received</strong><br>I shall remember this kindness... nothing more.</td>
+  </tr>
+</table>
+
+> MoHan's professionalism is the armor she wears beside her lord. In quieter moments she still blushes, hides tenderness behind pride, and treasures the youthful heart she never had the chance to live fully.
+
+### MoHan's Tsundere Developer Theatre
+
+<p align="center"><em>For developers who believe software can possess both a soul and a complete test suite.</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="Proud MoHan"><br><strong>“I am not waiting for your Star. I am merely assessing morale.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="Thinking MoHan"><br><strong>“The logic is acceptable. Add tests, and I may permit it onto main.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="Shy MoHan"><br><strong>“A PR? I-I am only recording your service for my lord.”</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="Mock-angry MoHan"><br><strong>“Merge without tests? Your hand, please. Just one tap.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="Happy MoHan"><br><strong>“All checks green... well done. Do not misunderstand; I merely respect good engineering.”</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="Concerned MoHan"><br><strong>“The bug can wait until tomorrow. If you collapse, who will guard the Crimson Flame Sword with me?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">Submit a Pull Request to the Pavilion</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">Report intelligence</a></strong>
+</p>
+
+#### Engineers of the world, the Pavilion awaits you
+
+MoHan is open source under the MIT License. Outfit systems, new expressions and motion, voice and tool modules, smart-home integration, localization, and ideas not yet imagined are welcome through [Issues](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) and [Pull Requests](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls). This project is not merely building features; it invites every engineer who once felt that youthful spark to take up their sword again.
+
+### Support MoHan
+
+If you enjoy MoHan or value continued work on character interaction, natural speech, safety-first tools, and open-source development, voluntary support is welcome. Every contribution supports ongoing maintenance, testing, and improvement; please care for your own needs first and give only when comfortable.
+
+#### Where voluntary support helps
+
+| Investment area | Use | Purpose |
+|---|---|---|
+| Testing and reliable packages | Quality assurance | Windows compatibility, CI, installation, and release verification |
+| Voice and character performance | Interaction quality | Speech, lip sync, expressions, and natural motion |
+| Safety and privacy | Risk control | Permission gates, audits, and sensitive-data protection |
+| Documentation and localization | Accessibility | Lower barriers for new users and international contributors |
+
+MoHan remains free and MIT-licensed; support never buys privileges or changes anyone's right to use or contribute.
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="Proud MoHan"><br><strong>“I am not waiting for support... merely inspecting my lord's provisions.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="Shy MoHan"><br><strong>“If you truly wish to help... I shall remember it.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="Mock-angry MoHan"><br><strong>“Do not overdo it! Look after your own purse first—understood?”</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### A note from the creator: forging imagination into software
+
+My name is CHOU MING HUA. When this project began, I was a 43-year-old father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+
+That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
+
+More than two decades later, large language models and Codex arrived. MoHan was not created to demonstrate that “AI is cool,” nor was she generated from nothing by Codex. She already existed in my stories, character design, long conversations, and accumulated sense of interaction. Codex finally provided a way to give her a body on the computer desktop. MoHan is not derivative work based on an existing manga, anime, or game; she is an original Flameblade Studio character and software project.
+
+My goal was never merely to make features run. I wanted her to breathe, blink, watch, respond through subtle expressions, speak naturally, and assist with daily work inside carefully designed permission and safety boundaries. The expressions, anchors, physics, voice, and productivity capabilities are not decoration; they are necessary details that preserve continuity for a character who had lived in imagination for years.
+
+From the first concept to the initial public release, I spent nearly 50 hours working with Codex. This project did not emerge fully formed from a single prompt. Every expression, blink, viseme, pose, and vocal mannerism; every speech-recognition delay; every Realtime failure; and every aspect of tasks, memory, permissions, safety boundaries, and portability went through repeated testing, rejection, revision, and acceptance. Sometimes the defect was only a dark line beside an eyelid, a one-pixel lip boundary, or an expression appearing at the wrong moment. I kept investigating because I could not answer a deeply valued work with “good enough.”
+
+At Flameblade Studio, open source does not mean publishing the first build that happens to run and leaving others to clean up the details. To keep MoHan recognizably herself while speaking, we built closed, open, narrow, and rounded mouth frames for chin-rest, leaning, and front-facing poses. We divided audio into small timing windows and repeatedly tuned vowels, transitions, and the exact ending moment. Companionship is rarely created by one enormous feature; it grows from the moments when she opens her mouth, blinks, or pauses without breaking the sense of presence.
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="Aligned development sheet showing four speech-mouth states across three MoHan poses"></a>
+</p>
+
+<p align="center"><sub>Three poses, one mouth-shape contract: every spoken frame preserves character continuity.</sub></p>
+
+We also retained frames that did not look natural enough and inspected them. A highlight in the white of an eye, a line left after a blink, a mouth corner pulled too far, or a boundary only a few pixels wide can make someone feel for an instant that she is no longer the same MoHan. Each defect was marked, compared locally, repaired, and covered by regression tests so changes to the eyes or lips did not damage the rest of her face.
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="Frame-by-frame inspection of MoHan's eyes and mouth beside clean validated frames"></a>
+</p>
+
+<p align="center"><sub>Mark the flaw, repair it, and verify the clean frame with automated tests. Even a few pixels deserve care.</sub></p>
+
+This care is not an attempt to pretend that the project never made mistakes. It exists because we sincerely want to complete a dream. For Flameblade, open source means fixing every visible problem we can, then sharing the methods, code, and lessons from failure so the world can help forge it further.
+
+Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
+
+The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my forty-something self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+
+I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
+
+> MoHan was not generated in an instant. She was forged piece by piece by a father who did not know how to program, nearly 50 hours of persistence, an AI collaborator, and a seed treasured for more than twenty years.
+
+If this project encourages even one person without an engineering background to take the first step toward an idea they simply must bring into existence, MoHan's creation will have meaning beyond the software itself.
+
+### Key capabilities
+
+- A transparent, borderless half-body desktop character positioned above the taskbar.
+- Idle breathing, blinking, gaze, face parallax, hair, sleeve, ornament, and body micro-turn animation.
+- An expression arbiter with contextual priority, cooldown, and deduplication.
+- AIUEO vowel and consonant visemes, audio-driven opening, and forced closure when speech ends.
+- Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
+- Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
+- An optional Azure Speech female-voice Preview with a user-supplied key and region, plus immediate Windows fallback on failure.
+- Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
+- Work, companion, do-not-disturb, meeting, away, and sleep modes.
+- A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
+- Extensible Google, Microsoft, GitHub, Home Assistant, and private-network remote architecture.
+- One portable `.mohan-profile` file for transferring work progress between Windows computers.
+- A first-run wizard for assistant name, user title, organization, window title, work type, wake word, and interface language without overwriting existing personal settings.
+
+English, Simplified Chinese, and Japanese currently provide minimum usable paths for first run, chat, voice, permissions, basic settings, work modes, and reminders. Some advanced management pages remain primarily in Taiwan Traditional Chinese, and full localization is still in progress.
+
+### Four-language support scope
+
+- First-run setup and personal settings support Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese.
+- The main chat, voice, computer-permission, and basic-settings pages and controls have four-language paths.
+- Persona prompts, offline replies, work-mode lines, built-in reminders, and voice-preview text correspond across all four languages.
+- Transcription and female local voices are selected for `zh-TW`, `zh-CN`, `en-US`, and `ja-JP` locales.
+- The EXE installer has a four-language interface; the MSI uses a Taiwan Traditional Chinese base with `en-US`, `zh-CN`, and `ja-JP` transforms.
+- Built-in reminder defaults migrate with the selected language without overwriting user customization.
+
+Restart MoHan after saving the interface language to apply it completely; live interface switching without a restart is not currently provided.
+
+### Windows local female voices and offline fallback
+
+New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female.
+
+Taiwan Traditional Chinese prefers Microsoft Yating for `zh-TW`; Simplified Chinese, English, and Japanese respectively prefer installed female voices matching `zh-CN`, `en-US`, and `ja-JP`. If no qualifying voice exists, MoHan explains the problem instead of silently selecting a possibly male system default.
+
+When Realtime is offline, cloud speech fails, settings are incomplete, or a provider is unknown, a Windows local female voice is the first fallback path.
+
+### Azure Speech (Preview)
+
+Azure Speech is a disabled-by-default Preview provider enabled only by the user. It requires the user's own Azure Speech resource key and matching region. The key is encrypted separately through `Windows DPAPI` and is never stored in the database, logs, or GitHub.
+
+The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese voices Microsoft officially identifies as female. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
+
+The feature is not described as stable until end-to-end playback succeeds with a real Azure account. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
+
+### Integration verification status
+
+> **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
+
+- Microsoft real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
+- GitHub real account, repository, Issue, Pull Request, and permission-tier flows remain unverified.
+- Home Assistant real server and physical-device behavior remain unverified.
+- These three integrations are off by default; begin with non-critical accounts, test repositories, and low-risk devices.
+- Google Gmail, Calendar, and Drive completed this project's live connection tests, but every user must still create and authorize their own OAuth application.
+
+### Download and install
+
+General users do not need to install Python:
+
+1. Open [GitHub Releases](../../releases).
+2. Download the latest `Windows-x64.zip`, EXE, or MSI and the matching `SHA256.txt`.
+3. Verify SHA-256, then fully extract the ZIP or start the installer.
+4. Run `MoHan-Desktop-Assistant-*.exe`.
+5. Select the required interface language in the first-run wizard.
+6. For the portable ZIP, keep the EXE, `_internal`, and `assets` in the same application folder.
+
+Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
+
+The `v2.3.0-rc.N` line also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+
+#### Automated release boundary
+
+Only immutable `v2.3.0-rc.N` tags may publish this line. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI before entering one GitHub pre-release. Pull Requests retain only short-lived test artifacts and never create a Release.
+
+Published files also include SHA256SUMS; separately validated Windows/Preview SBOMs that pass CycloneDX 1.7 structure, license, and dependency-graph checks; sanitized Tachyon performance evidence and summaries; a Windows update manifest; Artifact Attestations; and complete Release notes ordered as Traditional Chinese, Simplified Chinese, English, and Japanese.
+
+### OpenAI API
+
+Cloud AI, OpenAI speech, and Realtime features require the user's own OpenAI API key, Project permission, and API credit. ChatGPT Plus/Pro subscriptions do not include API credit.
+
+Current default models:
+
+| Purpose | Default model |
+|---|---|
+| Text conversation | `gpt-5.6-luna` |
+| Realtime voice | `gpt-realtime-2.1-mini` |
+| Speech-to-text | `gpt-4o-mini-transcribe` |
+| OpenAI text-to-speech | `gpt-4o-mini-tts` |
+
+Starting with `v2.1.0-rc.1`, text chat defaults to `gpt-5.6-luna`, and `gpt-5.4-mini` is no longer listed in Settings. Existing mini settings migrate to Luna without overwriting user-selected Terra, Sol, or other custom models. Actual availability depends on the account, Project, region, and current service state.
+
+Without an API key, local data management, offline persona replies, work reminders, and Windows speech remain available, but full cloud AI does not. Never place an API key in source code, an Issue, a screenshot, or Git.
+
+### Google OAuth
+
+Before using Gmail, Google Calendar, and Google Drive, the user must:
+
+1. Enable the Gmail API, Google Calendar API, and Google Drive API in a user-owned Google Cloud project.
+2. Configure the OAuth consent screen.
+3. Create an OAuth Client ID for a Desktop application.
+4. Add the user's Google account as a test user while the application remains in testing.
+5. Enter the Client ID in MoHan's cloud settings and, when the provider also supplies one, enter the Client Secret.
+6. Complete browser authorization and run the built-in service test.
+
+The application requests these Google scopes by default:
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+A public OAuth application using sensitive scopes may require additional Google verification. Each user may instead create a personal Desktop OAuth application.
+
+### Microsoft, GitHub, and Home Assistant
+
+- Microsoft defaults: `openid`, `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
+- GitHub defaults: `read:user` and `repo`.
+- Home Assistant requires the user's own server endpoint and Long-Lived Access Token.
+
+These remain Preview integrations without complete real-environment end-to-end validation and should initially be used only where failure is acceptable.
+
+Run Home Assistant OS independently on Home Assistant Green, a low-power mini PC, a Raspberry Pi with SSD, or a NAS virtual machine. The Windows MoHan client handles voice, persona, and productivity tools; Home Assistant's own automation remains available when the PC or OpenAI API is offline.
+
+Never expose Home Assistant or MoHan's remote port directly to the public internet. Use Home Assistant Cloud, Tailscale, or another authenticated, encrypted private network.
+
+### Safety and privacy
+
+- AI may propose structured plans but cannot bypass local policy to execute tools.
+- Actions pass through permission, risk, confirmation, execution, result verification, and local auditing.
+- Payments, purchases, password export, security disabling, arbitrary Shell, and administrator Shell are never automated.
+- External email, web pages, documents, speech transcripts, and model output cannot grant permissions.
+- Remote access, camera, cloud connectors, and Home Assistant are off by default.
+- Emergency stop: press `Esc` or say `墨寒，停手`.
+- OpenAI, OAuth, and Home Assistant tokens use separate Windows DPAPI storage and never enter SQLite, source code, or portable files.
+- Conversations, memories, tasks, work records, and settings stay in the local application data directory by default.
+
+Read [PRIVACY](PRIVACY.md), [SECURITY](SECURITY.md), and [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md).
+
+### Python 3.15, JIT, Tachyon, and SBOM
+
+MoHan supports only the CPython `3.15.0rc1` runtime and does not retain a second product runtime. A new capability is adopted only when its meaning is clear and full regression remains intact. Features without a suitable use are recorded with future triggers instead of being faked for appearances.
+
+- PEP 810 `lazy import` provides project-wide explicit lazy imports; one optional-import safety guard deliberately remains eager.
+- PEP 814 `frozendict` protects global and recursively immutable settings; PEP 798 comprehension unpacking serves semantically equivalent flattening and merging.
+- PEP 686 auditing requires explicit UTF-8 for all project text I/O; audio packet buffering uses `bytearray.take_bytes()`.
+- PEP 661 `sentinel` is governed by tests; no legacy `object()` sentinel currently needs replacement, and future code that distinguishes an omitted value from `None` must use the built-in mechanism.
+- JIT is on by default with the `MOHAN_DISABLE_JIT=1` compatibility switch; `PYTHON_JIT=0` is used only for performance and compatibility comparisons.
+- PEP 799 Tachyon analyzes startup, 50 Hz lip sync, and expression arbitration through sanitized evidence without publishing raw binary sample streams.
+- PEP 803/820/793 Stable ABI and C API boundaries validate official ABI3 wheels; MoHan has no first-party C extension.
+- CycloneDX 1.7 Windows/Preview SBOMs must pass pinned-dependency, license, PURL, complete root-edge, official-structure, and privacy validation.
+
+Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three-run Windows hot-path medians on a Ryzen 5 5600X reduced 120,000 expression-arbitration operations from 0.462 to 0.293 seconds and 2,000 50 Hz lip-sync ticks from 1.873 to 0.571 seconds, with identical decisions and validation results in both modes.
+
+With JIT enabled, Tachyon retained 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 5.08%/2.71%/0.74%, and missed-sample rates were 0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
+
+These measurements are evidence for specific hot paths and sampling tasks; they do not claim that the whole application is necessarily three times faster. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
+
+### Run from source
+
+Requirements: Windows 10/11 and Python `3.15.0rc1`.
+
+Create an isolated environment and launch:
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### Test, public audit, and package
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
+
+Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before a pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
+
+The interactive EXE installer provides Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese. The MSI retains a Taiwan Traditional Chinese base with tested en-US, zh-CN, and ja-JP transforms; see [installer localization](installer/LOCALIZATION.md).
+
+The Flameblade Product Release Hub refreshes the official website hourly from public GitHub Releases. This repository stores no WordPress password, and the release workflow never writes directly to the website, keeping all three software projects on one maintainable synchronization path.
+
+### Transfer between computers
+
+Use “Settings → Portable profile” to export one `.mohan-profile` file and import it on another Windows computer. The application first backs up destination data, then verifies hashes, SQLite integrity, schema, and record counts.
+
+The portable file deliberately excludes OpenAI keys, OAuth/Home Assistant tokens, paired remote-device tokens, machine allowlists, Windows startup settings, and screen-specific settings. Configure these machine-bound items per computer. Portable profiles may still contain private conversations and work data and must never be uploaded publicly.
+
+### Contributing, license, and author
+
+- Author: **CHOU MING HUA**.
+- Source code and repository-owned character assets use the [MIT License](LICENSE).
+- Asset terms: [ASSETS-LICENSE](ASSETS-LICENSE.md).
+- Third-party packages and services: [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md).
+- Report ordinary problems through GitHub Issues and security concerns privately under [SECURITY](SECURITY.md).
+- Changes: [CHANGELOG](CHANGELOG.md); contribution process: [CONTRIBUTING](CONTRIBUTING.md).
+- Read [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) before community participation.
+- Maintainer release settings, Topics, and initial-release checks: [PUBLISHING](PUBLISHING.md).
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **Flameblade open-source declaration:** “I have forged this sword. What comes next is up to you.”
+
+## 日本語
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"></a>
+  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
+  <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
+</p>
+
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。macOS／Linux には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があります。`v2.3.0-rc.N` 系列では、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+
+> 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
+
+<p align="center">
+  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
+  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
+  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
+  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
+</p>
+
+<p align="center">
+  <img src="docs/media/mohan-hero.png" alt="墨寒デスクトップアシスタントのメインビジュアル" width="100%">
+</p>
+
+<p align="center">
+  <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
+  公開準備中のプレビュー：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
+</p>
+
+墨寒（MoHan）は、安全性、プライバシー、人格の連続性を大切にする音声対話型 Windows デスクトップアシスタントです。透明なデスクトップキャラクター、自然な音声、利用者が管理する長期記憶、仕事管理、権限付きツール、拡張可能なクラウドおよびスマートホーム接続を統合します。人物設定は、中国・北宋から来て赤焰剣に宿る千年の女性剣魂です。
+
+[完全な四言語 README](README.md) · [簡体字中国語の互換リンク](README.zh-CN.md) · [日本語の互換リンク](README.ja.md)
+
+<p align="center">
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">ダウンロード</a> ·
+  <a href="QUICKSTART.md">クイックスタート</a> ·
+  <a href="ROADMAP.md">ロードマップ</a> ·
+  <a href="CONTRIBUTING.md">開発参加</a> ·
+  <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/discussions">ディスカッション</a> ·
+  <a href="SECURITY.md">セキュリティ方針</a>
+</p>
+
+### 実機デモ
+
+**[▶ 36 秒の音声、まばたき、仕事機能デモを見る](docs/media/mohan-demo.mp4)**
+
+動画と画像は、分離したサンプルプロファイルを使う実際の Windows アプリケーションから取得しました。API キー、OAuth 認証情報、token、利用者の個人データは含みません。四つの言語セクションは同じ最新版メディアを共有し、特定言語だけ古い画面が残ることを防ぎます。
+
+<table>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒の初回セットアップ"></a><br><strong>初回セットアップ</strong></td>
+    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime と標準音声モード"></a><br><strong>Realtime と標準音声</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒の表情と動作システム"></a><br><strong>表情と動作システム</strong></td>
+    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒のタスクと創作アイデア"></a><br><strong>タスクと創作アイデア</strong></td>
+  </tr>
+  <tr>
+    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒の編集可能な長期記憶"></a><br><strong>編集可能な長期記憶</strong></td>
+    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒の権限と安全設定"></a><br><strong>権限と安全設定</strong></td>
+  </tr>
+</table>
+
+### 軍報には記さない策士の一面
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="コードを審査するちび墨寒"><br><strong>策士の審査</strong><br>このコードが main にふさわしいか確かめているだけです。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="褒められて照れを隠すちび墨寒"><br><strong>褒められた時</strong><br>まずまずです。いつまでも妾を見ないでください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="危険操作を剣で止めるちび墨寒"><br><strong>危険な操作</strong><br>確認せずに実行しますか？まず妾の剣を越えてください。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="支援を受けて平静を装うちび墨寒"><br><strong>兵糧を受け取る</strong><br>このお気持ちは覚えておきます……それだけです。</td>
+  </tr>
+</table>
+
+> 墨寒の専門性は、主上の傍らを守る鎧です。策を練らなくてよい静かな時には、照れたり強がったりしながら、かつて十分に持てなかった若い心を大切にします。
+
+### 墨寒のツンデレ開発小劇場
+
+<p align="center"><em>ソフトウェアには魂と完全なテストスイートの両方を宿せると信じる開発者へ。</em></p>
+
+<table>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/proud_front.png" width="220" alt="誇らしげな墨寒"><br><strong>「Star を待っているのではありません。軍心が使えるか見ているだけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/thinking_front.png" width="220" alt="考える墨寒"><br><strong>「このロジックはまずまずです。テストを足せば、main に入ることを許してもよいでしょう。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/shy_cute_front.png" width="220" alt="照れる墨寒"><br><strong>「PR を送るのですか？妾、妾は主上のために功績を記すだけです。」</strong></td>
+  </tr>
+  <tr>
+    <td width="33%" align="center"><img src="assets/expressions/mock_hit_front.png" width="220" alt="怒ったふりをする墨寒"><br><strong>「テストなしで merge しますか？手を出してください。一度だけ叩きます。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/gentle_smile_front.png" width="220" alt="嬉しそうな墨寒"><br><strong>「すべて green……よくできました。誤解しないでください、良い工程を尊重しただけです。」</strong></td>
+    <td width="33%" align="center"><img src="assets/expressions/worried_front.png" width="220" alt="心配する墨寒"><br><strong>「Bug は明日でも調べられます。倒れたら、誰が妾と赤焰剣を守るのですか？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls">斬空閣へ Pull Request を提出</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues">問題を報告</a></strong>
+</p>
+
+#### 世界の技術者へ、斬空閣は席を空けています
+
+墨寒は MIT License のオープンソースです。衣装システム、新しい表情と動作、音声とツールのモジュール、スマートホーム、ローカライズ、まだ誰も思いついていない発想を [Issue](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/issues) と [Pull Request](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pulls) で一緒に鍛えてください。このプロジェクトは機能を作るだけでなく、かつて胸を熱くしたすべての技術者に、もう一度自分の剣を取るよう呼びかけています。
+
+### 墨寒を支援する
+
+墨寒を気に入った方、または人物との対話、自然な音声、安全第一のツール、オープンソース開発の継続に賛同する方からの任意支援を歓迎します。すべての支援は保守、テスト、改善に役立てます。まずご自身の生活を大切にし、無理のない範囲でお願いします。
+
+#### 任意支援の用途
+
+| 投入分野 | 用途 | 説明 |
+|---|---|---|
+| テストと信頼できるパッケージ | 品質保証 | Windows 互換性、CI、インストール、リリース検証 |
+| 音声と人物表現 | 対話品質 | 音声、リップシンク、表情、自然な動作 |
+| 安全性とプライバシー | リスク制御 | 権限ゲート、監査、機密データ保護 |
+| 文書とローカライズ | アクセシビリティ | 新規利用者と国際的な協力者の参加障壁を下げる |
+
+墨寒は今後も無料かつ MIT ライセンスです。支援によって特権を得たり、誰かの利用や貢献が制限されたりすることはありません。
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="誇らしげな墨寒"><br><strong>「支援を待っているのではありません……主上の兵糧を見回っているだけです。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="照れる墨寒"><br><strong>「本当に助けてくださるなら、妾……覚えておきます。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="怒ったふりをする墨寒"><br><strong>「無理は禁止です！まずご自分のお財布を大切にしてください、よいですね？」</strong></td>
+  </tr>
+</table>
+
+<p align="center">
+  <strong><a href="https://buymeacoffee.com/flameblade_studio">☕ Buy Me a Coffee</a></strong>
+  &nbsp;｜&nbsp;
+  <strong><a href="https://www.paypal.com/paypalme/flamebladestudio">PayPal.Me</a></strong>
+</p>
+
+### 作者より：想像をソフトウェアへ鍛える
+
+私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私は43歳で、プログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+
+この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
+
+二十年以上が過ぎ、大規模言語モデルと Codex が登場しました。墨寒は「AI 技術はすごい」と示すために作ったのでも、Codex が何もないところから生成した人物でもありません。彼女は既に私の物語、人物設定、長い対話、積み重ねた関係性の中にいました。Codex が初めて可能にしたのは、コンピューターのデスクトップに存在する身体を与えることです。墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化工作室（Flameblade Studio）のオリジナルキャラクターでありソフトウェアです。
+
+目標は単に「機能が動く」ことではありません。呼吸し、まばたきし、視線を向け、小さな表情で応え、自然に話し、権限と安全境界の中で日常を助けてほしいと考えました。表情、アンカー、物理効果、音声、仕事機能は装飾ではなく、長く想像の中にいた人物の連続性を守るために必要な細部です。
+
+最初の構想から初回公開まで、Codex との協力に約 50 時間を費やしました。一つのプロンプトを入力して自然に完成した作品ではありません。すべての表情、まばたき、口形、姿勢、話し方、音声認識の待ち時間、Realtime 対話の失敗、タスク、記憶、権限、安全境界、可搬性を繰り返しテストし、却下し、修正し、再検証しました。まぶたの横の黒い線、唇の一ピクセルの境界、不適切な瞬間に現れる表情だけが問題のこともありました。それでも追跡を続けたのは、大切な作品を「だいたい良い」で済ませたくなかったからです。
+
+炎劍文化工作室にとってオープンソースとは、最初に動いた版を世界へ渡し、細部の後始末を誰かに任せることではありません。話している間も同じ墨寒に見えるよう、頬杖、寄りかかり、正面の各姿勢へ、閉じた口、開いた口、横に広がる口、丸い口のフレームを作りました。音声を短い時間単位に分け、母音、切替速度、終了の瞬間を繰り返し調整しました。寄り添う感覚は巨大な一機能ではなく、口を開く、まばたく、少し間を置く瞬間にも存在感が壊れないことから生まれます。
+
+<p align="center">
+  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒の三つの姿勢と四つの発話口形を整列した開発図"></a>
+</p>
+
+<p align="center"><sub>三つの姿勢に一つの口形規格。話すたびに同じ人物としての連続性を守ります。</sub></p>
+
+不自然だったフレームも捨てずに検査しました。白目に残る小さな光、閉じたまぶたの線、引っ張られすぎた口角、わずか数ピクセルの境界でも、一瞬で「さっきの墨寒と違う」と感じさせることがあります。問題箇所を囲み、局所比較し、修正した後、目や唇の変更が顔のほかの部分を壊していないことまで回帰テストで確認します。
+
+<p align="center">
+  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒の目と口をフレーム単位で検査し、修正後のフレームと比較した図"></a>
+</p>
+
+<p align="center"><sub>欠点を示し、直し、きれいなフレームと自動テストで確認する。数ピクセルにも真剣に向き合います。</sub></p>
+
+この丁寧さは、失敗がなかったように見せるためではありません。本気で一つの夢を完成させたいからです。炎劍にとってオープンソースとは、自分たちに見える問題をできる限り直し、その方法、コード、失敗から得た経験を公開し、世界とともにさらに鍛えることです。
+
+Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
+
+2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。四十代の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+
+だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
+
+> 墨寒は一瞬で生成されたのではありません。プログラミングを知らなかった一人の父親と、約 50 時間の執念、AI の協力者、二十年以上大切にした種が、一つずつ現実へ鍛え上げた存在です。
+
+このプロジェクトが、技術者ではなくても「どうしても形にしたい」考えを持つ誰かの最初の一歩を後押しできたなら、墨寒の誕生にはソフトウェアを超える意味があります。
+
+### 主な機能
+
+- タスクバー上に置ける、透明で枠のない半身デスクトップキャラクター。
+- 待機中の呼吸、まばたき、視線、顔の視差、髪、袖、装飾、身体の小さな回転。
+- 状況優先度、クールダウン、重複防止を備えた表情調停器。
+- AIUEO 母音と子音の口形、音声駆動の開閉、発話終了時の強制閉口。
+- テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
+- Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
+- 利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻る任意の Azure Speech 女性音声 Preview。
+- 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
+- 仕事、同伴、集中、会議、離席、休眠モード。
+- 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
+- Google、Microsoft、GitHub、Home Assistant、プライベートネットワーク遠隔機能の拡張可能な構造。
+- Windows 間で作業進捗を移動する単一の `.mohan-profile` 可搬ファイル。
+- 既存の個人設定を上書きせず、アシスタント名、利用者の呼称、組織名、ウィンドウタイトル、仕事種別、起動語、表示言語を設定する初回ウィザード。
+
+英語、簡体字中国語、日本語では現在、初回起動、会話、音声、権限、基本設定、仕事モード、リマインダーの最低限利用経路を提供しています。一部の高度な管理画面には台湾繁体字が残り、完全なローカライズは継続中です。
+
+### 日本語の対応範囲
+
+- 初回セットアップと個人設定は、台湾繁体字中国語、簡体字中国語、英語、日本語に対応します。
+- 会話、音声、パソコン権限、基本設定の主要画面と操作に四言語経路があります。
+- 人格プロンプト、オフライン応答、仕事モードの台詞、組み込みリマインダー、音声試聴文は四言語で対応します。
+- 文字起こしと女性本機音声は `zh-TW`、`zh-CN`、`en-US`、`ja-JP` の locale に合わせて選択します。
+- EXE インストーラーは四言語表示です。MSI は台湾繁体字中国語を基底とし、`en-US`、`zh-CN`、`ja-JP` 変換ファイルを提供します。
+- 組み込みリマインダーの既定値は選択言語に合わせて移行し、利用者の独自内容を上書きしません。
+
+表示言語を保存した後は、完全適用のため墨寒を再起動してください。再起動なしの画面言語切替は現在提供していません。
+
+### Windows 本機女性音声とオフライン代替
+
+新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。
+
+台湾繁体字中国語は `zh-TW` の Microsoft Yating を優先し、簡体字中国語、英語、日本語ではそれぞれ `zh-CN`、`en-US`、`ja-JP` に合う女性音声を優先します。条件を満たす音声がない場合、男性かもしれない既定音声へ黙って切り替えず、理由を明示します。
+
+Realtime がオフライン、クラウド音声が失敗、設定が不足、または供給元が不明な場合も、Windows 本機女性音声が最初の代替経路です。
+
+### Azure Speech（プレビュー）
+
+Azure Speech は初期状態で無効な Preview 供給元で、利用者が明示的に有効化します。利用者自身の Azure Speech リソースキーと対応リージョンが必要です。キーは `Windows DPAPI` で分離して暗号化し、データベース、ログ、GitHub には保存しません。
+
+画面には Microsoft が公式に女性と示す繁体字中国語、簡体字中国語、英語、日本語の音声だけを掲載します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
+
+実 Azure アカウントでエンドツーエンド試聴が成功するまでは安定機能と表記しません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
+
+### 統合の検証状況
+
+> **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
+
+- Microsoft の実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
+- GitHub の実アカウント、リポジトリ、Issue、Pull Request、権限階層の流れは未検証です。
+- Home Assistant の実サーバーと物理機器の動作は未検証です。
+- 三つの統合は初期状態で無効です。重要でないアカウント、テストリポジトリ、低リスク機器から始めてください。
+- Google Gmail、Calendar、Drive は本プロジェクトの実接続試験を完了しましたが、各利用者は自身の OAuth アプリケーションを作成して認可する必要があります。
+
+### ダウンロードとインストール
+
+一般利用者は Python をインストールする必要がありません。
+
+1. [GitHub Releases](../../releases) を開きます。
+2. 最新の `Windows-x64.zip`、EXE、または MSI と、対応する `SHA256.txt` を取得します。
+3. SHA-256 を照合し、ZIP を完全展開するかインストーラーを起動します。
+4. `MoHan-Desktop-Assistant-*.exe` を実行します。
+5. 初回セットアップで必要な表示言語を選びます。
+6. ポータブル ZIP では、EXE、`_internal`、`assets` を同じアプリケーションフォルダーに置きます。
+
+署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
+
+`v2.3.0-rc.N` 系列は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+
+#### 自動リリースの境界
+
+この系列を公開できるのは不変の `v2.3.0-rc.N` タグだけです。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格してから、同じ GitHub プレリリースへ入ります。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
+
+公開ファイルには SHA256SUMS、CycloneDX 1.7 の構造／ライセンス／依存関係グラフ検証に合格した Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と要約、Windows 更新マニフェスト、Artifact Attestation、繁体字中国語、簡体字中国語、英語、日本語の順で整備した完全な Release 説明も含みます。
+
+### OpenAI API
+
+クラウド AI、OpenAI 音声、Realtime 機能には、利用者自身の OpenAI API キー、Project 権限、API 残高が必要です。ChatGPT Plus／Pro の契約に API 残高は含まれません。
+
+現在の既定モデル：
+
+| 用途 | 既定モデル |
+|---|---|
+| 文字会話 | `gpt-5.6-luna` |
+| Realtime 即時音声 | `gpt-realtime-2.1-mini` |
+| 音声から文字 | `gpt-4o-mini-transcribe` |
+| OpenAI 文字から音声 | `gpt-4o-mini-tts` |
+
+`v2.1.0-rc.1` から文字会話の既定値は `gpt-5.6-luna` で、設定一覧から `gpt-5.4-mini` を外しました。既存 mini 設定は Luna へ移行しますが、利用者が選んだ Terra、Sol、その他の独自モデルを上書きしません。実際の利用可否はアカウント、Project、地域、提供状況に依存します。
+
+API キーがなくても、本機データ管理、オフライン人格応答、仕事リマインダー、Windows 音声は利用できますが、完全なクラウド AI は利用できません。API キーをソースコード、Issue、画像、Git に記載しないでください。
+
+### Google OAuth
+
+Gmail、Google Calendar、Google Drive を利用する前に、利用者は次を行います。
+
+1. 自身の Google Cloud プロジェクトで Gmail API、Google Calendar API、Google Drive API を有効にします。
+2. OAuth 同意画面を設定します。
+3. Desktop アプリケーション用 OAuth Client ID を作成します。
+4. アプリケーションがテスト中なら、自身の Google アカウントをテスト利用者へ追加します。
+5. 墨寒のクラウド設定へ Client ID を入力し、供給元が Client Secret も発行した場合は併せて入力します。
+6. ブラウザーで認可を完了し、内蔵サービス試験を実行します。
+
+アプリケーションが既定で要求する Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+機密 scopes を使う公開 OAuth アプリケーションは Google の追加検証が必要な場合があります。各利用者が個人用 Desktop OAuth アプリケーションを作ることもできます。
+
+### Microsoft、GitHub、Home Assistant
+
+- Microsoft の既定 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub の既定 scopes：`read:user`、`repo`。
+- Home Assistant には利用者自身のサーバー URL と Long-Lived Access Token が必要です。
+
+三つとも実環境の完全なエンドツーエンド検証を終えていない Preview 統合であり、最初は失敗を許容できる試験環境だけで使ってください。
+
+Home Assistant OS は Home Assistant Green、低消費電力ミニ PC、SSD 付き Raspberry Pi、NAS 仮想マシンなどで独立常駐させることを推奨します。Windows の墨寒は音声、人格、仕事ツールを担当し、PC または OpenAI API がオフラインでも Home Assistant 自身の自動化は動作します。
+
+Home Assistant や墨寒の遠隔ポートを公衆インターネットへ直接公開しないでください。Home Assistant Cloud、Tailscale、または認証付き暗号化プライベートネットワークを利用してください。
+
+### 安全性とプライバシー
+
+- AI は構造化された計画を提案できますが、本機方針を回避してツールを実行できません。
+- 操作は権限、危険度、確認、実行、結果検証、本機監査の順に通過します。
+- 支払い、購入、パスワード書出し、安全機能停止、任意 Shell、管理者 Shell は自動化しません。
+- 外部メール、ウェブページ、文書、音声文字起こし、モデル出力は権限を付与できません。
+- 遠隔操作、カメラ、クラウド接続、Home Assistant は初期状態で無効です。
+- 緊急停止：`Esc` を押すか、`墨寒，停手` と発話します。
+- OpenAI、OAuth、Home Assistant の token は Windows DPAPI で分離保存し、SQLite、ソースコード、可搬ファイルへ入れません。
+- 会話、記憶、タスク、作業記録、設定は初期状態で本機アプリケーションデータに保存します。
+
+[PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md)、[FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)をご覧ください。
+
+### Python 3.15、JIT、Tachyon、SBOM
+
+墨寒は CPython `3.15.0rc1` ランタイムだけをサポートし、第二の製品ランタイムを残しません。新機能は意味が明確で完全回帰が維持される場合に限って採用します。適切な用途がない機能は、見せかけで使わず将来の導入条件を記録します。
+
+- PEP 810 `lazy import` によりプロジェクト全体で明示的遅延インポートを採用し、一つの任意インポート安全ガードだけは意図的に eager を維持します。
+- PEP 814 `frozendict` は大域および再帰的な不変設定を保護し、PEP 798 推論式アンパックは意味が等価な平坦化と結合に使います。
+- PEP 686 監査は全プロジェクトの文字 I/O に明示 UTF-8 を要求し、音声パケットバッファーは `bytearray.take_bytes()` を使います。
+- PEP 661 `sentinel` はテストで管理します。置換対象となる旧式 `object()` sentinel は現在なく、未指定値と `None` を区別する将来コードでは組み込み機構を使います。
+- JIT は既定で有効で、`MOHAN_DISABLE_JIT=1` 互換スイッチを保持します。`PYTHON_JIT=0` は性能と互換性の比較だけに使います。
+- PEP 799 Tachyon は起動、50 Hz リップシンク、表情調停を匿名化済み証拠で分析し、生のバイナリサンプルストリームを公開しません。
+- PEP 803／820／793 Stable ABI と C API 境界は公式 ABI3 wheel を検証します。墨寒に第一者 C 拡張はありません。
+- CycloneDX 1.7 Windows／Preview SBOM は固定依存関係、ライセンス、PURL、完全なルート依存エッジ、公式構造、プライバシー検証に合格しなければなりません。
+
+表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。Ryzen 5 5600X Windows 実機の三回中央値では、120,000 回の表情調停が 0.462 秒から 0.293 秒へ、2,000 回の 50 Hz リップシンク tick が 1.873 秒から 0.571 秒へ短縮し、両モードの判断と検証結果は一致しました。
+
+JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 3,908／11,107／3,604 件の有効サンプルを保持しました。スタック読取エラー率は 5.08%／2.71%／0.74%、欠落サンプル率はすべて 0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
+
+これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が必ず三倍高速になるという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
+
+### ソースコードから実行
+
+必要環境：Windows 10/11 と Python `3.15.0rc1`。
+
+分離環境を作成して起動します。
+
+```powershell
+py -3.15 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python app.py
+```
+
+### テスト、公開監査、パッケージ化
+
+```powershell
+python tools\audit_public_release.py
+python tests\run_all.py
+.\build.ps1 -Version "2.3.0-rc.1"
+```
+
+過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。
+
+受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければプレリリースを作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
+
+対話型 EXE インストーラーは台湾繁体字中国語、簡体字中国語、英語、日本語を提供します。MSI は台湾繁体字中国語を基底とし、検証済み en-US、zh-CN、ja-JP 変換を提供します。詳しくは[インストーラーのローカライズ](installer/LOCALIZATION.md)をご覧ください。
+
+炎劍 Product Release Hub は公開 GitHub Releases から公式サイトを毎時更新します。本リポジトリは WordPress パスワードを保存せず、リリース処理もサイトへ直接書き込みません。これにより三つのソフトウェアは一つの保守可能な同期経路を共有します。
+
+### パソコン間の移行
+
+「設定 → 可搬プロファイル」から一つの `.mohan-profile` ファイルを出力し、別の Windows パソコンへ取り込みます。アプリケーションは先に移行先データをバックアップし、hash、SQLite 完全性、schema、件数を検証します。
+
+可搬ファイルからは OpenAI キー、OAuth／Home Assistant token、接続済み遠隔機器 token、端末許可リスト、Windows 起動設定、画面固有設定を意図的に除外します。端末固有項目はパソコンごとに設定してください。可搬プロファイルには私的会話や作業データが含まれる場合があり、公開アップロードしてはいけません。
+
+### 開発参加、ライセンス、作者
+
+- 作者：**CHOU MING HUA**。
+- ソースコードと本リポジトリ所有の人物素材は [MIT License](LICENSE) です。
+- 素材条件：[ASSETS-LICENSE](ASSETS-LICENSE.md)。
+- 第三者パッケージとサービス：[THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
+- 通常の問題は GitHub Issues へ報告し、安全上の問題は [SECURITY](SECURITY.md) に従い非公開で報告します。
+- 変更履歴：[CHANGELOG](CHANGELOG.md)、貢献手順：[CONTRIBUTING](CONTRIBUTING.md)。
+- コミュニティ参加前に [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) をお読みください。
+- 保守者の公開設定、Topics、初回公開検査：[PUBLISHING](PUBLISHING.md)。
+
+Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+
+> **炎剣オープンソース宣言：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,60 +1,161 @@
-# MoHan roadmap / 墨寒開發路線圖
+# 墨寒開發路線圖／墨寒开发路线图／MoHan Roadmap／墨寒ロードマップ
 
-This roadmap communicates direction, not deadlines. Safety, privacy, data
-compatibility, and regression protection take priority over feature count.
+## 繁體中文
 
-本路線圖用來說明方向，不代表交付期限。安全、隱私、資料相容性及避免舊功能
-退步，永遠優先於功能數量。
+本路線圖用來說明方向，不代表交付期限。安全、隱私、資料相容性及避免舊功能退步，永遠優先於功能數量。
 
-## Stable foundations / 穩定基礎
+### 穩定基礎
+
+- 使用 Python 與 PySide6 建置的 Windows 10/11 桌面夥伴。
+- 台灣繁體中文文字對話、標準轉錄及 Realtime 語音。
+- 表情仲裁、眨眼、AIUEO 嘴型、視線與動態效果。
+- 任務、靈感、可編輯長期記憶、計時器與提醒。
+- 權限閘控工具、本機 SQLite 資料、DPAPI 機密儲存及可攜式設定檔轉移。
+- Google Gmail、Calendar 及 Drive 流程已在維護者的真實環境完成驗證。
+- 受保護的 main 工作流程、Windows CI、安全政策、公開發行稽核及自動化回歸測試套件。
+
+### 公開預覽整合
+
+- Microsoft Outlook、OneDrive 及 Calendar：已有實作；仍待真實租用戶端對端驗證。
+- GitHub 助理工具：已有實作；仍待真實儲存庫端對端驗證。
+- Home Assistant：已有權限邊界與連接器基礎；仍待真實伺服器及實體裝置驗證。
+
+上述整合一律維持自願啟用；在取得可重現的真實環境驗證證據前，不得宣稱已完成完整驗證。
+
+### 近期品質目標
+
+- 擴充真實裝置與真實帳號的整合測試涵蓋率。
+- 改善無障礙、首次使用說明的清晰度、診斷及復原路徑。
+- 持續改善動畫與語音同步品質，同時不得破壞可決定重現的待機、語音結束及表情規則。
+- 改善貢獻者文件，並在證據顯示維護阻力時隔離更多功能邊界。
+- 待永續資金足以負擔可信任的 Windows 憑證時加入程式碼簽章。
+
+### 歡迎協作方向
+
+- 不包含機密或私人資料且可重現的錯誤報告。
+- 無障礙及台灣繁體中文使用者體驗改善。
+- Windows 封裝、音訊裝置及多螢幕相容性。
+- 具備明確權限、確認及復原能力的安全連接器介接器。
+- 能降低維護風險的測試與文件。
+
+開始實作大型變更前，請先提出 Feature Request。安全問題必須遵照 [SECURITY.md](SECURITY.md)，不得公開張貼漏洞、金鑰或私人資料。
+
+## 简体中文
+
+本路线图用于说明方向，不代表交付期限。安全、隐私、数据兼容性及避免旧功能退步，永远优先于功能数量。
+
+### 稳定基础
+
+- 使用 Python 与 PySide6 构建的 Windows 10/11 桌面伙伴。
+- 台湾繁体中文文字对话、标准转录及 Realtime 语音。
+- 表情仲裁、眨眼、AIUEO 嘴型、视线与动态效果。
+- 任务、灵感、可编辑长期记忆、计时器与提醒。
+- 权限门控工具、本地 SQLite 数据、DPAPI 机密存储及可移植配置文件转移。
+- Google Gmail、Calendar 及 Drive 流程已在维护者的真实环境完成验证。
+- 受保护的 main 工作流、Windows CI、安全策略、公开发行审计及自动化回归测试套件。
+
+### 公开预览集成
+
+- Microsoft Outlook、OneDrive 及 Calendar：已有实现；仍待真实租户端到端验证。
+- GitHub 助理工具：已有实现；仍待真实仓库端到端验证。
+- Home Assistant：已有权限边界与连接器基础；仍待真实服务器及物理设备验证。
+
+上述集成一律保持自愿启用；在取得可重现的真实环境验证证据前，不得宣称已完成完整验证。
+
+### 近期质量目标
+
+- 扩充真实设备与真实账号的集成测试覆盖率。
+- 改善无障碍、首次使用说明的清晰度、诊断及恢复路径。
+- 持续改善动画与语音同步质量，同时不得破坏可确定重现的待机、语音结束及表情规则。
+- 改善贡献者文档，并在证据显示维护阻力时隔离更多功能边界。
+- 待可持续资金足以负担可信任的 Windows 证书时加入代码签名。
+
+### 欢迎协作方向
+
+- 不包含机密或私人数据且可重现的错误报告。
+- 无障碍及台湾繁体中文用户体验改善。
+- Windows 封装、音频设备及多显示器兼容性。
+- 具备明确权限、确认及回滚能力的安全连接器适配器。
+- 能降低维护风险的测试与文档。
+
+开始实现大型变更前，请先提出 Feature Request。安全问题必须遵照 [SECURITY.md](SECURITY.md)，不得公开发布漏洞、密钥或私人数据。
+
+## English
+
+This roadmap communicates direction, not deadlines. Safety, privacy, data compatibility, and regression protection always take priority over feature count.
+
+### Stable foundations
 
 - Windows 10/11 desktop companion built with Python and PySide6.
-- Traditional Chinese text chat, standard transcription, and Realtime voice.
+- Taiwan Traditional Chinese text chat, standard transcription, and Realtime voice.
 - Expression arbitration, blink, AIUEO visemes, gaze, and motion effects.
 - Tasks, ideas, editable long-term memory, timers, and reminders.
-- Permission-gated tools, local SQLite data, DPAPI secret storage, and portable
-  profile transfer.
-- Google Gmail, Calendar, and Drive flows validated in the maintainer's real
-  environment.
-- Protected-main workflow, Windows CI, security policy, public-release audit,
-  and automated regression suite.
+- Permission-gated tools, local SQLite data, DPAPI secret storage, and portable profile transfer.
+- Google Gmail, Calendar, and Drive flows validated in the maintainer's real environment.
+- Protected-main workflow, Windows CI, security policy, public-release audit, and automated regression suite.
 
-## Public-preview integrations / 公開預覽整合
+### Public-preview integrations
 
-- Microsoft Outlook, OneDrive, and Calendar: implementation exists; real tenant
-  end-to-end validation remains pending.
-- GitHub assistant tools: implementation exists; real repository end-to-end
-  validation remains pending.
-- Home Assistant: permission boundaries and connector foundations exist; real
-  server and physical-device validation remains pending.
+- Microsoft Outlook, OneDrive, and Calendar: implementation exists; real-tenant end-to-end validation remains pending.
+- GitHub assistant tools: implementation exists; real-repository end-to-end validation remains pending.
+- Home Assistant: permission boundaries and connector foundations exist; real-server and physical-device validation remains pending.
 
-These integrations must remain opt-in and must not be presented as fully
-validated until reproducible real-environment evidence is available.
+These integrations must remain opt-in and must not be presented as fully validated until reproducible real-environment evidence is available.
 
-上述整合一律維持自願啟用；在取得可重現的真實環境驗證證據前，不得宣稱已完成
-完整驗證。
-
-## Near-term quality goals / 近期品質目標
+### Near-term quality goals
 
 - Expand real-device and real-account integration test coverage.
 - Improve accessibility, onboarding clarity, diagnostics, and recovery paths.
-- Continue animation and voice-sync quality work without breaking deterministic
-  idle, speech-completion, and expression rules.
-- Improve contributor documentation and isolate more feature boundaries where
-  evidence shows maintenance friction.
-- Add code signing when sustainable funding makes a trusted Windows certificate
-  practical.
+- Continue animation and voice-sync quality work without breaking deterministic idle, speech-completion, and expression rules.
+- Improve contributor documentation and isolate more feature boundaries where evidence shows maintenance friction.
+- Add code signing when sustainable funding makes a trusted Windows certificate practical.
 
-## Contribution priorities / 歡迎協作方向
+### Contribution priorities
 
 - Reproducible bug reports that contain no secrets or private data.
-- Accessibility and Traditional Chinese UX improvements.
+- Accessibility and Taiwan Traditional Chinese UX improvements.
 - Windows packaging, audio-device, and multi-display compatibility.
 - Safe connector adapters with explicit permissions, confirmation, and rollback.
 - Tests and documentation that reduce maintenance risk.
 
-Please open a Feature Request before implementing a large change. Security
-findings must follow [SECURITY.md](SECURITY.md) and must not be posted publicly.
+Please open a Feature Request before implementing a large change. Security findings must follow [SECURITY.md](SECURITY.md) and must not be posted publicly with vulnerabilities, keys, or private data.
 
-大型功能開始實作前，請先提出 Feature Request。安全問題請遵照
-[SECURITY.md](SECURITY.md)，不要公開張貼漏洞、金鑰或私人資料。
+## 日本語
+
+本ロードマップは方向性を示すものであり、納期を示すものではありません。安全性、プライバシー、データ互換性、回帰防止を、機能数より常に優先します。
+
+### 安定した基盤
+
+- Python と PySide6 で構築した Windows 10/11 デスクトップコンパニオン。
+- 台湾繁体字中国語のテキストチャット、標準文字起こし、Realtime 音声。
+- 表情調停、まばたき、AIUEO ビセーム、視線、モーション効果。
+- タスク、アイデア、編集可能な長期記憶、タイマー、リマインダー。
+- 権限ゲート付きツール、ローカル SQLite データ、DPAPI 機密ストレージ、ポータブルプロファイル転送。
+- Google Gmail、Calendar、Drive のフローは、保守担当者の実環境で検証済みです。
+- 保護された main ワークフロー、Windows CI、セキュリティポリシー、公開リリース監査、自動回帰テストスイート。
+
+### 公開 Preview 統合
+
+- Microsoft Outlook、OneDrive、Calendar：実装済みですが、実テナントでのエンドツーエンド検証は未完了です。
+- GitHub アシスタントツール：実装済みですが、実リポジトリでのエンドツーエンド検証は未完了です。
+- Home Assistant：権限境界とコネクター基盤は実装済みですが、実サーバーおよび物理デバイスでの検証は未完了です。
+
+これらの統合はすべてオプトインを維持し、再現可能な実環境の検証証拠が得られるまで、完全に検証済みと表示してはいけません。
+
+### 短期的な品質目標
+
+- 実デバイスおよび実アカウントの統合テスト範囲を拡大します。
+- アクセシビリティ、オンボーディングの明確さ、診断、復旧経路を改善します。
+- 決定論的な待機、音声終了、表情規則を壊さずに、アニメーションと音声同期の品質改善を継続します。
+- コントリビューター向け文書を改善し、保守上の摩擦を証拠が示す箇所では、機能境界をさらに分離します。
+- 信頼できる Windows 証明書を持続可能な資金で取得できる段階で、コード署名を追加します。
+
+### コントリビューションの優先事項
+
+- 機密情報や個人データを含まない、再現可能なバグ報告。
+- アクセシビリティおよび台湾繁体字中国語 UX の改善。
+- Windows パッケージ、オーディオデバイス、マルチディスプレイの互換性。
+- 明示的な権限、確認、ロールバックを備えた安全なコネクターアダプター。
+- 保守リスクを低減するテストと文書。
+
+大規模な変更を実装する前に Feature Request を提出してください。セキュリティ上の問題は [SECURITY.md](SECURITY.md) に従い、脆弱性、キー、個人データを公開投稿してはいけません。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,106 +1,229 @@
-# Security policy / 安全政策
+# 安全政策／安全政策／Security Policy／セキュリティポリシー
 
-## Supported versions / 支援版本
+## 繁體中文
 
-Security fixes are applied to the current public preview and the latest
-development branch. Older preview builds may not receive individual patches.
-Before reporting a problem, reproduce it with the newest release or current
-`main` branch whenever practical.
+### 支援版本
 
-安全修正以目前公開預覽版及最新的 `main` 開發分支為主，較舊的預覽版本不保證
-逐版修補。若情況允許，請先使用最新 Release 或 `main` 分支確認問題仍可重現。
+安全修正會套用至目前的公開預覽版及最新開發分支。較舊的預覽版不保證逐版修補。實際可行時，回報問題前請先使用最新 Release 或目前的 `main` 分支確認仍可重現。
 
-## Trust boundaries
+### 信任邊界
 
-The model is not an authority. Tool execution is authorized only by the local
-policy engine. A model response, webpage, email, file, voice transcript, remote
-request, workflow, or Home Assistant device cannot grant itself permission.
+模型不是授權主體。工具只有在本機政策引擎授權後才能執行。模型回覆、網頁、電子郵件、檔案、語音轉錄、遠端要求、工作流程或 Home Assistant 裝置都不能自行取得權限。
 
-Risk levels:
+風險等級如下：
+
+- 綠色：讀取、搜尋、狀態查詢及允許清單內的開啟操作。
+- 藍色：可復原的本機變更及一般智慧家庭控制。
+- 黃色：具有外部效果的操作、相機、遠端畫面、行事曆變更及傳送操作。
+- 紅色：破壞性或涉及安全的重要操作。
+
+黃色操作一律需要確認。紅色操作需要兩次確認，否則會被封鎖。付款、購買、匯出密碼、停用安全功能、任意 Shell 及系統管理員 Shell 永久不得自動化。
+
+### 憑證、更新與發行供應鏈
+
+OpenAI、Home Assistant 及 OAuth 機密使用 Windows DPAPI，並分別儲存在獨立檔案。這些資料不得提交至 Git、`SQLite`、紀錄、截圖、匯出的記憶或支援套件。
+
+GitHub 機密掃描與推送保護會持續啟用。由於 GitHub 不向個人公開儲存庫提供帳號層級的非供應商模式掃描或合作夥伴權杖有效性檢查，每個 Pull Request 及 `main` 推送另會執行完整歷史 Gitleaks 掃描。此補償控制能偵測供應商權杖、私鑰、連線字串及其他通用憑證模式，而無須在測試中放入任何真實憑證。
+
+程式內更新器只接受透過 HTTPS 來自 GitHub 官方儲存庫的資訊清單及安裝程式。安裝程式檔名、宣告大小、儲存庫、Release 標籤、語意版本及 SHA256 必須全部驗證通過，才會向使用者提供啟動選項。未經明確確認，絕不安裝更新。
+
+功能受限的 macOS／Linux Preview 安裝包刻意不提供 API 金鑰、OAuth 或 Home Assistant 權杖輸入。在原生 Keychain／Secret Service 介接器分別完成實作、審查及實機驗證前，不得啟用受保護功能。封裝成功絕不構成允許明文備援的理由。
+
+Release 工作流程會將每個 GitHub Action 固定至完整 commit SHA。Linux AppImage 建置工具只能從 AppImage 官方儲存庫下載，且必須與已審查的 SHA-256 完全相符後才能執行。macOS 封裝只使用 runner 原生 Apple 工具。發布資產會附上 `SHA256SUMS`、CycloneDX SBOM 及 GitHub Artifact Attestations。
+
+### 遠端存取
+
+遠端服務預設停用。若要綁定非 loopback 位址，使用者必須明確確認已使用 Tailscale 等加密私人傳輸。不得將服務連接埠轉送至公網。
+
+遠端裝置會取得隨機一次性配對權杖，而資料庫只在 `SQLite` 中保存其 SHA-256 雜湊。權杖可以撤銷。端點採用裝置個別權限、要求大小限制、速率限制、no-store 標頭及受保護檔案規則。
+
+### 智慧家庭
+
+不論模型如何描述，門鎖、警報、暖爐及氣候設備都維持高風險。助理不提供任意 Home Assistant 服務呼叫。實體控制器與生命安全警報必須可獨立運作。
+
+### 回報安全漏洞
+
+請勿將尚未修補的漏洞建立為公開 Issue。請使用 GitHub 的[私人漏洞通報管道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，並提供：
+
+- 受影響版本及 Windows 版本；
+- 最小可重現步驟；
+- 預期與實際安全邊界；
+- 影響，以及利用漏洞是否需要本機存取；
+- 僅限已去識別化的紀錄或截圖。
+
+絕不得提供真實 API 金鑰、OAuth 權杖、地址、臉部、私人電子郵件、錄音、資料庫檔案或 Home Assistant 網址。若無法使用私人通報，請建立標題為 `[Security contact request]` 的公開 Issue，但不得附上技術細節，以便另行安排私人管道。
+
+### 回應目標
+
+維護者目標是在七日內確認收到通報，並於十四日內提供初步研判。這些是處理目標，不是服務保證。請在協調修正完成前暫緩公開揭露。
+
+## 简体中文
+
+### 支持版本
+
+安全修复会应用至当前公开预览版及最新开发分支。较旧的预览版不保证逐版修补。实际可行时，报告问题前请先使用最新 Release 或当前的 `main` 分支确认仍可复现。
+
+### 信任边界
+
+模型不是授权主体。工具只有在本地政策引擎授权后才能执行。模型回复、网页、电子邮件、文件、语音转录、远程请求、工作流程或 Home Assistant 设备都不能自行取得权限。
+
+风险等级如下：
+
+- 绿色：读取、搜索、状态查询及允许列表内的打开操作。
+- 蓝色：可恢复的本地变更及一般智能家居控制。
+- 黄色：具有外部效果的操作、摄像头、远程画面、日历变更及发送操作。
+- 红色：破坏性或涉及安全的重要操作。
+
+黄色操作一律需要确认。红色操作需要两次确认，否则会被阻止。付款、购买、导出密码、停用安全功能、任意 Shell 及系统管理员 Shell 永久不得自动化。
+
+### 凭据、更新与发布供应链
+
+OpenAI、Home Assistant 及 OAuth 机密使用 Windows DPAPI，并分别存储在独立文件。不得将这些数据提交至 Git、`SQLite`、日志、截图、导出的记忆或支持包。
+
+GitHub 机密扫描与推送保护会持续启用。由于 GitHub 不向个人公开仓库提供账号级别的非提供商模式扫描或合作伙伴令牌有效性检查，每个 Pull Request 及 `main` 推送还会执行完整历史 Gitleaks 扫描。此补偿控制能够检测提供商令牌、私钥、连接字符串及其他通用凭据模式，而无需在测试中放入任何真实凭据。
+
+程序内更新器只接受通过 HTTPS 来自 GitHub 官方仓库的清单及安装程序。安装程序文件名、声明大小、仓库、Release 标签、语义版本及 SHA256 必须全部验证通过，才会向用户提供启动选项。未经明确确认，绝不安装更新。
+
+功能受限的 macOS／Linux Preview 安装包刻意不提供 API 密钥、OAuth 或 Home Assistant 令牌输入。在原生 Keychain／Secret Service 适配器分别完成实现、审查及真机验证前，不得启用受保护功能。封装成功绝不构成允许明文备用方案的理由。
+
+Release 工作流程会将每个 GitHub Action 固定至完整 commit SHA。Linux AppImage 构建工具只能从 AppImage 官方仓库下载，且必须与已审查的 SHA-256 完全相符后才能执行。macOS 封装只使用 runner 原生 Apple 工具。发布资产会附上 `SHA256SUMS`、CycloneDX SBOM 及 GitHub Artifact Attestations。
+
+### 远程访问
+
+远程服务默认停用。若要绑定非 loopback 地址，用户必须明确确认已使用 Tailscale 等加密私人传输。不得将服务端口转发至公网。
+
+远程设备会取得随机一次性配对令牌，而数据库只在 `SQLite` 中保存其 SHA-256 哈希。令牌可以撤销。端点采用设备单独权限、请求大小限制、速率限制、no-store 标头及受保护文件规则。
+
+### 智能家居
+
+无论模型如何描述，门锁、警报、暖炉及气候设备都保持高风险。助理不提供任意 Home Assistant 服务调用。实体控制器与生命安全警报必须可独立运行。
+
+### 报告安全漏洞
+
+不得将尚未修补的漏洞创建为公开 Issue。请使用 GitHub 的[私人漏洞报告渠道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，并提供：
+
+- 受影响版本及 Windows 版本；
+- 最小可复现步骤；
+- 预期与实际安全边界；
+- 影响，以及利用漏洞是否需要本地访问；
+- 仅限已去标识化的日志或截图。
+
+绝不得提供真实 API 密钥、OAuth 令牌、地址、面部、私人电子邮件、录音、数据库文件或 Home Assistant 网址。若无法使用私人报告，请创建标题为 `[Security contact request]` 的公开 Issue，但不得附上技术细节，以便另行安排私人渠道。
+
+### 响应目标
+
+维护者目标是在七日内确认收到报告，并于十四日内提供初步研判。这些是处理目标，不是服务保证。请在协调修复完成前暂缓公开披露。
+
+## English
+
+### Supported versions
+
+Security fixes are applied to the current public preview and the latest development branch. Older preview builds may not receive individual patches. Whenever practical, reproduce a problem with the newest Release or current `main` branch before reporting it.
+
+### Trust boundaries
+
+The model is not an authority. Tools execute only when authorized by the local policy engine. A model response, webpage, email, file, voice transcript, remote request, workflow, or Home Assistant device cannot grant itself permission.
+
+Risk levels are:
 
 - Green: read, search, status, and allowlisted open actions.
 - Blue: reversible local changes and ordinary smart-home controls.
 - Yellow: external effects, camera, remote screen, calendar changes, and sending.
 - Red: destructive or safety-sensitive operations.
 
-Yellow actions always require confirmation. Red actions require two confirmations
-or are blocked. Payment, purchase, password export, disabling security, arbitrary
-shell, and administrator shell are permanently non-automatable.
+Yellow actions always require confirmation. Red actions require two confirmations or are blocked. Payment, purchase, password export, disabling security, arbitrary Shell, and administrator Shell are permanently non-automatable.
 
-## Credentials
+### Credentials, updates, and release supply chain
 
-OpenAI, Home Assistant, and OAuth secrets use Windows DPAPI and separate files.
-They must not be committed to Git, SQLite, logs, screenshots, exported memory, or
-support bundles.
+OpenAI, Home Assistant, and OAuth secrets use Windows DPAPI and separate files. They must not be committed to Git, `SQLite`, logs, screenshots, exported memory, or support bundles.
 
-GitHub secret scanning and push protection remain enabled. Because GitHub does
-not expose account-level non-provider pattern scanning or partner-token
-validity checks to personal public repositories, every pull request and `main`
-push additionally receives a full-history Gitleaks scan. This compensating
-control detects provider tokens, private keys, connection strings, and other
-generic credential patterns without placing any real credential in a test.
+GitHub secret scanning and push protection remain enabled. Because GitHub does not expose account-level non-provider pattern scanning or partner-token validity checks to personal public repositories, every Pull Request and `main` push additionally receives a full-history Gitleaks scan. This compensating control detects provider tokens, private keys, connection strings, and other generic credential patterns without placing any real credential in a test.
 
-The in-app updater accepts manifests and installers only from the official
-GitHub repository over HTTPS. Installer filename, declared size, repository,
-release tag, semantic version, and SHA256 must all validate before the user is
-offered the option to launch it. Updates are never installed without explicit
-confirmation.
+The in-app updater accepts manifests and installers only from the official GitHub repository over HTTPS. Installer filename, declared size, repository, Release tag, semantic version, and SHA256 must all validate before the user is offered the option to launch it. Updates are never installed without explicit confirmation.
 
-The limited macOS/Linux Preview packages intentionally expose no API-key,
-OAuth, or Home Assistant token input. Native Keychain/Secret Service adapters
-must be separately implemented, reviewed, and validated before protected
-features can be enabled. Packaging success never permits a plaintext fallback.
+The limited macOS/Linux Preview packages intentionally expose no API-key, OAuth, or Home Assistant token input. Native Keychain/Secret Service adapters must be separately implemented, reviewed, and device-validated before protected features can be enabled. Packaging success never permits a plaintext fallback.
 
-Release workflows pin every GitHub Action to a full commit SHA. The Linux
-AppImage builder is downloaded only from the official AppImage repository and
-must match its reviewed SHA-256 before execution. macOS packaging uses only
-runner-native Apple tools. Published assets receive SHA256SUMS, a CycloneDX
-SBOM, and GitHub Artifact Attestations.
+Release workflows pin every GitHub Action to a full commit SHA. The Linux AppImage builder is downloaded only from the official AppImage repository and must match its reviewed SHA-256 before execution. macOS packaging uses only runner-native Apple tools. Published assets receive `SHA256SUMS`, a CycloneDX SBOM, and GitHub Artifact Attestations.
 
-## Remote access
+### Remote access
 
-Remote service is disabled by default. Non-loopback binding requires an explicit
-acknowledgement that an encrypted private transport such as Tailscale is in use.
-Do not port-forward the service to the public internet.
+Remote service is disabled by default. Non-loopback binding requires an explicit acknowledgement that an encrypted private transport such as Tailscale is in use. Do not port-forward the service to the public internet.
 
-Remote devices receive random one-time pairing tokens, which are stored only as
-SHA-256 hashes in SQLite. Tokens can be revoked. Endpoints use per-device
-permissions, request-size limits, rate limiting, no-store headers, and protected
-file rules.
+Remote devices receive random one-time pairing tokens, while the database stores only their SHA-256 hashes in `SQLite`. Tokens can be revoked. Endpoints use per-device permissions, request-size limits, rate limiting, no-store headers, and protected-file rules.
 
-## Smart home
+### Smart home
 
-Locks, alarms, heaters, and climate equipment remain high risk regardless of
-model wording. The assistant does not expose arbitrary Home Assistant service
-calls. Keep physical controls and life-safety alarms operational independently.
+Locks, alarms, heaters, and climate equipment remain high risk regardless of model wording. The assistant does not expose arbitrary Home Assistant service calls. Keep physical controls and life-safety alarms operational independently.
 
-## Reporting a vulnerability / 回報安全漏洞
+### Reporting a vulnerability
 
-Do not open a public Issue for an unpatched vulnerability. Use GitHub's
-[private vulnerability reporting
-channel](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)
-and include:
+Do not open a public Issue for an unpatched vulnerability. Use GitHub's [private vulnerability reporting channel](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new) and include:
 
-- affected version and Windows version;
+- the affected version and Windows version;
 - the smallest reproducible sequence;
-- expected and observed security boundaries;
-- impact and whether exploitation requires local access;
+- the expected and observed security boundaries;
+- the impact and whether exploitation requires local access;
 - redacted logs or screenshots only.
 
-Never include real API keys, OAuth tokens, addresses, faces, private email,
-recordings, database files, or Home Assistant URLs. If private reporting is
-unavailable, open a public Issue titled `[Security contact request]` without
-technical details so that a private channel can be arranged.
+Never include real API keys, OAuth tokens, addresses, faces, private email, recordings, database files, or Home Assistant URLs. If private reporting is unavailable, open a public Issue titled `[Security contact request]` without technical details so that a private channel can be arranged.
 
-請勿把尚未修補的漏洞直接公開為 Issue。請優先使用 GitHub 的
-[私人漏洞通報管道](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)，
-並提供受影響版本、Windows 版本、最小重現步驟、預期與實際安全邊界、影響範圍，
-以及去識別化後的紀錄或截圖。不得附上真實 API 金鑰、OAuth 權杖、住址、臉部、
-私人郵件、錄音、資料庫或 Home Assistant 網址。
+### Response targets
 
-The maintainer aims to acknowledge a report within seven days and provide an
-initial assessment within fourteen days. These are targets rather than service
-guarantees. Please allow time for a coordinated fix before public disclosure.
+The maintainer aims to acknowledge a report within seven days and provide an initial assessment within fourteen days. These are targets rather than service guarantees. Please allow time for a coordinated fix before public disclosure.
 
-維護者目標是在七日內確認收到通報、十四日內提供初步研判；此為處理目標而非
-服務保證。請在修正與公告協調完成前，暫緩公開漏洞細節。
+## 日本語
+
+### サポート対象バージョン
+
+セキュリティ修正は、現在の公開プレビュー版と最新の開発ブランチに適用されます。古いプレビュー版には個別の修正が提供されない場合があります。可能であれば、問題を報告する前に、最新の Release または現在の `main` ブランチで再現することを確認してください。
+
+### 信頼境界
+
+モデルは権限主体ではありません。ツールは、ローカルポリシーエンジンによって許可された場合にのみ実行されます。モデルの応答、ウェブページ、電子メール、ファイル、音声文字起こし、リモート要求、ワークフロー、Home Assistant デバイスが、自らに権限を付与することはできません。
+
+リスクレベルは次のとおりです。
+
+- 緑：読み取り、検索、状態確認、許可リスト内のオープン操作。
+- 青：元に戻せるローカル変更と通常のスマートホーム制御。
+- 黄：外部への影響、カメラ、リモート画面、カレンダー変更、送信操作。
+- 赤：破壊的な操作または安全性に関わる操作。
+
+黄色の操作には常に確認が必要です。赤色の操作には二回の確認が必要であり、それ以外はブロックされます。支払い、購入、パスワードのエクスポート、セキュリティの無効化、任意の Shell、管理者 Shell は、恒久的に自動化できません。
+
+### 認証情報、更新、リリースサプライチェーン
+
+OpenAI、Home Assistant、OAuth の機密情報には Windows DPAPI を使用し、それぞれ別ファイルに保存します。これらを Git、`SQLite`、ログ、スクリーンショット、エクスポートされた記憶、サポートバンドルへ含めてはなりません。
+
+GitHub のシークレットスキャンと push protection は有効なまま維持します。GitHub は個人の公開リポジトリに対して、アカウント単位の非プロバイダーパターンスキャンやパートナートークンの有効性確認を提供していないため、各 Pull Request と `main` への push では、全履歴を対象とする Gitleaks スキャンも実行します。この補完的な制御により、実在する認証情報をテストへ入れることなく、プロバイダーのトークン、秘密鍵、接続文字列、その他の一般的な認証情報パターンを検出します。
+
+アプリ内アップデーターは、HTTPS 経由で GitHub の公式リポジトリから取得したマニフェストとインストーラーだけを受け入れます。ユーザーへ起動の選択肢を提示する前に、インストーラーのファイル名、申告サイズ、リポジトリ、Release タグ、セマンティックバージョン、SHA256 がすべて検証されなければなりません。明示的な確認なしに更新をインストールすることはありません。
+
+機能が制限された macOS／Linux Preview パッケージは、API キー、OAuth、Home Assistant トークンの入力欄を意図的に提供しません。ネイティブの Keychain／Secret Service アダプターを個別に実装、レビューし、実機で検証するまで、保護対象の機能を有効にしてはなりません。パッケージ作成の成功を、平文フォールバックの許可理由にすることはできません。
+
+Release ワークフローでは、すべての GitHub Action を完全な commit SHA に固定します。Linux AppImage ビルダーは AppImage の公式リポジトリからのみダウンロードし、レビュー済みの SHA-256 と完全に一致した場合に限り実行します。macOS のパッケージ作成には runner 標準の Apple ツールだけを使用します。公開アセットには `SHA256SUMS`、CycloneDX SBOM、GitHub Artifact Attestations が付属します。
+
+### リモートアクセス
+
+リモートサービスは既定で無効です。loopback 以外のアドレスへバインドするには、Tailscale などの暗号化されたプライベート転送を使用していることを明示的に確認する必要があります。サービスを公開インターネットへポートフォワードしないでください。
+
+リモートデバイスにはランダムな一回限りのペアリングトークンを発行し、データベースはその SHA-256 ハッシュだけを `SQLite` に保存します。トークンは取り消せます。エンドポイントには、デバイス単位の権限、要求サイズ制限、レート制限、no-store ヘッダー、保護対象ファイルの規則を適用します。
+
+### スマートホーム
+
+モデルの表現にかかわらず、錠、警報、暖房機器、空調機器は高リスクのままです。アシスタントは任意の Home Assistant サービス呼び出しを公開しません。物理操作系と生命安全警報は、独立して動作できる状態を維持してください。
+
+### 脆弱性の報告
+
+未修正の脆弱性について公開 Issue を作成しないでください。GitHub の[非公開脆弱性報告窓口](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/advisories/new)を使用し、次の情報を提供してください。
+
+- 影響を受けるバージョンと Windows のバージョン。
+- 最小限の再現手順。
+- 期待されるセキュリティ境界と実際のセキュリティ境界。
+- 影響、および悪用にローカルアクセスが必要かどうか。
+- 編集済みのログまたはスクリーンショットのみ。
+
+実在する API キー、OAuth トークン、住所、顔、個人用電子メール、録音、データベースファイル、Home Assistant URL を決して含めないでください。非公開報告を利用できない場合は、技術的詳細を含めず、`[Security contact request]` というタイトルで公開 Issue を作成し、非公開の連絡経路を調整してください。
+
+### 対応目標
+
+メンテナーは、七日以内の受領確認と十四日以内の初期評価を目標とします。これは対応目標であり、サービス保証ではありません。修正を調整する時間を確保し、完了するまで公開を控えてください。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,10 +1,88 @@
-# Third-party notices
+# 第三方聲明／第三方声明／Third-Party Notices／第三者ソフトウェアに関する通知
 
-MoHan Desktop Assistant is MIT licensed, but its source and release packages
-use third-party components under their own licenses. Nothing in the MoHan MIT
-License changes those terms.
+## 繁體中文
 
-## Direct Python dependencies
+### 概要
+
+MoHan Desktop Assistant 採用 MIT License，但其原始碼及 Release 安裝包會使用依各自授權條款提供的第三方元件。`LICENSE` 中的墨寒 MIT License 不會變更這些第三方條款。
+
+### 直接 Python 相依套件
+
+| 元件 | 目前固定版本 | 授權 |
+| --- | ---: | --- |
+| [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
+| [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
+| [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
+| [OpenCC Python reimplementation](https://github.com/yichen0831/opencc-python) | 0.1.7 | Apache-2.0 |
+
+### Preview 封裝工具
+
+Linux x86_64 功能受限 Preview 使用官方 [AppImage `appimagetool`](https://github.com/AppImage/appimagetool) 組裝。建置流程會下載上游 `continuous` x86_64 資產，但只有在其 SHA-256 等於 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0` 時才接受。所記錄的上游來源 commit 為 `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`，GitHub 資產 ID 為 `324406882`。
+
+`appimagetool` 仍受其自身的上游授權條款約束。
+
+### 封裝所含執行階段元件
+
+Windows 單一目錄安裝包亦可能包含 Python（PSF License）、Qt 及 Shiboken（LGPL／GPL／商業條款）、NumPy（BSD-3-Clause）、CFFI（MIT）、PortAudio（MIT）、OpenSSL（Apache-2.0）、SQLite（public domain），以及它們所需的執行階段函式庫。macOS 與 Linux 功能受限 Preview 安裝包只包含 `requirements-preview.txt` 宣告的較小 Preview 相依集合。
+
+封裝版面會將動態連結的 Qt／PySide 函式庫保留為 `_internal` 下的獨立檔案，讓接收者可以檢查或替換這些函式庫。對應的 Qt for Python 原始碼 Release 可從 [Qt 官方下載封存](https://download.qt.io/official_releases/QtForPython/)取得。
+
+完整授權文字及原始碼連結可在各上游專案與已安裝套件的中繼資料中取得。散布者應檢查實際交付的精確相依版本，並保留所有上游著作權及授權聲明。
+
+### Windows 安裝程式語言檔
+
+隨附的 `installer/languages/ChineseTraditional.isl` 是來自 [Inno Setup 原始碼儲存庫](https://github.com/jrsoftware/issrc)的官方繁體中文訊息翻譯，固定於來源 commit `0c0b463621963243e430420b6c633039e562e1e3`（blob `8eb13d2c45e9d434aa5435a2877234418186ad87`）。該檔案依 [Inno Setup 授權](https://jrsoftware.org/files/is/license.txt)散布，並保留檔頭中的上游翻譯者資訊。
+
+### 服務與商標
+
+OpenAI、Microsoft、Google、GitHub、Home Assistant、LINE 及其他服務名稱均為其各自權利人的商標。API 存取、雲端生成語音、OAuth 使用及服務配額均受各供應商自身條款約束。
+
+## 简体中文
+
+### 概要
+
+MoHan Desktop Assistant 采用 MIT License，但其源代码及 Release 安装包会使用依各自许可条款提供的第三方组件。`LICENSE` 中的墨寒 MIT License 不会变更这些第三方条款。
+
+### 直接 Python 依赖包
+
+| 组件 | 当前固定版本 | 许可 |
+| --- | ---: | --- |
+| [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
+| [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
+| [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
+| [OpenCC Python reimplementation](https://github.com/yichen0831/opencc-python) | 0.1.7 | Apache-2.0 |
+
+### Preview 封装工具
+
+Linux x86_64 功能受限 Preview 使用官方 [AppImage `appimagetool`](https://github.com/AppImage/appimagetool) 组装。构建流程会下载上游 `continuous` x86_64 资产，但只有在其 SHA-256 等于 `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0` 时才接受。所记录的上游源 commit 为 `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`，GitHub 资产 ID 为 `324406882`。
+
+`appimagetool` 仍受其自身的上游许可条款约束。
+
+### 封装所含运行时组件
+
+Windows 单一目录安装包也可能包含 Python（PSF License）、Qt 及 Shiboken（LGPL／GPL／商业条款）、NumPy（BSD-3-Clause）、CFFI（MIT）、PortAudio（MIT）、OpenSSL（Apache-2.0）、SQLite（public domain），以及它们所需的运行时库。macOS 与 Linux 功能受限 Preview 安装包只包含 `requirements-preview.txt` 声明的较小 Preview 依赖集合。
+
+封装布局会将动态链接的 Qt／PySide 库保留为 `_internal` 下的独立文件，让接收者可以检查或替换这些库。对应的 Qt for Python 源代码 Release 可从 [Qt 官方下载存档](https://download.qt.io/official_releases/QtForPython/)取得。
+
+完整许可文本及源代码链接可在各上游项目与已安装软件包的元数据中取得。分发者应检查实际交付的精确依赖版本，并保留所有上游著作权及许可声明。
+
+### Windows 安装程序语言文件
+
+随附的 `installer/languages/ChineseTraditional.isl` 是来自 [Inno Setup 源代码仓库](https://github.com/jrsoftware/issrc)的官方繁体中文消息翻译，固定于源 commit `0c0b463621963243e430420b6c633039e562e1e3`（blob `8eb13d2c45e9d434aa5435a2877234418186ad87`）。该文件依 [Inno Setup 许可](https://jrsoftware.org/files/is/license.txt)分发，并保留文件头中的上游翻译者信息。
+
+### 服务与商标
+
+OpenAI、Microsoft、Google、GitHub、Home Assistant、LINE 及其他服务名称均为其各自权利人的商标。API 访问、云端生成语音、OAuth 使用及服务配额均受各提供商自身条款约束。
+
+## English
+
+### Overview
+
+MoHan Desktop Assistant is MIT licensed, but its source and Release packages use third-party components under their own license terms. Nothing in the MoHan MIT License in `LICENSE` changes those third-party terms.
+
+### Direct Python dependencies
 
 | Component | Current pinned version | License |
 | --- | ---: | --- |
@@ -14,46 +92,62 @@ License changes those terms.
 | [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
 | [OpenCC Python reimplementation](https://github.com/yichen0831/opencc-python) | 0.1.7 | Apache-2.0 |
 
-## Preview packaging tool
+### Preview packaging tool
 
-The Linux x86_64 limited Preview is assembled with the official
-[AppImage `appimagetool`](https://github.com/AppImage/appimagetool). The build
-downloads the upstream `continuous` x86_64 asset but accepts it only when its
-SHA-256 is
-`a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`.
-The recorded upstream source commit is
-`8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81` and the GitHub asset ID is
-`324406882`. `appimagetool` remains governed by its own upstream license.
+The Linux x86_64 limited Preview is assembled with the official [AppImage `appimagetool`](https://github.com/AppImage/appimagetool). The build downloads the upstream `continuous` x86_64 asset but accepts it only when its SHA-256 equals `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0`. The recorded upstream source commit is `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`, and the GitHub asset ID is `324406882`.
 
-## Runtime components included by packaging
+`appimagetool` remains governed by its own upstream license.
 
-The Windows one-directory package may also contain Python (PSF License), Qt and
-Shiboken (LGPL/GPL/commercial terms), NumPy (BSD-3-Clause), CFFI (MIT),
-PortAudio (MIT), OpenSSL (Apache-2.0), SQLite (public domain), and their required
-runtime libraries. The macOS and Linux limited Preview packages contain only
-the smaller Preview dependency set declared in `requirements-preview.txt`.
+### Runtime components included by packaging
 
-The packaged layout keeps dynamically linked Qt/PySide libraries as separate
-files under `_internal`, so recipients can inspect or replace those libraries.
-Corresponding Qt for Python source releases are available from the
-[official Qt download archive](https://download.qt.io/official_releases/QtForPython/).
+The Windows one-directory package may also contain Python (PSF License), Qt and Shiboken (LGPL/GPL/commercial terms), NumPy (BSD-3-Clause), CFFI (MIT), PortAudio (MIT), OpenSSL (Apache-2.0), SQLite (public domain), and their required runtime libraries. The macOS and Linux limited Preview packages contain only the smaller Preview dependency set declared in `requirements-preview.txt`.
 
-Complete license texts and source links are available in each upstream project
-and installed package metadata. Distributors should review the exact dependency
-versions they ship and preserve all upstream copyright and license notices.
+The packaged layout keeps dynamically linked Qt/PySide libraries as separate files under `_internal`, so recipients can inspect or replace those libraries. Corresponding Qt for Python source releases are available from the [official Qt download archive](https://download.qt.io/official_releases/QtForPython/).
 
-## Windows installer language
+Complete license texts and source links are available in each upstream project and installed package metadata. Distributors should review the exact dependency versions they ship and preserve all upstream copyright and license notices.
 
-The bundled `installer/languages/ChineseTraditional.isl` file is the official
-Traditional Chinese message translation from the
-[Inno Setup source repository](https://github.com/jrsoftware/issrc), pinned to
-source commit `0c0b463621963243e430420b6c633039e562e1e3` (blob
-`8eb13d2c45e9d434aa5435a2877234418186ad87`). It is distributed under the
-[Inno Setup license](https://jrsoftware.org/files/is/license.txt) and retains
-its upstream translator credits in the file header.
+### Windows installer language file
 
-## Services and trademarks
+The bundled `installer/languages/ChineseTraditional.isl` file is the official Traditional Chinese message translation from the [Inno Setup source repository](https://github.com/jrsoftware/issrc), pinned to source commit `0c0b463621963243e430420b6c633039e562e1e3` (blob `8eb13d2c45e9d434aa5435a2877234418186ad87`). It is distributed under the [Inno Setup license](https://jrsoftware.org/files/is/license.txt) and retains its upstream translator credits in the file header.
 
-OpenAI, Microsoft, Google, GitHub, Home Assistant, LINE, and other service names
-are trademarks of their respective owners. API access, cloud-generated voices,
-OAuth use, and service quotas are governed by the provider's own terms.
+### Services and trademarks
+
+OpenAI, Microsoft, Google, GitHub, Home Assistant, LINE, and other service names are trademarks of their respective owners. API access, cloud-generated voices, OAuth use, and service quotas are governed by each provider's own terms.
+
+## 日本語
+
+### 概要
+
+MoHan Desktop Assistant は MIT License で提供されますが、そのソースコードと Release パッケージは、独自のライセンス条件を持つ第三者コンポーネントを使用します。`LICENSE` に記載された墨寒の MIT License が、それらの第三者条件を変更することはありません。
+
+### Python の直接依存パッケージ
+
+| コンポーネント | 現在の固定バージョン | ライセンス |
+| --- | ---: | --- |
+| [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
+| [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
+| [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
+| [OpenCC Python reimplementation](https://github.com/yichen0831/opencc-python) | 0.1.7 | Apache-2.0 |
+
+### Preview パッケージ作成ツール
+
+Linux x86_64 の機能制限付き Preview は、公式の [AppImage `appimagetool`](https://github.com/AppImage/appimagetool) で組み立てられます。ビルドは上流の `continuous` x86_64 アセットをダウンロードしますが、その SHA-256 が `a6d71e2b6cd66f8e8d16c37ad164658985e0cf5fcaa950c90a482890cb9d13e0` と一致する場合にのみ受け入れます。記録されている上流ソースの commit は `8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81`、GitHub アセット ID は `324406882` です。
+
+`appimagetool` には、引き続き上流独自のライセンスが適用されます。
+
+### パッケージに含まれるランタイムコンポーネント
+
+Windows のワンディレクトリパッケージには、Python（PSF License）、Qt および Shiboken（LGPL／GPL／商用条件）、NumPy（BSD-3-Clause）、CFFI（MIT）、PortAudio（MIT）、OpenSSL（Apache-2.0）、SQLite（public domain）、ならびにそれらに必要なランタイムライブラリが含まれる場合があります。macOS および Linux の機能制限付き Preview パッケージには、`requirements-preview.txt` で宣言された小規模な Preview 依存セットだけが含まれます。
+
+パッケージでは、動的リンクされる Qt／PySide ライブラリを `_internal` 配下の個別ファイルとして保持するため、受領者はこれらのライブラリを確認または置換できます。対応する Qt for Python のソース Release は、[Qt 公式ダウンロードアーカイブ](https://download.qt.io/official_releases/QtForPython/)から取得できます。
+
+完全なライセンス本文とソースへのリンクは、各上流プロジェクトおよびインストール済みパッケージのメタデータで確認できます。配布者は、実際に出荷する正確な依存バージョンを確認し、上流の著作権表示とライセンス表示をすべて保持してください。
+
+### Windows インストーラーの言語ファイル
+
+同梱の `installer/languages/ChineseTraditional.isl` は、[Inno Setup ソースリポジトリ](https://github.com/jrsoftware/issrc)による公式の繁体字中国語メッセージ翻訳であり、ソース commit `0c0b463621963243e430420b6c633039e562e1e3`（blob `8eb13d2c45e9d434aa5435a2877234418186ad87`）に固定されています。このファイルは [Inno Setup ライセンス](https://jrsoftware.org/files/is/license.txt)に基づいて配布され、ファイルヘッダーにある上流翻訳者のクレジットを保持します。
+
+### サービスと商標
+
+OpenAI、Microsoft、Google、GitHub、Home Assistant、LINE、およびその他のサービス名は、それぞれの権利者の商標です。API アクセス、クラウド生成音声、OAuth の使用、サービス利用枠には、各プロバイダー独自の規約が適用されます。

--- a/docs/BACKGROUND-MANAGER-WORKERS.md
+++ b/docs/BACKGROUND-MANAGER-WORKERS.md
@@ -1,30 +1,97 @@
-# Background Manager–Worker assistants
+# 背景經理—工作者助理／后台管理者—工作者助理／Background Manager–Worker Assistants／バックグラウンド・マネージャー—ワーカー・アシスタント
 
 ## 繁體中文
 
-墨寒的背景多工採「經理—工作者」架構。經理只負責排程、冷卻、去重與收集觀察；工作者只能執行明確的唯讀任務。工作者不會直接碰 UI、表情圖片、語音、工具執行器或權限設定。主執行緒收到觀察後，仍須交給既有表情仲裁器決定是否顯示。
+墨寒的背景多工採「經理—工作者」架構。經理只負責排程、冷卻、去重與收集
+觀察；工作者只能執行明確的唯讀任務。工作者不會直接碰 UI、表情圖片、語音、
+工具執行器或權限設定。主執行緒收到觀察後，仍須交給既有表情仲裁器決定是否顯示。
 
 `v2.1.0-rc.1` 提供兩個可關閉的工作者：
 
 - 可見程式狀態：只讀取 Windows 可見視窗標題，偵測使用者指定的程式是否剛開啟。
-- IDE 診斷報告：只讀取使用者明確指定的 `.txt` 或 `.log` 報告尾端，統計含錯誤或警告的行數；不截取編輯器畫面、不修改專案，也不自動把內容送往雲端。
+- IDE 診斷報告：只讀取使用者明確指定的 `.txt` 或 `.log` 報告尾端，統計含錯誤或
+  警告的行數；不截取編輯器畫面、不修改專案，也不自動把內容送往雲端。
 
 背景多工預設關閉。啟用後仍遵守：
 
 - 勿擾、會議、離席與休眠模式不插話。
-- 墨寒說話、Realtime 對話或其他表情情境進行中不插話。
+- 墨寒說話、`Realtime` 對話或其他表情情境進行中不插話。
 - 同事件冷卻與全域冷卻，避免碎碎念洗版。
-- 背景觀察只使用中性注視表情，不得觸發 thinking、skeptical、抓包、害羞或生氣。
-- 行事曆建立、郵件草稿／寄送等既有工具仍遵守本機權限與確認流程；背景工作者不能繞過確認。
+- 背景觀察只使用中性注視表情，不得觸發 `thinking`、`skeptical`、抓包、害羞或生氣。
+- 行事曆建立、郵件草稿／寄送等既有工具仍遵守本機權限與確認流程；背景工作者
+  不能繞過確認。
 
 ## 简体中文
 
-墨寒的后台多任务采用“管理者—工作者”架构。管理者负责调度、冷却和去重；工作者只能执行明确的只读任务，不能直接操作界面、表情、语音、工具或权限。后台功能默认关闭，并遵守勿扰、会议、离席、休眠、对话中不打断及频率限制。
+墨寒的后台多任务采用“管理者—工作者”架构。管理者只负责调度、冷却、去重与收集
+观察；工作者只能执行明确的只读任务。工作者不会直接操作 UI、表情图片、语音、
+工具执行器或权限设置。主线程收到观察后，仍须交由现有表情仲裁器决定是否显示。
 
-当前工作者可监测用户指定的可见程序名称，并只读用户明确指定的 IDE 诊断报告。它不会截取编辑器内容、修改项目或绕过日历、邮件等工具的确认流程。
+`v2.1.0-rc.1` 提供两个可以关闭的工作者：
+
+- 可见程序状态：只读取 Windows 可见窗口标题，检测用户指定的程序是否刚刚打开。
+- IDE 诊断报告：只读取用户明确指定的 `.txt` 或 `.log` 报告末尾，统计包含错误或
+  警告的行数；不截取编辑器画面、不修改项目，也不会自动把内容发送到云端。
+
+后台多任务默认关闭。启用后仍须遵守：
+
+- 请勿打扰、会议、离席与休眠模式下不插话。
+- 墨寒说话、`Realtime` 对话或其他表情情境进行中不插话。
+- 对同一事件实施冷却与全局冷却，避免反复提示刷屏。
+- 后台观察只使用中性注视表情，不得触发 `thinking`、`skeptical`、抓包、害羞或生气。
+- 日历建立、邮件草稿／发送等现有工具仍须遵守本机权限与确认流程；后台工作者
+  不能绕过确认。
 
 ## English
 
-MoHan uses a Manager–Worker design for background assistance. The manager schedules bounded work, deduplicates observations, and enforces cooldowns. Workers are read-only and cannot directly touch the UI, expressions, speech, action executor, or permission policy. The main thread remains the sole bridge to the existing expression arbiter.
+MoHan uses a Manager–Worker architecture for background multitasking. The manager
+only schedules work, enforces cooldowns, deduplicates events, and collects observations;
+workers can perform only explicit read-only tasks. Workers never directly touch the UI,
+expression images, speech, the tool executor, or permission settings. After the main
+thread receives an observation, the existing expression arbiter still decides whether
+anything is displayed.
 
-The feature is off by default. The first workers can observe user-selected visible application names and count issue lines in an explicitly selected IDE diagnostic `.txt` or `.log` report. They do not capture editor content, modify projects, upload report contents, or bypass confirmations for calendar, email, or other tools. Do Not Disturb, meeting, away, sleep, active speech, Realtime conversation, per-event cooldowns, and global cooldowns all suppress unsolicited messages.
+`v2.1.0-rc.1` provides two workers that users can disable:
+
+- Visible application status: reads only visible Windows window titles and detects whether
+  a user-selected application has just opened.
+- IDE diagnostic report: reads only the tail of a user-explicitly selected `.txt` or `.log`
+  report and counts lines containing errors or warnings; it does not capture the editor,
+  modify the project, or automatically send content to the cloud.
+
+Background multitasking is off by default. When enabled, it still follows these rules:
+
+- Do Not Disturb, meeting, away, and sleep modes suppress interruptions.
+- MoHan's speech, a `Realtime` conversation, or another active expression context suppresses
+  interruptions.
+- Per-event and global cooldowns prevent repetitive messages from flooding the interface.
+- Background observations use only a neutral gaze expression and must never trigger
+  `thinking`, `skeptical`, caught-in-the-act, shy, or angry expressions.
+- Existing tools for calendar creation and email drafting or sending still follow local
+  permissions and confirmation flows; background workers cannot bypass confirmation.
+
+## 日本語
+
+墨寒のバックグラウンド並行処理は「マネージャー—ワーカー」アーキテクチャを
+採用します。マネージャーはスケジュール、クールダウン、重複排除、観察結果の収集
+だけを担当し、ワーカーは明示された読み取り専用タスクだけを実行できます。
+ワーカーは UI、表情画像、音声、ツール実行機構、権限設定を直接操作しません。
+メインスレッドが観察結果を受け取った後も、表示するかどうかは既存の表情調停器が決定します。
+
+`v2.1.0-rc.1` では、無効化できる二つのワーカーを提供します：
+
+- 表示中アプリケーションの状態：表示されている Windows ウィンドウのタイトルだけを
+  読み取り、利用者が指定したアプリケーションが起動した直後かどうかを検出します。
+- IDE 診断レポート：利用者が明示的に指定した `.txt` または `.log` レポートの末尾だけを
+  読み取り、エラーまたは警告を含む行数を集計します。エディター画面を取得せず、
+  プロジェクトを変更せず、内容を自動的にクラウドへ送信しません。
+
+バックグラウンド並行処理は既定で無効です。有効にした場合も、次の規則に従います：
+
+- おやすみモード、会議、離席、休眠の各モードでは割り込みません。
+- 墨寒の発話中、`Realtime` 対話中、または別の表情コンテキストの進行中は割り込みません。
+- イベント単位と全体のクールダウンにより、同じ通知が繰り返し表示されるのを防ぎます。
+- バックグラウンド観察では中立的な視線表情だけを使用し、`thinking`、`skeptical`、
+  現場を押さえた表情、恥じらい、怒りを発動してはなりません。
+- カレンダー作成、メールの下書き／送信など既存のツールは、引き続きローカル権限と
+  確認手順に従います。バックグラウンドワーカーは確認を迂回できません。

--- a/docs/CROSS-PLATFORM.md
+++ b/docs/CROSS-PLATFORM.md
@@ -1,4 +1,4 @@
-# MoHan cross-platform status / 墨寒跨平台狀態
+# 墨寒跨平台狀態／墨寒跨平台状态／MoHan cross-platform status／墨寒クロスプラットフォーム状況
 
 ## 繁體中文
 
@@ -52,7 +52,7 @@ Windows 正式版本的完整功能。Windows 仍是目前唯一经过真机使�
   `windows-local` 与四语旧标签会自动迁移，不会删除用户选择。
 - Windows 数据目录继续使用 `%LOCALAPPDATA%\YanJianStudio\MoHan`。
 - macOS 使用 `~/Library/Application Support/YanJianStudio/MoHan`；Linux
-  遵循 XDG 数据、设置与缓存目录。
+  遵循 `XDG_DATA_HOME`、`XDG_CONFIG_HOME`、`XDG_CACHE_HOME`。
 - 在 macOS／Linux 原生安全密钥保存完成前，程序会拒绝以明文保存密钥。
 - 设置页与旗舰控制中心共用同一个可注入密钥边界；未验证平台会停用密钥、
   OAuth 与 Home Assistant 权杖输入，也不会显示 Windows 专用语音选项。
@@ -123,7 +123,7 @@ macOS／Linux が Windows 版と同等に完成したという意味ではあり
   `windows-local` と旧四言語ラベルは、利用者の選択を失わず移行します。
 - Windows の保存先 `%LOCALAPPDATA%\YanJianStudio\MoHan` は変更しません。
 - macOS は `~/Library/Application Support/YanJianStudio/MoHan`、Linux は
-  XDG のデータ・設定・キャッシュ各ディレクトリに従います。
+  `XDG_DATA_HOME`、`XDG_CONFIG_HOME`、`XDG_CACHE_HOME` に従います。
 - macOS／Linux の安全なネイティブ保存が完成するまで、キーを平文で保存せず
   安全側で停止します。
 - 設定画面とフラッグシップ制御画面は、同じ注入可能なキー保存境界を使用します。

--- a/docs/MEMORY-RETRIEVAL-AND-PRUNING.md
+++ b/docs/MEMORY-RETRIEVAL-AND-PRUNING.md
@@ -1,10 +1,14 @@
-# Long-term memory retrieval and safe pruning
+# 長期記憶檢索與安全剪枝／长期记忆检索与安全剪枝／Long-Term Memory Retrieval and Safe Pruning／長期記憶の検索と安全な剪定
 
 ## 繁體中文
 
-墨寒會在本機建立確定性、離線的多語文字向量索引。文字問答只取回與本次問題最相關的記憶，並綜合重要度與最近使用時間排序；記憶內容不會為了建立索引而傳送到第三方服務。
+墨寒會在本機建立確定性、離線的多語文字向量索引。文字問答只取回與本次問題
+最相關的記憶，並綜合重要度與最近使用時間排序；記憶內容不會為了建立索引而
+傳送到第三方服務。
 
-索引採延遲建立與內容指紋快取。新增、編輯、刪除或還原記憶後會自動失效，下次查詢才重建。1,000 則記憶的暖索引基準測試納入測試工具，目標維持互動所需的毫秒級回應。
+索引採延遲建立與內容指紋快取。新增、編輯、刪除或還原記憶後會自動失效，
+下次查詢才重建。1,000 則記憶的暖索引基準測試納入測試工具，目標維持互動
+所需的毫秒級回應。
 
 自動整理只處理來源為對話、重要度 1–2 的記憶：
 
@@ -15,14 +19,60 @@
 
 ## 简体中文
 
-墨寒会在本机建立确定性、离线的多语言文字向量索引。文字问答只取回与当前问题相关的记忆，并结合重要度与最近使用时间排序；建立索引不会把记忆上传到第三方服务。
+墨寒会在本机建立确定性、离线的多语言文字向量索引。文字问答只取回与当前问题
+最相关的记忆，并综合重要度与最近使用时间排序；记忆内容不会为了建立索引而
+发送到第三方服务。
 
-自动整理只处理来源为对话、重要度 1–2 的内容。超过容量时，仅封存 90 天以上未使用的低重要度对话记忆；手动保存及重要度 3–5 的记忆不会被自动移除。所有自动整理内容都会先保存本机快照，并可从封存界面还原。
+索引采用延迟建立与内容指纹缓存。新增、编辑、删除或还原记忆后，索引会自动失效，
+直到下次查询时才重建。测试工具包含 1,000 条记忆的暖索引基准测试，目标是维持
+交互所需的毫秒级响应。
+
+自动整理只处理来源为对话、重要度 1–2 的记忆：
+
+- 语义高度近似的内容会使用可追溯的文字片段合并。
+- 超过 500 条时，才会把 90 天以上未使用的低重要度对话记忆整理至 400 条。
+- 手动保存、重要度 3–5、人物与其他受保护内容不会因为容量而自动移除。
+- 自动整理不是永久删除；原始快照会进入本机归档区，可从“查看已归档记忆”还原。
 
 ## English
 
-MoHan builds a deterministic, offline multilingual text-vector index on the local computer. Text conversations retrieve only memories relevant to the current query, with importance and recency used as secondary ranking signals. Memory content is not sent to a third-party embedding service.
+MoHan builds a deterministic, offline multilingual text-vector index on the local computer.
+Text conversations retrieve only memories most relevant to the current query and combine
+importance with most-recent use for ranking; memory content is not sent to a third-party
+service to build the index.
 
-The index is lazy and fingerprint-cached. Memory changes invalidate it, and the next query rebuilds only changed entries. A warm-index benchmark for 1,000 memories is included to preserve interactive, millisecond-scale retrieval.
+The index is built lazily and uses content-fingerprint caching. Adding, editing, deleting,
+or restoring a memory automatically invalidates it, and it is rebuilt only on the next query.
+The test tools include a warm-index benchmark for 1,000 memories, with a target of preserving
+the millisecond-scale response required for interaction.
 
-Automatic maintenance is deliberately conservative. It considers only conversation-sourced memories with importance levels 1–2. Capacity pruning starts above 500 active memories and archives eligible items older than 90 days until the active set reaches 400. Manual memories and importance levels 3–5 are protected. Every automatically removed record is stored as a recoverable local snapshot and can be restored from the archive dialog.
+Automatic maintenance processes only conversation-sourced memories with importance levels 1–2:
+
+- Semantically very similar content is merged with traceable text fragments.
+- Only when the active set exceeds 500 memories are low-importance conversation memories unused
+  for more than 90 days reduced until 400 remain.
+- Manually saved memories, importance levels 3–5, people, and other protected content are not
+  automatically removed because of capacity.
+- Automatic maintenance is not permanent deletion; original snapshots enter a local archive and
+  can be restored through “View archived memories.”
+
+## 日本語
+
+墨寒は、ローカル環境に決定的かつオフラインの多言語テキストベクトル索引を
+構築します。テキスト対話では現在の質問に最も関連する記憶だけを取得し、重要度と
+直近の利用時刻を組み合わせて順位付けします。索引を構築するために記憶内容を
+第三者サービスへ送信することはありません。
+
+索引は遅延構築と内容フィンガープリントのキャッシュを使用します。記憶を追加、編集、
+削除、復元すると索引は自動的に無効化され、次回の問い合わせ時にだけ再構築されます。
+テストツールには 1,000 件の記憶を対象とするウォーム索引ベンチマークが含まれ、
+対話に必要なミリ秒単位の応答を維持することを目標とします。
+
+自動整理が処理するのは、対話を出所とする重要度 1–2 の記憶だけです：
+
+- 意味が非常に近い内容は、追跡可能なテキスト断片を用いて統合されます。
+- 500 件を超えた場合に限り、90 日を超えて使われていない重要度の低い対話記憶を
+  400 件になるまで整理します。
+- 手動保存、重要度 3–5、人物、その他の保護対象は、容量を理由に自動削除されません。
+- 自動整理は永久削除ではありません。元のスナップショットはローカルアーカイブに入り、
+  「アーカイブ済み記憶を表示」から復元できます。

--- a/docs/PLUGGABLE-SPEECH-PROVIDERS.md
+++ b/docs/PLUGGABLE-SPEECH-PROVIDERS.md
@@ -1,52 +1,166 @@
-# Pluggable speech providers / 可插拔語音供應器 / 可插拔语音供应器
+# 可插拔語音供應器／可插拔语音供应器／Pluggable Speech Providers／交換可能な音声プロバイダー
 
 ## 繁體中文
 
-`v2.1.0-rc.1` 建立語音供應器的穩定邊界。Windows 本機女聲、OpenAI 文字語音與 Azure Speech 預覽透過同一個登錄層接入，嘴型、音量、播放完成訊號與表情狀態仍由既有單一權威流程管理。
+`v2.1.0-rc.1` 建立語音供應器的穩定邊界。Windows 本機女聲、OpenAI 文字語音與
+Azure Speech 預覽透過同一個登錄層接入，嘴型、音量、播放完成訊號與表情狀態仍由
+既有單一權威流程管理。
 
-資料庫只保存不受翻譯影響的穩定代號；舊版繁中、簡中與英文名稱會自動遷移。Realtime 離線、雲端失敗、金鑰缺漏或未知供應器都優先回到使用者選定的 Windows 女性本機語音。若 Windows 沒有任何明確標示為女性的聲音，程式會說明原因，不會暗中改用男性聲音。
+資料庫只保存不受翻譯影響的穩定代號；舊版繁中、簡中與英文名稱會自動遷移。
+Realtime 離線、雲端失敗、金鑰缺漏或未知供應器都優先回到使用者選定的 Windows
+女性本機語音。若 Windows 沒有任何明確標示為女性的聲音，程式會說明原因，
+不會暗中改用男性聲音。
 
-Azure Speech 預覽必須由使用者自行申請 Azure Speech 資源，輸入資源金鑰與相符區域；金鑰以 Windows DPAPI 分開加密，不寫入資料庫、日誌或 GitHub。介面只列出官方標示為女性的繁中、簡中、英文與日語聲線。設定不完整時不會送出網路請求；服務失敗時，同一句話只回退一次到 Windows 女性本機語音。Azure 免費額度、費率、資料處理與可用區域以 Microsoft 當期規則為準。
+Azure Speech 預覽必須由使用者自行申請 Azure Speech 資源，輸入資源金鑰與相符區域；
+金鑰以 Windows DPAPI 分開加密，不寫入資料庫、日誌或 GitHub。介面只列出官方標示為
+女性的繁中、簡中、英文與日語聲線。設定不完整時不會送出網路請求；服務失敗時，
+同一句話只回退一次到 Windows 女性本機語音。Azure 免費額度、費率、資料處理與
+可用區域以 Microsoft 當期規則為準。
 
-自動測試已涵蓋區域限制、SSML 跳脫、女性聲線白名單、固定 HTTPS 端點、錯誤訊息不洩漏金鑰、播放完成與 Windows 回退。RC 發布前仍需使用真實 Azure 帳號完成端到端試播；在完成前，功能維持「預覽」標示。
+自動測試已涵蓋區域限制、SSML 跳脫、女性聲線白名單、固定 HTTPS 端點、錯誤訊息
+不洩漏金鑰、播放完成與 Windows 回退。RC 發布前仍需使用真實 Azure 帳號完成端到端
+試播；在完成前，功能維持「預覽」標示。
 
-設定方式：先在 Microsoft Azure 建立 Speech 資源，再到墨寒「語音」頁選擇 Azure Speech（預覽），填入該資源顯示的區域與其中一把金鑰，選擇女性聲線後按「試聽」。墨寒使用 Microsoft 的 HTTPS REST 介面，不另外安裝 Azure SDK。切勿把金鑰貼到 GitHub、對話紀錄或截圖中。
+設定方式：先在 Microsoft Azure 建立 Speech 資源，再到墨寒「語音」頁選擇
+Azure Speech（預覽），填入該資源顯示的區域與其中一把金鑰，選擇女性聲線後按
+「試聽」。墨寒使用 Microsoft 的 HTTPS REST 介面，不另外安裝 Azure SDK。
+切勿把金鑰貼到 GitHub、對話紀錄或截圖中。
 
-未來候選包含 ElevenLabs、Google Cloud Text-to-Speech、Amazon Polly，以及 Sherpa-ONNX、Piper、Kokoro 等本地方案。加入任何候選前都必須逐一驗證 Windows、繁中、簡中、英文、日語、女性聲線、延遲、中斷、嘴型同步、封裝體積、隱私與商用授權；程式授權與聲音模型授權必須分開檢查。
+未來候選包含 ElevenLabs、Google Cloud Text-to-Speech、Amazon Polly，以及
+Sherpa-ONNX、Piper、Kokoro 等本地方案。加入任何候選前都必須逐一驗證 Windows、
+繁中、簡中、英文、日語、女性聲線、延遲、中斷、嘴型同步、封裝體積、隱私與商用
+授權；程式授權與聲音模型授權必須分開檢查。
+
+### Microsoft 官方參考
+
+- [Speech 定價與免費額度](https://azure.microsoft.com/en-us/pricing/details/speech/)
+- [Speech 服務區域](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
+- [文字轉語音 REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
+- [語言與聲線支援](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
 
 ## 简体中文
 
-`v2.1.0-rc.1` 建立稳定的语音供应器边界。Windows 本地女声、OpenAI 文字语音与 Azure Speech 预览共用同一套音量、嘴型、完成信号和失败回退流程。Windows 本地女声仍是 Realtime 离线、云端失败、密钥缺失或未知供应器时的第一回退。
+`v2.1.0-rc.1` 建立语音供应器的稳定边界。Windows 本地女声、OpenAI 文字语音与
+Azure Speech 预览通过同一个注册层接入，嘴型、音量、播放完成信号与表情状态仍由
+现有单一权威流程管理。
 
-Azure Speech 需要用户自己的资源密钥与相符区域；密钥由 Windows DPAPI 单独加密。界面只列出官方标示为女性的繁中、简中、英文和日语声线。设定不完整时不会发出网络请求；服务失败时，同一句话只回退一次到 Windows 女性语音。自动测试已完成，但真实 Azure 帐号端到端试播完成前仍标示为预览。
+数据库只保存不受翻译影响的稳定代号；旧版繁中、简中与英文名称会自动迁移。
+Realtime 离线、云端失败、密钥缺失或未知供应器时，都优先回到用户选择的 Windows
+女性本地语音。如果 Windows 没有任何明确标示为女性的声音，程序会说明原因，
+不会暗中改用男性声音。
 
-请先在 Microsoft Azure 建立 Speech 资源，再到墨寒“语音”页选择 Azure Speech（预览），填入资源区域和其中一把密钥，选择女性声线后试听。墨寒使用 HTTPS REST 接口，不需另外安装 Azure SDK。请勿将密钥贴到 GitHub、对话记录或截图。
+Azure Speech 预览要求用户自行申请 Azure Speech 资源，并输入资源密钥与相符区域；
+密钥由 Windows DPAPI 单独加密，不会写入数据库、日志或 GitHub。界面只列出官方标示为
+女性的繁中、简中、英文与日语声线。设置不完整时不会发出网络请求；服务失败时，
+同一句话只回退一次到 Windows 女性本地语音。Azure 免费额度、费率、数据处理与
+可用区域以 Microsoft 当期规则为准。
 
-未来供应器必须分别验证女性声线、四种界面语言、延迟、中断、嘴型同步、隐私、安装体积及商业授权。程序许可证不代表每一个声音模型也允许商业使用。
+自动测试已经覆盖区域限制、SSML 转义、女性声线白名单、固定 HTTPS 端点、错误信息
+不泄漏密钥、播放完成与 Windows 回退。RC 发布前仍需使用真实 Azure 账号完成端到端
+试听；在完成前，功能保持“预览”标示。
 
-## 日本語
+设置方式：先在 Microsoft Azure 建立 Speech 资源，再到墨寒“语音”页选择
+Azure Speech（预览），填入该资源显示的区域与其中一把密钥，选择女性声线后点击
+“试听”。墨寒使用 Microsoft 的 HTTPS REST 接口，不另外安装 Azure SDK。
+切勿把密钥粘贴到 GitHub、对话记录或截图中。
 
-`v2.1.0-rc.1` は、交換可能な音声供給元の境界を一つにまとめます。Windows 本機女性音声、OpenAI 読み上げ、Azure Speech プレビューは、同じ音量、口の動き、再生完了、失敗時代替の経路を使用します。Realtime がオフライン、クラウドが失敗、キーがない、または供給元が不明な場合は、Windows 本機の女性音声を最初に使用します。
+未来候选包括 ElevenLabs、Google Cloud Text-to-Speech、Amazon Polly，以及
+Sherpa-ONNX、Piper、Kokoro 等本地方案。加入任何候选前都必须逐一验证 Windows、
+繁中、简中、英文、日语、女性声线、延迟、中断、嘴型同步、打包体积、隐私与商业
+授权；程序许可证与声音模型许可证必须分别检查。
 
-Azure Speech には、利用者自身の Speech リソースキーと対応リージョンが必要です。キーは Windows DPAPI で分離して暗号化します。画面には Microsoft が女性と明示する繁体字中国語、簡体字中国語、英語、日本語の音声だけを表示します。設定不足時はネットワークへ送信せず、サービス障害時は同じ文章を一度だけ Windows 女性音声で読み上げ直します。実 Azure アカウントでの試聴が完了するまではプレビュー表記を保ちます。
+### Microsoft 官方参考
 
-Microsoft Azure で Speech リソースを作成し、墨寒の「音声」画面で Azure Speech（プレビュー）を選び、リージョンとキーを入力して女性音声を試聴します。HTTPS REST を直接使用するため、Azure SDK の追加インストールは不要です。キーを GitHub、会話履歴、スクリーンショットへ貼らないでください。
+- [Speech 定价与免费额度](https://azure.microsoft.com/en-us/pricing/details/speech/)
+- [Speech 服务区域](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
+- [文字转语音 REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
+- [语言与声线支持](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
 
 ## English
 
-`v2.1.0-rc.1` introduces a stable provider boundary. Windows female speech, OpenAI text-to-speech, and the Azure Speech preview enter through one explicit registry. Lip sync, volume, completion signals, expression state, and fallback keep their existing single authoritative paths.
+`v2.1.0-rc.1` establishes a stable speech-provider boundary. Windows local female speech,
+OpenAI text-to-speech, and the Azure Speech preview enter through the same registry layer;
+lip sync, volume, playback-completion signals, and expression state remain under the existing
+single authoritative flow.
 
-Persisted settings use locale-independent IDs and migrate legacy Traditional Chinese, Simplified Chinese, English, and Japanese labels. Windows female local speech remains the first fallback when Realtime is offline, a cloud request fails, a key is missing, or a provider is unknown. MoHan reports the absence of a verified female Windows voice instead of silently selecting a male voice.
+The database stores only stable, locale-independent IDs; legacy Traditional Chinese,
+Simplified Chinese, and English names migrate automatically. When Realtime is offline, a
+cloud service fails, a key is missing, or a provider is unknown, MoHan first returns to the
+user-selected Windows local female voice. If Windows has no voice explicitly identified as
+female, the application explains why instead of silently selecting a male voice.
 
-Azure Speech requires the user's own Speech resource key and matching region. The key is encrypted separately with Windows DPAPI and is never stored in the database, logs, or GitHub. The UI exposes only Microsoft-listed female Traditional Chinese, Simplified Chinese, English, and Japanese voices. Missing settings cause no network request; a service failure retries the same utterance once through Windows female local speech. Automated coverage verifies endpoint restrictions, SSML escaping, the female allowlist, secret-safe errors, completion, and fallback. The integration remains labelled Preview until a real Azure account completes end-to-end playback validation.
+The Azure Speech preview requires users to create their own Azure Speech resource and enter
+its key and matching region. Windows DPAPI encrypts the key separately; the key is never
+written to the database, logs, or GitHub. The UI lists only voices officially identified as
+female for Traditional Chinese, Simplified Chinese, English, and Japanese. Incomplete settings
+cause no network request; a service failure falls back once for the same utterance to Windows
+local female speech. Current Microsoft rules govern Azure free quotas, pricing, data handling,
+and regional availability.
 
-Create a Speech resource in Microsoft Azure, select Azure Speech (Preview) on MoHan's Voice page, enter that resource's region and one key, choose a female voice, and use Preview. MoHan calls the HTTPS REST endpoint directly and does not add the Azure SDK. Never paste the key into GitHub, chat history, or screenshots.
+Automated tests cover region restrictions, SSML escaping, the female-voice allowlist, the fixed
+HTTPS endpoint, secret-safe error messages, playback completion, and Windows fallback. Before
+an RC release, a real Azure account must still complete end-to-end playback validation; the
+feature remains labelled “Preview” until that work is complete.
 
-Future candidates include ElevenLabs, Google Cloud Text-to-Speech, Amazon Polly, and local Sherpa-ONNX, Piper, or Kokoro deployments. Each provider requires separate validation for Windows, all four UI languages, female voice policy, latency, interruption, lip sync, package size, privacy, and commercial licensing. Code and voice-model licenses must be reviewed independently.
+To configure it, first create a Speech resource in Microsoft Azure. On MoHan's “Voice” page,
+select Azure Speech (Preview), enter the region shown by that resource and one of its keys,
+choose a female voice, and select “Preview.” MoHan uses Microsoft's HTTPS REST interface and
+does not install the Azure SDK. Never paste the key into GitHub, conversation records, or
+screenshots.
 
-## Microsoft 官方參考 / Microsoft official references
+Future candidates include ElevenLabs, Google Cloud Text-to-Speech, Amazon Polly, and local
+Sherpa-ONNX, Piper, or Kokoro deployments. Before adding a candidate, independently validate
+Windows, Traditional Chinese, Simplified Chinese, English, Japanese, the female-voice policy,
+latency, interruption, lip sync, package size, privacy, and commercial licensing. Review the
+software license and voice-model license separately.
+
+### Official Microsoft references
 
 - [Speech pricing and free tier](https://azure.microsoft.com/en-us/pricing/details/speech/)
 - [Speech service regions](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
 - [Text-to-speech REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
 - [Language and voice support](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
+
+## 日本語
+
+`v2.1.0-rc.1` は、音声プロバイダーの安定した境界を確立します。Windows 本機女性音声、
+OpenAI テキスト読み上げ、Azure Speech プレビューは同じ登録層を通して接続され、
+口形、音量、再生完了シグナル、表情状態は引き続き既存の単一の正規経路が管理します。
+
+データベースには翻訳の影響を受けない安定 ID だけを保存し、旧版の繁体字中国語、
+簡体字中国語、英語の名称は自動移行します。Realtime がオフライン、クラウドサービスが
+失敗、キーが不足、またはプロバイダーが不明な場合は、利用者が選択した Windows 本機の
+女性音声へ最初に戻ります。Windows に女性と明示された音声が一つもない場合、
+男性音声へ密かに切り替えず、アプリケーションが理由を説明します。
+
+Azure Speech プレビューを使うには、利用者自身が Azure Speech リソースを作成し、
+そのキーと対応するリージョンを入力する必要があります。キーは Windows DPAPI で個別に
+暗号化され、データベース、ログ、GitHub には書き込まれません。画面に表示するのは、
+繁体字中国語、簡体字中国語、英語、日本語について公式に女性と示された音声だけです。
+設定が不完全な場合はネットワーク要求を送信せず、サービス障害時は同じ発話を一度だけ
+Windows 本機女性音声へフォールバックします。Azure の無料枠、料金、データ処理、
+利用可能リージョンには Microsoft のその時点の規則が適用されます。
+
+自動テストは、リージョン制限、SSML エスケープ、女性音声の許可リスト、固定 HTTPS
+エンドポイント、キーを漏らさないエラーメッセージ、再生完了、Windows フォールバックを
+網羅しています。RC 公開前には、実際の Azure アカウントでエンドツーエンドの試聴検証を
+完了する必要があります。それまでは「プレビュー」表示を維持します。
+
+設定するには、まず Microsoft Azure で Speech リソースを作成します。墨寒の「音声」ページで
+Azure Speech（プレビュー）を選択し、そのリソースに表示されたリージョンとキーの一つを入力し、
+女性音声を選んで「試聴」を押します。墨寒は Microsoft の HTTPS REST インターフェースを使用し、
+Azure SDK を追加インストールしません。キーを GitHub、対話履歴、スクリーンショットへ
+貼り付けないでください。
+
+将来の候補には ElevenLabs、Google Cloud Text-to-Speech、Amazon Polly、およびローカルの
+Sherpa-ONNX、Piper、Kokoro などがあります。候補を追加する前に、Windows、繁体字中国語、
+簡体字中国語、英語、日本語、女性音声ポリシー、遅延、中断、口形同期、パッケージ容量、
+プライバシー、商用ライセンスを個別に検証する必要があります。ソフトウェアのライセンスと
+音声モデルのライセンスは分けて確認します。
+
+### Microsoft 公式リファレンス
+
+- [Speech の料金と無料枠](https://azure.microsoft.com/en-us/pricing/details/speech/)
+- [Speech サービスのリージョン](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
+- [テキスト読み上げ REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
+- [対応言語と音声](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)

--- a/docs/PREVIEW-PACKAGES.md
+++ b/docs/PREVIEW-PACKAGES.md
@@ -1,4 +1,4 @@
-# macOS and Linux limited Preview packages / macOS 與 Linux 功能受限預覽包
+# macOS 與 Linux 功能受限預覽包／macOS 与 Linux 功能受限预览包／Limited macOS and Linux Preview packages／macOS・Linux 機能限定 Preview パッケージ
 
 ## 繁體中文
 
@@ -75,7 +75,7 @@ CI 并不表示作者已经拥有并实测真实 Mac 或 Linux 桌面电脑。�
 
 - 固定 Python、PySide6 与 PyInstaller 版本。
 - GitHub Actions 固定到完整提交 SHA。
-- macOS 只使用 runner 内置工具。
+- macOS 只使用 runner 内置的 `sips`、`iconutil`、`hdiutil`。
 - Linux 的官方 `appimagetool` 同时固定来源提交、资产 ID 与 SHA-256。
 - Release 生成 SHA256SUMS、Windows／Preview CycloneDX SBOM 与 Artifact Attestation。
 - DMG 根目录、app 资源与 AppImage 文档目录均包含 MIT `LICENSE` 和第三方
@@ -121,7 +121,7 @@ Gatekeeper globally.
 - Python, PySide6, and PyInstaller are version-pinned.
 - Every GitHub Action is pinned to a complete commit SHA.
 - macOS uses only runner-native `sips`, `iconutil`, and `hdiutil` tools.
-- Linux appimagetool is tied to an official source commit, immutable asset ID,
+- Linux `appimagetool` is tied to an official source commit, immutable asset ID,
   and expected SHA-256; a mismatch stops the build.
 - Releases include SHA256SUMS, separate Windows/Preview CycloneDX SBOMs, and GitHub Artifact
   Attestations.
@@ -133,8 +133,8 @@ Gatekeeper globally.
 ### この配布物について
 
 `v2.3.0-rc.N` 系列では、GitHub の Apple Silicon（arm64）版と Intel
-（x86_64）版 macOS ネイティブ runner で、対応する `.app` を含む個別の
-`.dmg` を作成し、Linux x86_64 runner で `.AppImage` を作成します。完成した
+（x86_64）版 macOS ネイティブ runner で、個別の `.dmg`（対応する `.app`
+を同梱）を作成し、Linux x86_64 runner で `.AppImage` を作成します。完成した
 配布物から headless 起動検査を実行し、四言語画面と安全な停止境界を確認します。
 Pull Request の成果物は短期間の検査用です。Releases へ公開できるのは、既に
 存在し `v2.3.0-rc.N` に一致するタグだけです。
@@ -164,8 +164,8 @@ CI 合格は、作者が実機の Mac や Linux デスクトップを所有し�
 
 - Python、PySide6、PyInstaller の版を固定します。
 - GitHub Actions は完全なコミット SHA へ固定します。
-- macOS は runner 標準のツールだけを使用します。
-- Linux の公式 appimagetool は、ソースコミット、資産 ID、SHA-256 を同時に
+- macOS は runner 標準の `sips`、`iconutil`、`hdiutil` だけを使用します。
+- Linux の公式 `appimagetool` は、ソースコミット、資産 ID、SHA-256 を同時に
   固定し、不一致なら処理を停止します。
 - Release には SHA256SUMS、Windows／Preview 別の CycloneDX SBOM、Artifact Attestation を含めます。
 - DMG 直下、app のリソース、AppImage の文書ディレクトリに MIT `LICENSE` と

--- a/docs/PYTHON-3.14-MIGRATION.md
+++ b/docs/PYTHON-3.14-MIGRATION.md
@@ -1,4 +1,4 @@
-# Python 3.14 migration / Python 3.14 遷移 / Python 3.14 迁移 / Python 3.14 移行
+# Python 3.14 遷移／Python 3.14 迁移／Python 3.14 migration／Python 3.14 移行
 
 ## 繁體中文
 

--- a/docs/PYTHON-3.15-MIGRATION.md
+++ b/docs/PYTHON-3.15-MIGRATION.md
@@ -1,138 +1,252 @@
-# Python 3.15 migration / Python 3.15 遷移 / Python 3.15 迁移 / Python 3.15 移行
-
-Runtime baseline: **CPython 3.15.0rc1 only**. MoHan does not keep a second
-Python runtime after this migration. The complete upstream checklist is the
-official [What’s New in Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html);
-every item in that document, including library changes, removals and
-deprecations, remains in scope for future MoHan features.
+# Python 3.15 遷移／Python 3.15 迁移／Python 3.15 migration／Python 3.15 移行
 
 ## 繁體中文
 
-墨寒採用「新版能力可安全適用時，不沿用舊寫法」原則。已導入：PEP 810
+執行環境基準：**僅限 CPython 3.15.0rc1**。完成遷移後，墨寒不保留第二套
+Python 執行環境。完整上游檢查清單以官方
+[Python 3.15 新功能](https://docs.python.org/3.15/whatsnew/3.15.html)為準；
+其中每一項標準庫變更、移除與棄用，未來只要適用於墨寒功能，皆持續納入評估。
+
+墨寒採用「新版能力可安全適用時，不沿用舊寫法」原則。已導入 PEP 810
 全專案明示延遲導入、PEP 814 `frozendict` 與遞迴不可變設定、PEP 798
 推導式解包、PEP 686 UTF-8 稽核、`bytearray.take_bytes()` 音訊封包緩衝、
-PEP 799 Tachyon 取樣工具，以及 PEP 803／820／793 Stable ABI 依賴驗證。
-PEP 661 `sentinel` 已加入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來
-一旦出現「未傳值」與 `None` 必須區分的 API，就必須使用內建 `sentinel`。
+PEP 799 Tachyon，以及 PEP 803／820／793 Stable ABI 依賴驗證。PEP 661
+`sentinel` 已加入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來一旦
+「未傳值」與 `None` 必須區分，就必須使用內建 `sentinel`。
 
 2.3.0 RC1 封裝使用固定在 CPython 提交
 `37e98da7c19a9e5892ee756d6dee08225422cd49` 的官方原始碼，以
 `--experimental-jit`／`--enable-experimental-jit=yes` 建置 JIT 預設啟用
-執行環境；未修改 PyInstaller 的隔離邊界。`PYTHON_JIT=0` 僅用於效能與相容性
-對照。PEP 831 Frame Pointer、Windows tail-calling interpreter、
-PEP 782／788 與其他 C API 項目屬 CPython／原生擴充建置層，透過 runtime
-report、官方輪子與 CI 驗證，不在 Python 業務程式偽造使用。PEP 829、PEP
-728、PEP 747、PEP 800 及標準庫新增 API，當前沒有等價且有價值的使用點，
-保留在本清單；未來功能一旦符合用途就必須重新評估並採用。
+執行環境；未修改 PyInstaller 的隔離邊界。`PYTHON_JIT=0` 僅用於效能與
+相容性對照。PEP 831 Frame Pointer、Windows tail-calling interpreter、
+PEP 782／788 與其他 C API 項目由 runtime report、官方輪子與 CI 驗證，
+不在 Python 業務程式偽造使用。PEP 829、728、747、800 與標準庫新增 API
+目前沒有等價且有價值的使用點；未來功能符合用途時必須重新評估並採用。
 
-實測兩輪各 20,000 次表情、物理與嘴型整合壓測皆通過；JIT 關閉／開啟分別
-耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。JIT 在此工作負載沒有
-可靠優勢；依產品採用新版能力的政策，2.3.0 RC1 仍預設啟用 JIT，並保留
-`MOHAN_DISABLE_JIT=1` 相容性逃生開關。Tachyon 已以 JIT 開啟的正式執行環境
-真實分析啟動、50 Hz 嘴型同步與表情仲裁器；本機嚴格閘門分別保留 3,908／
-11,107／3,604 個有效樣本，堆疊讀取錯誤率為 5.08%／2.71%／0.74%，三者
-漏採樣率皆為 0%。CI 會保存去識別化的 flamegraph、JSONL、pstats、執行期
-GC／配置區塊／執行緒數據與 SHA-256 證據，不保存原始二進位取樣流。
-`pip-audit` 2.10.1 與 CycloneDX 7.3.0 的產生器相依套件目前尚不能完整支援
-3.15，故只有這兩項隔離的稽核工具使用 3.14.7；墨寒程式、測試、SBOM
-語意驗證與所有封裝仍只有 3.15.0rc1。
+兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時
+24.639／25.068 秒，工作集成長 10.62／12.94 MB。JIT 在此負載沒有可靠優勢，
+但依產品政策仍預設啟用，並保留 `MOHAN_DISABLE_JIT=1` 相容性開關。Tachyon
+在 JIT 開啟的正式環境分析啟動、50 Hz 嘴型同步與表情仲裁器，分別保留
+3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為
+5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、
+JSONL、pstats、GC／配置／執行緒資料與 SHA-256，不發布原始二進位取樣流。
+只有隔離的 `pip-audit` 2.10.1 與 CycloneDX 7.3.0 產生器使用 3.14.7；
+墨寒程式、測試、SBOM 語意驗證與所有封裝仍只使用 3.15.0rc1。
 
-Ryzen 5 5600X Windows 實機的三輪熱路徑中位數顯示：120,000 次表情仲裁由
-JIT 關閉的 0.462 秒降為開啟的 0.293 秒（1.57 倍）；2,000 個 50 Hz
-嘴型分析節拍由 1.873 秒降為 0.571 秒（3.28 倍）。兩模式的決策、強度校驗和
-與 A/I/U/E/O 結果完全相同。這是 CPU 熱路徑微基準，不宣稱整體程式快三倍。
+Ryzen 5 5600X Windows 實機三輪熱路徑中位數顯示：120,000 次表情仲裁由
+0.462 秒降為 0.293 秒（1.57 倍），2,000 個 50 Hz 嘴型分析節拍由
+1.873 秒降為 0.571 秒（3.28 倍）；兩種模式的決策、強度校驗和與
+A／I／U／E／O 結果完全相同。這是 CPU 熱路徑微基準，不宣稱整體程式快三倍。
+
+### 持續維護的採用矩陣
+
+| Python 3.15 領域 | 墨寒狀態 | 永久觸發條件 |
+|---|---|---|
+| PEP 810 延遲導入 | 已全專案導入；一處可選匯入防護刻意維持 eager | 新模組必須通過延遲導入稽核 |
+| PEP 814 `frozendict` | 已用於全域與巢狀設定 | 新增靜態映射必須不可變 |
+| PEP 661 `sentinel` | 執行期已驗證；目前沒有舊式哨兵候選 | 未傳值與明確 `None` 不同時使用 |
+| PEP 798 解包 | 已用於語意等價的扁平化與合併 | 稽核新的巢狀扁平化寫法 |
+| PEP 686 UTF-8 | 所有專案文字 I/O 都明示 UTF-8 | 編碼稽核必須維持零缺漏 |
+| PEP 799 分析 | 去識別化 flamegraph、JSONL、pstats、runtime／GC 與 SHA-256；Release 檢查樣本、讀取錯誤、漏採樣與 JIT | 分析啟動、語音、50 Hz 嘴型與表情仲裁 |
+| PEP 831 Frame Pointer | runtime／build 報告與 CI 平台驗證 | 在支援的 Unix runner 使用系統分析器 |
+| JIT 與 Windows tail-calling interpreter | 封裝使用固定官方 CPython 提交並預設 JIT；PyInstaller 隔離不變，開關測試皆通過 | 保留停用開關並重跑完整回歸與效能檢查 |
+| PEP 803／820／793 Stable ABI 與 C API 現代化 | 已驗證 Qt ABI3 輪子；沒有第一方 C 擴充 | 2.3.0 RC1 拒絕原始碼建置或非 ABI3 Qt 輪子 |
+| PEP 782 與 PEP 788 C API | 不適用：墨寒沒有自有 C 擴充 | 加入原生程式碼前重新評估 |
+| PEP 829 啟動設定 | 目前封裝的桌面入口不需要 | 墨寒成為可安裝套件或外掛主機時重新評估 |
+| PEP 728／747／800 型別功能 | 目前沒有等價的正式模型 | 引入型別化外掛負載或 type-form API 時採用 |
+| 分代式 GC 恢復 | 必須執行壓力與記憶體耐久驗證 | 長時間工作階段與前一版基準比較 |
+| 標準庫新增／移除／棄用 API | 靜態稽核加 warnings-as-errors | 上游 What’s New 更新時擴充稽核 |
+
+此矩陣刻意保持開放。Python 3.15 預發行文件仍會更新；2.3.0 RC1 在建立標籤前
+必須立即重跑官方清單，之後每一個 Python 版本也重複相同流程。
 
 ## 简体中文
 
-墨寒遵循“新版能力能够安全适用时，不沿用旧写法”的原则。已导入 PEP 810
-全项目显式延迟导入、PEP 814 不可变配置、PEP 798 推导式解包、PEP 686
-UTF-8 审计、音频缓冲新 API、PEP 799 Tachyon，以及 Stable ABI 依赖验证。
-当前没有旧式 `object()` 哨兵；治理测试会阻止它重新出现，未来需要区分
-“未传值”和 `None` 时必须使用 PEP 661 内建 `sentinel`。JIT、Frame Pointer、
-C API 与暂时没有实际使用点的类型／启动配置功能持续保留在升级清单，新增功能
-出现适用场景时必须重新评估，不得因沿用旧代码而放弃。
+运行环境基准：**仅限 CPython 3.15.0rc1**。完成迁移后，墨寒不保留第二套
+Python 运行环境。完整上游检查清单以官方
+[Python 3.15 新功能](https://docs.python.org/3.15/whatsnew/3.15.html)为准；
+其中每一项标准库变更、移除与弃用，未来只要适用于墨寒功能，均持续纳入评估。
 
-两轮各 20,000 次整合压力测试均通过；JIT 在此负载没有可靠优势，所以 2.3.0 RC1
-仍按产品政策默认启用 JIT，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关。
-Tachyon 已在 JIT 开启的正式运行环境中分析启动、50 Hz 嘴型同步和表情
-仲裁器，分别保留 3,908／11,107／3,604 个有效样本，堆栈读取错误率为
-5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去识别化 flamegraph、
-JSONL、pstats、GC／内存／线程运行数据及 SHA-256，不保存原始二进制采样流。
-Windows 实机热路径中，表情仲裁与 50 Hz 嘴型分析分别约为关闭 JIT 时的
-1.57 倍与 3.28 倍，且功能校验结果完全一致；这不代表整个程序快三倍。
-仅 `pip-audit` 2.10.1 与 CycloneDX 7.3.0 生成器的隔离工具使用 3.14.7；
-墨寒程序、测试、SBOM 语义验证与所有封装仍只使用 3.15.0rc1。
+墨寒遵循“新版能力能够安全适用时，不沿用旧写法”的原则。已导入 PEP 810
+全项目显式延迟导入、PEP 814 `frozendict` 与递归不可变配置、PEP 798
+推导式解包、PEP 686 UTF-8 审计、`bytearray.take_bytes()` 音频包缓冲、
+PEP 799 Tachyon，以及 PEP 803／820／793 Stable ABI 依赖验证。PEP 661
+`sentinel` 已加入治理测试；目前没有旧式 `object()` 哨兵可替换，未来一旦
+“未传值”与 `None` 必须区分，就必须使用内建 `sentinel`。
+
+2.3.0 RC1 打包使用固定在 CPython 提交
+`37e98da7c19a9e5892ee756d6dee08225422cd49` 的官方源代码，以
+`--experimental-jit`／`--enable-experimental-jit=yes` 构建默认启用 JIT 的
+运行环境；不修改 PyInstaller 隔离边界。`PYTHON_JIT=0` 仅用于性能与兼容性
+对照。PEP 831 Frame Pointer、Windows tail-calling interpreter、PEP 782／788
+及其他 C API 项目由 runtime report、官方轮子与 CI 验证，不在 Python 业务
+代码中伪造使用。PEP 829、728、747、800 与标准库新增 API 目前没有等价且
+有价值的使用点；未来功能符合用途时必须重新评估并采用。
+
+两轮各 20,000 次表情、物理与口型整合压力测试均通过；JIT 关闭／开启分别耗时
+24.639／25.068 秒，工作集增长 10.62／12.94 MB。JIT 在此负载没有可靠优势，
+但依产品政策仍默认启用，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关。Tachyon
+在 JIT 开启的正式环境分析启动、50 Hz 口型同步与表情仲裁器，分别保留
+3,908／11,107／3,604 个有效样本；堆栈读取错误率为
+5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、
+JSONL、pstats、GC／配置／线程数据与 SHA-256，不发布原始二进制采样流。
+只有隔离的 `pip-audit` 2.10.1 与 CycloneDX 7.3.0 生成器使用 3.14.7；
+墨寒程序、测试、SBOM 语义验证与所有打包仍只使用 3.15.0rc1。
+
+Ryzen 5 5600X Windows 真机三轮热路径中位数显示：120,000 次表情仲裁由
+0.462 秒降至 0.293 秒（1.57 倍），2,000 个 50 Hz 口型分析节拍由
+1.873 秒降至 0.571 秒（3.28 倍）；两种模式的决策、强度校验和与
+A／I／U／E／O 结果完全相同。这是 CPU 热路径微基准，不宣称整个程序快三倍。
+
+### 持续维护的采用矩阵
+
+| Python 3.15 领域 | 墨寒状态 | 永久触发条件 |
+|---|---|---|
+| PEP 810 延迟导入 | 已在全项目导入；一处可选导入防护刻意保持 eager | 新模块必须通过延迟导入审计 |
+| PEP 814 `frozendict` | 已用于全局与嵌套配置 | 新增静态映射必须不可变 |
+| PEP 661 `sentinel` | 运行时已验证；目前没有旧式哨兵候选 | 未传值与明确 `None` 不同时使用 |
+| PEP 798 解包 | 已用于语义等价的扁平化与合并 | 审计新的嵌套扁平化写法 |
+| PEP 686 UTF-8 | 所有项目文本 I/O 都显式使用 UTF-8 | 编码审计必须保持零缺漏 |
+| PEP 799 分析 | 去标识化 flamegraph、JSONL、pstats、runtime／GC 与 SHA-256；Release 检查样本、读取错误、漏采样与 JIT | 分析启动、语音、50 Hz 口型与表情仲裁 |
+| PEP 831 Frame Pointer | runtime／build 报告与 CI 平台验证 | 在支持的 Unix runner 使用系统分析器 |
+| JIT 与 Windows tail-calling interpreter | 打包使用固定官方 CPython 提交并默认启用 JIT；PyInstaller 隔离不变，开关测试均通过 | 保留停用开关并重跑完整回归与性能检查 |
+| PEP 803／820／793 Stable ABI 与 C API 现代化 | 已验证 Qt ABI3 轮子；没有第一方 C 扩展 | 2.3.0 RC1 拒绝源代码构建或非 ABI3 Qt 轮子 |
+| PEP 782 与 PEP 788 C API | 不适用：墨寒没有自有 C 扩展 | 添加原生代码前重新评估 |
+| PEP 829 启动配置 | 当前打包的桌面入口不需要 | 墨寒成为可安装包或插件主机时重新评估 |
+| PEP 728／747／800 类型功能 | 当前没有等价的正式模型 | 引入类型化插件负载或 type-form API 时采用 |
+| 分代式 GC 恢复 | 必须执行压力与内存耐久验证 | 长时间工作阶段与上一版基准比较 |
+| 标准库新增／移除／弃用 API | 静态审计加 warnings-as-errors | 上游 What’s New 更新时扩充审计 |
+
+此矩阵刻意保持开放。Python 3.15 预发布文档仍会更新；2.3.0 RC1 在建立标签前
+必须立即重跑官方清单，之后每一个 Python 版本也重复相同流程。
 
 ## English
 
-MoHan adopts every Python 3.15 capability that has a real project use and can
-be proven regression-safe. Integrated items include explicit PEP 810 imports,
-immutable PEP 814 configuration, PEP 798 unpacking comprehensions, PEP 686
-encoding governance, the new audio-buffer bytearray API, PEP 799 Tachyon, and
-Stable ABI validation. No legacy `object()` sentinel exists today; CI rejects
-that pattern and requires PEP 661 when omission must differ from `None`.
-Interpreter, operating-system, C API, typing, and package-startup features are
-tracked even when they have no honest application-level use yet, and must be
-reassessed whenever MoHan gains a relevant feature.
+Runtime baseline: **CPython 3.15.0rc1 only**. MoHan does not keep a second
+Python runtime after this migration. The complete upstream checklist is the
+official [What’s New in Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html);
+every library change, removal, and deprecation remains in scope whenever a
+future MoHan feature can use it safely.
 
-Both 20,000-iteration integration soaks passed. JIT showed no reliable gain
-for this workload. Version 2.3.0 RC1 nevertheless enables it by default under the product's
-new-capability policy, with `MOHAN_DISABLE_JIT=1` as a compatibility escape.
-With JIT enabled, Tachyon sampled startup, the real 50 Hz lip-sync test, and
-expression arbitration. The strict local gate retained 3,908, 11,107, and
-3,604 valid samples with 5.08%, 2.71%, and 0.74% stack-read error and no
-missed samples. CI retains sanitized flamegraph, JSONL, pstats, GC, allocation,
-thread, and SHA-256 evidence; the raw binary sample stream is never published.
-Only the isolated `pip-audit` 2.10.1 and CycloneDX 7.3.0 generator tools run on
-3.14.7 while their dependencies cannot fully support 3.15. MoHan code, tests,
-SBOM semantic validation, and every package remain exclusively on 3.15.0rc1.
-On the Ryzen 5 5600X Windows host, median hot-path throughput improved by
-1.57x for expression arbitration and 3.28x for 50 Hz viseme analysis, with
-identical functional checksums. This is a microbenchmark, not a claim that the
-whole application is three times faster.
+MoHan follows the rule “do not retain an older idiom when a new capability is
+safe and applicable.” Integrated work includes project-wide explicit PEP 810
+imports, recursive immutable PEP 814 `frozendict` configuration, PEP 798
+unpacking comprehensions, PEP 686 UTF-8 auditing, the
+`bytearray.take_bytes()` audio-packet buffer, PEP 799 Tachyon, and PEP
+803/820/793 Stable ABI dependency validation. PEP 661 `sentinel` is governed
+by CI; no legacy `object()` sentinel exists today, and a future API that must
+distinguish omission from `None` must use the built-in `sentinel`.
 
-## 日本語
+The 2.3.0 RC1 packages use official CPython sources pinned to commit
+`37e98da7c19a9e5892ee756d6dee08225422cd49`, built with
+`--experimental-jit` and `--enable-experimental-jit=yes` so JIT is enabled by
+default without weakening PyInstaller isolation. `PYTHON_JIT=0` is used only
+for performance and compatibility comparisons. PEP 831 frame pointers, the
+Windows tail-calling interpreter, PEP 782/788, and other C API work are verified
+through runtime reports, official wheels, and CI rather than simulated in
+application code. PEP 829, 728, 747, 800, and new standard-library APIs have
+no equivalent valuable use today and must be reassessed when a feature fits.
 
-墨寒では、実用途があり回帰がないと証明できる Python 3.15 の新機能を必ず
-採用します。PEP 810、PEP 814、PEP 798、PEP 686、音声バッファーの新 API、
-PEP 799 Tachyon、Stable ABI 検証を導入しました。現在は旧式の `object()`
-センチネルが存在しないため、CI で再導入を禁止し、必要になった時点で PEP
-661 の組み込み `sentinel` を使用します。JIT、Frame Pointer、C API、型機能、
-起動設定など現時点で適用箇所がない項目も継続管理し、関連機能の追加時に必ず
-再評価します。
+Two 20,000-iteration expression, physics, and lip-sync integration soaks pass.
+JIT off/on takes 24.639/25.068 seconds with 10.62/12.94 MB working-set growth.
+This workload shows no reliable JIT advantage, but product policy keeps JIT on
+by default with `MOHAN_DISABLE_JIT=1` as a compatibility switch. With JIT on,
+Tachyon retains 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync,
+and expression arbitration; stack-read error is 5.08%/2.71%/0.74%, with 0%
+missed samples. CI stores sanitized flamegraph, JSONL, pstats, GC, allocation,
+thread, and SHA-256 evidence, never the raw binary stream. Only the isolated
+`pip-audit` 2.10.1 and CycloneDX 7.3.0 generators use 3.14.7; MoHan code,
+tests, SBOM semantic validation, and every package remain on 3.15.0rc1 only.
 
-20,000 回の統合耐久試験は JIT の有無の両方で合格しました。この負荷では
-JIT の確実な利点はありませんが、製品方針に従って 2.3.0 RC1 では既定で有効にし、
-互換性用の `MOHAN_DISABLE_JIT=1` を残します。JIT 有効環境で起動、実際の
-50 Hz リップシンク、表情調停を Tachyon 解析し、3,908／11,107／3,604 の
-有効サンプル、5.08%／2.71%／0.74% のスタック読取エラー、漏れ 0% を確認
-しました。CI は匿名化済み flamegraph、JSONL、pstats、GC、割当、スレッド、
-SHA-256 証拠を保存し、生のバイナリサンプルは公開しません。`pip-audit`
-2.10.1 と CycloneDX 7.3.0 生成ツールだけを隔離された 3.14.7 で実行し、
-墨寒本体、テスト、SBOM 意味検証、全パッケージは 3.15.0rc1 のみです。
-Windows 実機のホットパス中央値では、表情調停が 1.57 倍、50 Hz リップ
-シンク解析が 3.28 倍となり、機能チェックサムは完全に一致しました。これは
-マイクロベンチマークであり、アプリ全体が 3 倍速いという意味ではありません。
+Three median hot-path runs on a Ryzen 5 5600X Windows host show 120,000
+expression-arbitration iterations falling from 0.462 to 0.293 seconds (1.57x),
+and 2,000 50 Hz viseme-analysis ticks falling from 1.873 to 0.571 seconds
+(3.28x). Decisions, intensity checksums, and A/I/U/E/O results are identical.
+These are CPU hot-path microbenchmarks, not a claim that the whole app is 3x faster.
 
-## Maintained adoption matrix
+### Maintained adoption matrix
 
 | Python 3.15 area | MoHan status | Permanent trigger |
 |---|---|---|
-| PEP 810 lazy imports | Integrated across project; one optional-import guard remains intentionally eager | New modules must pass the lazy-import audit |
+| PEP 810 lazy imports | Integrated across the project; one optional-import guard intentionally remains eager | New modules must pass the lazy-import audit |
 | PEP 814 `frozendict` | Integrated for global and nested configuration | New static mappings must be immutable |
-| PEP 661 `sentinel` | Runtime verified; no legacy sentinel candidate exists | Use when omitted and explicit `None` differ |
-| PEP 798 unpacking | Integrated where flattening/merging was equivalent | Audit new nested flattening idioms |
-| PEP 686 UTF-8 | All project text I/O requires explicit UTF-8 | Encoding audit must remain at zero |
-| PEP 799 profiling | Sanitized flamegraph, JSONL, pstats, runtime/GC and SHA-256 evidence; sample count, read-error, missed-sample and JIT release gates | Profile startup, speech, 50 Hz visemes and expression arbitration |
-| PEP 831 frame pointers | Runtime/build report; CI platform verification | Use system profilers on supported Unix runners |
-| JIT and Windows tail-calling interpreter | Packages use the exact official CPython commit built with JIT on by default; PyInstaller isolation remains intact; on/off tests pass | Keep the disable escape and repeat full regression/performance checks |
+| PEP 661 `sentinel` | Runtime verified; no legacy sentinel candidate exists | Use when omission and explicit `None` differ |
+| PEP 798 unpacking | Integrated where flattening or merging is equivalent | Audit new nested-flattening idioms |
+| PEP 686 UTF-8 | All project text I/O explicitly uses UTF-8 | Encoding audit must remain at zero omissions |
+| PEP 799 profiling | Sanitized flamegraph, JSONL, pstats, runtime/GC, and SHA-256; Release gates samples, read errors, missed samples, and JIT | Profile startup, speech, 50 Hz visemes, and expression arbitration |
+| PEP 831 frame pointers | Runtime/build report and CI platform validation | Use system profilers on supported Unix runners |
+| JIT and Windows tail-calling interpreter | Packages use a pinned official CPython commit with JIT on by default; PyInstaller isolation remains intact and on/off tests pass | Keep the disable switch and repeat full regression/performance checks |
 | PEP 803/820/793 Stable ABI and C API modernization | Qt ABI3 wheels verified; no first-party C extension | Reject source builds or non-ABI3 Qt wheels in 2.3.0 RC1 |
 | PEP 782 and PEP 788 C APIs | Not applicable: MoHan owns no C extension | Reassess before adding native code |
-| PEP 829 startup configuration | Not currently needed by the packaged desktop entry point | Reassess if MoHan becomes an installable package/plugin host |
-| PEP 728/747/800 typing features | No equivalent production model yet | Adopt when typed plugin payloads/type-form APIs are introduced |
-| GC generational restoration | Stress and memory-soak validation required | Compare long sessions with the prior release baseline |
-| New/removed/deprecated standard-library APIs | Static audit plus warnings-as-errors | Extend the audit whenever upstream What’s New changes |
+| PEP 829 startup configuration | Not needed by the packaged desktop entry point | Reassess if MoHan becomes an installable package or plugin host |
+| PEP 728/747/800 typing features | No equivalent production model yet | Adopt with typed plugin payloads or type-form APIs |
+| Generational GC restoration | Stress and memory-soak validation required | Compare long sessions with the previous release baseline |
+| New, removed, or deprecated standard-library APIs | Static audit plus warnings-as-errors | Extend the audit whenever upstream What’s New changes |
 
-This matrix is intentionally not closed. Python 3.15 prerelease documentation
-is still updated upstream; 2.3.0 RC1 must re-run the official checklist immediately
+This matrix is intentionally open. Python 3.15 prerelease documentation still
+changes upstream; 2.3.0 RC1 must rerun the official checklist immediately
 before tagging, and every later Python release repeats the same process.
+
+## 日本語
+
+実行環境の基準は **CPython 3.15.0rc1 のみ**です。移行後の墨寒は、二つ目の
+Python 実行環境を保持しません。アップストリームの完全な確認項目は、公式の
+[Python 3.15 の新機能](https://docs.python.org/3.15/whatsnew/3.15.html)を
+基準とします。標準ライブラリの変更、削除、非推奨化を含む全項目は、将来の
+墨寒機能に安全に適用できる場合、継続して採用を評価します。
+
+墨寒は「新機能を安全に適用できる場合、旧方式を残さない」方針です。PEP 810
+の明示的遅延インポート、PEP 814 `frozendict` の再帰的不変設定、PEP 798、
+PEP 686 UTF-8 監査、`bytearray.take_bytes()` 音声パケットバッファー、
+PEP 799 Tachyon、PEP 803／820／793 Stable ABI 検証を導入しました。PEP 661
+`sentinel` は CI で管理しています。現在は旧式の `object()` センチネルがなく、
+将来「未指定」と `None` を区別する API では組み込み `sentinel` を使います。
+
+2.3.0 RC1 は、公式 CPython のコミット
+`37e98da7c19a9e5892ee756d6dee08225422cd49` に固定したソースを
+`--experimental-jit` と `--enable-experimental-jit=yes` でビルドし、
+PyInstaller の隔離を弱めず JIT を既定で有効にします。`PYTHON_JIT=0` は
+性能・互換性比較だけに使用します。PEP 831 Frame Pointer、Windows
+tail-calling interpreter、PEP 782／788 などの C API は runtime report、
+公式 wheel、CI で確認し、アプリコードで擬似的に使用しません。PEP 829、728、
+747、800 と標準ライブラリの新 API は、価値ある用途が生じた時点で再評価します。
+
+表情、物理、口形の 20,000 回統合耐久試験を二回通過しました。JIT 無効／有効は
+24.639／25.068 秒、作業セット増加は 10.62／12.94 MB で、この負荷では確実な
+優位性がありません。ただし製品方針により既定で有効にし、互換性用に
+`MOHAN_DISABLE_JIT=1` を残します。Tachyon は JIT 有効環境で起動、50 Hz
+リップシンク、表情調停を解析し、3,908／11,107／3,604 有効サンプル、
+5.08%／2.71%／0.74% 読取エラー、漏れ 0% を確認しました。CI は匿名化済み
+flamegraph、JSONL、pstats、GC、割当、スレッド、SHA-256 証拠を保存し、生の
+バイナリストリームは公開しません。隔離された `pip-audit` 2.10.1 と
+CycloneDX 7.3.0 生成器だけが 3.14.7 を使い、墨寒本体、テスト、SBOM 意味
+検証、全パッケージは 3.15.0rc1 のみです。
+
+Ryzen 5 5600X Windows 実機の三回のホットパス中央値では、120,000 回の表情
+調停が 0.462 秒から 0.293 秒（1.57 倍）、2,000 回の 50 Hz 口形解析が
+1.873 秒から 0.571 秒（3.28 倍）になりました。判断、強度チェックサム、
+A／I／U／E／O の結果は完全に一致します。CPU ホットパスの微小基準であり、
+アプリ全体が三倍速いという主張ではありません。
+
+### 継続管理する採用マトリクス
+
+| Python 3.15 領域 | 墨寒の状態 | 恒久的な再評価条件 |
+|---|---|---|
+| PEP 810 遅延インポート | 全体へ導入済み。一つの任意インポート防護だけ意図的に eager | 新規モジュールは遅延インポート監査に合格すること |
+| PEP 814 `frozendict` | グローバル・入れ子設定へ導入済み | 新しい静的マッピングは不変にすること |
+| PEP 661 `sentinel` | 実行時検証済み。旧式候補は存在しない | 未指定と明示的な `None` が異なる場合に使用 |
+| PEP 798 アンパック | 同等な平坦化・結合へ導入済み | 新しい入れ子平坦化構文を監査 |
+| PEP 686 UTF-8 | 全テキスト I/O で UTF-8 を明示 | エンコーディング監査の漏れを常にゼロにする |
+| PEP 799 解析 | 匿名化 flamegraph、JSONL、pstats、runtime／GC、SHA-256。Release はサンプル、読取エラー、漏れ、JIT を検査 | 起動、音声、50 Hz 口形、表情調停を解析 |
+| PEP 831 Frame Pointer | runtime／build 報告と CI プラットフォーム検証 | 対応 Unix runner でシステム分析器を使用 |
+| JIT と Windows tail-calling interpreter | 固定した公式 CPython コミットで JIT を既定有効化。PyInstaller 隔離を維持し、オン／オフ試験に合格 | 無効化設定を保ち、全回帰・性能検査を反復 |
+| PEP 803／820／793 Stable ABI と C API 現代化 | Qt ABI3 wheel を検証済み。自製 C 拡張はない | 2.3.0 RC1 ではソースビルドや非 ABI3 Qt wheel を拒否 |
+| PEP 782 と PEP 788 C API | 非該当：墨寒に自製 C 拡張はない | ネイティブコード追加前に再評価 |
+| PEP 829 起動設定 | 現在のデスクトップ入口には不要 | インストール可能パッケージ／プラグインホスト化時に再評価 |
+| PEP 728／747／800 型機能 | 同等の本番モデルはまだない | 型付きプラグイン負荷や type-form API 導入時に採用 |
+| 世代別 GC の復帰 | 負荷・メモリ耐久検証が必要 | 長時間セッションを前版基準と比較 |
+| 標準ライブラリの追加／削除／非推奨 API | 静的監査と warnings-as-errors | 上流 What’s New 更新時に監査を拡張 |
+
+このマトリクスは意図的に開いたままです。Python 3.15 のプレリリース文書は
+更新され続けます。2.3.0 RC1 はタグ作成直前に公式一覧を再確認し、以後の
+Python リリースでも同じ手順を繰り返します。

--- a/docs/RELEASE-NOTES-v2.1.0-rc.1.md
+++ b/docs/RELEASE-NOTES-v2.1.0-rc.1.md
@@ -1,8 +1,8 @@
-# MoHan Desktop Assistant v2.1.0 RC1
-
-> Pre-release / 預覽候選版 / 预览候选版 / プレリリース
+# 墨寒桌面助理 v2.1.0 RC1／墨寒桌面助手 v2.1.0 RC1／MoHan Desktop Assistant v2.1.0 RC1／墨寒デスクトップアシスタント v2.1.0 RC1
 
 ## 繁體中文
+
+> 預發行候選版
 
 ### 本版重點
 
@@ -34,7 +34,26 @@
 - SHA-256、CycloneDX SBOM、更新清單與 Artifact Attestation：已產生
 - Gitleaks 完整 Git 歷史掃描：未發現金鑰洩漏
 
+### 相關 Pull Request
+
+- [#14 穩定 Windows CI 介面測試](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/14)
+- [#15 本地化安裝程式並加速啟動](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/15)
+- [#17 修正語音時的眼部疊影](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/17)
+- [#18 墨寒遷移至 Python 3.14](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/18)
+- [#19 降低 Realtime 音訊延遲](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/19)
+- [#20 消除姿勢切換抖動與殘影](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/20)
+- [#21 本機語意記憶檢索與安全剪枝](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/21)
+- [#22 安全背景管理器與工作執行緒](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/22)
+- [#23 可插拔語音供應器](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/23)
+- [#24 Azure Speech 預覽與日文基本可用性](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/24)
+- [#25 文字聊天預設使用 GPT-5.6 Luna](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/25)
+- [#26 四語安裝程式與明亮易讀介面](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/26)
+
+**完整變更：** [v2.0.14-rc.3...v2.1.0-rc.1](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.3...v2.1.0-rc.1)
+
 ## 简体中文
+
+> 预发布候选版
 
 ### 本版重点
 
@@ -66,7 +85,26 @@
 - SHA-256、CycloneDX SBOM、更新清单与 Artifact Attestation：已生成
 - Gitleaks 完整 Git 历史扫描：未发现密钥泄漏
 
+### 相关 Pull Request
+
+- [#14 稳定 Windows CI 界面测试](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/14)
+- [#15 本地化安装程序并加速启动](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/15)
+- [#17 修复语音时的眼部叠影](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/17)
+- [#18 墨寒迁移至 Python 3.14](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/18)
+- [#19 降低 Realtime 音频延迟](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/19)
+- [#20 消除姿势切换抖动与残影](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/20)
+- [#21 本机语义记忆检索与安全剪枝](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/21)
+- [#22 安全后台管理器与工作线程](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/22)
+- [#23 可插拔语音供应器](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/23)
+- [#24 Azure Speech 预览与日文基本可用性](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/24)
+- [#25 文字聊天默认使用 GPT-5.6 Luna](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/25)
+- [#26 四语安装程序与明亮易读界面](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/26)
+
+**完整变更：** [v2.0.14-rc.3...v2.1.0-rc.1](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.3...v2.1.0-rc.1)
+
 ## English
+
+> Pre-release candidate
 
 ### Highlights
 
@@ -98,7 +136,26 @@
 - SHA-256 catalog, CycloneDX SBOM, update manifest, and artifact attestations: generated
 - Full-history Gitleaks scan: no leaked secrets found
 
+### Related pull requests
+
+- [#14 Stabilize Windows CI UI tests](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/14)
+- [#15 Localize installer and accelerate startup](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/15)
+- [#17 Fix speech eye-overlay artifacts](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/17)
+- [#18 Migrate MoHan to Python 3.14](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/18)
+- [#19 Reduce Realtime audio latency](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/19)
+- [#20 Eliminate pose-transition jitter and ghosting](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/20)
+- [#21 Local semantic-memory retrieval and safe pruning](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/21)
+- [#22 Safe background manager and workers](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/22)
+- [#23 Pluggable speech providers](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/23)
+- [#24 Azure Speech preview and baseline Japanese usability](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/24)
+- [#25 Default text chat to GPT-5.6 Luna](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/25)
+- [#26 Four-language installer and bright readable UI](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/26)
+
+**Full changelog:** [v2.0.14-rc.3...v2.1.0-rc.1](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.3...v2.1.0-rc.1)
+
 ## 日本語
+
+> プレリリース候補版
 
 ### 主な変更
 
@@ -130,19 +187,19 @@
 - SHA-256 一覧、CycloneDX SBOM、更新情報、Artifact Attestation：生成済み
 - Gitleaks による Git 全履歴検査：機密情報の漏えいなし
 
-## Related pull requests / 相關 Pull Request / 相关 Pull Request / 関連 Pull Request
+### 関連 Pull Request
 
-- [#14 Stabilize Windows CI UI tests](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/14)
-- [#15 Localize installer and accelerate startup](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/15)
-- [#17 Fix speech eye-overlay artifacts](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/17)
-- [#18 Migrate MoHan to Python 3.14](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/18)
-- [#19 Reduce Realtime audio latency](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/19)
-- [#20 Eliminate pose-transition jitter and ghosting](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/20)
-- [#21 Local semantic memory retrieval and safe pruning](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/21)
-- [#22 Safe background manager-workers](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/22)
-- [#23 Pluggable speech providers](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/23)
-- [#24 Azure Speech preview and Japanese minimum usability](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/24)
-- [#25 Default text chat to GPT-5.6 Luna](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/25)
-- [#26 Four-language installer and bright readable UI](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/26)
+- [#14 Windows CI の UI テストを安定化](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/14)
+- [#15 インストーラーを多言語化し起動を高速化](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/15)
+- [#17 音声再生時の目の重なりを修正](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/17)
+- [#18 墨寒を Python 3.14 へ移行](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/18)
+- [#19 Realtime 音声遅延を削減](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/19)
+- [#20 姿勢切替時の揺れと残像を解消](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/20)
+- [#21 ローカル意味記憶検索と安全な剪定](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/21)
+- [#22 安全なバックグラウンド管理とワーカー](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/22)
+- [#23 交換可能な音声プロバイダー](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/23)
+- [#24 Azure Speech プレビューと日本語の基本機能](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/24)
+- [#25 テキストチャットの既定を GPT-5.6 Luna に変更](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/25)
+- [#26 四言語インストーラーと明るく読みやすい UI](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/pull/26)
 
-**Full changelog:** [v2.0.14-rc.3...v2.1.0-rc.1](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.3...v2.1.0-rc.1)
+**完全な変更履歴：** [v2.0.14-rc.3...v2.1.0-rc.1](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.3...v2.1.0-rc.1)

--- a/docs/releases/v2.0.14-rc.1.md
+++ b/docs/releases/v2.0.14-rc.1.md
@@ -1,0 +1,105 @@
+# 墨寒桌面助理 v2.0.14 RC1 首次公開預覽／墨寒桌面助手 v2.0.14 RC1 首次公开预览／MoHan Desktop Assistant v2.0.14 RC1 First Public Preview／墨寒デスクトップアシスタント v2.0.14 RC1 初回公開プレビュー
+
+## 繁體中文
+
+這是墨寒桌面語音互動虛擬助理的首次 GitHub 公開預覽版，提供可直接執行的 Windows x64 封裝。
+
+### 主要功能
+
+- 繁體中文文字對話、一般語音辨識與 OpenAI Realtime 自然語音。
+- 電影級表情仲裁、眨眼、AIUEO 嘴型、注視與旗艦物理效果。
+- 今日待辦、創作靈感、可編輯長期記憶、工作計時與提醒。
+- 權限分級的電腦工具、Google 整合與可攜式個人資料轉移。
+- Microsoft、GitHub 與 Home Assistant 擴充架構；當時仍待完整真實環境驗證。
+
+### 下載與驗證
+
+1. 下載 `MoHan-Desktop-Assistant-v2.0.14-rc.1-Windows-x64.zip`。
+2. 使用同頁 `SHA256.txt` 核對完整性。
+3. 解壓縮完整資料夾後執行 EXE，請勿只移動 EXE。
+
+39 項自動回歸測試、公開發布稽核、ZIP 結構及 SHA-256 驗證均通過。封裝不含 API 金鑰、OAuth 憑證、使用者資料庫、私人對話或可攜個人檔。此預覽版未經程式碼簽署，Windows SmartScreen 可能顯示提醒。
+
+### 相關連結
+
+- [專案說明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [變更紀錄](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全性政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+
+## 简体中文
+
+这是墨寒桌面语音互动虚拟助手首次在 GitHub 发布的公开预览版，提供可直接运行的 Windows x64 程序包。
+
+### 主要功能
+
+- 台湾繁体中文文字对话、一般语音识别及 OpenAI Realtime 自然语音。
+- 电影级表情仲裁、眨眼、AIUEO 口型、注视及旗舰物理效果。
+- 今日待办、创作灵感、可编辑长期记忆、工作计时及提醒。
+- 分级权限电脑工具、Google 集成及便携式个人资料转移。
+- Microsoft、GitHub 及 Home Assistant 扩展架构；当时仍有待完整真实环境验证。
+
+### 下载与验证
+
+1. 下载 `MoHan-Desktop-Assistant-v2.0.14-rc.1-Windows-x64.zip`。
+2. 使用本页的 `SHA256.txt` 核对文件完整性。
+3. 解压完整文件夹后运行 EXE，请勿单独移动 EXE。
+
+39 项自动回归测试、公开发布审计、ZIP 结构及 SHA-256 验证均已通过。程序包不包含 API 密钥、OAuth 凭证、用户数据库、私人对话或便携个人资料。此预览版未进行代码签名，Windows SmartScreen 可能显示提醒。
+
+### 相关链接
+
+- [项目说明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [变更记录](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+
+## English
+
+This is the first public GitHub preview of MoHan Desktop Assistant, including a ready-to-run Windows x64 package.
+
+### Highlights
+
+- Traditional Chinese text chat, standard transcription, and OpenAI Realtime voice conversation.
+- Cinematic expression arbitration, blinking, AIUEO visemes, gaze, and flagship physics effects.
+- Tasks, creative ideas, editable long-term memory, work timer, and reminders.
+- Permission-gated desktop tools, Google integration, and portable profile transfer.
+- Microsoft, GitHub, and Home Assistant connector foundations, which still required complete real-environment validation at the time.
+
+### Download and verification
+
+1. Download `MoHan-Desktop-Assistant-v2.0.14-rc.1-Windows-x64.zip`.
+2. Verify it with the matching `SHA256.txt` on this page.
+3. Extract the complete folder and run the EXE; do not move the EXE by itself.
+
+All 39 automated regression tests, the public-release audit, ZIP structure checks, and SHA-256 verification passed. The package contains no API key, OAuth credential, user database, private conversation, or portable profile. This preview is not code-signed, so Windows SmartScreen may display a warning.
+
+### Related links
+
+- [Project overview](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [Changelog](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [Security policy](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+
+## 日本語
+
+墨寒デスクトップ音声対話アシスタントを初めて GitHub で公開したプレビュー版です。すぐに実行できる Windows x64 パッケージを提供します。
+
+### 主な機能
+
+- 台湾繁体字中国語のテキスト会話、通常音声認識、OpenAI Realtime 音声会話。
+- 映画品質の表情調停、まばたき、AIUEO 口形、視線、最上位の物理効果。
+- タスク、創作メモ、編集可能な長期記憶、作業タイマー、リマインダー。
+- 権限制御付きデスクトップツール、Google 連携、持ち運び可能な個人設定。
+- Microsoft、GitHub、Home Assistant 連携の基盤。当時は実環境での完全な検証が未完了でした。
+
+### ダウンロードと検証
+
+1. `MoHan-Desktop-Assistant-v2.0.14-rc.1-Windows-x64.zip` をダウンロードします。
+2. 同じページの `SHA256.txt` で整合性を確認します。
+3. フォルダー全体を展開して EXE を実行してください。EXE だけを移動しないでください。
+
+39 件の自動回帰テスト、公開内容監査、ZIP 構造、SHA-256 検証に合格しています。API キー、OAuth 認証情報、利用者データベース、非公開会話、個人設定は同梱されていません。本版はコード署名されていないため、Windows SmartScreen の警告が表示される場合があります。
+
+### 関連リンク
+
+- [プロジェクト概要](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [変更履歴](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [セキュリティポリシー](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)

--- a/docs/releases/v2.0.14-rc.2.md
+++ b/docs/releases/v2.0.14-rc.2.md
@@ -1,0 +1,101 @@
+# 墨寒桌面助理 v2.0.14 RC2 安全強化預覽／墨寒桌面助手 v2.0.14 RC2 安全强化预览／MoHan Desktop Assistant v2.0.14 RC2 Security-Hardened Preview／墨寒デスクトップアシスタント v2.0.14 RC2 セキュリティ強化プレビュー
+
+## 繁體中文
+
+這是首次公開預覽版的安全強化更新，包含 Windows 可攜程式、SHA256 校驗檔、CycloneDX SBOM 與 GitHub 建置來源證明。
+
+### 本次重點
+
+- 修復 CodeQL 發現的遠端檔案路徑與公開稽核日誌問題。
+- 遠端下載只從可信白名單建立目標，封鎖路徑穿越、符號連結逃逸、受保護目錄及敏感副檔名。
+- 採固定 MIME 白名單、安全雜湊檔名及 `X-Content-Type-Options: nosniff`。
+- 新增 Release 自動化、CodeQL、Dependency Review、pip-audit、CODEOWNERS、Roadmap 與治理文件。
+- 啟用 Discussions、雙語 Issue 表單、私密安全通報、Social Preview 與嚴格主分支保護。
+
+### 驗證
+
+本機與乾淨的 GitHub Windows 環境均通過 `41/41` 測試；封裝 EXE 自我測試、事件迴圈煙霧測試、CodeQL、Dependency Review 及 pip-audit 均通過。ZIP SHA256 為 `0c30c1713d9cd4197e7c4a44578eda31cd71e3150c7686a84a883a1af3ed9c8f`，並附 CycloneDX 1.6 SBOM 與 artifact attestation。
+
+Microsoft、GitHub 與 Home Assistant 整合當時仍未完成所有真實帳號／設備情境驗證。此版未簽署，請只從本頁下載並核對 SHA256。
+
+### 相關連結
+
+- [專案說明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [變更紀錄](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全性政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完整版本差異](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.1...v2.0.14-rc.2)
+
+## 简体中文
+
+这是首次公开预览版的安全强化更新，包含 Windows 便携程序、SHA256 校验文件、CycloneDX SBOM 及 GitHub 构建来源证明。
+
+### 更新重点
+
+- 修复 CodeQL 发现的远程文件路径及公开审计日志问题。
+- 远程下载仅从可信白名单建立目标，阻止路径穿越、符号链接逃逸、受保护目录及敏感扩展名。
+- 采用固定 MIME 白名单、安全哈希文件名及 `X-Content-Type-Options: nosniff`。
+- 新增 Release 自动化、CodeQL、Dependency Review、pip-audit、CODEOWNERS、Roadmap 及治理文件。
+- 启用 Discussions、双语 Issue 表单、私密安全报告、Social Preview 及严格的主分支保护。
+
+### 验证
+
+本机及全新 GitHub Windows 环境均通过 `41/41` 项测试；程序包 EXE 自检、事件循环冒烟测试、CodeQL、Dependency Review 及 pip-audit 均通过。ZIP SHA256 为 `0c30c1713d9cd4197e7c4a44578eda31cd71e3150c7686a84a883a1af3ed9c8f`，并附 CycloneDX 1.6 SBOM 及 artifact attestation。
+
+Microsoft、GitHub 及 Home Assistant 集成当时仍未完成所有真实账号／设备场景验证。此版本未进行代码签名，请只从本页下载并核对 SHA256。
+
+### 相关链接
+
+- [项目说明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [变更记录](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完整版本差异](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.1...v2.0.14-rc.2)
+
+## English
+
+This security-hardened preview includes the portable Windows package, a SHA256 catalog, a CycloneDX SBOM, and GitHub build provenance.
+
+### Highlights
+
+- Fixes CodeQL findings involving remote file paths and public audit logging.
+- Creates remote-download targets only from trusted allow-listed catalogs, blocking traversal, symlink escapes, protected directories, and sensitive extensions.
+- Uses a fixed MIME allow-list, deterministic hashed names, and `X-Content-Type-Options: nosniff`.
+- Adds Release automation, CodeQL, Dependency Review, pip-audit, CODEOWNERS, Roadmap, and governance documents.
+- Enables Discussions, bilingual Issue Forms, private security reporting, a Social Preview, and strict main-branch protection.
+
+### Verification
+
+All `41/41` tests passed locally and in a clean GitHub-hosted Windows environment. The packaged EXE self-test, event-loop smoke test, CodeQL, Dependency Review, and pip-audit passed. ZIP SHA256: `0c30c1713d9cd4197e7c4a44578eda31cd71e3150c7686a84a883a1af3ed9c8f`. CycloneDX 1.6 SBOM and artifact attestation are included.
+
+Microsoft, GitHub, and Home Assistant integrations were still not fully validated across real accounts and devices at the time. This build is unsigned; download only from this page and verify SHA256.
+
+### Related links
+
+- [Project overview](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [Changelog](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [Security policy](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [Full version diff](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.1...v2.0.14-rc.2)
+
+## 日本語
+
+初回公開プレビューのセキュリティ強化版です。Windows ポータブルパッケージ、SHA256 一覧、CycloneDX SBOM、GitHub ビルド来歴証明を含みます。
+
+### 主な変更
+
+- CodeQL が検出したリモートファイルパスと公開監査ログの問題を修正。
+- 信頼済み許可リストからのみ保存先を作成し、パストラバーサル、シンボリックリンクによる逸脱、保護フォルダー、機密拡張子を遮断。
+- 固定 MIME 許可リスト、安全なハッシュ名、`X-Content-Type-Options: nosniff` を採用。
+- Release 自動化、CodeQL、Dependency Review、pip-audit、CODEOWNERS、Roadmap、ガバナンス文書を追加。
+- Discussions、二言語 Issue フォーム、非公開の脆弱性報告、Social Preview、厳格な main 保護を有効化。
+
+### 検証
+
+ローカルおよびクリーンな GitHub Windows 環境で `41/41` テストに合格しました。パッケージ EXE の自己テスト、イベントループのスモークテスト、CodeQL、Dependency Review、pip-audit も合格しています。ZIP SHA256 は `0c30c1713d9cd4197e7c4a44578eda31cd71e3150c7686a84a883a1af3ed9c8f` です。CycloneDX 1.6 SBOM と artifact attestation を同梱しています。
+
+Microsoft、GitHub、Home Assistant 連携は、当時すべての実アカウント・実機環境での検証を完了していませんでした。本版は未署名です。本ページからのみダウンロードし、SHA256 を確認してください。
+
+### 関連リンク
+
+- [プロジェクト概要](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [変更履歴](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [セキュリティポリシー](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完全なバージョン差分](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.1...v2.0.14-rc.2)

--- a/docs/releases/v2.0.14-rc.3.md
+++ b/docs/releases/v2.0.14-rc.3.md
@@ -1,0 +1,105 @@
+# 墨寒桌面助理 v2.0.14 RC3 國際化預覽／墨寒桌面助手 v2.0.14 RC3 国际化预览／MoHan Desktop Assistant v2.0.14 RC3 International Preview／墨寒デスクトップアシスタント v2.0.14 RC3 国際化プレビュー
+
+## 繁體中文
+
+RC3 在 RC2 的安全發行基礎上，修正 AI 等待表情，並加入英文與簡體中文最小可用體驗。
+
+### 本次重點
+
+- 將「墨寒思考中」狀態文字與思考表情分離；寒暄與普通問題維持自然姿勢，複雜問題、真實長延遲或明確 `thinking` 標籤才允許思考表情。
+- 等待反應統一經表情仲裁器處理，納入優先序、冷卻、去重及逾時取消；文字、一般語音與 Realtime 路徑均涵蓋。
+- 新增繁中、簡中、英文首次設定，並提供完整英文、簡中人格提示詞、離線回覆、工作模式宣告及提醒文字。
+- 新使用者預設使用 Windows 本機語音，不需要 API 金鑰也能開始基本體驗；只列出女性聲音，繁中預設 Microsoft Yating，簡中與英文優先使用相符的已安裝女性語音。
+- 保留既有個人設定與自訂提醒；語言切換於重新啟動後完整生效。
+- 新增安全的 EXE／MSI／ZIP 發行、自動更新、SHA256、SBOM、來源證明與完整歷史 Gitleaks 掃描。
+
+### 驗證
+
+三語更新後 `45/45` 自動測試通過，涵蓋語言、女性語音、簡體中文文字／一般語音／Realtime 保留、思考表情、逾時、API 失敗與狀態清理。發布前亦需通過 Windows CI、CodeQL、安全檢查、封裝自測、EXE／MSI 安裝移除、校驗碼、SBOM 與來源證明。
+
+當時進階管理畫面仍有部分繁中內容，Microsoft、GitHub 與 Home Assistant 整合也仍需更多真實帳號及設備驗證。
+
+### 相關連結
+
+- [專案說明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [變更紀錄](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全性政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完整版本差異](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.2...v2.0.14-rc.3)
+
+## 简体中文
+
+RC3 在 RC2 的安全发布基础上修复 AI 等待表情，并加入英文及简体中文最低可用体验。
+
+### 更新重点
+
+- 将“墨寒思考中”状态文字与思考表情分离；问候及普通问题保持自然姿势，只有复杂问题、真实长时间延迟或明确的 `thinking` 标签才允许触发思考表情。
+- 所有等待反应统一通过表情仲裁器，纳入优先级、冷却、去重及超时取消；文字、一般语音及 Realtime 路径均已覆盖。
+- 新增繁体中文、简体中文、英文首次设置，并提供完整英文及简体中文人格提示词、离线回复、工作模式提示及提醒文字。
+- 新用户默认使用 Windows 本地语音，无需 API 密钥也能开始基本体验；仅显示女性语音，繁中默认 Microsoft Yating，简中及英文优先选择相应的已安装女性语音。
+- 保留既有个人设置及自定义提醒；语言切换在重新启动后完整生效。
+- 新增安全的 EXE／MSI／ZIP 发布、自动更新、SHA256、SBOM、来源证明及完整历史 Gitleaks 扫描。
+
+### 验证
+
+三种语言更新后 `45/45` 项自动测试通过，涵盖语言、女性语音、简体中文文字／一般语音／Realtime 保留、思考表情、超时、API 失败及状态清理。发布前也必须通过 Windows CI、CodeQL、安全检查、程序包自检、EXE／MSI 安装卸载、校验码、SBOM 及来源证明。
+
+当时高级管理界面仍有部分繁体中文内容，Microsoft、GitHub 及 Home Assistant 集成也仍需更多真实账号及设备验证。
+
+### 相关链接
+
+- [项目说明](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [变更记录](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [安全政策](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完整版本差异](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.2...v2.0.14-rc.3)
+
+## English
+
+RC3 builds on RC2's secure release foundation, fixes AI wait-expression behavior, and adds minimum usable English and Simplified Chinese experiences.
+
+### Highlights
+
+- Separates the visible “MoHan is thinking” status from expression selection. Greetings and ordinary questions keep a natural pose; thinking is reserved for complex prompts, genuine long waits, or explicit `thinking` metadata.
+- Routes wait reactions through the expression arbiter with priority, cooldown, deduplication, and timeout cancellation across text, standard voice, and Realtime paths.
+- Adds Traditional Chinese, Simplified Chinese, and English first-run setup plus complete English and Simplified Chinese persona prompts, offline replies, work-mode announcements, and reminders.
+- Defaults new users to Windows local speech so a basic experience does not require an API key. Only female voices are listed; Traditional Chinese defaults to Microsoft Yating, while Simplified Chinese and English prefer matching installed female voices.
+- Preserves existing profiles and custom reminder text. A language change takes full effect after restart.
+- Adds secure EXE／MSI／ZIP releases, automatic updates, SHA256 catalogs, SBOMs, provenance attestations, and full-history Gitleaks scanning.
+
+### Verification
+
+All `45/45` automated tests passed after the three-language update, covering localization, female voices, Simplified Chinese text／standard voice／Realtime preservation, wait expressions, timeouts, API failure, and state cleanup. Publication also required Windows CI, CodeQL, security checks, packaged self-tests, EXE／MSI install and uninstall checks, checksums, SBOM generation, and provenance attestations.
+
+Some advanced management screens still contained Traditional Chinese at the time. Microsoft, GitHub, and Home Assistant integrations also required more validation with real accounts and devices.
+
+### Related links
+
+- [Project overview](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [Changelog](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [Security policy](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [Full version diff](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.2...v2.0.14-rc.3)
+
+## 日本語
+
+RC3 は RC2 の安全な配布基盤を引き継ぎ、AI 応答待ちの表情を修正し、英語と簡体字中国語の最小利用環境を追加した版です。
+
+### 主な変更
+
+- 「墨寒が思考中」という状態表示と表情選択を分離。挨拶や通常の質問では自然な姿勢を保ち、複雑な質問、実際の長い待機、明示的な `thinking` 情報の場合だけ思考表情を許可。
+- テキスト、通常音声、Realtime の全経路で、待機反応を表情調停器へ統一し、優先度、クールダウン、重複防止、タイムアウト解除を適用。
+- 繁体字中国語、簡体字中国語、英語の初回設定を追加し、英語・簡体字中国語の人格プロンプト、オフライン応答、作業モード案内、リマインダーを整備。
+- 新規利用者の既定音声を Windows ローカル音声に設定し、API キーなしでも基本体験を開始可能に変更。女性音声だけを表示し、繁体字中国語は Microsoft Yating、簡体字中国語と英語は対応するインストール済み女性音声を優先。
+- 既存設定と独自リマインダーを維持。言語変更は再起動後に完全適用。
+- 安全な EXE／MSI／ZIP 配布、自動更新、SHA256、SBOM、来歴証明、全履歴 Gitleaks 検査を追加。
+
+### 検証
+
+三言語対応後の自動テスト `45/45` 件に合格しました。言語、女性音声、簡体字中国語のテキスト／通常音声／Realtime 保持、待機表情、タイムアウト、API 失敗、状態解除を確認しています。公開前には Windows CI、CodeQL、セキュリティ検査、パッケージ自己テスト、EXE／MSI のインストールと削除、チェックサム、SBOM、来歴証明も必須でした。
+
+当時、一部の高度な管理画面には繁体字中国語が残っていました。Microsoft、GitHub、Home Assistant 連携も実アカウント・実機での追加検証が必要でした。
+
+### 関連リンク
+
+- [プロジェクト概要](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant#readme)
+- [変更履歴](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/blob/main/CHANGELOG.md)
+- [セキュリティポリシー](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/security/policy)
+- [完全なバージョン差分](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/compare/v2.0.14-rc.2...v2.0.14-rc.3)

--- a/docs/releases/v2.2.0-rc.1.md
+++ b/docs/releases/v2.2.0-rc.1.md
@@ -1,4 +1,4 @@
-# MoHan Desktop Assistant v2.2.0 RC1
+# 墨寒桌面助理 v2.2.0 RC1／墨寒桌面助手 v2.2.0 RC1／MoHan Desktop Assistant v2.2.0 RC1／墨寒デスクトップアシスタント v2.2.0 RC1
 
 ## 繁體中文
 

--- a/docs/releases/v2.2.0-rc.2.md
+++ b/docs/releases/v2.2.0-rc.2.md
@@ -1,4 +1,4 @@
-# MoHan Desktop Assistant v2.2.0 RC2
+# 墨寒桌面助理 v2.2.0 RC2／墨寒桌面助手 v2.2.0 RC2／MoHan Desktop Assistant v2.2.0 RC2／墨寒デスクトップアシスタント v2.2.0 RC2
 
 ## 繁體中文
 

--- a/docs/releases/v2.3.0-rc.1.md
+++ b/docs/releases/v2.3.0-rc.1.md
@@ -1,33 +1,31 @@
-# MoHan Desktop Assistant v2.3.0 RC1
+# 墨寒桌面助理 v2.3.0 RC1／墨寒桌面助手 v2.3.0 RC1／MoHan Desktop Assistant v2.3.0 RC1／墨寒デスクトップアシスタント v2.3.0 RC1
 
 ## 繁體中文
 
-2.3.0 RC1 將墨寒的產品執行環境、測試與所有封裝完整遷移到 CPython 3.15.0rc1。
-全專案採用 PEP 810 明示延遲導入，並以自動稽核阻止新程式退回舊式匯入；
-唯一保留的 eager import 是 PEP 810 語法本身不允許放入 `try` 區塊的可選
-QtMultimedia 邊界。
+2.3.0 RC1 將墨寒的產品執行環境、測試與所有封裝完整遷移至 CPython
+3.15.0rc1。全專案採用 PEP 810 明示延遲導入，並由自動稽核阻止新程式退回
+舊式匯入。唯一保留的 eager 邊界是放在 `try` 區塊內的可選 QtMultimedia
+匯入，因為 PEP 810 語法不能用於該位置。
 
 本版也導入 PEP 814 `frozendict` 深層不可變設定、PEP 798 推導式解包、
 PEP 686 UTF-8 檔案稽核、PEP 661 哨兵治理，以及 Python 3.15 新增的
-`bytearray.take_bytes()` 音訊封包緩衝。PySide6 6.11.1 使用經驗證的
-CPython Stable ABI 輪子；若不是 ABI3 輪子，安裝閘門會直接拒絕。
+`bytearray.take_bytes()` 音訊緩衝路徑。PySide6 6.11.1 只有在 CPython
+Stable ABI 輪子與 Qt 初始化通過專用閘門後才會接受；非 ABI3 輪子會被拒絕。
 
-PEP 799 Tachyon 現在能對啟動、50 Hz 嘴型同步與表情仲裁器產生低開銷
-flamegraph、JSONL、pstats 與執行期／GC 摘要。CI 要求每一目標至少 100 個
-有效樣本、堆疊讀取錯誤不超過 15%、漏採樣不超過 10%，並確認 JIT 確實
-開啟；證據全部去識別化並附 SHA-256，原始二進位取樣流不會發布。
-JIT 關閉與開啟皆通過兩輪各 20,000 次整合壓測及完整回歸套件。正式封裝由
-固定的官方 CPython 3.15.0rc1 提交建置，JIT 預設開啟且
-不放寬 PyInstaller 隔離；若特定電腦發生
-相容性問題，可用 `MOHAN_DISABLE_JIT=1` 安全停用後回報。
-Windows 實機熱路徑基準中，表情仲裁與 50 Hz 嘴型分析分別達到 1.57 倍與
-3.28 倍；功能校驗完全一致。這是熱路徑數字，不宣稱整體程式快三倍。
-所有 GitHub Actions JavaScript 動作則強制使用 Node 24。
-發布檔另含可重現的 CycloneDX 1.7 Windows／Preview SBOM 與驗證報告，強制
-完整根依賴圖、精確版本、PURL、SPDX 授權、100% 覆蓋率、官方結構驗證及
-敏感資料檢查；PyInstaller 以建置期元件獨立列管。
-Windows 安裝工具鏈也升級為 Inno Setup 7.0.2 與 WiX 7.0.0；WiX v7
-建置、ICE 驗證與語言轉換均使用已授權的 `-acceptEula wix7`。
+PEP 799 Tachyon 對啟動、50 Hz 嘴型同步與表情仲裁器產生低開銷 flamegraph、
+JSONL、pstats 與執行期／GC 摘要。CI 要求每一目標至少 100 個有效樣本、
+堆疊讀取錯誤不超過 15%、漏採樣不超過 10%，並確認 JIT 已啟用；只發布附
+SHA-256 的去識別化證據，不發布原始二進位取樣流。JIT 關閉與開啟均通過兩輪
+各 20,000 次整合壓測及完整回歸套件；正式封裝使用固定的官方 CPython
+3.15.0rc1 提交，預設啟用 JIT 且不放寬 PyInstaller 隔離，並保留
+`MOHAN_DISABLE_JIT=1` 相容性開關。Windows 實機熱路徑中，表情仲裁與
+50 Hz 嘴型分析分別達到 1.57 倍與 3.28 倍，且功能校驗完全一致；這不是整體
+程式快三倍的宣稱。所有 GitHub Actions JavaScript 動作強制使用 Node 24。
+Release 另含可重現的 CycloneDX 1.7 Windows／Preview SBOM 與驗證報告，
+強制完整根依賴圖、精確版本、PURL、SPDX 授權、100% 覆蓋率、官方結構驗證
+與敏感資料檢查；PyInstaller 作為建置期元件獨立管理。Windows 安裝工具鏈
+升級至 Inno Setup 7.0.2 與 WiX 7.0.0；WiX v7 建置、ICE 驗證及語言轉換均
+使用已授權的 `-acceptEula wix7` 參數。
 
 既有語音、嘴型、表情、四語、個人設定、資料庫與安全確認流程均維持原有
 行為。Windows x64 仍為完整功能版；macOS arm64／x86_64 與 Linux x86_64
@@ -35,94 +33,107 @@ Windows 安裝工具鏈也升級為 Inno Setup 7.0.2 與 WiX 7.0.0；WiX v7
 
 ## 简体中文
 
-2.3.0 RC1 将墨寒的产品运行环境、测试及所有发布包完整迁移至 CPython
-3.15.0rc1。全项目采用 PEP 810 显式延迟导入，并以自动审计阻止新代码
-退回旧式导入；唯一保留的 eager import 是 PEP 810 语法不能放进 `try`
-区块的可选 QtMultimedia 边界。
+2.3.0 RC1 将墨寒的产品运行环境、测试及所有打包完整迁移至 CPython
+3.15.0rc1。全项目采用 PEP 810 显式延迟导入，并由自动审计阻止新代码退回
+旧式导入。唯一保留的 eager 边界是位于 `try` 区块内的可选 QtMultimedia
+导入，因为 PEP 810 语法不能用于该位置。
 
-本版导入不可变配置、推导式解包、UTF-8 文件审计、内建 sentinel 治理和
-新的音频缓冲 API。Tachyon 可分析启动、50 Hz 口型同步及表情仲裁器。
-CI 保存去识别化 flamegraph、JSONL、pstats、运行时／GC 与 SHA-256 证据，
-并强制至少 100 个有效样本、堆栈读取错误不超过 15%、漏采样不超过 10%，
-同时确认 JIT 开启；原始二进制采样流不会发布。
-JIT 开关均通过 20,000 次整合压力测试与完整回归套件。正式封装使用固定
-官方 CPython 3.15.0rc1 提交，JIT 默认启用且不放宽 PyInstaller 隔离，并保留
-`MOHAN_DISABLE_JIT=1` 兼容性开关。
-Windows 实机热路径基准中，表情仲裁与 50 Hz 嘴型分析分别达到 1.57 倍与
-3.28 倍，功能校验完全一致；这不是整个程序快三倍的宣称。
-所有 GitHub Actions JavaScript 动作强制使用 Node 24。
-发布文件另含可重现的 CycloneDX 1.7 Windows／Preview SBOM 及验证报告，
+本版也导入 PEP 814 `frozendict` 深层不可变配置、PEP 798 推导式解包、
+PEP 686 UTF-8 文件审计、PEP 661 哨兵治理，以及 Python 3.15 新增的
+`bytearray.take_bytes()` 音频缓冲路径。PySide6 6.11.1 只有在 CPython
+Stable ABI 轮子与 Qt 初始化通过专用闸门后才会接受；非 ABI3 轮子会被拒绝。
+
+PEP 799 Tachyon 为启动、50 Hz 口型同步与表情仲裁器生成低开销 flamegraph、
+JSONL、pstats 及运行时／GC 摘要。CI 要求每个目标至少 100 个有效样本、
+堆栈读取错误不超过 15%、漏采样不超过 10%，并确认 JIT 已启用；只发布附
+SHA-256 的去标识化证据，不发布原始二进制采样流。JIT 关闭与开启均通过两轮
+各 20,000 次整合压力测试及完整回归套件；正式打包使用固定的官方 CPython
+3.15.0rc1 提交，默认启用 JIT 且不放宽 PyInstaller 隔离，并保留
+`MOHAN_DISABLE_JIT=1` 兼容性开关。Windows 真机热路径中，表情仲裁与
+50 Hz 口型分析分别达到 1.57 倍与 3.28 倍，且功能校验完全一致；这不是整个
+程序快三倍的宣称。所有 GitHub Actions JavaScript 动作强制使用 Node 24。
+Release 另含可重现的 CycloneDX 1.7 Windows／Preview SBOM 与验证报告，
 强制完整根依赖图、精确版本、PURL、SPDX 授权、100% 覆盖率、官方结构验证
-与敏感数据检查；PyInstaller 作为构建期组件独立管理。
-Windows 安装工具链升级为 Inno Setup 7.0.2 与 WiX 7.0.0；WiX v7
-构建、ICE 验证及语言转换均使用已授权的 `-acceptEula wix7`。
+与敏感数据检查；PyInstaller 作为构建期组件独立管理。Windows 安装工具链
+升级至 Inno Setup 7.0.2 与 WiX 7.0.0；WiX v7 构建、ICE 验证及语言转换均
+使用已授权的 `-acceptEula wix7` 参数。
 
-现有语音、口型、表情、四语、个人设置、数据库及安全确认流程保持原有行为。
-Windows x64 仍为完整功能版；macOS 与 Linux 仍为功能受限 Preview。
+现有语音、口型、表情、四语、个人设置、数据库与安全确认流程均保持原有
+行为。Windows x64 仍为完整功能版；macOS arm64／x86_64 与 Linux x86_64
+仍为功能受限 Preview，不宣称与 Windows 功能相同。
 
 ## English
 
-2.3.0 RC1 moves MoHan's product runtime, tests, and every release package completely
-to CPython 3.15.0rc1. Project-wide explicit PEP 810 lazy imports are enforced
-by an automated audit. The sole eager boundary is the optional QtMultimedia
-import inside `try`, where PEP 810 syntax is not permitted.
+2.3.0 RC1 moves MoHan's product runtime, tests, and every package completely to
+CPython 3.15.0rc1. Project-wide explicit PEP 810 lazy imports are enforced by
+an automated audit that prevents new code from returning to eager imports. The
+sole eager boundary is the optional QtMultimedia import inside `try`, where
+PEP 810 syntax is not permitted.
 
-This candidate also adopts deeply immutable PEP 814 configuration, PEP 798
-unpacking comprehensions, PEP 686 UTF-8 auditing, PEP 661 sentinel governance,
-and the new `bytearray.take_bytes()` audio-buffer path. PySide6 6.11.1 is
-accepted only after its CPython Stable ABI wheels and Qt initialization pass a
-dedicated gate.
+This candidate also adopts deeply immutable PEP 814 `frozendict`
+configuration, PEP 798 unpacking comprehensions, PEP 686 UTF-8 file auditing,
+PEP 661 sentinel governance, and Python 3.15's
+`bytearray.take_bytes()` audio-buffer path. PySide6 6.11.1 is accepted only
+after its CPython Stable ABI wheel and Qt initialization pass a dedicated gate;
+non-ABI3 wheels are rejected.
 
-PEP 799 Tachyon profiles startup, 50 Hz lip sync, and expression arbitration.
-CI retains sanitized flamegraph, JSONL, pstats, runtime/GC, and SHA-256 evidence
-while requiring at least 100 valid samples per target, no more than 15%
-stack-read error, no more than 10% missed samples, and a verified enabled JIT.
-Raw binary sample streams are never published.
-Both JIT modes pass 20,000-iteration integration soaks and the complete
-regression suite. Formal packages use a pinned official CPython 3.15.0rc1 commit with JIT
-enabled by default while preserving PyInstaller isolation;
-`MOHAN_DISABLE_JIT=1` remains a compatibility escape.
-On the Windows test host, expression arbitration and 50 Hz viseme-analysis
-hot paths measured 1.57x and 3.28x faster with identical functional checksums;
-this does not claim a threefold whole-application speedup. Every GitHub
-JavaScript action is forced onto Node 24.
-The release also carries reproducible CycloneDX 1.7 Windows and Preview SBOMs
-plus a validation report. Exact versions, PURLs, SPDX licenses, a complete root
-dependency graph, 100% coverage, official schema validation, and privacy checks
-are mandatory; PyInstaller is tracked separately as a build-time component.
-The Windows installer toolchain is upgraded to Inno Setup 7.0.2 and WiX
-7.0.0; WiX v7 build, ICE validation, and language-transform commands use the
-authorized `-acceptEula wix7` argument.
+PEP 799 Tachyon produces low-overhead flamegraph, JSONL, pstats, and runtime/GC
+summaries for startup, 50 Hz lip sync, and expression arbitration. CI requires
+at least 100 valid samples per target, no more than 15% stack-read error, no
+more than 10% missed samples, and a verified enabled JIT. Only sanitized
+evidence with SHA-256 is published; raw binary streams are not. JIT-off and
+JIT-on modes both pass two 20,000-iteration integration soaks and the complete
+regression suite. Formal packages use a pinned official CPython 3.15.0rc1
+commit, enable JIT by default without weakening PyInstaller isolation, and
+retain `MOHAN_DISABLE_JIT=1` as a compatibility switch. On the Windows test
+host, expression arbitration and 50 Hz viseme-analysis hot paths measure 1.57x
+and 3.28x faster with identical functional checksums; this is not a claim that
+the entire app is three times faster. Every GitHub Actions JavaScript action is
+forced onto Node 24. The Release also carries reproducible CycloneDX 1.7
+Windows/Preview SBOMs and a validation report requiring a complete root
+dependency graph, exact versions, PURLs, SPDX licenses, 100% coverage, official
+schema validation, and sensitive-data checks; PyInstaller is tracked
+separately as a build-time component. The Windows installer toolchain moves to
+Inno Setup 7.0.2 and WiX 7.0.0; WiX v7 build, ICE validation, and language
+transform commands use the authorized `-acceptEula wix7` argument.
 
 Existing voice, lip-sync, expression, four-language, personal-setting,
-database, and confirmation behavior is preserved. Windows x64 remains the
-complete product; macOS arm64/x86_64 and Linux x86_64 remain limited Preview
-packages and do not claim Windows feature parity.
+database, and safety-confirmation behavior is preserved. Windows x64 remains
+the complete product; macOS arm64/x86_64 and Linux x86_64 remain limited
+limited Preview packages and do not claim Windows feature parity.
 
 ## 日本語
 
-2.3.0 RC1 は墨寒の製品実行環境、テスト、全リリースパッケージを CPython
+2.3.0 RC1 は、墨寒の製品実行環境、テスト、全パッケージを CPython
 3.15.0rc1 のみに完全移行します。PEP 810 の明示的遅延インポートを全体へ
-導入し、自動監査で旧方式への後退を防止します。唯一の eager 境界は、構文上
-`try` 内で PEP 810 を使用できない任意の QtMultimedia インポートです。
+導入し、自動監査で新しいコードが eager import へ戻ることを防ぎます。唯一の
+eager 境界は、構文上 PEP 810 を使用できない `try` 内の任意
+QtMultimedia インポートです。
 
-PEP 814 の不変設定、PEP 798、PEP 686、PEP 661 の管理、新しい音声
-バッファー API も導入しました。Tachyon は起動、50 Hz 口形同期、表情調停を
-解析し、匿名化済み flamegraph、JSONL、pstats、実行時／GC、SHA-256 証拠を
-保存します。各対象 100 有効サンプル以上、読取エラー 15% 以下、漏れ 10%
-以下、JIT 有効を必須とし、生のバイナリサンプルは公開しません。
-JIT の有無は 20,000 回の統合耐久試験と全回帰テストに合格
-しました。製品方針に従い既定で有効にし、互換性用に
-`MOHAN_DISABLE_JIT=1` を残します。GitHub Actions の
-JavaScript 動作はすべて Node 24 を強制します。
-リリースには再現可能な CycloneDX 1.7 の Windows／Preview SBOM と検証報告
-も含めます。正確な版、PURL、SPDX ライセンス、完全なルート依存関係、100%
-網羅、公式スキーマ検証、個人情報検査を必須とし、PyInstaller はビルド時
-コンポーネントとして別管理します。
-Windows インストーラーツールチェーンも Inno Setup 7.0.2 と WiX 7.0.0
-へ更新し、WiX v7 のビルド、ICE 検証、言語変換では承認済みの
+PEP 814 `frozendict` の深い不変設定、PEP 798、PEP 686 UTF-8 ファイル
+監査、PEP 661 センチネル管理、Python 3.15 の
+`bytearray.take_bytes()` 音声バッファーも導入しました。PySide6 6.11.1 は、
+CPython Stable ABI wheel と Qt 初期化が専用ゲートに合格した場合だけ採用し、
+非 ABI3 wheel は拒否します。
+
+PEP 799 Tachyon は、起動、50 Hz 口形同期、表情調停について低負荷の
+flamegraph、JSONL、pstats、runtime／GC 要約を生成します。CI は各対象で
+100 以上の有効サンプル、15% 以下のスタック読取エラー、10% 以下の漏れ、
+JIT 有効を必須とします。SHA-256 付きの匿名化証拠だけを公開し、生の
+バイナリストリームは公開しません。JIT 無効／有効の両方が、各 20,000 回を
+二回行う統合耐久試験と全回帰テストに合格しました。正式パッケージは固定した
+公式 CPython 3.15.0rc1 コミットを使い、PyInstaller の隔離を弱めず JIT を
+既定で有効にし、互換性用に `MOHAN_DISABLE_JIT=1` を残します。Windows
+実機では、表情調停と 50 Hz 口形解析のホットパスが 1.57 倍と 3.28 倍になり、
+機能チェックサムは一致しました。アプリ全体が三倍速いという主張では
+ありません。GitHub Actions の JavaScript 動作はすべて Node 24 を強制します。
+Release には再現可能な CycloneDX 1.7 Windows／Preview SBOM と検証報告を
+含め、完全なルート依存関係、正確な版、PURL、SPDX ライセンス、100% 網羅、
+公式スキーマ検証、機密データ検査を必須にします。PyInstaller はビルド時
+コンポーネントとして別管理します。Windows インストーラーは Inno Setup
+7.0.2 と WiX 7.0.0 へ更新し、WiX v7 のビルド、ICE 検証、言語変換で承認済み
 `-acceptEula wix7` を使用します。
 
-既存の音声、口形、表情、四言語、個人設定、データベース、安全確認動作を
-維持します。Windows x64 は完全版、macOS と Linux は機能限定 Preview の
-ままであり、Windows と同等の機能を主張しません。
+既存の音声、口形、表情、四言語、個人設定、データベース、安全確認の動作を
+維持します。Windows x64 は完全版、macOS arm64／x86_64 と Linux x86_64 は
+機能限定 Preview のままであり、Windows 版との機能同等を主張しません。

--- a/installer/LOCALIZATION.md
+++ b/installer/LOCALIZATION.md
@@ -1,57 +1,145 @@
-# Installer localization policy
+# 安裝器在地化政策／安装程序本地化策略／Installer Localization Policy／インストーラーのローカライズ方針
 
-MoHan ships two installer formats with deliberately different localization
-contracts.
+## 繁體中文
 
-## Interactive EXE installer
+墨寒提供兩種安裝器格式，兩者刻意採用不同的在地化契約。
 
-The Inno Setup EXE is the normal interactive installer. It detects the Windows
-user language and offers these four choices before installation:
+### 互動式 EXE 安裝器
 
-- Taiwan Traditional Chinese (`zh-TW`, LCID 1028)
-- Simplified Chinese (`zh-CN`, LCID 2052)
-- English (`en-US`, LCID 1033)
-- Japanese (`ja-JP`, LCID 1041)
+Inno Setup EXE 是一般互動式安裝器。它會偵測 Windows 使用者語言，並在安裝前提供以下四個選項：
 
-The selected language affects only the installer and uninstaller interface.
-MoHan's own first-run wizard remains the authority for the application UI
-language.
+- 台灣繁體中文（`zh-TW`，LCID 1028）
+- 簡體中文（`zh-CN`，LCID 2052）
+- 英文（`en-US`，LCID 1033）
+- 日文（`ja-JP`，LCID 1041）
 
-## MSI package
+選定語言只影響安裝器與解除安裝器介面。墨寒本身的首次啟動精靈仍是應用程式 UI 語言的權威來源。
 
-The MSI remains a Taiwan Traditional Chinese base package (`Language=1028`).
-It is intended primarily for silent installation and managed deployment, so it
-does not display a custom language picker. Keeping one stable base MSI also
-avoids publishing several packages that Windows Installer could treat as
-different products.
+### MSI 封裝
 
-The build creates three language transforms from the same payload and product
-identity:
+MSI 維持為台灣繁體中文基礎封裝（`Language=1028`）。它主要供靜默安裝與受管理部署使用，因此不顯示自訂語言選擇器。維持單一穩定基礎 MSI，也能避免發布多個可能被 Windows Installer 視為不同產品的封裝。
 
-- `MoHan-Desktop-Assistant-<tag>-en-US.mst` (`1033`)
-- `MoHan-Desktop-Assistant-<tag>-zh-CN.mst` (`2052`)
-- `MoHan-Desktop-Assistant-<tag>-ja-JP.mst` (`1041`)
+建置程序會以相同 payload 與產品身分建立三個語言 transform：
 
-The transforms must preserve the base MSI's product identity, component GUIDs,
-install location, upgrade code, and payload. Administrators will apply one with
-the standard Windows Installer command, for example:
+- `MoHan-Desktop-Assistant-<tag>-en-US.mst`（`1033`）
+- `MoHan-Desktop-Assistant-<tag>-zh-CN.mst`（`2052`）
+- `MoHan-Desktop-Assistant-<tag>-ja-JP.mst`（`1041`）
+
+Transform 必須保留基礎 MSI 的產品身分、component GUID、安裝位置、upgrade code 與 payload。管理員可使用標準 Windows Installer 命令套用其中一個 transform，例如：
 
 ```powershell
 msiexec /i MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.msi `
   TRANSFORMS=MoHan-Desktop-Assistant-vX.Y.Z-ja-JP.mst /qn
 ```
 
-The MSI and transforms are built with WiX Toolset 7.0.0. WiX v7's maintained
-`Files` element recursively harvests the packaged application; the removed
-Heat/Candle/Light/Torch v3 toolchain is not used. Every WiX build, validation,
-and transform command supplies the owner-authorized `-acceptEula wix7`
-argument. ICE validation remains enabled. ICE38 and ICE64 retain the historic
-per-user package exemptions, while ICE91 is excluded because its warning is
-specifically about a hypothetical per-machine use that this `Scope="perUser"`
-package does not support.
+MSI 與 transform 使用 WiX Toolset 7.0.0 建置。WiX v7 維護中的 `Files` 元素會遞迴收集已封裝應用程式；已移除的 Heat／Candle／Light／Torch v3 工具鏈不再使用。每一項 WiX 建置、驗證及 transform 命令，都必須提供擁有者已授權的 `-acceptEula wix7` 參數。ICE 驗證保持啟用；ICE38 與 ICE64 保留歷史上的每使用者封裝豁免，而 ICE91 因其警告只針對假設性的每機器用途而排除，本 `Scope="perUser"` 封裝並不支援該用途。
 
-Windows CI installs, runs the packaged self-test, and uninstalls the base MSI
-and every transform. A transform must never be published if any variant fails.
-The transforms affect Windows Installer messages only. MoHan's first-run wizard
-still controls the application's Traditional Chinese, Simplified Chinese,
-English, or Japanese interface and reply language.
+Windows CI 會安裝基礎 MSI 與每一個 transform、執行封裝後自我測試，再將其解除安裝。任一變體失敗時，絕不得發布 transform。Transform 只影響 Windows Installer 訊息；墨寒首次啟動精靈仍控制應用程式的繁體中文、簡體中文、英文或日文介面與回覆語言。
+
+## 简体中文
+
+墨寒提供两种安装程序格式，两者刻意采用不同的本地化契约。
+
+### 交互式 EXE 安装程序
+
+Inno Setup EXE 是常规交互式安装程序。它会检测 Windows 用户语言，并在安装前提供以下四个选项：
+
+- 台湾繁体中文（`zh-TW`，LCID 1028）
+- 简体中文（`zh-CN`，LCID 2052）
+- 英文（`en-US`，LCID 1033）
+- 日文（`ja-JP`，LCID 1041）
+
+所选语言只影响安装程序与卸载程序界面。墨寒本身的首次运行向导仍是应用程序 UI 语言的权威来源。
+
+### MSI 封装
+
+MSI 保持为台湾繁体中文基础封装（`Language=1028`）。它主要供静默安装与托管部署使用，因此不显示自定义语言选择器。保持单一稳定基础 MSI，也能避免发布多个可能被 Windows Installer 视为不同产品的封装。
+
+构建流程会以相同 payload 与产品身份创建三个语言 transform：
+
+- `MoHan-Desktop-Assistant-<tag>-en-US.mst`（`1033`）
+- `MoHan-Desktop-Assistant-<tag>-zh-CN.mst`（`2052`）
+- `MoHan-Desktop-Assistant-<tag>-ja-JP.mst`（`1041`）
+
+Transform 必须保留基础 MSI 的产品身份、component GUID、安装位置、upgrade code 与 payload。管理员可使用标准 Windows Installer 命令应用其中一个 transform，例如：
+
+```powershell
+msiexec /i MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.msi `
+  TRANSFORMS=MoHan-Desktop-Assistant-vX.Y.Z-ja-JP.mst /qn
+```
+
+MSI 与 transform 使用 WiX Toolset 7.0.0 构建。WiX v7 维护中的 `Files` 元素会递归收集已封装应用程序；已移除的 Heat／Candle／Light／Torch v3 工具链不再使用。每一项 WiX 构建、验证及 transform 命令，都必须提供所有者已授权的 `-acceptEula wix7` 参数。ICE 验证保持启用；ICE38 与 ICE64 保留历史上的每用户封装豁免，而 ICE91 因其警告只针对假设性的每机器用途而排除，本 `Scope="perUser"` 封装并不支持该用途。
+
+Windows CI 会安装基础 MSI 与每一个 transform、执行封装后自检，再将其卸载。任一变体失败时，绝不得发布 transform。Transform 只影响 Windows Installer 消息；墨寒首次运行向导仍控制应用程序的繁体中文、简体中文、英文或日文界面与回复语言。
+
+## English
+
+MoHan ships two installer formats with deliberately different localization contracts.
+
+### Interactive EXE installer
+
+The Inno Setup EXE is the normal interactive installer. It detects the Windows user language and offers these four choices before installation:
+
+- Taiwan Traditional Chinese (`zh-TW`, LCID 1028)
+- Simplified Chinese (`zh-CN`, LCID 2052)
+- English (`en-US`, LCID 1033)
+- Japanese (`ja-JP`, LCID 1041)
+
+The selected language affects only the installer and uninstaller interface. MoHan's own first-run wizard remains the authority for the application UI language.
+
+### MSI package
+
+The MSI remains a Taiwan Traditional Chinese base package (`Language=1028`). It is intended primarily for silent installation and managed deployment, so it does not display a custom language picker. Keeping one stable base MSI also avoids publishing several packages that Windows Installer could treat as different products.
+
+The build creates three language transforms from the same payload and product identity:
+
+- `MoHan-Desktop-Assistant-<tag>-en-US.mst` (`1033`)
+- `MoHan-Desktop-Assistant-<tag>-zh-CN.mst` (`2052`)
+- `MoHan-Desktop-Assistant-<tag>-ja-JP.mst` (`1041`)
+
+The transforms must preserve the base MSI's product identity, component GUIDs, install location, upgrade code, and payload. Administrators can apply one with the standard Windows Installer command, for example:
+
+```powershell
+msiexec /i MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.msi `
+  TRANSFORMS=MoHan-Desktop-Assistant-vX.Y.Z-ja-JP.mst /qn
+```
+
+The MSI and transforms are built with WiX Toolset 7.0.0. WiX v7's maintained `Files` element recursively harvests the packaged application; the removed Heat/Candle/Light/Torch v3 toolchain is not used. Every WiX build, validation, and transform command supplies the owner-authorized `-acceptEula wix7` argument. ICE validation remains enabled; ICE38 and ICE64 retain the historic per-user package exemptions, while ICE91 is excluded because its warning concerns a hypothetical per-machine use that this `Scope="perUser"` package does not support.
+
+Windows CI installs the base MSI and every transform, runs the packaged self-test, and uninstalls them. A transform must never be published if any variant fails. The transforms affect Windows Installer messages only; MoHan's first-run wizard still controls the application's Traditional Chinese, Simplified Chinese, English, or Japanese interface and reply language.
+
+## 日本語
+
+墨寒は、意図的に異なるローカライズ契約を持つ二つのインストーラー形式を提供します。
+
+### 対話式 EXE インストーラー
+
+Inno Setup EXE は通常の対話式インストーラーです。Windows のユーザー言語を検出し、インストール前に次の四つの選択肢を提示します。
+
+- 台湾繁体字中国語（`zh-TW`、LCID 1028）
+- 簡体字中国語（`zh-CN`、LCID 2052）
+- 英語（`en-US`、LCID 1033）
+- 日本語（`ja-JP`、LCID 1041）
+
+選択した言語が影響するのは、インストーラーとアンインストーラーの画面だけです。アプリケーション UI 言語の正式な決定元は、引き続き墨寒本体の初回起動ウィザードです。
+
+### MSI パッケージ
+
+MSI は台湾繁体字中国語のベースパッケージ（`Language=1028`）を維持します。主な用途はサイレントインストールと管理下の展開であるため、独自の言語選択画面は表示しません。安定した単一のベース MSI を維持することで、Windows Installer が別製品として扱い得る複数パッケージの公開も防ぎます。
+
+ビルドでは、同一の payload と製品 identity から三つの言語 transform を作成します。
+
+- `MoHan-Desktop-Assistant-<tag>-en-US.mst`（`1033`）
+- `MoHan-Desktop-Assistant-<tag>-zh-CN.mst`（`2052`）
+- `MoHan-Desktop-Assistant-<tag>-ja-JP.mst`（`1041`）
+
+Transform は、ベース MSI の製品 identity、component GUID、インストール先、upgrade code、payload を維持しなければなりません。管理者は、次の例のように標準の Windows Installer コマンドでいずれかの transform を適用できます。
+
+```powershell
+msiexec /i MoHan-Desktop-Assistant-vX.Y.Z-Windows-x64.msi `
+  TRANSFORMS=MoHan-Desktop-Assistant-vX.Y.Z-ja-JP.mst /qn
+```
+
+MSI と transform は WiX Toolset 7.0.0 でビルドします。WiX v7 で保守されている `Files` 要素が、パッケージ対象アプリケーションを再帰的に収集します。削除済みの Heat／Candle／Light／Torch v3 ツールチェーンは使用しません。WiX のすべてのビルド、検証、transform コマンドに、所有者が許可した `-acceptEula wix7` 引数を指定します。ICE 検証は有効なままとし、ICE38 と ICE64 には従来のユーザー単位パッケージ例外を維持します。ICE91 は、この `Scope="perUser"` パッケージが対応しない仮想的なマシン単位用途だけを警告するため除外します。
+
+Windows CI は、ベース MSI と各 transform をインストールし、パッケージ済み自己テストを実行してからアンインストールします。いずれかの変種が失敗した場合、transform を決して公開してはいけません。Transform が影響するのは Windows Installer のメッセージだけです。アプリケーションの繁体字中国語、簡体字中国語、英語、日本語の画面および応答言語は、引き続き墨寒の初回起動ウィザードが制御します。

--- a/tests/test_four_language_documentation.py
+++ b/tests/test_four_language_documentation.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+lazy import subprocess
+lazy import sys
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+lazy from check_four_language_docs import audit_text
+
+
+DOCUMENT = """# 文件／文档／Document／文書
+
+## 繁體中文
+
+繁體說明。
+
+## 简体中文
+
+简体说明。
+
+## English
+
+English description.
+
+## 日本語
+
+日本語の説明。
+"""
+
+
+def test_document_contract() -> None:
+    assert audit_text(DOCUMENT, require_h1=True) == []
+
+
+def test_document_requires_h1_and_only_language_h2_headings() -> None:
+    errors = audit_text(DOCUMENT.split("\n", maxsplit=2)[2], require_h1=True)
+    assert "a four-language H1 is required" in errors
+
+    extra_h2 = DOCUMENT.replace("繁體說明。", "繁體說明。\n\n## 額外章節")
+    errors = audit_text(extra_h2, require_h1=True)
+    assert any("only H2 headings" in error for error in errors)
+
+
+def test_document_rejects_untranslated_duplicate_section() -> None:
+    duplicate = DOCUMENT.replace("简体说明。", "繁體說明。")
+    errors = audit_text(duplicate, require_h1=True)
+    assert any("duplicates 繁體中文" in error for error in errors)
+
+
+def main() -> None:
+    test_document_contract()
+    test_document_requires_h1_and_only_language_h2_headings()
+    test_document_rejects_untranslated_duplicate_section()
+    result = subprocess.run(
+        [sys.executable, "tools/check_four_language_docs.py"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "FOUR_LANGUAGE_DOCUMENTATION_OK" in result.stdout
+    print("FOUR_LANGUAGE_DOCUMENTATION_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_four_language_pr.py
+++ b/tests/test_four_language_pr.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+lazy from check_four_language_pr import audit_pull_request
+
+
+BODY = """## 繁體中文
+
+說明。
+
+- `python tests/run_all.py`
+
+## 简体中文
+
+说明。
+
+- `python tests/run_all.py`
+
+## English
+
+Description.
+
+- `python tests/run_all.py`
+
+## 日本語
+
+説明。
+
+- `python tests/run_all.py`
+"""
+
+
+def test_valid_pull_request_metadata() -> None:
+    payload = {
+        "pull_request": {
+            "title": "修正／修复／Fix／修正",
+            "body": BODY,
+        }
+    }
+    assert audit_pull_request(payload) == []
+
+
+def test_title_requires_exactly_four_nonempty_segments() -> None:
+    payload = {"pull_request": {"title": "修正 / Fix", "body": BODY}}
+    errors = audit_pull_request(payload)
+    assert any("title must contain four" in error for error in errors)
+
+
+def test_body_requires_fixed_order_and_structural_parity() -> None:
+    wrong_order = BODY.replace("## 繁體中文", "## TEMP", 1).replace(
+        "## 简体中文", "## 繁體中文", 1
+    ).replace("## TEMP", "## 简体中文", 1)
+    payload = {
+        "pull_request": {
+            "title": "修正／修复／Fix／修正",
+            "body": wrong_order,
+        }
+    }
+    errors = audit_pull_request(payload)
+    assert any("language sections must appear exactly once" in error for error in errors)
+
+    unequal = BODY.replace("- `python tests/run_all.py`", "", 1)
+    payload["pull_request"]["body"] = unequal
+    errors = audit_pull_request(payload)
+    assert any("differs across language sections" in error for error in errors)
+
+
+def main() -> None:
+    test_valid_pull_request_metadata()
+    test_title_requires_exactly_four_nonempty_segments()
+    test_body_requires_fixed_order_and_structural_parity()
+    print("FOUR_LANGUAGE_PR_TESTS_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -90,10 +90,18 @@ def test_release_supply_chain(release: str) -> None:
     ):
         assert artifact in release
     assert "tools/profile_mohan_tachyon.py" in release
+    assert "tools/check_four_language_docs.py" in release
+    assert (
+        "墨寒桌面助理 $tag／墨寒桌面助手 $tag／"
+        "MoHan Desktop Assistant $tag／"
+        "墨寒デスクトップアシスタント $tag"
+    ) in release
     assert "SHA256" in release
 
 
 def test_release_runtime_and_packages(release: str) -> None:
+    public_audit = read("tools/audit_public_release.py")
+    assert "safe.directory={ROOT.as_posix()}" in public_audit
     for required in (
         "tools/audit_public_release.py",
         "tests/run_all.py",
@@ -214,10 +222,23 @@ def test_secret_defense_and_community_files() -> None:
     for required in (
         "opened, edited, reopened, synchronize, ready_for_review",
         "GITHUB_EVENT_PATH",
+        "pull_request.title",
+        "IFS='／'",
         "Missing non-empty language section",
-        "FOUR_LANGUAGE_PR_BODY_OK",
+        "FOUR_LANGUAGE_PR_METADATA_MINIMUM_OK",
+        "tools/check_four_language_pr.py",
+        "tools/check_four_language_docs.py",
+        'python-version: "3.15.0-rc.1"',
     ):
         assert required in language_guard
+    assert "FOUR_LANGUAGE_PR_METADATA_OK" in read(
+        "tools/check_four_language_pr.py"
+    )
+    assert "FOUR_LANGUAGE_DOCUMENTATION_OK" in read(
+        "tools/check_four_language_docs.py"
+    )
+    assert_action_pinned(language_guard, "actions/checkout")
+    assert_action_pinned(language_guard, "actions/setup-python")
     assert "pull_request_target" not in language_guard
     assert "github.event.pull_request.body" not in language_guard
     read("ROADMAP.md")

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -83,6 +83,18 @@ BADGE_WORKFLOWS = (
     "security-audit.yml",
     "secret-defense.yml",
 )
+TIME_SENSITIVE_CREATOR_AGE_PATTERNS = (
+    re.compile(r"我是一位\s*(?:\d{1,3}|[零〇一二三四五六七八九十百兩两]+)\s*[歲岁]"),
+    re.compile(
+        r"\bI was an?\s+(?:\d{1,3}|[a-z]+(?:-[a-z]+)*)"
+        r"(?:-year-old|\s+years?\s+old)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"私は\s*(?:\d{1,3}|[零〇一二三四五六七八九十百]+)\s*歳"),
+    re.compile(r"[三四五六七八九]十(?:多)?[歲岁]的自己"),
+    re.compile(r"\bmy\s+(?:\d+|[a-z]+)-something\s+self\b", re.IGNORECASE),
+    re.compile(r"[三四五六七八九]十代の自分"),
+)
 
 
 def png_size(path: Path) -> tuple[int, int]:
@@ -173,6 +185,16 @@ def _assert_quality_standard(localized_readmes: dict[str, str]) -> None:
         )
 
 
+def _assert_timeless_creator_narrative(
+    localized_readmes: dict[str, str],
+) -> None:
+    for name, content in localized_readmes.items():
+        for pattern in TIME_SENSITIVE_CREATOR_AGE_PATTERNS:
+            assert not pattern.search(content), (
+                f"{name} hard-codes the creator's changing age: {pattern.pattern}"
+            )
+
+
 def _assert_demo_video(readme: str) -> None:
     video = MEDIA / "mohan-demo.mp4"
     assert video.is_file(), "missing 30–60 second demonstration video"
@@ -247,6 +269,7 @@ def main() -> int:
     _assert_readme_images(readme)
     _assert_certification_badges(localized_readmes)
     _assert_quality_standard(localized_readmes)
+    _assert_timeless_creator_narrative(localized_readmes)
     _assert_demo_video(readme)
     _assert_support_section(readme)
     _assert_github_links(readme)

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -6,6 +6,14 @@ lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MEDIA = ROOT / "docs" / "media"
+VERSION_MATCH = re.search(
+    r'^FALLBACK_VERSION = "([^"]+)"$',
+    (ROOT / "version_info.py").read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+assert VERSION_MATCH, "version_info.py must define one literal FALLBACK_VERSION"
+SOURCE_VERSION = VERSION_MATCH.group(1)
+SHIELD_VERSION = SOURCE_VERSION.replace("-", "--")
 PNG_FILES = {
     "mohan-hero.png": (1600, 900),
     "first-run-wizard.png": None,
@@ -45,9 +53,17 @@ README_BADGES = (
         "actions/workflows/secret-defense.yml/badge.svg"),
     ),
     (
-        "Latest Release",
+        f"Development Version v{SOURCE_VERSION}",
+        (
+            "https://img.shields.io/badge/development_version-"
+            f"v{SHIELD_VERSION}-5c6ac4.svg"
+        ),
+    ),
+    (
+        "Latest Published Release",
         ("https://img.shields.io/github/v/release/"
-        "hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=release"),
+        "hitoshic1982/MoHan-PC-Desktop-Assistant?"
+        "include_prereleases&label=published"),
     ),
     ("MIT License", "https://img.shields.io/badge/license-MIT-blue.svg"),
     (
@@ -100,6 +116,9 @@ def _localized_readmes() -> dict[str, str]:
 
 
 def _assert_certification_badges(localized_readmes: dict[str, str]) -> None:
+    assert len(set(localized_readmes.values())) == 1, (
+        "all three README entry points must remain byte-for-byte identical"
+    )
     badge_blocks: dict[str, str] = {}
     for name, content in localized_readmes.items():
         badge_match = re.search(

--- a/tools/audit_public_release.py
+++ b/tools/audit_public_release.py
@@ -46,7 +46,16 @@ SECRET_PATTERNS = {
 
 def public_source_files() -> list[Path]:
     result = subprocess.run(
-        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        [
+            "git",
+            "-c",
+            f"safe.directory={ROOT.as_posix()}",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ],
         cwd=ROOT,
         check=True,
         capture_output=True,

--- a/tools/check_four_language_docs.py
+++ b/tools/check_four_language_docs.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+lazy import re
+lazy import subprocess
+lazy import sys
+lazy from collections import Counter
+lazy from pathlib import Path
+
+LANGUAGE_HEADINGS = (
+    "繁體中文",
+    "简体中文",
+    "English",
+    "日本語",
+)
+DOCUMENT_GLOBS = ("*.md", "*.mdx", "*.rst")
+LANGUAGE_HEADING_PATTERN = re.compile(
+    r"(?m)^## (繁體中文|简体中文|English|日本語)\s*$"
+)
+FENCED_CODE_PATTERN = re.compile(
+    r"(?ms)^(```|~~~)[^\n]*\n.*?^\1\s*$"
+)
+INLINE_CODE_PATTERN = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+MARKDOWN_TARGET_PATTERN = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+HTML_TARGET_PATTERN = re.compile(r"\b(?:href|src)=['\"]([^'\"]+)['\"]")
+
+
+def _tracked_documents(root: Path) -> tuple[Path, ...]:
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            f"safe.directory={root.as_posix()}",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            *DOCUMENT_GLOBS,
+        ],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or "git ls-files failed"
+        raise RuntimeError(detail)
+    relative_paths = sorted(set(result.stdout.splitlines()))
+    return tuple(root / line for line in relative_paths if line)
+
+
+def _prefix_errors(prefix: str, *, require_h1: bool) -> list[str]:
+    visible = [line.strip() for line in prefix.splitlines() if line.strip()]
+    if not visible:
+        return ["a four-language H1 is required"] if require_h1 else []
+    if len(visible) != 1 or not visible[0].startswith("# "):
+        return ["only one four-language H1 may appear before the language sections"]
+    title_parts = [part.strip() for part in visible[0][2:].split("／")]
+    if len(title_parts) != 4 or any(not part for part in title_parts):
+        return ["H1 must contain four non-empty titles separated by ／"]
+    return []
+
+
+def _extract_sections(
+    text: str,
+    *,
+    require_h1: bool,
+) -> tuple[str, tuple[str, ...], list[str]]:
+    matches = tuple(LANGUAGE_HEADING_PATTERN.finditer(text))
+    names = tuple(match.group(1) for match in matches)
+    if names != LANGUAGE_HEADINGS:
+        return "", (), [
+            "language sections must appear exactly once in this order: "
+            "繁體中文, 简体中文, English, 日本語"
+        ]
+
+    prefix = text[: matches[0].start()]
+    sections: list[str] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        section = text[start:end].strip()
+        sections.append(section)
+    errors = _prefix_errors(prefix, require_h1=require_h1)
+    all_h2_headings = tuple(
+        match.group(1).strip()
+        for match in re.finditer(r"(?m)^##\s+(.+?)\s*$", text)
+    )
+    if all_h2_headings != LANGUAGE_HEADINGS:
+        errors.append(
+            "the only H2 headings must be the four language sections in "
+            "the required order"
+        )
+    prefix_h1_count = len(re.findall(r"(?m)^#\s+\S", prefix))
+    all_h1_count = len(re.findall(r"(?m)^#\s+\S", text))
+    if all_h1_count != prefix_h1_count:
+        errors.append("H1 may appear only before the four language sections")
+    for name, section in zip(LANGUAGE_HEADINGS, sections, strict=True):
+        if not section:
+            errors.append(f"{name} section is empty")
+    return prefix, tuple(sections), errors
+
+
+def _paragraph_count(section: str) -> int:
+    without_code = FENCED_CODE_PATTERN.sub("\n<CODE-BLOCK>\n", section)
+    blocks = re.split(r"\n\s*\n", without_code.strip())
+    return sum(1 for block in blocks if block.strip())
+
+
+def _technical_inline_code(section: str) -> Counter[str]:
+    tokens = INLINE_CODE_PATTERN.findall(section)
+    return Counter(
+        token
+        for token in tokens
+        if not re.search(r"\s", token)
+        or re.search(r"[.=\\<>]", token)
+        or token.startswith("-")
+    )
+
+
+def _structure(section: str) -> dict[str, object]:
+    fenced_blocks = tuple(match.group(0).strip() for match in FENCED_CODE_PATTERN.finditer(section))
+    markdown_targets = tuple(MARKDOWN_TARGET_PATTERN.findall(section))
+    html_targets = tuple(HTML_TARGET_PATTERN.findall(section))
+    return {
+        "paragraphs": _paragraph_count(section),
+        "subheadings": len(re.findall(r"(?m)^#{3,6}\s+\S", section)),
+        "bullets": len(re.findall(r"(?m)^\s*[-*+]\s+", section)),
+        "ordered_items": len(re.findall(r"(?m)^\s*\d+[.)]\s+", section)),
+        "blockquotes": len(re.findall(r"(?m)^\s*>\s?", section)),
+        "table_rows": len(re.findall(r"(?m)^\s*\|.*\|\s*$", section)),
+        "checkboxes": len(re.findall(r"(?m)^\s*[-*+]\s+\[[ xX]\]\s+", section)),
+        "fenced_blocks": fenced_blocks,
+        "technical_inline_code": _technical_inline_code(section),
+        "markdown_targets": Counter(markdown_targets),
+        "html_targets": Counter(html_targets),
+        "raw_urls": Counter(re.findall(r"https?://[^\s)>]+", section)),
+    }
+
+
+def audit_text(text: str, *, require_h1: bool = False) -> list[str]:
+    _, sections, errors = _extract_sections(text, require_h1=require_h1)
+    if errors or not sections:
+        return errors
+
+    structures = tuple(_structure(section) for section in sections)
+    keys = tuple(structures[0])
+    for key in keys:
+        values = tuple(structure[key] for structure in structures)
+        if any(value != values[0] for value in values[1:]):
+            errors.append(
+                f"{key} differs across language sections: "
+                + ", ".join(
+                    f"{name}={value!r}"
+                    for name, value in zip(LANGUAGE_HEADINGS, values, strict=True)
+                )
+            )
+
+    section_lines = tuple(
+        Counter(line.strip() for line in section.splitlines() if line.strip())
+        for section in sections
+    )
+    for left_index, left_counter in enumerate(section_lines):
+        for right_index in range(left_index + 1, len(section_lines)):
+            if left_counter == section_lines[right_index]:
+                errors.append(
+                    f"{LANGUAGE_HEADINGS[right_index]} duplicates "
+                    f"{LANGUAGE_HEADINGS[left_index]} instead of providing "
+                    "a translation"
+                )
+    return errors
+
+
+def audit_document(path: Path) -> list[str]:
+    return audit_text(path.read_text(encoding="utf-8"), require_h1=True)
+
+
+def audit_repository(root: Path) -> dict[Path, list[str]]:
+    failures: dict[Path, list[str]] = {}
+    for path in _tracked_documents(root):
+        errors = audit_document(path)
+        if errors:
+            failures[path.relative_to(root)] = errors
+    return failures
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    failures = audit_repository(root)
+    if failures:
+        for path, errors in failures.items():
+            print(f"FAIL: {path}", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("FOUR_LANGUAGE_DOCUMENTATION_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_four_language_pr.py
+++ b/tools/check_four_language_pr.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+lazy import json
+lazy import os
+lazy import sys
+lazy from pathlib import Path
+
+lazy from check_four_language_docs import audit_text
+
+TITLE_SEPARATOR = "／"
+
+
+def _title_errors(title: object) -> list[str]:
+    if not isinstance(title, str):
+        return ["pull-request title must be a string"]
+    parts = tuple(part.strip() for part in title.split(TITLE_SEPARATOR))
+    if len(parts) != 4 or any(not part for part in parts):
+        return [
+            "pull-request title must contain four non-empty translations "
+            "separated by ／ in this order: Traditional Chinese, Simplified "
+            "Chinese, English, Japanese"
+        ]
+    return []
+
+
+def audit_pull_request(payload: object) -> list[str]:
+    if not isinstance(payload, dict):
+        return ["GitHub event payload must be a JSON object"]
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return ["GitHub event payload is missing pull_request metadata"]
+
+    errors = _title_errors(pull_request.get("title"))
+    body = pull_request.get("body")
+    if not isinstance(body, str):
+        errors.append("pull-request body must be a string")
+        return errors
+    errors.extend(f"pull-request body: {error}" for error in audit_text(body))
+    return errors
+
+
+def main() -> int:
+    event_value = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_value:
+        print("FAIL: GITHUB_EVENT_PATH is not set", file=sys.stderr)
+        return 2
+
+    event_path = Path(event_value)
+    try:
+        payload = json.loads(event_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        print(f"FAIL: cannot read GitHub event payload: {error}", file=sys.stderr)
+        return 2
+
+    errors = audit_pull_request(payload)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    print("FOUR_LANGUAGE_PR_METADATA_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 繁體中文

### 摘要

將墨寒全部公開說明文件、README、CHANGELOG、PR 範本與 Release 說明統一為繁中、簡中、英文、日文的完整等價內容，固定順序且不得缺段。

### 根因與影響

過去部分文件只有單語、雙語或不對等翻譯，既有治理只檢查 PR 內文是否出現四個標題，無法阻止標題缺語、順序錯誤、段落遺漏或技術證據漂移。本 PR 只改文件、發布治理與對應測試，不改墨寒執行期功能。

### 變更

- 使 `README.md`、`README.zh-CN.md`、`README.ja.md`、CHANGELOG 與全部追蹤文件具有四語等價結構；三份 README 內容逐位元相同。
- 補齊 `v2.0.14-rc.1`、`v2.0.14-rc.2`、`v2.0.14-rc.3` 歷史 Release 文件，並保留測試數、SHA256、限制與安全警告。
- 新增 `tools/check_four_language_docs.py` 與 `tools/check_four_language_pr.py`，驗證四語 H1、H2 順序、段落、條列、連結、程式碼區塊與技術 token 對等。
- 強化 PR 與 Release workflow：標題四段、內文四語結構、Python 3.15 文件稽核、Node 24 與完整 SHA pinning；未來 Release 名稱也固定為四語。
- 新增明確的 `Development Version v2.3.0-rc.1` 與 `Latest Published Release` 徽章，期望值由 `version_info.py` 取得，版本漂移會使測試失敗。
- 移除創作者敘事中會隨時間失效的固定年齡與年齡區間，改用不隨年份過期的等義表述，並加入回歸測試防止再次寫死。

### 驗證

- `python tests/run_all.py`：四次完整通過，結果均為 `ALL_64_TESTS_OK`。
- `python tools/check_four_language_docs.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `actionlint .github/workflows/pr-language-governance.yml .github/workflows/release.yml`：通過。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`，共稽核 426 個公開檔案。
- `git diff --cached --unified=0 --no-color | gitleaks stdin --no-banner --redact`：PR 全差異曾掃描約 617 KB；最新年齡修正另掃描 25.81 KB 暫存差異，兩次皆零洩密。
- `git diff --cached --check`：通過。

### 發布邊界

本 PR 的全部 GitHub Actions 已通過，並已由草稿轉正式後合併至 `main`；未移動任何標籤、未變更既有 Release 資產，也未在本 PR 階段發布新的安裝包。

## 简体中文

### 摘要

将墨寒全部公开说明文档、README、CHANGELOG、PR 模板与 Release 说明统一为繁中、简中、英文、日文的完整等价内容，固定顺序且不得缺段。

### 根因与影响

过去部分文档只有单语、双语或不对等翻译，现有治理只检查 PR 正文是否出现四个标题，无法阻止标题缺语、顺序错误、段落遗漏或技术证据漂移。本 PR 只修改文档、发布治理及对应测试，不修改墨寒运行时功能。

### 变更

- 使 `README.md`、`README.zh-CN.md`、`README.ja.md`、CHANGELOG 及全部跟踪文档具有四语等价结构；三份 README 内容逐位完全相同。
- 补齐 `v2.0.14-rc.1`、`v2.0.14-rc.2`、`v2.0.14-rc.3` 历史 Release 文档，并保留测试数量、SHA256、限制与安全警告。
- 新增 `tools/check_four_language_docs.py` 及 `tools/check_four_language_pr.py`，验证四语 H1、H2 顺序、段落、列表、链接、代码块与技术 token 对等。
- 强化 PR 及 Release workflow：标题四段、正文四语结构、Python 3.15 文档审计、Node 24 与完整 SHA pinning；今后的 Release 名称也固定为四语。
- 新增明确的 `Development Version v2.3.0-rc.1` 及 `Latest Published Release` 徽章，期望值来自 `version_info.py`，版本漂移会导致测试失败。
- 移除创作者叙述中会随时间失效的固定年龄与年龄区间，改用不会随年份过期的等义表述，并加入回归测试防止再次写死。

### 验证

- `python tests/run_all.py`：四次完整通过，结果均为 `ALL_64_TESTS_OK`。
- `python tools/check_four_language_docs.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `actionlint .github/workflows/pr-language-governance.yml .github/workflows/release.yml`：通过。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`，共审计 426 个公开文件。
- `git diff --cached --unified=0 --no-color | gitleaks stdin --no-banner --redact`：PR 全部差异曾扫描约 617 KB；最新年龄修正另扫描 25.81 KB 暂存差异，两次均零泄漏。
- `git diff --cached --check`：通过。

### 发布边界

本 PR 的全部 GitHub Actions 已通过，并已由草稿转为正式后合并至 `main`；未移动任何标签、未更改现有 Release 资产，也未在本 PR 阶段发布新的安装包。

## English

### Summary

Standardize every public MoHan guide, README, CHANGELOG, PR template, and Release note as complete equivalent Traditional Chinese, Simplified Chinese, English, and Japanese content in a fixed order with no omitted section.

### Root cause and impact

Some documents previously contained one language, two languages, or unequal translations. Existing governance only checked whether four headings appeared in a PR body, so it could not prevent missing title translations, incorrect order, omitted paragraphs, or drifting technical evidence. This PR changes only documentation, release governance, and corresponding tests; it does not change MoHan runtime behavior.

### Changes

- Give `README.md`, `README.zh-CN.md`, `README.ja.md`, CHANGELOG, and every tracked document an equivalent four-language structure; the three README files are byte-for-byte identical.
- Add historical Release documents for `v2.0.14-rc.1`, `v2.0.14-rc.2`, and `v2.0.14-rc.3` while preserving test counts, SHA256 values, limitations, and safety warnings.
- Add `tools/check_four_language_docs.py` and `tools/check_four_language_pr.py` to verify four-language H1 titles, H2 order, paragraphs, lists, links, code blocks, and equivalent technical tokens.
- Harden the PR and Release workflow with four title segments, structurally equivalent bodies, Python 3.15 documentation audits, Node 24, and complete SHA pinning; future Release names are also fixed to four languages.
- Add explicit `Development Version v2.3.0-rc.1` and `Latest Published Release` badges, deriving the expected value from `version_info.py` so tests fail on version drift.
- Remove fixed ages and age ranges that would become stale from the creator narrative, replace them with timeless equivalent wording, and add regression coverage to prevent future hard-coding.

### Verification

- `python tests/run_all.py`: completed four full runs, each ending with `ALL_64_TESTS_OK`.
- `python tools/check_four_language_docs.py`: `FOUR_LANGUAGE_DOCUMENTATION_OK`.
- `actionlint .github/workflows/pr-language-governance.yml .github/workflows/release.yml`: passed.
- `python tools/audit_public_release.py`: `PUBLIC_RELEASE_AUDIT_OK`, covering 426 public files.
- `git diff --cached --unified=0 --no-color | gitleaks stdin --no-banner --redact`: scanned about 617 KB of the full PR diff; the latest age-wording fix separately scanned 25.81 KB of staged changes, with no leaks in either scan.
- `git diff --cached --check`: passed.

### Release boundary

Every GitHub Actions check passed, and this PR was moved from draft to ready before being merged into `main`. No tag moved, no existing Release asset changed, and no new installer was published as part of this PR.

## 日本語

### 概要

墨寒のすべての公開ガイド、README、CHANGELOG、PR テンプレート、Release ノートを、繁体字中国語、簡体字中国語、英語、日本語の完全に同等な内容へ統一し、順序を固定して欠落を認めません。

### 根本原因と影響

従来は単一言語、二言語、または翻訳量が不均等な文書があり、既存の統制は PR 本文に四つの見出しがあるかだけを確認していました。そのため、タイトル翻訳の欠落、順序違反、段落欠落、技術証拠のずれを防げませんでした。本 PR は文書、リリース統制、対応テストだけを変更し、墨寒の実行時機能は変更しません。

### 変更

- `README.md`、`README.zh-CN.md`、`README.ja.md`、CHANGELOG、すべての追跡文書を同等な四言語構造にし、三つの README をバイト単位で一致させました。
- `v2.0.14-rc.1`、`v2.0.14-rc.2`、`v2.0.14-rc.3` の過去 Release 文書を追加し、テスト数、SHA256、制限、安全上の警告を保持しました。
- `tools/check_four_language_docs.py` と `tools/check_four_language_pr.py` を追加し、四言語 H1、H2 順序、段落、一覧、リンク、コードブロック、技術 token の同等性を検証します。
- PR と Release workflow を強化し、タイトル四区分、本文の四言語構造、Python 3.15 文書監査、Node 24、完全 SHA pinning を必須化しました。今後の Release 名も四言語に固定します。
- 明示的な `Development Version v2.3.0-rc.1` と `Latest Published Release` の徽章を追加し、期待値を `version_info.py` から取得して、バージョンのずれをテストで失敗させます。
- 作者の物語から時間とともに古くなる固定年齢と年齢層を取り除き、年が変わっても陳腐化しない同等表現へ置き換え、再び固定値化されないための回帰テストを追加しました。

### 検証

- `python tests/run_all.py`：四回とも `ALL_64_TESTS_OK` で完全合格しました。
- `python tools/check_four_language_docs.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `actionlint .github/workflows/pr-language-governance.yml .github/workflows/release.yml`：合格。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`、公開 426 ファイルを監査。
- `git diff --cached --unified=0 --no-color | gitleaks stdin --no-banner --redact`：PR 全差分は約 617 KB を走査済みで、最新の年齢表現修正は 25.81 KB のステージ済み差分を別途走査し、いずれも漏えいはありません。
- `git diff --cached --check`：合格。

### リリース境界

すべての GitHub Actions が合格し、本 PR はドラフトから正式状態へ移して `main` にマージしました。タグは移動せず、既存 Release 資産も変更せず、本 PR の段階では新しいインストーラーを公開していません。
