### PR TITLE
修正 Release 說明重複字並強化四語治理／修正 Release 说明重复词并强化四语治理／Fix Release-note word repetition and harden four-language governance／Release ノートの重複語を修正し四言語統制を強化

### DIFF
--- a/docs/releases/v2.3.0-rc.1.md
+++ b/docs/releases/v2.3.0-rc.1.md
@@ -100,7 +100,7 @@ transform commands use the authorized `-acceptEula wix7` argument.
 Existing voice, lip-sync, expression, four-language, personal-setting,
 database, and safety-confirmation behavior is preserved. Windows x64 remains
 the complete product; macOS arm64/x86_64 and Linux x86_64 remain limited
-limited Preview packages and do not claim Windows feature parity.
+Preview packages and do not claim Windows feature parity.
 
 ## 日本語
 

--- a/tests/test_four_language_documentation.py
+++ b/tests/test_four_language_documentation.py
@@ -49,10 +49,20 @@ def test_document_rejects_untranslated_duplicate_section() -> None:
     assert any("duplicates 繁體中文" in error for error in errors)
 
 
+def test_document_rejects_wrapped_english_word_repetition() -> None:
+    duplicate = DOCUMENT.replace(
+        "English description.",
+        "English remains limited\nlimited Preview.",
+    )
+    errors = audit_text(duplicate, require_h1=True)
+    assert "English section repeats adjacent word 'limited'" in errors
+
+
 def main() -> None:
     test_document_contract()
     test_document_requires_h1_and_only_language_h2_headings()
     test_document_rejects_untranslated_duplicate_section()
+    test_document_rejects_wrapped_english_word_repetition()
     result = subprocess.run(
         [sys.executable, "tools/check_four_language_docs.py"],
         cwd=ROOT,

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -217,7 +217,8 @@ def test_four_language_release_notes_and_boundaries() -> None:
     )
     positions = [notes.index(heading) for heading in expected_headings]
     assert positions == sorted(positions)
-    for phrase in ("limited Preview", "功能受限", "機能限定"):
+    assert re.search(r"limited\s+Preview", notes)
+    for phrase in ("功能受限", "機能限定"):
         assert phrase in notes
     guide = read("docs/PREVIEW-PACKAGES.md")
     for heading in expected_headings:

--- a/tools/check_four_language_docs.py
+++ b/tools/check_four_language_docs.py
@@ -22,6 +22,12 @@ FENCED_CODE_PATTERN = re.compile(
 INLINE_CODE_PATTERN = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
 MARKDOWN_TARGET_PATTERN = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)(?:\s+[^)]*)?\)")
 HTML_TARGET_PATTERN = re.compile(r"\b(?:href|src)=['\"]([^'\"]+)['\"]")
+ADJACENT_ENGLISH_WORD_PATTERN = re.compile(
+    r"\b(?P<word>[A-Za-z][A-Za-z0-9-]{2,})"
+    r"(?:[ \t]+|\r?\n[ \t]*)"
+    r"(?P=word)\b",
+    re.IGNORECASE,
+)
 
 
 def _tracked_documents(root: Path) -> tuple[Path, ...]:
@@ -139,10 +145,21 @@ def _structure(section: str) -> dict[str, object]:
     }
 
 
+def _english_repetition_errors(section: str) -> list[str]:
+    prose = FENCED_CODE_PATTERN.sub("", section)
+    prose = INLINE_CODE_PATTERN.sub("<INLINE-CODE>", prose)
+    return [
+        f"English section repeats adjacent word {match.group('word')!r}"
+        for match in ADJACENT_ENGLISH_WORD_PATTERN.finditer(prose)
+    ]
+
+
 def audit_text(text: str, *, require_h1: bool = False) -> list[str]:
     _, sections, errors = _extract_sections(text, require_h1=require_h1)
     if errors or not sections:
         return errors
+
+    errors.extend(_english_repetition_errors(sections[2]))
 
     structures = tuple(_structure(section) for section in sections)
     keys = tuple(structures[0])


### PR DESCRIPTION
## 繁體中文

### 摘要

修正 v2.3.0 RC1 英文 Release 說明中跨行重複的單字，並把同類問題納入全庫四語文件治理。

### 根因與影響

原句在 Markdown 換行處形成 `limited limited`，一般單行搜尋會漏掉；既有 Preview 測試又把 `limited Preview` 鎖成同一行，導致移除錯字後出現不必要的格式耦合。本 PR 只改文件治理、Release 說明與對應測試，不改墨寒執行期功能。

### 變更

- 從 `docs/releases/v2.3.0-rc.1.md` 移除重複的 `limited`，保留功能受限 Preview 的原意。
- 強化 `tools/check_four_language_docs.py`，偵測英文相鄰重複字，即使兩個單字分處一次自然換行；程式碼區塊與行內程式碼不納入誤判。
- 在 `tests/test_four_language_documentation.py` 加入跨行錯字回歸，並讓 `tests/test_preview_packaging.py` 以 `limited\s+Preview` 驗證語意而非換行位置。

### 驗證

- `python tests/run_all.py`：修正格式耦合後從頭完整通過，結果為 `ALL_64_TESTS_OK`。
- `python tests/test_four_language_documentation.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `python tests/test_preview_packaging.py`：`PREVIEW_PACKAGING_OK`。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`，稽核 426 個公開檔案。
- `git diff --cached --no-color | gitleaks stdin --redact --no-banner`：掃描 3.92 KB 差異，零洩密。

### 發布邊界

本 PR 維持草稿直到全部 GitHub Actions 通過；不移動標籤、不修改既有 Release 資產，也不發布新安裝包。

## 简体中文

### 摘要

修正 v2.3.0 RC1 英文 Release 说明中跨行重复的单词，并将同类问题纳入全库四语文档治理。

### 根因与影响

原句在 Markdown 换行处形成 `limited limited`，普通单行搜索会遗漏；现有 Preview 测试又将 `limited Preview` 锁定为同一行，导致移除错词后出现不必要的格式耦合。本 PR 只修改文档治理、Release 说明及对应测试，不修改墨寒运行时功能。

### 变更

- 从 `docs/releases/v2.3.0-rc.1.md` 移除重复的 `limited`，保留功能受限 Preview 的原意。
- 强化 `tools/check_four_language_docs.py`，检测英文相邻重复词，即使两个单词分处一次自然换行；代码块与行内代码不纳入误判。
- 在 `tests/test_four_language_documentation.py` 加入跨行错词回归，并让 `tests/test_preview_packaging.py` 以 `limited\s+Preview` 验证语义而非换行位置。

### 验证

- `python tests/run_all.py`：修正格式耦合后从头完整通过，结果为 `ALL_64_TESTS_OK`。
- `python tests/test_four_language_documentation.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `python tests/test_preview_packaging.py`：`PREVIEW_PACKAGING_OK`。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`，审计 426 个公开文件。
- `git diff --cached --no-color | gitleaks stdin --redact --no-banner`：扫描 3.92 KB 差异，零泄漏。

### 发布边界

本 PR 保持草稿直到全部 GitHub Actions 通过；不移动标签、不修改现有 Release 资产，也不发布新的安装包。

## English

### Summary

Fix a word repeated across a line wrap in the v2.3.0 RC1 English Release notes and make the repository-wide four-language documentation gate prevent the same defect.

### Root cause and impact

The sentence formed `limited limited` at a Markdown line wrap, which ordinary line-based search missed. The existing Preview test also required `limited Preview` on one physical line, creating needless formatting coupling after the typo was removed. This PR changes only documentation governance, Release notes, and corresponding tests; it does not change MoHan runtime behavior.

### Changes

- Remove the repeated `limited` from `docs/releases/v2.3.0-rc.1.md` while preserving the limited-Preview boundary.
- Harden `tools/check_four_language_docs.py` to detect adjacent repeated English words even when separated by one natural line wrap, while excluding fenced and inline code from false positives.
- Add a wrapped-word regression to `tests/test_four_language_documentation.py` and make `tests/test_preview_packaging.py` validate `limited\s+Preview` semantically instead of depending on line placement.

### Verification

- `python tests/run_all.py`: completed a fresh full run after fixing the formatting coupling, ending with `ALL_64_TESTS_OK`.
- `python tests/test_four_language_documentation.py`: `FOUR_LANGUAGE_DOCUMENTATION_OK`.
- `python tests/test_preview_packaging.py`: `PREVIEW_PACKAGING_OK`.
- `python tools/audit_public_release.py`: `PUBLIC_RELEASE_AUDIT_OK`, covering 426 public files.
- `git diff --cached --no-color | gitleaks stdin --redact --no-banner`: scanned 3.92 KB of changes with no leaks.

### Release boundary

This PR remains a draft until every GitHub Actions check passes. It moves no tag, modifies no existing Release asset, and publishes no new installer.

## 日本語

### 概要

v2.3.0 RC1 の英語 Release ノートで改行をまたいで重複した単語を修正し、同じ欠陥をリポジトリ全体の四言語文書ゲートで防止します。

### 根本原因と影響

Markdown の改行位置で `limited limited` が生じ、通常の行単位検索では見落とされました。既存の Preview テストも `limited Preview` を同じ物理行に固定していたため、誤字を除いた後に不要な書式結合が発生しました。本 PR は文書統制、Release ノート、対応テストだけを変更し、墨寒の実行時機能は変更しません。

### 変更

- `docs/releases/v2.3.0-rc.1.md` から重複した `limited` を除き、機能限定 Preview の境界を維持します。
- `tools/check_four_language_docs.py` を強化し、一回の自然な改行を挟んだ場合も英語の隣接重複語を検出し、フェンスコードと行内コードは誤検出から除外します。
- `tests/test_four_language_documentation.py` に改行またぎの回帰テストを追加し、`tests/test_preview_packaging.py` は行位置ではなく `limited\s+Preview` の意味を検証します。

### 検証

- `python tests/run_all.py`：書式結合を修正後に最初から完全実行し、`ALL_64_TESTS_OK` で終了しました。
- `python tests/test_four_language_documentation.py`：`FOUR_LANGUAGE_DOCUMENTATION_OK`。
- `python tests/test_preview_packaging.py`：`PREVIEW_PACKAGING_OK`。
- `python tools/audit_public_release.py`：`PUBLIC_RELEASE_AUDIT_OK`、公開 426 ファイルを監査。
- `git diff --cached --no-color | gitleaks stdin --redact --no-banner`：3.92 KB の差分を走査し、漏えいなし。

### リリース境界

すべての GitHub Actions が合格するまで本 PR はドラフトのままです。タグを移動せず、既存 Release 資産を変更せず、新しいインストーラーも公開しません。