### PR TITLE
發布 v2.3.0 RC2／发布 v2.3.0 RC2／Release v2.3.0 RC2／v2.3.0 RC2 を公開

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,23 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
-### v2.3.0 RC1 — 規劃中，尚未發布
+### v2.3.0 RC2 — 2026-08-10
 
 - 全面遷移至 CPython 3.15.0rc1，產品執行、測試與所有封裝不再保留舊版
   Python 路徑；全專案採用 PEP 810 明示延遲導入並加入靜態治理稽核。
 - 導入 PEP 814 `frozendict` 深層不可變設定、PEP 798 推導式解包、PEP 686
-  UTF-8 檔案稽核、PEP 661 哨兵治理及 `bytearray.take_bytes()` 音訊緩衝。
+  UTF-8 檔案稽核、PEP 661 哨兵治理及 `bytearray.take_bytes()` 音訊緩衝；
+  開頭比對改用 Python 3.15 語意更明確的 `re.prefixmatch()`。
 - 加入 PEP 799 Tachyon 取樣分析，可直接檢查啟動、50 Hz 嘴型同步與表情
-  仲裁器；JIT 開關均通過完整測試，2.3.0 RC1 預設啟用並保留相容性停用開關。
+  仲裁器；JIT 開關均通過完整測試，2.3.0 RC2 預設啟用並保留相容性停用開關。
 - CI 與 Release 以有效樣本、讀取錯誤、漏採樣及 JIT 狀態阻擋不合格的
   Tachyon 證據，並發布去識別化結果；CycloneDX 1.7 SBOM 強制完整依賴圖、
   PURL、SPDX 授權、官方結構驗證及 100% 覆蓋率。
 - 所有 GitHub Actions JavaScript 動作強制使用 Node 24；PySide6 以受控 ABI3
   輪子驗證跨越 3.15 中繼資料限制，Stable ABI、依賴安全稽核、封裝與完整
   發布安全閘門維持不變。
+- README 統一為繁中、簡中、英文、日文單一四語文件，移除重複相容文件與
+  直接收款連結；贊助入口只引導至儲存庫上方的官方 Sponsor 按鈕。
 
 ### v2.2.0 RC2 — 2026-08-07
 
@@ -137,20 +140,23 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
-### v2.3.0 RC1 — 计划中，尚未发布
+### v2.3.0 RC2 — 2026-08-10
 
 - 全面迁移至 CPython 3.15.0rc1，产品运行、测试及所有发布包不再保留旧版
   Python 路径；全项目采用 PEP 810 显式延迟导入并加入静态治理审计。
 - 导入 PEP 814 `frozendict` 深层不可变配置、PEP 798 推导式解包、PEP 686
-  UTF-8 文件审计、PEP 661 哨兵治理及 `bytearray.take_bytes()` 音频缓冲。
+  UTF-8 文件审计、PEP 661 哨兵治理及 `bytearray.take_bytes()` 音频缓冲；
+  开头匹配改用 Python 3.15 语义更明确的 `re.prefixmatch()`。
 - 加入 PEP 799 Tachyon 采样分析，可直接检查启动、50 Hz 口型同步与表情
-  仲裁器；JIT 开关均通过完整测试，2.3.0 RC1 默认启用并保留兼容性停用开关。
+  仲裁器；JIT 开关均通过完整测试，2.3.0 RC2 默认启用并保留兼容性停用开关。
 - CI 与 Release 以有效样本、读取错误、漏采样及 JIT 状态阻止不合格的
   Tachyon 证据，并发布去标识化结果；CycloneDX 1.7 SBOM 强制完整依赖图、
   PURL、SPDX 许可证、官方结构验证及 100% 覆盖率。
 - 所有 GitHub Actions JavaScript 动作强制使用 Node 24；PySide6 以受控 ABI3
   轮子验证跨越 3.15 元数据限制，Stable ABI、依赖安全审计、打包及完整
   发布安全闸门保持不变。
+- README 统一为繁中、简中、英文、日文单一四语文件，删除重复兼容文件及
+  直接收款链接；赞助入口只引导至仓库上方的官方 Sponsor 按钮。
 
 ### v2.2.0 RC2 — 2026-08-07
 
@@ -269,16 +275,17 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 
 All notable public changes to MoHan Desktop Assistant are documented here.
 
-### v2.3.0 RC1 — planned, not yet published
+### v2.3.0 RC2 — 2026-08-10
 
 - Moves the product, tests, and every package exclusively to CPython
   3.15.0rc1, with project-wide explicit PEP 810 lazy imports and static
   governance auditing; no legacy Python path remains.
 - Adds deeply immutable PEP 814 `frozendict` configuration, PEP 798 unpacking
   comprehensions, PEP 686 UTF-8 file auditing, PEP 661 sentinel governance,
-  and the new `bytearray.take_bytes()` audio-buffer API.
+  the new `bytearray.take_bytes()` audio-buffer API, and Python 3.15's more
+  explicit `re.prefixmatch()` for prefix matching.
 - Adds PEP 799 Tachyon profiling for startup, 50 Hz lip sync, and expression
-  arbitration. Both JIT modes pass the complete suite; 2.3.0 RC1 defaults JIT
+  arbitration. Both JIT modes pass the complete suite; 2.3.0 RC2 defaults JIT
   on while retaining a compatibility disable switch.
 - Gates sanitized Tachyon evidence on valid samples, stack-read errors, missed
   samples, and JIT state. CycloneDX 1.7 SBOMs require complete dependency
@@ -287,6 +294,9 @@ All notable public changes to MoHan Desktop Assistant are documented here.
   the 3.15 metadata limit through a controlled ABI3 wheel validation, while
   Stable ABI, dependency-audit, packaging, and complete release safety gates
   remain unchanged.
+- Consolidates the README into one Traditional Chinese, Simplified Chinese,
+  English, and Japanese document, removes duplicate compatibility files and
+  direct payment links, and points support only to GitHub's official Sponsor button.
 
 ### v2.2.0 RC2 — 2026-08-07
 
@@ -434,16 +444,17 @@ speech, gaze, and physics stress test passed before this release candidate.
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
 
-### v2.3.0 RC1 — 予定、未公開
+### v2.3.0 RC2 — 2026-08-10
 
 - 製品、テスト、全パッケージを CPython 3.15.0rc1 のみに移行し、旧 Python
   経路を廃止しました。PEP 810 の明示的遅延インポートと静的ガバナンス監査を
   全プロジェクトへ導入しました。
 - PEP 814 `frozendict` の深い不変設定、PEP 798 の内包表記アンパック、
   PEP 686 UTF-8 ファイル監査、PEP 661 センチネル管理、新しい
-  `bytearray.take_bytes()` 音声バッファー API を導入しました。
+  `bytearray.take_bytes()` 音声バッファー API、先頭一致を明示する Python 3.15 の
+  `re.prefixmatch()` を導入しました。
 - PEP 799 Tachyon による起動、50 Hz 口形同期、表情調停のサンプリング解析を
-  導入しました。JIT の有無は全テストに合格し、2.3.0 RC1 では既定で有効に
+  導入しました。JIT の有無は全テストに合格し、2.3.0 RC2 では既定で有効に
   しながら互換性用の無効化設定を残します。
 - Tachyon 証拠は有効サンプル、読取エラー、漏れ、JIT 状態で判定し、匿名化して
   公開します。CycloneDX 1.7 SBOM は完全な依存関係、PURL、SPDX ライセンス、
@@ -451,6 +462,9 @@ speech, gaze, and physics stress test passed before this release candidate.
 - GitHub Actions の JavaScript 動作はすべて Node 24 を強制します。PySide6 は
   管理された ABI3 wheel 検証によって 3.15 のメタデータ制限に対応し、Stable
   ABI、依存関係の安全監査、パッケージング、完全なリリース安全ゲートを維持します。
+- README を繁体字中国語、簡体字中国語、英語、日本語の一つの四言語文書へ統合し、
+  重複する互換文書と直接決済リンクを削除しました。支援案内はリポジトリ上部の
+  公式 Sponsor ボタンだけに統一します。
 
 ### v2.2.0 RC2 — 2026-08-07
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "2.0.10-RC"
-date-released: "2026-07-31"
+version: "2.3.0-rc.2"
+date-released: "2026-08-10"
 license: MIT
 abstract: >-
   A configurable Windows AI desktop companion and permission-gated

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,8 +38,8 @@ open-source
 
 ### 已準備的公開預發行版
 
-- 標籤：`v2.3.0-rc.1`
-- 標題：`MoHan Desktop Assistant v2.3.0 RC1`
+- 標籤：`v2.3.0-rc.2`
+- 標題：`MoHan Desktop Assistant v2.3.0 RC2`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
@@ -195,8 +195,8 @@ open-source
 
 ### 已准备的公开预发布版
 
-- 标签：`v2.3.0-rc.1`
-- 标题：`MoHan Desktop Assistant v2.3.0 RC1`
+- 标签：`v2.3.0-rc.2`
+- 标题：`MoHan Desktop Assistant v2.3.0 RC2`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
@@ -352,8 +352,8 @@ open-source
 
 ### Prepared public pre-release
 
-- Tag: `v2.3.0-rc.1`
-- Title: `MoHan Desktop Assistant v2.3.0 RC1`
+- Tag: `v2.3.0-rc.2`
+- Title: `MoHan Desktop Assistant v2.3.0 RC2`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
@@ -509,8 +509,8 @@ open-source
 
 ### 準備済みの公開プレリリース
 
-- タグ：`v2.3.0-rc.1`
-- タイトル：`MoHan Desktop Assistant v2.3.0 RC1`
+- タグ：`v2.3.0-rc.2`
+- タイトル：`MoHan Desktop Assistant v2.3.0 RC2`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.1.exe`。
+2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.2.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.1.exe`。
+2. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.2.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-2.3.0-rc.1.exe`.
+2. Run `MoHan-Desktop-Assistant-2.3.0-rc.2.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-2.3.0-rc.1.exe` を実行します。
+2. `MoHan-Desktop-Assistant-2.3.0-rc.2.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.2" src="https://img.shields.io/badge/development_version-v2.3.0--rc.2-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -32,7 +32,7 @@
 
 <p align="center">
   <strong>軟體作者：CHOU MING HUA</strong><br>
-  準備發布的公開預覽版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  準備發布的公開預覽版：v2.3.0 RC2（`v2.3.0-rc.2`）<br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -332,11 +332,11 @@ https://www.googleapis.com/auth/drive.metadata.readonly
 - PEP 803／820／793 Stable ABI 與 C API 邊界會驗證官方 ABI3 輪子；墨寒沒有第一方 C 擴充。
 - CycloneDX 1.7 Windows／Preview SBOM 必須符合鎖定依賴、授權、PURL、完整根依賴邊、官方結構與隱私驗證。
 
-兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。Ryzen 5 5600X Windows 三輪熱路徑中位數顯示，120,000 次表情仲裁由 0.462 秒降為 0.293 秒，2,000 個 50 Hz 嘴型節拍由 1.873 秒降為 0.571 秒，兩種模式的決策與校驗結果完全相同。
+兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。同一部 Ryzen 5 5600X Windows 實機另執行三輪熱路徑比較；JIT 開啟相對關閉時，120,000 次表情仲裁為 0.86–0.98 倍（中位數 0.97 倍，未證實加速），2,000 個 50 Hz 嘴型節拍為 1.45–1.65 倍（中位數 1.48 倍），每輪的決策與校驗結果完全相同。
 
-Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為 5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
+Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 4,553／11,482／3,475 個有效樣本；堆疊讀取錯誤率為 6.20%／2.23%／0.57%，漏採樣率為 0.02%／0%／0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
 
-這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式必然快三倍。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
+這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式會得到一致加速。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
 
 ### 從原始碼執行
 
@@ -356,7 +356,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.1"
+.\build.ps1 -Version "2.3.0-rc.2"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
@@ -396,7 +396,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.2" src="https://img.shields.io/badge/development_version-v2.3.0--rc.2-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -420,7 +420,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>软件作者：CHOU MING HUA</strong><br>
-  准备发布的公开预览版：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  准备发布的公开预览版：v2.3.0 RC2（`v2.3.0-rc.2`）<br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -720,11 +720,11 @@ https://www.googleapis.com/auth/drive.metadata.readonly
 - PEP 803／820／793 Stable ABI 与 C API 边界会验证官方 ABI3 轮子；墨寒没有第一方 C 扩展。
 - CycloneDX 1.7 Windows／Preview SBOM 必须符合锁定依赖、许可证、PURL、完整根依赖边、官方结构与隐私验证。
 
-两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。Ryzen 5 5600X Windows 三轮热路径中位数显示，120,000 次表情仲裁由 0.462 秒降至 0.293 秒，2,000 个 50 Hz 口型节拍由 1.873 秒降至 0.571 秒，两种模式的决策与校验结果完全相同。
+两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。同一台 Ryzen 5 5600X Windows 真机另执行三轮热路径比较；JIT 开启相对关闭时，120,000 次表情仲裁为 0.86–0.98 倍（中位数 0.97 倍，未证实加速），2,000 个 50 Hz 口型节拍为 1.45–1.65 倍（中位数 1.48 倍），每轮的决策与校验结果完全相同。
 
-Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 3,908／11,107／3,604 个有效样本；堆栈读取错误率为 5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
+Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 4,553／11,482／3,475 个有效样本；堆栈读取错误率为 6.20%／2.23%／0.57%，漏采样率为 0.02%／0%／0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
 
-这些数据是指定热路径与采样工作的证据，不表示整套应用程序必然快三倍。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
+这些数据是指定热路径与采样工作的证据，不表示整套应用程序会获得一致加速。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
 
 ### 从源代码运行
 
@@ -744,7 +744,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.1"
+.\build.ps1 -Version "2.3.0-rc.2"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
@@ -784,7 +784,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.2" src="https://img.shields.io/badge/development_version-v2.3.0--rc.2-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -808,7 +808,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>Author: CHOU MING HUA</strong><br>
-  Prepared public preview: v2.3.0 RC1 (`v2.3.0-rc.1`)<br>
+  Prepared public preview: v2.3.0 RC2 (`v2.3.0-rc.2`)<br>
   Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -1108,11 +1108,11 @@ MoHan supports only the CPython `3.15.0rc1` runtime and does not retain a second
 - PEP 803/820/793 Stable ABI and C API boundaries validate official ABI3 wheels; MoHan has no first-party C extension.
 - CycloneDX 1.7 Windows/Preview SBOMs must pass pinned-dependency, license, PURL, complete root-edge, official-structure, and privacy validation.
 
-Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three-run Windows hot-path medians on a Ryzen 5 5600X reduced 120,000 expression-arbitration operations from 0.462 to 0.293 seconds and 2,000 50 Hz lip-sync ticks from 1.873 to 0.571 seconds, with identical decisions and validation results in both modes.
+Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three additional hot-path comparisons ran on the same Ryzen 5 5600X Windows host. With JIT on relative to off, 120,000 expression-arbitration operations measured 0.86–0.98x speed (0.97x median, with no demonstrated speedup), while 2,000 50 Hz lip-sync ticks measured 1.45–1.65x (1.48x median); decisions and validation results matched in every run.
 
-With JIT enabled, Tachyon retained 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 5.08%/2.71%/0.74%, and missed-sample rates were 0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
+With JIT enabled, Tachyon retained 4,553/11,482/3,475 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 6.20%/2.23%/0.57%, and missed-sample rates were 0.02%/0%/0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
 
-These measurements are evidence for specific hot paths and sampling tasks; they do not claim that the whole application is necessarily three times faster. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
+These measurements are evidence for specific hot paths and sampling tasks; they do not claim uniform acceleration of the complete application. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
 
 ### Run from source
 
@@ -1132,7 +1132,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.1"
+.\build.ps1 -Version "2.3.0-rc.2"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
@@ -1172,7 +1172,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.1" src="https://img.shields.io/badge/development_version-v2.3.0--rc.1-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.2" src="https://img.shields.io/badge/development_version-v2.3.0--rc.2-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -1196,7 +1196,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
-  公開準備中のプレビュー：v2.3.0 RC1（`v2.3.0-rc.1`）<br>
+  公開準備中のプレビュー：v2.3.0 RC2（`v2.3.0-rc.2`）<br>
   Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -1496,11 +1496,11 @@ Home Assistant や墨寒の遠隔ポートを公衆インターネットへ直�
 - PEP 803／820／793 Stable ABI と C API 境界は公式 ABI3 wheel を検証します。墨寒に第一者 C 拡張はありません。
 - CycloneDX 1.7 Windows／Preview SBOM は固定依存関係、ライセンス、PURL、完全なルート依存エッジ、公式構造、プライバシー検証に合格しなければなりません。
 
-表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。Ryzen 5 5600X Windows 実機の三回中央値では、120,000 回の表情調停が 0.462 秒から 0.293 秒へ、2,000 回の 50 Hz リップシンク tick が 1.873 秒から 0.571 秒へ短縮し、両モードの判断と検証結果は一致しました。
+表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。同じ Ryzen 5 5600X Windows 実機でホットパス比較をさらに三回実行しました。JIT 無効時に対する有効時の速度比は、120,000 回の表情調停で 0.86～0.98 倍（中央値 0.97 倍、加速は確認できず）、2,000 回の 50 Hz リップシンク tick で 1.45～1.65 倍（中央値 1.48 倍）となり、各回の判断と検証結果は一致しました。
 
-JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 3,908／11,107／3,604 件の有効サンプルを保持しました。スタック読取エラー率は 5.08%／2.71%／0.74%、欠落サンプル率はすべて 0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
+JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 4,553／11,482／3,475 件の有効サンプルを保持しました。スタック読取エラー率は 6.20%／2.23%／0.57%、欠落サンプル率は 0.02%／0%／0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
 
-これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が必ず三倍高速になるという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
+これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が一様に高速化するという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
 
 ### ソースコードから実行
 
@@ -1520,7 +1520,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.1"
+.\build.ps1 -Version "2.3.0-rc.2"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。

--- a/build.ps1
+++ b/build.ps1
@@ -28,11 +28,11 @@ if (-not $Python) {
 
 $PythonVersion = (& $Python -c "import platform; print(platform.python_version())").Trim()
 if ($LASTEXITCODE -ne 0 -or $PythonVersion -ne "3.15.0rc1") {
-    throw "MoHan 2.3.0 RC1 packages must be built with Python 3.15.0rc1; found $PythonVersion."
+    throw "MoHan $Version packages must be built with Python 3.15.0rc1; found $PythonVersion."
 }
 $JitContract = (& $Python -c "import sys; print(f'{sys._jit.is_available()}:{sys._jit.is_enabled()}')").Trim()
 if ($LASTEXITCODE -ne 0 -or $JitContract -ne "True:True") {
-    throw "MoHan 2.3.0 RC1 packages require a Python 3.15.0rc1 runtime built with JIT enabled by default; found $JitContract."
+    throw "MoHan $Version packages require a Python 3.15.0rc1 runtime built with JIT enabled by default; found $JitContract."
 }
 
 $BuildInfo = Join-Path $ProjectRoot "build-info.json"

--- a/docs/PYTHON-3.15-MIGRATION.md
+++ b/docs/PYTHON-3.15-MIGRATION.md
@@ -13,8 +13,10 @@ Python 執行環境。完整上游檢查清單以官方
 PEP 799 Tachyon，以及 PEP 803／820／793 Stable ABI 依賴驗證。PEP 661
 `sentinel` 已加入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來一旦
 「未傳值」與 `None` 必須區分，就必須使用內建 `sentinel`。
+開頭比對已改用語意明確的 `re.prefixmatch()`，並由稽核阻止軟性棄用的
+`re.match()` 回流。
 
-2.3.0 RC1 封裝使用固定在 CPython 提交
+2.3.0 RC2 封裝使用固定在 CPython 提交
 `37e98da7c19a9e5892ee756d6dee08225422cd49` 的官方原始碼，以
 `--experimental-jit`／`--enable-experimental-jit=yes` 建置 JIT 預設啟用
 執行環境；未修改 PyInstaller 的隔離邊界。`PYTHON_JIT=0` 僅用於效能與
@@ -27,16 +29,18 @@ PEP 782／788 與其他 C API 項目由 runtime report、官方輪子與 CI 驗�
 24.639／25.068 秒，工作集成長 10.62／12.94 MB。JIT 在此負載沒有可靠優勢，
 但依產品政策仍預設啟用，並保留 `MOHAN_DISABLE_JIT=1` 相容性開關。Tachyon
 在 JIT 開啟的正式環境分析啟動、50 Hz 嘴型同步與表情仲裁器，分別保留
-3,908／11,107／3,604 個有效樣本；堆疊讀取錯誤率為
-5.08%／2.71%／0.74%，漏採樣率皆為 0%。CI 保存去識別化 flamegraph、
+4,553／11,482／3,475 個有效樣本；堆疊讀取錯誤率為
+6.20%／2.23%／0.57%，漏採樣率為 0.02%／0%／0%。CI 保存去識別化 flamegraph、
 JSONL、pstats、GC／配置／執行緒資料與 SHA-256，不發布原始二進位取樣流。
 只有隔離的 `pip-audit` 2.10.1 與 CycloneDX 7.3.0 產生器使用 3.14.7；
 墨寒程式、測試、SBOM 語意驗證與所有封裝仍只使用 3.15.0rc1。
 
-Ryzen 5 5600X Windows 實機三輪熱路徑中位數顯示：120,000 次表情仲裁由
-0.462 秒降為 0.293 秒（1.57 倍），2,000 個 50 Hz 嘴型分析節拍由
-1.873 秒降為 0.571 秒（3.28 倍）；兩種模式的決策、強度校驗和與
-A／I／U／E／O 結果完全相同。這是 CPU 熱路徑微基準，不宣稱整體程式快三倍。
+同一部 Ryzen 5 5600X Windows 實機以目前的 3.15.0rc1 環境獨立執行三輪
+熱路徑比較。JIT 開啟相對關閉時，120,000 次表情仲裁的速度比為
+0.86–0.98 倍（中位數 0.97 倍，未證實加速）；2,000 個 50 Hz 嘴型分析節拍
+為 1.45–1.65 倍（中位數 1.48 倍）。每一輪的決策、強度校驗和與
+A／I／U／E／O 結果完全相同。結果顯示 JIT 效益取決於熱路徑，只證實受測
+嘴型分析路徑加速，不宣稱表情仲裁或整體程式會得到一致加速。
 
 ### 持續維護的採用矩陣
 
@@ -50,14 +54,14 @@ A／I／U／E／O 結果完全相同。這是 CPU 熱路徑微基準，不宣稱
 | PEP 799 分析 | 去識別化 flamegraph、JSONL、pstats、runtime／GC 與 SHA-256；Release 檢查樣本、讀取錯誤、漏採樣與 JIT | 分析啟動、語音、50 Hz 嘴型與表情仲裁 |
 | PEP 831 Frame Pointer | runtime／build 報告與 CI 平台驗證 | 在支援的 Unix runner 使用系統分析器 |
 | JIT 與 Windows tail-calling interpreter | 封裝使用固定官方 CPython 提交並預設 JIT；PyInstaller 隔離不變，開關測試皆通過 | 保留停用開關並重跑完整回歸與效能檢查 |
-| PEP 803／820／793 Stable ABI 與 C API 現代化 | 已驗證 Qt ABI3 輪子；沒有第一方 C 擴充 | 2.3.0 RC1 拒絕原始碼建置或非 ABI3 Qt 輪子 |
+| PEP 803／820／793 Stable ABI 與 C API 現代化 | 已驗證 Qt ABI3 輪子；沒有第一方 C 擴充 | 2.3.0 RC2 拒絕原始碼建置或非 ABI3 Qt 輪子 |
 | PEP 782 與 PEP 788 C API | 不適用：墨寒沒有自有 C 擴充 | 加入原生程式碼前重新評估 |
 | PEP 829 啟動設定 | 目前封裝的桌面入口不需要 | 墨寒成為可安裝套件或外掛主機時重新評估 |
 | PEP 728／747／800 型別功能 | 目前沒有等價的正式模型 | 引入型別化外掛負載或 type-form API 時採用 |
 | 分代式 GC 恢復 | 必須執行壓力與記憶體耐久驗證 | 長時間工作階段與前一版基準比較 |
 | 標準庫新增／移除／棄用 API | 靜態稽核加 warnings-as-errors | 上游 What’s New 更新時擴充稽核 |
 
-此矩陣刻意保持開放。Python 3.15 預發行文件仍會更新；2.3.0 RC1 在建立標籤前
+此矩陣刻意保持開放。Python 3.15 預發行文件仍會更新；2.3.0 RC2 在建立標籤前
 必須立即重跑官方清單，之後每一個 Python 版本也重複相同流程。
 
 ## 简体中文
@@ -73,8 +77,10 @@ Python 运行环境。完整上游检查清单以官方
 PEP 799 Tachyon，以及 PEP 803／820／793 Stable ABI 依赖验证。PEP 661
 `sentinel` 已加入治理测试；目前没有旧式 `object()` 哨兵可替换，未来一旦
 “未传值”与 `None` 必须区分，就必须使用内建 `sentinel`。
+开头匹配已改用语义明确的 `re.prefixmatch()`，并由审计阻止软性弃用的
+`re.match()` 回流。
 
-2.3.0 RC1 打包使用固定在 CPython 提交
+2.3.0 RC2 打包使用固定在 CPython 提交
 `37e98da7c19a9e5892ee756d6dee08225422cd49` 的官方源代码，以
 `--experimental-jit`／`--enable-experimental-jit=yes` 构建默认启用 JIT 的
 运行环境；不修改 PyInstaller 隔离边界。`PYTHON_JIT=0` 仅用于性能与兼容性
@@ -87,16 +93,18 @@ PEP 799 Tachyon，以及 PEP 803／820／793 Stable ABI 依赖验证。PEP 661
 24.639／25.068 秒，工作集增长 10.62／12.94 MB。JIT 在此负载没有可靠优势，
 但依产品政策仍默认启用，并保留 `MOHAN_DISABLE_JIT=1` 兼容性开关。Tachyon
 在 JIT 开启的正式环境分析启动、50 Hz 口型同步与表情仲裁器，分别保留
-3,908／11,107／3,604 个有效样本；堆栈读取错误率为
-5.08%／2.71%／0.74%，漏采样率均为 0%。CI 保存去标识化 flamegraph、
+4,553／11,482／3,475 个有效样本；堆栈读取错误率为
+6.20%／2.23%／0.57%，漏采样率为 0.02%／0%／0%。CI 保存去标识化 flamegraph、
 JSONL、pstats、GC／配置／线程数据与 SHA-256，不发布原始二进制采样流。
 只有隔离的 `pip-audit` 2.10.1 与 CycloneDX 7.3.0 生成器使用 3.14.7；
 墨寒程序、测试、SBOM 语义验证与所有打包仍只使用 3.15.0rc1。
 
-Ryzen 5 5600X Windows 真机三轮热路径中位数显示：120,000 次表情仲裁由
-0.462 秒降至 0.293 秒（1.57 倍），2,000 个 50 Hz 口型分析节拍由
-1.873 秒降至 0.571 秒（3.28 倍）；两种模式的决策、强度校验和与
-A／I／U／E／O 结果完全相同。这是 CPU 热路径微基准，不宣称整个程序快三倍。
+同一台 Ryzen 5 5600X Windows 真机以当前的 3.15.0rc1 环境独立执行三轮
+热路径比较。JIT 开启相对关闭时，120,000 次表情仲裁的速度比为
+0.86–0.98 倍（中位数 0.97 倍，未证实加速）；2,000 个 50 Hz 口型分析节拍
+为 1.45–1.65 倍（中位数 1.48 倍）。每一轮的决策、强度校验和与
+A／I／U／E／O 结果完全相同。结果显示 JIT 收益取决于热路径，只证实受测
+口型分析路径加速，不宣称表情仲裁或整个程序会获得一致加速。
 
 ### 持续维护的采用矩阵
 
@@ -110,14 +118,14 @@ A／I／U／E／O 结果完全相同。这是 CPU 热路径微基准，不宣称
 | PEP 799 分析 | 去标识化 flamegraph、JSONL、pstats、runtime／GC 与 SHA-256；Release 检查样本、读取错误、漏采样与 JIT | 分析启动、语音、50 Hz 口型与表情仲裁 |
 | PEP 831 Frame Pointer | runtime／build 报告与 CI 平台验证 | 在支持的 Unix runner 使用系统分析器 |
 | JIT 与 Windows tail-calling interpreter | 打包使用固定官方 CPython 提交并默认启用 JIT；PyInstaller 隔离不变，开关测试均通过 | 保留停用开关并重跑完整回归与性能检查 |
-| PEP 803／820／793 Stable ABI 与 C API 现代化 | 已验证 Qt ABI3 轮子；没有第一方 C 扩展 | 2.3.0 RC1 拒绝源代码构建或非 ABI3 Qt 轮子 |
+| PEP 803／820／793 Stable ABI 与 C API 现代化 | 已验证 Qt ABI3 轮子；没有第一方 C 扩展 | 2.3.0 RC2 拒绝源代码构建或非 ABI3 Qt 轮子 |
 | PEP 782 与 PEP 788 C API | 不适用：墨寒没有自有 C 扩展 | 添加原生代码前重新评估 |
 | PEP 829 启动配置 | 当前打包的桌面入口不需要 | 墨寒成为可安装包或插件主机时重新评估 |
 | PEP 728／747／800 类型功能 | 当前没有等价的正式模型 | 引入类型化插件负载或 type-form API 时采用 |
 | 分代式 GC 恢复 | 必须执行压力与内存耐久验证 | 长时间工作阶段与上一版基准比较 |
 | 标准库新增／移除／弃用 API | 静态审计加 warnings-as-errors | 上游 What’s New 更新时扩充审计 |
 
-此矩阵刻意保持开放。Python 3.15 预发布文档仍会更新；2.3.0 RC1 在建立标签前
+此矩阵刻意保持开放。Python 3.15 预发布文档仍会更新；2.3.0 RC2 在建立标签前
 必须立即重跑官方清单，之后每一个 Python 版本也重复相同流程。
 
 ## English
@@ -136,8 +144,10 @@ unpacking comprehensions, PEP 686 UTF-8 auditing, the
 803/820/793 Stable ABI dependency validation. PEP 661 `sentinel` is governed
 by CI; no legacy `object()` sentinel exists today, and a future API that must
 distinguish omission from `None` must use the built-in `sentinel`.
+Prefix matching now uses the explicit `re.prefixmatch()` API, and the audit
+prevents the soft-deprecated `re.match()` spelling from returning.
 
-The 2.3.0 RC1 packages use official CPython sources pinned to commit
+The 2.3.0 RC2 packages use official CPython sources pinned to commit
 `37e98da7c19a9e5892ee756d6dee08225422cd49`, built with
 `--experimental-jit` and `--enable-experimental-jit=yes` so JIT is enabled by
 default without weakening PyInstaller isolation. `PYTHON_JIT=0` is used only
@@ -151,18 +161,23 @@ Two 20,000-iteration expression, physics, and lip-sync integration soaks pass.
 JIT off/on takes 24.639/25.068 seconds with 10.62/12.94 MB working-set growth.
 This workload shows no reliable JIT advantage, but product policy keeps JIT on
 by default with `MOHAN_DISABLE_JIT=1` as a compatibility switch. With JIT on,
-Tachyon retains 3,908/11,107/3,604 valid samples for startup, 50 Hz lip sync,
-and expression arbitration; stack-read error is 5.08%/2.71%/0.74%, with 0%
-missed samples. CI stores sanitized flamegraph, JSONL, pstats, GC, allocation,
+Tachyon retains 4,553/11,482/3,475 valid samples for startup, 50 Hz lip sync,
+and expression arbitration; stack-read error is 6.20%/2.23%/0.57%, with
+0.02%/0%/0% missed samples. CI stores sanitized flamegraph, JSONL, pstats, GC,
+allocation,
 thread, and SHA-256 evidence, never the raw binary stream. Only the isolated
 `pip-audit` 2.10.1 and CycloneDX 7.3.0 generators use 3.14.7; MoHan code,
 tests, SBOM semantic validation, and every package remain on 3.15.0rc1 only.
 
-Three median hot-path runs on a Ryzen 5 5600X Windows host show 120,000
-expression-arbitration iterations falling from 0.462 to 0.293 seconds (1.57x),
-and 2,000 50 Hz viseme-analysis ticks falling from 1.873 to 0.571 seconds
-(3.28x). Decisions, intensity checksums, and A/I/U/E/O results are identical.
-These are CPU hot-path microbenchmarks, not a claim that the whole app is 3x faster.
+Three independent hot-path comparisons ran on the same Ryzen 5 5600X Windows
+host in the current 3.15.0rc1 environment. With JIT on relative to off,
+120,000 expression-arbitration iterations measured 0.86–0.98x speed
+(0.97x median, with no demonstrated speedup), while 2,000 50 Hz
+viseme-analysis ticks measured 1.45–1.65x (1.48x median). Decisions, intensity
+checksums, and A/I/U/E/O results were identical in every run. The benefit is
+hot-path dependent: these results demonstrate acceleration only for the
+measured viseme path, not uniform acceleration of expression arbitration or
+the complete application.
 
 ### Maintained adoption matrix
 
@@ -176,7 +191,7 @@ These are CPU hot-path microbenchmarks, not a claim that the whole app is 3x fas
 | PEP 799 profiling | Sanitized flamegraph, JSONL, pstats, runtime/GC, and SHA-256; Release gates samples, read errors, missed samples, and JIT | Profile startup, speech, 50 Hz visemes, and expression arbitration |
 | PEP 831 frame pointers | Runtime/build report and CI platform validation | Use system profilers on supported Unix runners |
 | JIT and Windows tail-calling interpreter | Packages use a pinned official CPython commit with JIT on by default; PyInstaller isolation remains intact and on/off tests pass | Keep the disable switch and repeat full regression/performance checks |
-| PEP 803/820/793 Stable ABI and C API modernization | Qt ABI3 wheels verified; no first-party C extension | Reject source builds or non-ABI3 Qt wheels in 2.3.0 RC1 |
+| PEP 803/820/793 Stable ABI and C API modernization | Qt ABI3 wheels verified; no first-party C extension | Reject source builds or non-ABI3 Qt wheels in 2.3.0 RC2 |
 | PEP 782 and PEP 788 C APIs | Not applicable: MoHan owns no C extension | Reassess before adding native code |
 | PEP 829 startup configuration | Not needed by the packaged desktop entry point | Reassess if MoHan becomes an installable package or plugin host |
 | PEP 728/747/800 typing features | No equivalent production model yet | Adopt with typed plugin payloads or type-form APIs |
@@ -184,7 +199,7 @@ These are CPU hot-path microbenchmarks, not a claim that the whole app is 3x fas
 | New, removed, or deprecated standard-library APIs | Static audit plus warnings-as-errors | Extend the audit whenever upstream What’s New changes |
 
 This matrix is intentionally open. Python 3.15 prerelease documentation still
-changes upstream; 2.3.0 RC1 must rerun the official checklist immediately
+changes upstream; 2.3.0 RC2 must rerun the official checklist immediately
 before tagging, and every later Python release repeats the same process.
 
 ## 日本語
@@ -201,8 +216,10 @@ PEP 686 UTF-8 監査、`bytearray.take_bytes()` 音声パケットバッファ�
 PEP 799 Tachyon、PEP 803／820／793 Stable ABI 検証を導入しました。PEP 661
 `sentinel` は CI で管理しています。現在は旧式の `object()` センチネルがなく、
 将来「未指定」と `None` を区別する API では組み込み `sentinel` を使います。
+先頭一致には明示的な `re.prefixmatch()` を使用し、監査によってソフト非推奨の
+`re.match()` が戻ることを防ぎます。
 
-2.3.0 RC1 は、公式 CPython のコミット
+2.3.0 RC2 は、公式 CPython のコミット
 `37e98da7c19a9e5892ee756d6dee08225422cd49` に固定したソースを
 `--experimental-jit` と `--enable-experimental-jit=yes` でビルドし、
 PyInstaller の隔離を弱めず JIT を既定で有効にします。`PYTHON_JIT=0` は
@@ -215,18 +232,20 @@ tail-calling interpreter、PEP 782／788 などの C API は runtime report、
 24.639／25.068 秒、作業セット増加は 10.62／12.94 MB で、この負荷では確実な
 優位性がありません。ただし製品方針により既定で有効にし、互換性用に
 `MOHAN_DISABLE_JIT=1` を残します。Tachyon は JIT 有効環境で起動、50 Hz
-リップシンク、表情調停を解析し、3,908／11,107／3,604 有効サンプル、
-5.08%／2.71%／0.74% 読取エラー、漏れ 0% を確認しました。CI は匿名化済み
+リップシンク、表情調停を解析し、4,553／11,482／3,475 有効サンプル、
+6.20%／2.23%／0.57% 読取エラー、漏れ 0.02%／0%／0% を確認しました。CI は匿名化済み
 flamegraph、JSONL、pstats、GC、割当、スレッド、SHA-256 証拠を保存し、生の
 バイナリストリームは公開しません。隔離された `pip-audit` 2.10.1 と
 CycloneDX 7.3.0 生成器だけが 3.14.7 を使い、墨寒本体、テスト、SBOM 意味
 検証、全パッケージは 3.15.0rc1 のみです。
 
-Ryzen 5 5600X Windows 実機の三回のホットパス中央値では、120,000 回の表情
-調停が 0.462 秒から 0.293 秒（1.57 倍）、2,000 回の 50 Hz 口形解析が
-1.873 秒から 0.571 秒（3.28 倍）になりました。判断、強度チェックサム、
-A／I／U／E／O の結果は完全に一致します。CPU ホットパスの微小基準であり、
-アプリ全体が三倍速いという主張ではありません。
+同じ Ryzen 5 5600X Windows 実機の現在の 3.15.0rc1 環境で、ホットパスを
+三回独立して比較しました。JIT 無効時に対する有効時の速度比は、120,000 回の
+表情調停で 0.86～0.98 倍（中央値 0.97 倍、加速は確認できず）、2,000 回の
+50 Hz 口形解析で 1.45～1.65 倍（中央値 1.48 倍）でした。各回の判断、強度
+チェックサム、A／I／U／E／O の結果は完全に一致しました。JIT の効果は
+ホットパスに依存し、今回の結果が示す加速は測定した口形解析経路だけです。
+表情調停やアプリ全体が一様に高速化するとは主張しません。
 
 ### 継続管理する採用マトリクス
 
@@ -240,7 +259,7 @@ A／I／U／E／O の結果は完全に一致します。CPU ホットパスの�
 | PEP 799 解析 | 匿名化 flamegraph、JSONL、pstats、runtime／GC、SHA-256。Release はサンプル、読取エラー、漏れ、JIT を検査 | 起動、音声、50 Hz 口形、表情調停を解析 |
 | PEP 831 Frame Pointer | runtime／build 報告と CI プラットフォーム検証 | 対応 Unix runner でシステム分析器を使用 |
 | JIT と Windows tail-calling interpreter | 固定した公式 CPython コミットで JIT を既定有効化。PyInstaller 隔離を維持し、オン／オフ試験に合格 | 無効化設定を保ち、全回帰・性能検査を反復 |
-| PEP 803／820／793 Stable ABI と C API 現代化 | Qt ABI3 wheel を検証済み。自製 C 拡張はない | 2.3.0 RC1 ではソースビルドや非 ABI3 Qt wheel を拒否 |
+| PEP 803／820／793 Stable ABI と C API 現代化 | Qt ABI3 wheel を検証済み。自製 C 拡張はない | 2.3.0 RC2 ではソースビルドや非 ABI3 Qt wheel を拒否 |
 | PEP 782 と PEP 788 C API | 非該当：墨寒に自製 C 拡張はない | ネイティブコード追加前に再評価 |
 | PEP 829 起動設定 | 現在のデスクトップ入口には不要 | インストール可能パッケージ／プラグインホスト化時に再評価 |
 | PEP 728／747／800 型機能 | 同等の本番モデルはまだない | 型付きプラグイン負荷や type-form API 導入時に採用 |
@@ -248,5 +267,5 @@ A／I／U／E／O の結果は完全に一致します。CPU ホットパスの�
 | 標準ライブラリの追加／削除／非推奨 API | 静的監査と warnings-as-errors | 上流 What’s New 更新時に監査を拡張 |
 
 このマトリクスは意図的に開いたままです。Python 3.15 のプレリリース文書は
-更新され続けます。2.3.0 RC1 はタグ作成直前に公式一覧を再確認し、以後の
+更新され続けます。2.3.0 RC2 はタグ作成直前に公式一覧を再確認し、以後の
 Python リリースでも同じ手順を繰り返します。

--- a/docs/releases/v2.3.0-rc.2.md
+++ b/docs/releases/v2.3.0-rc.2.md
@@ -1,0 +1,37 @@
+# 墨寒桌面助理 v2.3.0 RC2／墨寒桌面助手 v2.3.0 RC2／MoHan Desktop Assistant v2.3.0 RC2／墨寒デスクトップアシスタント v2.3.0 RC2
+
+## 繁體中文
+
+- 2.3.0 RC2 將產品執行環境、測試與所有封裝完整維持在 CPython 3.15.0rc1，採用 PEP 810 明示延遲導入、PEP 814 frozendict、PEP 798 推導式解包、PEP 686 UTF-8 稽核、PEP 661 哨兵治理、bytearray.take_bytes 音訊緩衝、re.prefixmatch 開頭比對與 Stable ABI 依賴驗證；JIT 預設啟用並保留相容性停用開關。
+- PEP 799 Tachyon 會分析啟動、50 Hz 嘴型同步與表情仲裁器，產生去識別化的 flamegraph、JSONL、pstats、執行期及 GC 摘要；本次 JIT 開啟預檢保留 4,553／11,482／3,475 個有效樣本，堆疊讀取錯誤率為 6.20%／2.23%／0.57%，漏採樣率為 0.02%／0%／0%，樣本、錯誤率、漏採樣、JIT 狀態與 SHA-256 閘門全數通過。
+- Windows 實機三輪微基準顯示，JIT 開啟相對關閉時，表情仲裁熱路徑為 0.86–0.98 倍（中位數 0.97 倍，未證實加速），50 Hz 嘴型分析為 1.45–1.65 倍（中位數 1.48 倍）；每輪功能校驗一致，結果只代表受測 CPU 熱路徑，不宣稱整體程式會得到一致加速。
+- GitHub Actions JavaScript 動作強制使用 Node 24；Windows 封裝使用 Inno Setup 7.0.2 與 WiX 7.0.0，並產生可重現的 CycloneDX 1.7 SBOM、驗證報告、雜湊清單與產物證明。只有完整測試、安全稽核、安裝與卸載測試及跨平台預覽檢查全部成功後才可發布。
+- README 已統一為繁中、簡中、英文、日文單一四語文件，提供四語快速跳轉並移除重複相容文件。直接收款連結已移除，贊助說明只引導至儲存庫上方由 GitHub 產生的官方 Sponsor 按鈕。
+- 既有語音、50 Hz 嘴型、表情、四語、個人設定、資料庫與安全確認流程均須維持原有行為。Windows x64 仍為完整功能版；macOS arm64／x86_64 與 Linux x86_64 仍為功能受限 Preview，不宣稱與 Windows 功能同等。
+
+## 简体中文
+
+- 2.3.0 RC2 将产品运行环境、测试及所有打包完整保持在 CPython 3.15.0rc1，采用 PEP 810 显式延迟导入、PEP 814 frozendict、PEP 798 推导式解包、PEP 686 UTF-8 审计、PEP 661 哨兵治理、bytearray.take_bytes 音频缓冲、re.prefixmatch 开头匹配及 Stable ABI 依赖验证；JIT 默认启用并保留兼容性停用开关。
+- PEP 799 Tachyon 会分析启动、50 Hz 口型同步与表情仲裁器，生成去标识化的 flamegraph、JSONL、pstats、运行时及 GC 摘要；本次 JIT 开启预检保留 4,553／11,482／3,475 个有效样本，堆栈读取错误率为 6.20%／2.23%／0.57%，漏采样率为 0.02%／0%／0%，样本、错误率、漏采样、JIT 状态与 SHA-256 闸门全部通过。
+- Windows 真机三轮微基准显示，JIT 开启相对关闭时，表情仲裁热路径为 0.86–0.98 倍（中位数 0.97 倍，未证实加速），50 Hz 口型分析为 1.45–1.65 倍（中位数 1.48 倍）；每轮功能校验一致，结果只代表受测 CPU 热路径，不宣称整个程序会获得一致加速。
+- GitHub Actions JavaScript 动作强制使用 Node 24；Windows 打包使用 Inno Setup 7.0.2 与 WiX 7.0.0，并生成可重现的 CycloneDX 1.7 SBOM、验证报告、哈希清单及产物证明。只有完整测试、安全审计、安装与卸载测试及跨平台预览检查全部成功后才可发布。
+- README 已统一为繁中、简中、英文、日文单一四语文件，提供四语快速跳转并删除重复兼容文件。直接收款链接已删除，赞助说明只引导至仓库上方由 GitHub 生成的官方 Sponsor 按钮。
+- 现有语音、50 Hz 口型、表情、四语、个人设置、数据库与安全确认流程均须保持原有行为。Windows x64 仍为完整功能版；macOS arm64／x86_64 与 Linux x86_64 仍为功能受限 Preview，不宣称与 Windows 功能相同。
+
+## English
+
+- Version 2.3.0 RC2 keeps the product runtime, tests, and every package entirely on CPython 3.15.0rc1. It uses explicit PEP 810 lazy imports, PEP 814 frozendict, PEP 798 unpacking comprehensions, PEP 686 UTF-8 auditing, PEP 661 sentinel governance, bytearray.take_bytes audio buffering, re.prefixmatch prefix matching, and Stable ABI dependency validation. JIT remains enabled by default with a compatibility disable switch.
+- PEP 799 Tachyon profiles startup, 50 Hz lip sync, and expression arbitration, producing sanitized flamegraph, JSONL, pstats, runtime, and GC summaries. This JIT-on preflight retained 4,553/11,482/3,475 valid samples, with stack-read error rates of 6.20%/2.23%/0.57% and missed-sample rates of 0.02%/0%/0%; sample, error-rate, missed-sample, JIT-state, and SHA-256 gates all passed.
+- Three Windows hardware microbenchmark runs measured JIT-on versus JIT-off expression arbitration at 0.86–0.98x (0.97x median, with no demonstrated speedup) and 50 Hz viseme analysis at 1.45–1.65x (1.48x median). Functional checks matched in every run; the results apply only to the measured CPU hot paths and do not claim uniform acceleration of the complete application.
+- Every GitHub Actions JavaScript action is forced onto Node 24. Windows packaging uses Inno Setup 7.0.2 and WiX 7.0.0 and produces reproducible CycloneDX 1.7 SBOMs, validation reports, checksum catalogs, and artifact attestations. Publication is allowed only after the complete suite, security audits, install and uninstall tests, and cross-platform Preview checks all succeed.
+- The README is now one canonical Traditional Chinese, Simplified Chinese, English, and Japanese document with four-language quick links; duplicate compatibility files are removed. Direct payment links are removed, and support guidance points only to GitHub's official Sponsor button above the repository.
+- Existing voice, 50 Hz lip-sync, expression, four-language, personal-setting, database, and safety-confirmation behavior must remain unchanged. Windows x64 remains the complete product; macOS arm64/x86_64 and Linux x86_64 remain limited Preview packages and do not claim Windows feature parity.
+
+## 日本語
+
+- 2.3.0 RC2 は、製品実行環境、テスト、全パッケージを CPython 3.15.0rc1 のみに維持します。PEP 810 の明示的遅延インポート、PEP 814 frozendict、PEP 798 の内包表記アンパック、PEP 686 UTF-8 監査、PEP 661 センチネル管理、bytearray.take_bytes 音声バッファー、re.prefixmatch 先頭一致、Stable ABI 依存関係検証を採用し、JIT は既定で有効のまま互換性用の無効化設定を残します。
+- PEP 799 Tachyon は起動、50 Hz 口形同期、表情調停を解析し、匿名化した flamegraph、JSONL、pstats、実行時、GC の要約を生成します。今回の JIT 有効事前検証では 4,553／11,482／3,475 件の有効サンプル、6.20%／2.23%／0.57% のスタック読取エラー率、0.02%／0%／0% の欠落率を記録し、サンプル、エラー率、欠落、JIT 状態、SHA-256 の全ゲートに合格しました。
+- Windows 実機で三回実行したマイクロベンチマークでは、JIT 無効時に対する有効時の速度比が、表情調停で 0.86～0.98 倍（中央値 0.97 倍、加速は確認できず）、50 Hz 口形解析で 1.45～1.65 倍（中央値 1.48 倍）でした。各回の機能検証は一致し、結果は測定した CPU ホットパスだけを示すもので、アプリ全体が一様に高速化するとは主張しません。
+- GitHub Actions の JavaScript 動作はすべて Node 24 を強制します。Windows パッケージは Inno Setup 7.0.2 と WiX 7.0.0 を使い、再現可能な CycloneDX 1.7 SBOM、検証報告、チェックサム一覧、成果物証明を生成します。全テスト、安全監査、インストールとアンインストール試験、クロスプラットフォーム Preview 検査がすべて成功した場合だけ公開できます。
+- README は繁体字中国語、簡体字中国語、英語、日本語の一つの四言語文書へ統一し、四言語のクイックリンクを備え、重複する互換文書を削除しました。直接決済リンクを削除し、支援案内はリポジトリ上部に GitHub が生成する公式 Sponsor ボタンだけへ誘導します。
+- 既存の音声、50 Hz 口形、表情、四言語、個人設定、データベース、安全確認の動作は維持しなければなりません。Windows x64 は完全版のままです。macOS arm64／x86_64 と Linux x86_64 は機能限定 Preview のままであり、Windows 版との機能同等を主張しません。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "2.3.0rc1"
+version = "2.3.0rc2"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/realtime_voice.py
+++ b/realtime_voice.py
@@ -362,7 +362,7 @@ class RealtimeVoiceClient(QObject):
             if (
                 value
                 and len(value) <= 40
-                and not re.match(
+                and not re.prefixmatch(
                     r"^(?:請|使用|保留|不要|轉錄|語言|请|准确|"
                     r"Please|Preserve|Keep|do not|日本語|固有名詞)",
                     value,

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "2.3.0rc1"
+version = "2.3.0rc2"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -194,7 +194,7 @@ def test_release_gate_is_pinned() -> None:
 
 
 def test_release_version_has_one_source_of_truth() -> None:
-    assert FALLBACK_VERSION == "2.3.0-rc.1"
+    assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*", FALLBACK_VERSION)
     tag = f"v{FALLBACK_VERSION}"
     assert (ROOT / "docs" / "releases" / f"{tag}.md").is_file()
     release = read(".github/workflows/release.yml")
@@ -208,7 +208,7 @@ def test_release_version_has_one_source_of_truth() -> None:
 
 
 def test_four_language_release_notes_and_boundaries() -> None:
-    notes = read("docs/releases/v2.3.0-rc.1.md")
+    notes = read(f"docs/releases/v{FALLBACK_VERSION}.md")
     expected_headings = (
         "## 繁體中文",
         "## 简体中文",

--- a/tests/test_python315_runtime.py
+++ b/tests/test_python315_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 lazy import io
+lazy import re
 lazy import subprocess
 lazy import sys
 lazy from pathlib import Path
@@ -42,6 +43,7 @@ def main() -> None:
     assert callable(sys.get_lazy_imports_filter)
     assert callable(sys.set_lazy_imports_filter)
     assert io.text_encoding(None) == "utf-8"
+    assert re.prefixmatch(r"^MoHan", "MoHan Desktop Assistant") is not None
     assert JIT_DISABLE_ENV == "MOHAN_DISABLE_JIT"
     assert JIT_REEXEC_ENV == "MOHAN_JIT_REEXEC"
     aware_now = local_aware_time()

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -20,8 +20,11 @@ lazy from tools.sync_wordpress_download_page import (
     release_block,
     replace_managed_block,
 )
+lazy from version_info import FALLBACK_VERSION
 
-VERSION = "2.3.0-rc.1"
+VERSION = FALLBACK_VERSION
+VERSION_PREFIX, CANDIDATE_NUMBER = VERSION.rsplit(".", maxsplit=1)
+NEXT_VERSION = f"{VERSION_PREFIX}.{int(CANDIDATE_NUMBER) + 1}"
 TAG = f"v{VERSION}"
 PREFIX = f"MoHan-Desktop-Assistant-{TAG}"
 REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
@@ -44,12 +47,16 @@ def assert_image(path: Path, size: tuple[int, int]) -> None:
 
 def test_version_runtime_and_evidence_policy() -> None:
     assert f'FALLBACK_VERSION = "{VERSION}"' in read("version_info.py")
+    package_version = VERSION.replace("-rc.", "rc")
+    for metadata in ("pyproject.toml", "sbom/preview.pyproject.toml"):
+        assert f'version = "{package_version}"' in read(metadata)
     current_docs = {
         name: read(name)
         for name in (
             "README.md",
             "QUICKSTART.md",
             "PUBLISHING.md",
+            "CITATION.cff",
         )
     }
     for name, content in current_docs.items():
@@ -425,11 +432,11 @@ def assert_release_website_block(manifest: dict[str, object]) -> None:
 
     initial = "<p>保留的網站內容</p>"
     first = replace_managed_block(initial, block)
-    second = replace_managed_block(first, block.replace(VERSION, "2.3.0-rc.2"))
+    second = replace_managed_block(first, block.replace(VERSION, NEXT_VERSION))
     assert second.count(START_MARKER) == 1
     assert second.count(END_MARKER) == 1
     assert "保留的網站內容" in second
-    assert "2.3.0-rc.2" in second
+    assert NEXT_VERSION in second
 
 
 def test_portable_website_block() -> None:

--- a/tests/test_sbom_validation.py
+++ b/tests/test_sbom_validation.py
@@ -24,6 +24,10 @@ lazy from tools.validate_release_sboms import (
     _validate_components,
     load_policies,
 )
+lazy from version_info import FALLBACK_VERSION
+
+CURRENT_TAG = f"v{FALLBACK_VERSION}"
+CURRENT_PACKAGE_VERSION = _release_version(CURRENT_TAG)
 
 
 def expect_value_error(operation: Callable[[], object]) -> str:
@@ -48,8 +52,8 @@ def runtime_policy(
 
 
 def test_release_version_and_repository_policy_are_synchronized() -> None:
-    assert _release_version("v2.3.0-rc.1") == "2.3.0rc1"
-    for invalid in ("2.3.0-rc.1", "v2.3.0", "v2.3.0-rc.0"):
+    assert _release_version("v9.8.7-rc.6") == "9.8.7rc6"
+    for invalid in ("9.8.7-rc.6", "v9.8.7", "v9.8.7-rc.0"):
         message = expect_value_error(lambda value=invalid: _release_version(value))
         assert "vN.N.N-rc.N" in message
 
@@ -74,7 +78,7 @@ def test_release_version_and_repository_policy_are_synchronized() -> None:
             pyproject=ROOT / "pyproject.toml",
             root_name="mohan-desktop-assistant",
         ),
-        "2.3.0rc1",
+        CURRENT_PACKAGE_VERSION,
         windows,
     )
     _project_metadata(
@@ -85,7 +89,7 @@ def test_release_version_and_repository_policy_are_synchronized() -> None:
             pyproject=ROOT / "sbom" / "preview.pyproject.toml",
             root_name="mohan-desktop-assistant-preview",
         ),
-        "2.3.0rc1",
+        CURRENT_PACKAGE_VERSION,
         preview,
     )
 

--- a/tools/audit_python315_compatibility.py
+++ b/tools/audit_python315_compatibility.py
@@ -6,15 +6,25 @@ lazy from pathlib import Path
 lazy from migrate_python315_imports import ROOT, python_files
 
 REMOVED_CALLS = frozenset({
+    "ctypes.SetPointerType",
+    "glob.glob0",
+    "glob.glob1",
+    "platform.java_ver",
     "threading.activeCount",
     "threading.currentThread",
     "threading.enumerateThreads",
+    "typing.no_type_check_decorator",
 })
 REMOVED_METHODS = frozenset({
+    "getmark",
+    "getmarkers",
     "getName",
     "isAlive",
     "isSet",
+    "is_reserved",
+    "load_module",
     "notifyAll",
+    "setmark",
     "setDaemon",
     "setName",
 })
@@ -34,11 +44,29 @@ REMOVED_MODULES = frozenset({
     "pipes",
     "sndhdr",
     "spwd",
+    "sre_compile",
+    "sre_constants",
+    "sre_parse",
     "sunau",
     "telnetlib",
     "uu",
     "xdrlib",
 })
+REMOVED_IMPORTS = frozendict({
+    "ctypes": frozenset({"SetPointerType"}),
+    "glob": frozenset({"glob0", "glob1"}),
+    "http.server": frozenset({"CGIHTTPRequestHandler"}),
+    "platform": frozenset({"java_ver"}),
+    "typing": frozenset({"no_type_check_decorator"}),
+})
+DEPRECATED_CALLS = frozenset({
+    "asyncio.get_event_loop_policy",
+    "asyncio.iscoroutinefunction",
+    "asyncio.set_event_loop_policy",
+    "os.path.commonprefix",
+    "sys._clear_type_cache",
+})
+DEPRECATED_MODULES = frozenset({"profile"})
 
 
 def call_name(node: ast.AST) -> str | None:
@@ -63,7 +91,9 @@ def literal_mode(node: ast.Call) -> str | None:
         value = node.args[1]
     else:
         return "r"
-    return value.value if isinstance(value, ast.Constant) and isinstance(value.value, str) else None
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    return None
 
 
 class CompatibilityAudit(ast.NodeVisitor):
@@ -97,12 +127,24 @@ class CompatibilityAudit(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
-            if alias.name.partition(".")[0] in REMOVED_MODULES:
+            root_name = alias.name.partition(".")[0]
+            if root_name in REMOVED_MODULES:
                 self.issue(node, f"REMOVED_MODULE {alias.name}")
+            if root_name in DEPRECATED_MODULES:
+                self.issue(node, f"DEPRECATED_MODULE {alias.name}")
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if node.module and node.module.partition(".")[0] in REMOVED_MODULES:
+        if not node.module:
+            return
+        root_name = node.module.partition(".")[0]
+        if root_name in REMOVED_MODULES:
             self.issue(node, f"REMOVED_MODULE {node.module}")
+        if root_name in DEPRECATED_MODULES:
+            self.issue(node, f"DEPRECATED_MODULE {node.module}")
+        removed_names = REMOVED_IMPORTS.get(node.module, frozenset())
+        for alias in node.names:
+            if alias.name in removed_names:
+                self.issue(node, f"REMOVED_API {node.module}.{alias.name}")
 
     def visit_Call(self, node: ast.Call) -> None:
         name = call_name(node.func)
@@ -111,6 +153,24 @@ class CompatibilityAudit(ast.NodeVisitor):
             and node.func.attr in REMOVED_METHODS
         ):
             self.issue(node, f"REMOVED_API {name}")
+        if name in DEPRECATED_CALLS:
+            self.issue(node, f"DEPRECATED_API {name}")
+        if name in {"RLock", "threading.RLock"} and (node.args or node.keywords):
+            self.issue(node, f"REMOVED_ARGUMENTS {name}")
+        if name == "importlib.resources.files" and keyword_present(node, "package"):
+            self.issue(node, "REMOVED_ARGUMENT importlib.resources.files.package")
+        if name == "sysconfig.is_python_build" and keyword_present(node, "check_home"):
+            self.issue(node, "REMOVED_ARGUMENT sysconfig.is_python_build.check_home")
+        if name in {"NamedTuple", "typing.NamedTuple"} and node.keywords:
+            self.issue(node, f"REMOVED_KEYWORD_FORM {name}")
+        if name in {"TypedDict", "typing.TypedDict"} and (
+            len(node.args) < 2
+            or (
+                isinstance(node.args[1], ast.Constant)
+                and node.args[1].value is None
+            )
+        ):
+            self.issue(node, f"REMOVED_EMPTY_FORM {name}")
 
         if name in {"open", "builtins.open", "io.open"}:
             mode = literal_mode(node)

--- a/tools/audit_python315_idioms.py
+++ b/tools/audit_python315_idioms.py
@@ -47,7 +47,10 @@ class IdiomAudit(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
-        if call_name(node.func) in {
+        name = call_name(node.func)
+        if name == "re.match":
+            self.finding(node, "LEGACY_RE_MATCH")
+        if name in {
             "chain.from_iterable",
             "itertools.chain.from_iterable",
         }:

--- a/tools/profile_mohan_tachyon.py
+++ b/tools/profile_mohan_tachyon.py
@@ -583,7 +583,11 @@ def _sanitize_text_artifact(
 ) -> None:
     content = path.read_text(encoding="utf-8")
     for source, replacement in replacements:
-        flags = re.IGNORECASE if re.match(r"^[a-z]:", source, re.IGNORECASE) else 0
+        flags = (
+            re.IGNORECASE
+            if re.prefixmatch(r"^[a-z]:", source, re.IGNORECASE)
+            else 0
+        )
         content = re.sub(
             re.escape(source),
             lambda _match, value=replacement: value,

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "2.3.0-rc.1"
+FALLBACK_VERSION = "2.3.0-rc.2"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文

### 摘要

- 將產品執行、測試與全部封裝更新為 CPython 3.15.0rc1，採用 PEP 810 明示延遲導入、PEP 814 `frozendict`、PEP 798 推導式解包、PEP 686 UTF-8 稽核、PEP 661 哨兵治理、`bytearray.take_bytes()`、`re.prefixmatch()` 與 Stable ABI 依賴驗證。
- JIT 依產品政策預設開啟並保留相容性停用開關；Tachyon 以去識別化證據分析啟動、50 Hz 嘴型同步與表情仲裁。
- 版本、README、Quickstart、Publishing、CHANGELOG、CITATION、SBOM 與四語 Release 說明統一為 v2.3.0-rc.2；GitHub Actions JavaScript 動作維持 Node 24，Windows 封裝維持 WiX 7.0.0 與 Inno Setup 7.0.2。
- 治理測試不再把目前候選版號散落寫死，改由單一版本來源驗證，降低未來維護耦合。

### 驗證

- JIT 開啟：65／65 完整測試通過。
- JIT 關閉相容模式：65／65 完整測試通過。
- Tachyon：啟動／嘴型／表情分別保留 4,553／11,482／3,475 個有效樣本，讀取錯誤率 6.20%／2.23%／0.57%，漏採樣率 0.02%／0%／0%，三項門檻違規皆為 0。
- 三輪實機微基準功能校驗完全一致；JIT 開啟相對關閉時，表情仲裁為 0.86–0.98 倍（未證實加速），50 Hz 嘴型分析為 1.45–1.65 倍，不將局部結果誇大為整體加速。
- Python 3.15 相容性與現代寫法稽核：163 個檔案、0 問題；公開發行稽核：426 個檔案、130.53 MiB；Gitleaks：125 筆 commit、0 洩漏。
- 僅在全部 GitHub Actions、原生封裝、安裝／移除、安全與跨平台 Preview 閘門全綠後合併與建立預發行版；角色視覺自然度仍保留使用者實機驗收。

## 简体中文

### 摘要

- 将产品运行、测试与全部打包更新为 CPython 3.15.0rc1，采用 PEP 810 显式延迟导入、PEP 814 `frozendict`、PEP 798 推导式解包、PEP 686 UTF-8 审计、PEP 661 哨兵治理、`bytearray.take_bytes()`、`re.prefixmatch()` 与 Stable ABI 依赖验证。
- JIT 依产品政策默认开启并保留兼容性停用开关；Tachyon 以去标识化证据分析启动、50 Hz 口型同步与表情仲裁。
- 版本、README、Quickstart、Publishing、CHANGELOG、CITATION、SBOM 与四语 Release 说明统一为 v2.3.0-rc.2；GitHub Actions JavaScript 动作保持 Node 24，Windows 打包保持 WiX 7.0.0 与 Inno Setup 7.0.2。
- 治理测试不再将当前候选版本号分散写死，改由单一版本来源验证，降低未来维护耦合。

### 验证

- JIT 开启：65／65 完整测试通过。
- JIT 关闭兼容模式：65／65 完整测试通过。
- Tachyon：启动／口型／表情分别保留 4,553／11,482／3,475 个有效样本，读取错误率 6.20%／2.23%／0.57%，漏采样率 0.02%／0%／0%，三项目标的门槛违规均为 0。
- 三轮真机微基准功能校验完全一致；JIT 开启相对关闭时，表情仲裁为 0.86–0.98 倍（未证实加速），50 Hz 口型分析为 1.45–1.65 倍，不将局部结果夸大为整体加速。
- Python 3.15 兼容性与现代写法审计：163 个文件、0 问题；公开发布审计：426 个文件、130.53 MiB；Gitleaks：125 个 commit、0 泄漏。
- 仅在全部 GitHub Actions、原生打包、安装／卸载、安全与跨平台 Preview 闸门全绿后合并并建立预发布版；角色视觉自然度仍保留用户真机验收。

## English

### Summary

- Move the product runtime, tests, and every package to CPython 3.15.0rc1, using explicit PEP 810 lazy imports, PEP 814 `frozendict`, PEP 798 unpacking comprehensions, PEP 686 UTF-8 auditing, PEP 661 sentinel governance, `bytearray.take_bytes()`, `re.prefixmatch()`, and Stable ABI dependency validation.
- Keep JIT enabled by default under product policy with a compatibility disable switch; Tachyon profiles startup, 50 Hz lip sync, and expression arbitration through sanitized evidence.
- Align the version, README, Quickstart, Publishing guide, CHANGELOG, CITATION, SBOM metadata, and four-language release notes on v2.3.0-rc.2. GitHub Actions JavaScript actions remain on Node 24, and Windows packaging remains on WiX 7.0.0 and Inno Setup 7.0.2.
- Replace scattered candidate-version assertions with validation derived from the single version source, reducing future maintenance coupling.

### Validation

- JIT enabled: all 65/65 tests passed.
- JIT-disabled compatibility mode: all 65/65 tests passed.
- Tachyon retained 4,553/11,482/3,475 valid startup/lip-sync/expression samples, with 6.20%/2.23%/0.57% read errors, 0.02%/0%/0% missed samples, and zero gate violations for all three targets.
- Functional checks matched across three hardware microbenchmark runs. JIT-on versus JIT-off expression arbitration measured 0.86–0.98x (no demonstrated speedup), while 50 Hz viseme analysis measured 1.45–1.65x; no hot-path result is presented as whole-application acceleration.
- Python 3.15 compatibility and idiom audits: 163 files, zero findings. Public-release audit: 426 files, 130.53 MiB. Gitleaks: 125 commits, zero leaks.
- Merge and pre-release publication are allowed only after every GitHub Actions, native-package, install/uninstall, security, and cross-platform Preview gate is green. Character-visual naturalness remains subject to the owner's physical-device acceptance.

## 日本語

### 概要

- 製品実行環境、テスト、全パッケージを CPython 3.15.0rc1 へ更新し、PEP 810 の明示的遅延インポート、PEP 814 `frozendict`、PEP 798 の内包表記アンパック、PEP 686 UTF-8 監査、PEP 661 センチネル管理、`bytearray.take_bytes()`、`re.prefixmatch()`、Stable ABI 依存関係検証を採用します。
- 製品方針により JIT を既定で有効にし、互換性用の無効化スイッチを保持します。Tachyon は匿名化済み証拠で起動、50 Hz 口形同期、表情調停を解析します。
- バージョン、README、Quickstart、Publishing、CHANGELOG、CITATION、SBOM、4 言語 Release 説明を v2.3.0-rc.2 に統一します。GitHub Actions の JavaScript 動作は Node 24、Windows パッケージは WiX 7.0.0 と Inno Setup 7.0.2 を維持します。
- 候補版番号を複数の管理テストへ固定せず、単一のバージョン情報から検証することで、将来の保守結合を減らします。

### 検証

- JIT 有効：65／65 の全テストに合格。
- JIT 無効互換モード：65／65 の全テストに合格。
- Tachyon は起動／口形／表情で 4,553／11,482／3,475 件の有効サンプル、6.20%／2.23%／0.57% の読取エラー率、0.02%／0%／0% の欠落率を記録し、三対象すべてのゲート違反は 0 です。
- 実機マイクロベンチマーク三回の機能検証は完全に一致しました。JIT 無効時に対する有効時の表情調停は 0.86～0.98 倍（加速は確認できず）、50 Hz 口形解析は 1.45～1.65 倍で、ホットパスの結果をアプリ全体の加速として提示しません。
- Python 3.15 互換性・現代構文監査：163 ファイル、指摘 0。公開リリース監査：426 ファイル、130.53 MiB。Gitleaks：125 commit、漏えい 0。
- 全 GitHub Actions、ネイティブパッケージ、インストール／削除、セキュリティ、クロスプラットフォーム Preview ゲートがすべて成功した場合だけマージおよびプレリリース公開を許可します。キャラクター表示の自然さは、引き続き所有者の実機確認対象です。
