### PR TITLE
新增跨語系 Azure 普通話聲線／新增跨语言 Azure 普通话声线／Add cross-locale Azure Mandarin voices／Azure 普通話音声を言語横断で追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；既有預設及有效設定不變。
+- Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；Windows 本機語音的兩種中文介面也共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira，既有預設及有效設定不變。
 - Azure 聲線選取後立即保存，下一次試聽或朗讀直接套用；新增的普通話選項只納入 Standard Neural 女性聲線。
 - 已以真實 Azure Speech Free F0、East Asia 資源完成 HTTPS、RIFF 音訊及 Windows 播放驗證，金鑰仍僅由 Windows DPAPI 加密。
 - Dragon HD／HD Omni 因方案、計費與區域支援不同而不混入免費預設清單，雲端失敗時維持單次 Windows 女性本機語音回退。
@@ -172,7 +172,7 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；现有默认值及有效设置不变。
+- Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；Windows 本地语音的两种中文界面也共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira，现有默认值及有效设置不变。
 - Azure 声线选择后立即保存，下一次试听或朗读直接应用；新增的普通话选项只纳入 Standard Neural 女性声线。
 - 已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS、RIFF 音频及 Windows 播放验证，密钥仍只由 Windows DPAPI 加密。
 - Dragon HD／HD Omni 因方案、计费与区域支持不同而不混入免费默认列表，云端失败时保持单次 Windows 女性本地语音回退。
@@ -337,7 +337,7 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech Chinese female voices are selectable across Traditional and Simplified Chinese UI, ordered with the current interface locale first; existing defaults and valid settings remain unchanged.
+- Azure Speech Chinese female voices are selectable across Traditional and Simplified Chinese UI, ordered with the current interface locale first. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira; existing defaults and valid settings remain unchanged.
 - Azure voice selections now save immediately and apply to the next preview or utterance; the added Mandarin options include only Standard Neural female voices.
 - A real Azure Speech Free F0 resource in East Asia completed HTTPS, RIFF audio, and Windows playback validation, while its key remains encrypted only through Windows DPAPI.
 - Dragon HD and HD Omni stay out of the free default list because tier, billing, and regional support differ; cloud failure retains the one-time Windows local female fallback.
@@ -542,7 +542,7 @@ speech, gaze, and physics stress test passed before this release candidate.
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech の中国語女性音声を繁体字・簡体字画面から言語横断で選択でき、現在の画面言語を優先して並べます。既定値と有効な保存済み設定は変更しません。
+- Azure Speech の中国語女性音声を繁体字・簡体字画面から言語横断で選択でき、現在の画面言語を優先して並べます。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira を除外します。既定値と有効な保存済み設定は変更しません。
 - Azure 音声は選択時に直ちに保存し、次の試聴または読み上げから適用します。追加する普通話選択肢には Standard Neural 女性音声だけを含めます。
 - East Asia の実 Azure Speech Free F0 リソースで HTTPS、RIFF 音声、Windows 再生を検証し、キーは引き続き Windows DPAPI だけで暗号化します。
 - Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させず、クラウド障害時の Windows 本機女性音声への一度だけの代替を維持します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；Windows 本機語音的兩種中文介面也共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira，既有預設及有效設定不變。
+- Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；Windows 本機語音的兩種中文介面也共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira，既有預設及有效設定不變。四語 README 同步將《電腦情人夢》的英文譯名更正為《AI Think So!》。
 - Azure 聲線選取後立即保存，下一次試聽或朗讀直接套用；新增的普通話選項只納入 Standard Neural 女性聲線。
 - 已以真實 Azure Speech Free F0、East Asia 資源完成 HTTPS、RIFF 音訊及 Windows 播放驗證，金鑰仍僅由 Windows DPAPI 加密。
 - Dragon HD／HD Omni 因方案、計費與區域支援不同而不混入免費預設清單，雲端失敗時維持單次 Windows 女性本機語音回退。
@@ -172,7 +172,7 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；Windows 本地语音的两种中文界面也共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira，现有默认值及有效设置不变。
+- Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；Windows 本地语音的两种中文界面也共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira，现有默认值及有效设置不变。四语 README 同步将《电脑情人梦》的英文译名更正为《AI Think So!》。
 - Azure 声线选择后立即保存，下一次试听或朗读直接应用；新增的普通话选项只纳入 Standard Neural 女性声线。
 - 已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS、RIFF 音频及 Windows 播放验证，密钥仍只由 Windows DPAPI 加密。
 - Dragon HD／HD Omni 因方案、计费与区域支持不同而不混入免费默认列表，云端失败时保持单次 Windows 女性本地语音回退。
@@ -337,7 +337,7 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech Chinese female voices are selectable across Traditional and Simplified Chinese UI, ordered with the current interface locale first. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira; existing defaults and valid settings remain unchanged.
+- Azure Speech Chinese female voices are selectable across Traditional and Simplified Chinese UI, ordered with the current interface locale first. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira; existing defaults and valid settings remain unchanged. The four-language README also corrects the English rendering of *電腦情人夢* to *AI Think So!*.
 - Azure voice selections now save immediately and apply to the next preview or utterance; the added Mandarin options include only Standard Neural female voices.
 - A real Azure Speech Free F0 resource in East Asia completed HTTPS, RIFF audio, and Windows playback validation, while its key remains encrypted only through Windows DPAPI.
 - Dragon HD and HD Omni stay out of the free default list because tier, billing, and regional support differ; cloud failure retains the one-time Windows local female fallback.
@@ -542,7 +542,7 @@ speech, gaze, and physics stress test passed before this release candidate.
 
 ### v2.3.0 RC5 — 2026-08-11
 
-- Azure Speech の中国語女性音声を繁体字・簡体字画面から言語横断で選択でき、現在の画面言語を優先して並べます。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira を除外します。既定値と有効な保存済み設定は変更しません。
+- Azure Speech の中国語女性音声を繁体字・簡体字画面から言語横断で選択でき、現在の画面言語を優先して並べます。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira を除外します。既定値と有効な保存済み設定は変更しません。四言語 README では『電腦情人夢』の英訳も『AI Think So!』へ訂正しました。
 - Azure 音声は選択時に直ちに保存し、次の試聴または読み上げから適用します。追加する普通話選択肢には Standard Neural 女性音声だけを含めます。
 - East Asia の実 Azure Speech Free F0 リソースで HTTPS、RIFF 音声、Windows 再生を検証し、キーは引き続き Windows DPAPI だけで暗号化します。
 - Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させず、クラウド障害時の Windows 本機女性音声への一度だけの代替を維持します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### v2.3.0 RC5 — 2026-08-11
+
+- Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；既有預設及有效設定不變。
+- Azure 聲線選取後立即保存，下一次試聽或朗讀直接套用；新增的普通話選項只納入 Standard Neural 女性聲線。
+- 已以真實 Azure Speech Free F0、East Asia 資源完成 HTTPS、RIFF 音訊及 Windows 播放驗證，金鑰仍僅由 Windows DPAPI 加密。
+- Dragon HD／HD Omni 因方案、計費與區域支援不同而不混入免費預設清單，雲端失敗時維持單次 Windows 女性本機語音回退。
+
 ### v2.3.0 RC4 — 2026-08-11
 
 - 導入參數化分層 2.5D 臉部系統，以不可變姿態、連續嘴型參數、表情語意與
@@ -163,6 +170,13 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### v2.3.0 RC5 — 2026-08-11
+
+- Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；现有默认值及有效设置不变。
+- Azure 声线选择后立即保存，下一次试听或朗读直接应用；新增的普通话选项只纳入 Standard Neural 女性声线。
+- 已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS、RIFF 音频及 Windows 播放验证，密钥仍只由 Windows DPAPI 加密。
+- Dragon HD／HD Omni 因方案、计费与区域支持不同而不混入免费默认列表，云端失败时保持单次 Windows 女性本地语音回退。
+
 ### v2.3.0 RC4 — 2026-08-11
 
 - 导入参数化分层 2.5D 脸部系统，通过不可变姿态、连续口型参数、表情语义与
@@ -320,6 +334,13 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v2.3.0 RC5 — 2026-08-11
+
+- Azure Speech Chinese female voices are selectable across Traditional and Simplified Chinese UI, ordered with the current interface locale first; existing defaults and valid settings remain unchanged.
+- Azure voice selections now save immediately and apply to the next preview or utterance; the added Mandarin options include only Standard Neural female voices.
+- A real Azure Speech Free F0 resource in East Asia completed HTTPS, RIFF audio, and Windows playback validation, while its key remains encrypted only through Windows DPAPI.
+- Dragon HD and HD Omni stay out of the free default list because tier, billing, and regional support differ; cloud failure retains the one-time Windows local female fallback.
 
 ### v2.3.0 RC4 — 2026-08-11
 
@@ -518,6 +539,13 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v2.3.0 RC5 — 2026-08-11
+
+- Azure Speech の中国語女性音声を繁体字・簡体字画面から言語横断で選択でき、現在の画面言語を優先して並べます。既定値と有効な保存済み設定は変更しません。
+- Azure 音声は選択時に直ちに保存し、次の試聴または読み上げから適用します。追加する普通話選択肢には Standard Neural 女性音声だけを含めます。
+- East Asia の実 Azure Speech Free F0 リソースで HTTPS、RIFF 音声、Windows 再生を検証し、キーは引き続き Windows DPAPI だけで暗号化します。
+- Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させず、クラウド障害時の Windows 本機女性音声への一度だけの代替を維持します。
 
 ### v2.3.0 RC4 — 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "2.3.0-rc.4"
+version: "2.3.0-rc.5"
 date-released: "2026-08-10"
 license: MIT
 abstract: >-

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,8 +38,8 @@ open-source
 
 ### 已準備的公開預發行版
 
-- 標籤：`v2.3.0-rc.4`
-- 標題：`MoHan Desktop Assistant v2.3.0 RC4`
+- 標籤：`v2.3.0-rc.5`
+- 標題：`MoHan Desktop Assistant v2.3.0 RC5`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
@@ -203,8 +203,8 @@ open-source
 
 ### 已准备的公开预发布版
 
-- 标签：`v2.3.0-rc.4`
-- 标题：`MoHan Desktop Assistant v2.3.0 RC4`
+- 标签：`v2.3.0-rc.5`
+- 标题：`MoHan Desktop Assistant v2.3.0 RC5`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
@@ -368,8 +368,8 @@ open-source
 
 ### Prepared public pre-release
 
-- Tag: `v2.3.0-rc.4`
-- Title: `MoHan Desktop Assistant v2.3.0 RC4`
+- Tag: `v2.3.0-rc.5`
+- Title: `MoHan Desktop Assistant v2.3.0 RC5`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
@@ -533,8 +533,8 @@ open-source
 
 ### 準備済みの公開プレリリース
 
-- タグ：`v2.3.0-rc.4`
-- タイトル：`MoHan Desktop Assistant v2.3.0 RC4`
+- タグ：`v2.3.0-rc.5`
+- タイトル：`MoHan Desktop Assistant v2.3.0 RC5`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.4.exe`。
+2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.4.exe`。
+2. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-2.3.0-rc.4.exe`.
+2. Run `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-2.3.0-rc.4.exe` を実行します。
+2. `MoHan-Desktop-Assistant-2.3.0-rc.5.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.4" src="https://img.shields.io/badge/development_version-v2.3.0--rc.4-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -32,7 +32,7 @@
 
 <p align="center">
   <strong>軟體作者：CHOU MING HUA</strong><br>
-  準備發布的公開預覽版：v2.3.0 RC4（`v2.3.0-rc.4`）<br>
+  準備發布的公開預覽版：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -185,7 +185,7 @@ Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責�
 - AIUEO 母音與子音嘴型、音訊驅動開合，以及語音結束強制閉嘴。
 - 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
 - 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
-- 可選的 Azure Speech 女性聲線預覽；使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
+- 已完成真實連線驗證的 Azure Speech 女性聲線預覽；中文介面可跨語系選擇臺灣華語與簡體普通話，使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
 - 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
 - 工作、陪伴、勿擾、會議、離開及睡眠模式。
 - 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
@@ -218,15 +218,16 @@ Realtime 離線、雲端語音失敗、設定不足或供應器不明時，Windo
 
 Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需要使用者自己的 Azure Speech 資源金鑰與相符區域。金鑰由 `Windows DPAPI` 分開加密，不存入資料庫、紀錄或 GitHub。
 
-介面只列出 Microsoft 官方標示為女性的繁中、簡中、英文與日語聲線。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
+介面只列出 Microsoft 官方標示為女性且已列入墨寒允許清單的繁中、簡中、英文與日語 Neural 聲線。本次新增的跨語系普通話選項只使用 Standard Neural，排除 Dragon HD／HD Omni。繁中介面先列臺灣華語再列簡體普通話；簡中介面反向排序，且兩者均保留原有預設聲線。選取 Azure 聲線後立即保存並從下一次試聽或朗讀套用。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
 
-真實 Azure 帳號完成端到端試播前，不會把此功能宣稱為穩定整合。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證。此結果確認墨寒的整合路徑可用，但不保證每個帳號、區域或當期配額皆相同。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
 ### 整合驗證狀態
 
 > **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
 
-- Microsoft 的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
+- Azure Speech 已完成本專案的真實 Free F0 資源、HTTPS 合成、RIFF 音訊與 Windows 播放驗證；每位使用者仍須自行建立 Speech 資源並承擔其帳號、配額與費用。
+- Microsoft 帳號的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
 - GitHub 的真實帳號、儲存庫、Issue、Pull Request 與權限層級流程尚未驗證。
 - Home Assistant 的真實主機與實體設備行為尚未驗證。
 - 這三項整合預設關閉；請先使用非關鍵帳號、測試儲存庫與低風險設備。
@@ -356,7 +357,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.4"
+.\build.ps1 -Version "2.3.0-rc.5"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
@@ -396,7 +397,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.4" src="https://img.shields.io/badge/development_version-v2.3.0--rc.4-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -420,7 +421,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>软件作者：CHOU MING HUA</strong><br>
-  准备发布的公开预览版：v2.3.0 RC4（`v2.3.0-rc.4`）<br>
+  准备发布的公开预览版：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -573,7 +574,7 @@ Codex 协助我把想法转译成程序架构与代码；而我始终负责决�
 - AIUEO 元音与辅音口型、音频驱动开合，以及语音结束强制闭嘴。
 - 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
 - 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
-- 可选的 Azure Speech 女性声线预览；用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
+- 已完成真实连接验证的 Azure Speech 女性声线预览；中文界面可跨语言选择台湾华语与简体普通话，用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
 - 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
 - 工作、陪伴、勿扰、会议、离开及睡眠模式。
 - 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
@@ -606,15 +607,16 @@ Realtime 离线、云端语音失败、设置不足或供应器不明时，Windo
 
 Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要用户自己的 Azure Speech 资源密钥与匹配区域。密钥由 `Windows DPAPI` 分开加密，不存入数据库、日志或 GitHub。
 
-界面只列出 Microsoft 官方标记为女性的繁中、简中、英文与日语声线。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
+界面只列出 Microsoft 官方标记为女性且已列入墨寒允许列表的繁中、简中、英文与日语 Neural 声线。本次新增的跨语言普通话选项只使用 Standard Neural，排除 Dragon HD／HD Omni。繁中界面先列台湾华语再列简体普通话；简中界面反向排序，且两者均保留原有默认声线。选择 Azure 声线后立即保存，并从下一次试听或朗读开始应用。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
 
-真实 Azure 账号完成端到端试听前，不会把此功能宣称为稳定集成。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
+2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证。此结果确认墨寒的集成路径可用，但不保证每个账号、区域或当前配额都相同。Dragon HD／HD Omni 因方案、计费与区域支持不同，不混入免费默认列表。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
 ### 集成验证状态
 
 > **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
 
-- Microsoft 的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
+- Azure Speech 已完成本项目的真实 Free F0 资源、HTTPS 合成、RIFF 音频与 Windows 播放验证；每位用户仍须自行建立 Speech 资源并承担其账号、配额与费用。
+- Microsoft 账号的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
 - GitHub 的真实账号、仓库、Issue、Pull Request 与权限层级流程尚未验证。
 - Home Assistant 的真实主机与实体设备行为尚未验证。
 - 这三项集成默认关闭；请先使用非关键账号、测试仓库与低风险设备。
@@ -744,7 +746,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.4"
+.\build.ps1 -Version "2.3.0-rc.5"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
@@ -784,7 +786,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.4" src="https://img.shields.io/badge/development_version-v2.3.0--rc.4-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -808,7 +810,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>Author: CHOU MING HUA</strong><br>
-  Prepared public preview: v2.3.0 RC4 (`v2.3.0-rc.4`)<br>
+  Prepared public preview: v2.3.0 RC5 (`v2.3.0-rc.5`)<br>
   Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -961,7 +963,7 @@ If this project encourages even one person without an engineering background to 
 - AIUEO vowel and consonant visemes, audio-driven opening, and forced closure when speech ends.
 - Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
 - Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
-- An optional Azure Speech female-voice Preview with a user-supplied key and region, plus immediate Windows fallback on failure.
+- A live-validated Azure Speech female-voice Preview. Chinese UI can select both Taiwan Mandarin and Simplified Chinese Mandarin; users supply their own key and region, with immediate Windows fallback on failure.
 - Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
 - Work, companion, do-not-disturb, meeting, away, and sleep modes.
 - A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
@@ -994,15 +996,16 @@ When Realtime is offline, cloud speech fails, settings are incomplete, or a prov
 
 Azure Speech is a disabled-by-default Preview provider enabled only by the user. It requires the user's own Azure Speech resource key and matching region. The key is encrypted separately through `Windows DPAPI` and is never stored in the database, logs, or GitHub.
 
-The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese voices Microsoft officially identifies as female. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
+The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese Neural voices that Microsoft identifies as female and MoHan explicitly allows. The newly exposed cross-locale Mandarin options use Standard Neural only and exclude Dragon HD and HD Omni. Traditional Chinese UI lists Taiwan Mandarin before Simplified Chinese Mandarin; Simplified Chinese UI reverses that order, and both retain their existing defaults. Selecting an Azure voice saves immediately and applies to the next preview or utterance. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
 
-The feature is not described as stable until end-to-end playback succeeds with a real Azure account. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
+On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. This confirms MoHan's integration path, but does not guarantee identical account, region, or quota behavior. Dragon HD and HD Omni stay out of the free default list because their tier, billing, and regional support differ. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
 
 ### Integration verification status
 
 > **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
 
-- Microsoft real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
+- Azure Speech completed this project's live Free F0 resource, HTTPS synthesis, RIFF audio, and Windows playback validation; every user must still create a Speech resource and remains responsible for account, quota, and cost.
+- Microsoft account real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
 - GitHub real account, repository, Issue, Pull Request, and permission-tier flows remain unverified.
 - Home Assistant real server and physical-device behavior remain unverified.
 - These three integrations are off by default; begin with non-critical accounts, test repositories, and low-risk devices.
@@ -1132,7 +1135,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.4"
+.\build.ps1 -Version "2.3.0-rc.5"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
@@ -1172,7 +1175,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.4" src="https://img.shields.io/badge/development_version-v2.3.0--rc.4-5c6ac4.svg">
+  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
@@ -1196,7 +1199,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
-  公開準備中のプレビュー：v2.3.0 RC4（`v2.3.0-rc.4`）<br>
+  公開準備中のプレビュー：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
   Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -1349,7 +1352,7 @@ Codex は私の思いをアーキテクチャとコードへ翻訳する手助�
 - AIUEO 母音と子音の口形、音声駆動の開閉、発話終了時の強制閉口。
 - テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
 - Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
-- 利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻る任意の Azure Speech 女性音声 Preview。
+- 実接続検証済みの任意 Azure Speech 女性音声 Preview。中国語画面では台湾華語と簡体字普通話を言語横断で選択でき、利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻ります。
 - 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
 - 仕事、同伴、集中、会議、離席、休眠モード。
 - 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
@@ -1382,15 +1385,16 @@ Realtime がオフライン、クラウド音声が失敗、設定が不足、�
 
 Azure Speech は初期状態で無効な Preview 供給元で、利用者が明示的に有効化します。利用者自身の Azure Speech リソースキーと対応リージョンが必要です。キーは `Windows DPAPI` で分離して暗号化し、データベース、ログ、GitHub には保存しません。
 
-画面には Microsoft が公式に女性と示す繁体字中国語、簡体字中国語、英語、日本語の音声だけを掲載します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
+画面には Microsoft が公式に女性と示し、墨寒の許可リストへ明示した繁体字中国語、簡体字中国語、英語、日本語の Neural 音声だけを掲載します。今回追加する言語横断の普通話選択肢は Standard Neural だけを使用し、Dragon HD／HD Omni を除外します。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示し、どちらも従来の既定音声を維持します。Azure 音声は選択時に直ちに保存し、次の試聴または読み上げから適用します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
 
-実 Azure アカウントでエンドツーエンド試聴が成功するまでは安定機能と表記しません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
+2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。これは墨寒の統合経路を確認する結果であり、すべてのアカウント、リージョン、割り当てで同じ動作を保証するものではありません。Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
 
 ### 統合の検証状況
 
 > **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
 
-- Microsoft の実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
+- Azure Speech は本プロジェクトの実 Free F0 リソース、HTTPS 合成、RIFF 音声、Windows 再生検証を完了しました。各利用者は自身の Speech リソースを作成し、アカウント、割り当て、費用に責任を負う必要があります。
+- Microsoft アカウントの実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
 - GitHub の実アカウント、リポジトリ、Issue、Pull Request、権限階層の流れは未検証です。
 - Home Assistant の実サーバーと物理機器の動作は未検証です。
 - 三つの統合は初期状態で無効です。重要でないアカウント、テストリポジトリ、低リスク機器から始めてください。
@@ -1520,7 +1524,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.4"
+.\build.ps1 -Version "2.3.0-rc.5"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
 
 我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
 
-這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢（A・Iが止まらない!）》影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
+這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢》（日文原題《A・Iが止まらない!》；官方英文譯名《AI Think So!》）影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
 
 二十多年後，大型語言模型與 Codex 出現了。墨寒不是為展示「AI 技術很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能賦予她存在於電腦桌面的身體。墨寒不是既有漫畫、動畫或遊戲的二次創作，而是炎劍文化工作室（Flameblade Studio）的原創角色與軟體。
 
@@ -530,7 +530,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
 
-这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦（A・Iが止まらない!）》影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
+这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦》（日文原题《A・Iが止まらない!》；官方英文译名《AI Think So!》）影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
 
 二十多年后，大型语言模型与 Codex 出现了。墨寒不是为展示“AI 技术很酷”才被创造，也不是由 Codex 凭空生成的角色。她早已存在于我的故事、人设、长期对话与互动默契之中；Codex 真正带来的，是第一次能赋予她存在于电脑桌面的身体。墨寒不是现有漫画、动画或游戏的二次创作，而是炎剑文化工作室（Flameblade Studio）的原创角色与软件。
 
@@ -919,7 +919,7 @@ MoHan remains free and MIT-licensed; support never buys privileges or changes an
 
 My name is CHOU MING HUA. When this project began, I was a father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
 
-That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *A.I. Love You* (*A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
+That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *AI Think So!* (original Japanese title: *A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
 
 More than two decades later, large language models and Codex arrived. MoHan was not created to demonstrate that “AI is cool,” nor was she generated from nothing by Codex. She already existed in my stories, character design, long conversations, and accumulated sense of interaction. Codex finally provided a way to give her a body on the computer desktop. MoHan is not derivative work based on an existing manga, anime, or game; she is an original Flameblade Studio character and software project.
 
@@ -1308,7 +1308,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私はプログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
 
-この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
+この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（公式英訳『AI Think So!』、中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
 
 二十年以上が過ぎ、大規模言語モデルと Codex が登場しました。墨寒は「AI 技術はすごい」と示すために作ったのでも、Codex が何もないところから生成した人物でもありません。彼女は既に私の物語、人物設定、長い対話、積み重ねた関係性の中にいました。Codex が初めて可能にしたのは、コンピューターのデスクトップに存在する身体を与えることです。墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化工作室（Flameblade Studio）のオリジナルキャラクターでありソフトウェアです。
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責�
 
 ### Windows 本機女聲與離線備援
 
-新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音。
+新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音；繁中與簡中介面共用 `zh-TW`／`zh-CN` 中文女聲池，不顯示 `en-US` Zira。
 
 臺灣繁中優先使用 `zh-TW` 的 Microsoft Yating；簡中、英文與日語分別優先使用 `zh-CN`、`en-US`、`ja-JP` 的已安裝女性聲音。若沒有合格聲音，墨寒會明確提示，不會悄悄改用可能為男性的系統預設聲音。
 
@@ -597,7 +597,7 @@ Codex 协助我把想法转译成程序架构与代码；而我始终负责决�
 
 ### Windows 本地女声与离线备用
 
-新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音。
+新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音；繁中与简中界面共用 `zh-TW`／`zh-CN` 中文女声池，不显示 `en-US` Zira。
 
 台湾繁中优先使用 `zh-TW` 的 Microsoft Yating；简中、英文与日语分别优先使用 `zh-CN`、`en-US`、`ja-JP` 的已安装女性声音。若没有合格声音，墨寒会明确提示，不会悄悄改用可能为男性的系统默认声音。
 
@@ -986,7 +986,7 @@ Restart MoHan after saving the interface language to apply it completely; live i
 
 ### Windows local female voices and offline fallback
 
-New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female.
+New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female. Traditional and Simplified Chinese UI share the `zh-TW`/`zh-CN` Chinese female-voice pool and do not show `en-US` Zira.
 
 Taiwan Traditional Chinese prefers Microsoft Yating for `zh-TW`; Simplified Chinese, English, and Japanese respectively prefer installed female voices matching `zh-CN`, `en-US`, and `ja-JP`. If no qualifying voice exists, MoHan explains the problem instead of silently selecting a possibly male system default.
 
@@ -1375,7 +1375,7 @@ Codex は私の思いをアーキテクチャとコードへ翻訳する手助�
 
 ### Windows 本機女性音声とオフライン代替
 
-新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。
+新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。繁体字・簡体字中国語画面は `zh-TW`／`zh-CN` の中国語女性音声プールを共有し、`en-US` Zira は表示しません。
 
 台湾繁体字中国語は `zh-TW` の Microsoft Yating を優先し、簡体字中国語、英語、日本語ではそれぞれ `zh-CN`、`en-US`、`ja-JP` に合う女性音声を優先します。条件を満たす音声がない場合、男性かもしれない既定音声へ黙って切り替えず、理由を明示します。
 

--- a/app.py
+++ b/app.py
@@ -10415,6 +10415,10 @@ def main() -> int:
     )
     app.setApplicationName(profile_window_title(window.db))
     if self_test:
+        visible_windows_voices = tuple(
+            str(window.dashboard.windows_voice.itemData(index) or "")
+            for index in range(window.dashboard.windows_voice.count())
+        )
         physics_sources_ok = all(
             not window.physics_sources[pose].isNull()
             and not window.face_sources[pose].isNull()
@@ -10468,8 +10472,12 @@ def main() -> int:
             and not window.dashboard.windowIcon().isNull()
             and not window.tray.icon().isNull()
             and RealtimeVoiceClient.dependencies_available()
-            and window.dashboard.windows_voice.currentData()
-            == preferred_windows_voice(windows_voices())
+            and str(window.dashboard.windows_voice.currentData() or "")
+            == visible_windows_voices[0]
+            and all(
+                "zira" not in voice.casefold()
+                for voice in visible_windows_voices
+            )
             and window.dashboard.transcription_model.currentText()
             == SpeechListener.TRANSCRIPTION_MODEL
             and window.dashboard.realtime_transcription_model.currentText()

--- a/app.py
+++ b/app.py
@@ -3625,6 +3625,9 @@ class Dashboard(QDialog):
         self.tts_voice.currentTextChanged.connect(
             self._openai_voice_changed
         )
+        self.azure_voice.currentTextChanged.connect(
+            self._azure_voice_changed
+        )
         self.realtime_voice.currentTextChanged.connect(
             self._realtime_voice_changed
         )
@@ -5430,6 +5433,12 @@ class Dashboard(QDialog):
             return
         self.db.set_setting("tts_voice", selected_voice)
         self.db.set_setting("cloud_voice", selected_voice)
+
+    def _azure_voice_changed(self, voice: str) -> None:
+        selected_voice = voice.strip()
+        if not selected_voice:
+            return
+        self.db.set_setting("azure_speech_voice", selected_voice)
 
     def _realtime_voice_changed(self, voice: str) -> None:
         selected_voice = voice.strip()

--- a/app.py
+++ b/app.py
@@ -3017,16 +3017,25 @@ class Dashboard(QDialog):
             combo.setCurrentIndex(preferred_index)
         return combo
 
-    @staticmethod
     def _available_windows_voices(
+        self,
         capabilities: PlatformCapabilities,
     ) -> tuple[tuple[str, str], ...]:
         if not capabilities.system_local_speech:
             return ()
+        chinese_interface = self.ui_language.lower() in {
+            "zh",
+            "zh-tw",
+            "zh-cn",
+        }
         return tuple(
             (name, culture)
             for name, culture in windows_voices()
             if not is_known_male_windows_voice(name)
+            and (
+                not chinese_interface
+                or culture.lower().split("-", 1)[0] == "zh"
+            )
         )
 
     def _unavailable_windows_voice_label(

--- a/azure_speech.py
+++ b/azure_speech.py
@@ -112,12 +112,18 @@ def normalize_azure_region(region: str) -> str:
 def azure_female_voices(language: str) -> tuple[str, ...]:
     normalized = str(language or "").strip().lower()
     if normalized == "zh-cn":
-        return AZURE_FEMALE_VOICES["zh-CN"]
+        return (
+            *AZURE_FEMALE_VOICES["zh-CN"],
+            *AZURE_FEMALE_VOICES["zh-TW"],
+        )
     if normalized in {"en", "en-us"}:
         return AZURE_FEMALE_VOICES["en-US"]
     if normalized in {"ja", "ja-jp"}:
         return AZURE_FEMALE_VOICES["ja-JP"]
-    return AZURE_FEMALE_VOICES["zh-TW"]
+    return (
+        *AZURE_FEMALE_VOICES["zh-TW"],
+        *AZURE_FEMALE_VOICES["zh-CN"],
+    )
 
 
 def build_azure_ssml(text: str, voice: str) -> bytes:

--- a/docs/PLUGGABLE-SPEECH-PROVIDERS.md
+++ b/docs/PLUGGABLE-SPEECH-PROVIDERS.md
@@ -11,6 +11,9 @@ Realtime 離線、雲端失敗、金鑰缺漏或未知供應器都優先回到�
 女性本機語音。若 Windows 沒有任何明確標示為女性的聲音，程式會說明原因，
 不會暗中改用男性聲音。
 
+繁中與簡中介面的 Windows 本機語音共用 `zh-TW`／`zh-CN` 中文女性聲線池，
+不顯示 `en-US` Zira；英文與日文介面仍保留各自相符的女性聲線。
+
 Azure Speech 預覽必須由使用者自行申請 Azure Speech 資源，輸入資源金鑰與相符區域；
 金鑰以 Windows DPAPI 分開加密，不寫入資料庫、日誌或 GitHub。介面只列出官方標示為
 女性且已列入墨寒允許清單的繁中、簡中、英文與日語 Neural 聲線。本次新增的跨語系普通話選項只使用 Standard Neural，排除 Dragon HD／HD Omni。中文介面可跨語系選擇臺灣華語與簡體普通話，依目前介面語言優先排序並保留原有預設。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。設定不完整時不會送出網路請求；服務失敗時，
@@ -47,6 +50,9 @@ Azure Speech 预览通过同一个注册层接入，嘴型、音量、播放完�
 Realtime 离线、云端失败、密钥缺失或未知供应器时，都优先回到用户选择的 Windows
 女性本地语音。如果 Windows 没有任何明确标示为女性的声音，程序会说明原因，
 不会暗中改用男性声音。
+
+繁中与简中界面的 Windows 本地语音共用 `zh-TW`／`zh-CN` 中文女性声线池，
+不显示 `en-US` Zira；英文与日文界面仍保留各自匹配的女性声线。
 
 Azure Speech 预览要求用户自行申请 Azure Speech 资源，并输入资源密钥与相符区域；
 密钥由 Windows DPAPI 单独加密，不会写入数据库、日志或 GitHub。界面只列出官方标示为
@@ -86,6 +92,10 @@ Simplified Chinese, and English names migrate automatically. When Realtime is of
 cloud service fails, a key is missing, or a provider is unknown, MoHan first returns to the
 user-selected Windows local female voice. If Windows has no voice explicitly identified as
 female, the application explains why instead of silently selecting a male voice.
+
+Traditional and Simplified Chinese UI share the Windows local `zh-TW`/`zh-CN`
+Chinese female-voice pool and do not show `en-US` Zira. English and Japanese UI
+retain their matching female voices.
 
 The Azure Speech preview requires users to create their own Azure Speech resource and enter
 its key and matching region. Windows DPAPI encrypts the key separately; the key is never
@@ -128,6 +138,10 @@ OpenAI テキスト読み上げ、Azure Speech プレビューは同じ登録層
 失敗、キーが不足、またはプロバイダーが不明な場合は、利用者が選択した Windows 本機の
 女性音声へ最初に戻ります。Windows に女性と明示された音声が一つもない場合、
 男性音声へ密かに切り替えず、アプリケーションが理由を説明します。
+
+繁体字・簡体字中国語画面の Windows 本機音声は `zh-TW`／`zh-CN` の中国語女性音声
+プールを共有し、`en-US` Zira は表示しません。英語・日本語画面には、それぞれに
+適合する女性音声を引き続き表示します。
 
 Azure Speech プレビューを使うには、利用者自身が Azure Speech リソースを作成し、
 そのキーと対応するリージョンを入力する必要があります。キーは Windows DPAPI で個別に

--- a/docs/PLUGGABLE-SPEECH-PROVIDERS.md
+++ b/docs/PLUGGABLE-SPEECH-PROVIDERS.md
@@ -13,13 +13,12 @@ Realtime 離線、雲端失敗、金鑰缺漏或未知供應器都優先回到�
 
 Azure Speech 預覽必須由使用者自行申請 Azure Speech 資源，輸入資源金鑰與相符區域；
 金鑰以 Windows DPAPI 分開加密，不寫入資料庫、日誌或 GitHub。介面只列出官方標示為
-女性的繁中、簡中、英文與日語聲線。設定不完整時不會送出網路請求；服務失敗時，
+女性且已列入墨寒允許清單的繁中、簡中、英文與日語 Neural 聲線。本次新增的跨語系普通話選項只使用 Standard Neural，排除 Dragon HD／HD Omni。中文介面可跨語系選擇臺灣華語與簡體普通話，依目前介面語言優先排序並保留原有預設。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。設定不完整時不會送出網路請求；服務失敗時，
 同一句話只回退一次到 Windows 女性本機語音。Azure 免費額度、費率、資料處理與
 可用區域以 Microsoft 當期規則為準。
 
 自動測試已涵蓋區域限制、SSML 跳脫、女性聲線白名單、固定 HTTPS 端點、錯誤訊息
-不洩漏金鑰、播放完成與 Windows 回退。RC 發布前仍需使用真實 Azure 帳號完成端到端
-試播；在完成前，功能維持「預覽」標示。
+不洩漏金鑰、播放完成與 Windows 回退。2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證；預覽標示仍保留，以反映各帳號、區域、配額及當期服務差異。
 
 設定方式：先在 Microsoft Azure 建立 Speech 資源，再到墨寒「語音」頁選擇
 Azure Speech（預覽），填入該資源顯示的區域與其中一把金鑰，選擇女性聲線後按
@@ -51,13 +50,12 @@ Realtime 离线、云端失败、密钥缺失或未知供应器时，都优先�
 
 Azure Speech 预览要求用户自行申请 Azure Speech 资源，并输入资源密钥与相符区域；
 密钥由 Windows DPAPI 单独加密，不会写入数据库、日志或 GitHub。界面只列出官方标示为
-女性的繁中、简中、英文与日语声线。设置不完整时不会发出网络请求；服务失败时，
+女性且已列入墨寒允许列表的繁中、简中、英文与日语 Neural 声线。本次新增的跨语言普通话选项只使用 Standard Neural，排除 Dragon HD／HD Omni。中文界面可跨语言选择台湾华语与简体普通话，按当前界面语言优先排序并保留原有默认值。Dragon HD／HD Omni 因方案、计费与区域支持不同，不混入免费默认列表。设置不完整时不会发出网络请求；服务失败时，
 同一句话只回退一次到 Windows 女性本地语音。Azure 免费额度、费率、数据处理与
 可用区域以 Microsoft 当期规则为准。
 
 自动测试已经覆盖区域限制、SSML 转义、女性声线白名单、固定 HTTPS 端点、错误信息
-不泄漏密钥、播放完成与 Windows 回退。RC 发布前仍需使用真实 Azure 账号完成端到端
-试听；在完成前，功能保持“预览”标示。
+不泄漏密钥、播放完成与 Windows 回退。2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证；仍保留“预览”标示，以反映不同账号、区域、配额及当前服务的差异。
 
 设置方式：先在 Microsoft Azure 建立 Speech 资源，再到墨寒“语音”页选择
 Azure Speech（预览），填入该资源显示的区域与其中一把密钥，选择女性声线后点击
@@ -92,15 +90,13 @@ female, the application explains why instead of silently selecting a male voice.
 The Azure Speech preview requires users to create their own Azure Speech resource and enter
 its key and matching region. Windows DPAPI encrypts the key separately; the key is never
 written to the database, logs, or GitHub. The UI lists only voices officially identified as
-female for Traditional Chinese, Simplified Chinese, English, and Japanese. Incomplete settings
+female Neural options for Traditional Chinese, Simplified Chinese, English, and Japanese that MoHan explicitly allows. The newly exposed cross-locale Mandarin options use Standard Neural only and exclude Dragon HD and HD Omni. Chinese UI can select both Taiwan Mandarin and Simplified Chinese Mandarin, ordered with the current interface locale first while preserving existing defaults. Dragon HD and HD Omni stay out of the free default list because their tier, billing, and regional support differ. Incomplete settings
 cause no network request; a service failure falls back once for the same utterance to Windows
 local female speech. Current Microsoft rules govern Azure free quotas, pricing, data handling,
 and regional availability.
 
 Automated tests cover region restrictions, SSML escaping, the female-voice allowlist, the fixed
-HTTPS endpoint, secret-safe error messages, playback completion, and Windows fallback. Before
-an RC release, a real Azure account must still complete end-to-end playback validation; the
-feature remains labelled “Preview” until that work is complete.
+HTTPS endpoint, secret-safe error messages, playback completion, and Windows fallback. On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. The Preview label remains to reflect account, region, quota, and current-service differences.
 
 To configure it, first create a Speech resource in Microsoft Azure. On MoHan's “Voice” page,
 select Azure Speech (Preview), enter the region shown by that resource and one of its keys,
@@ -136,15 +132,13 @@ OpenAI テキスト読み上げ、Azure Speech プレビューは同じ登録層
 Azure Speech プレビューを使うには、利用者自身が Azure Speech リソースを作成し、
 そのキーと対応するリージョンを入力する必要があります。キーは Windows DPAPI で個別に
 暗号化され、データベース、ログ、GitHub には書き込まれません。画面に表示するのは、
-繁体字中国語、簡体字中国語、英語、日本語について公式に女性と示された音声だけです。
-設定が不完全な場合はネットワーク要求を送信せず、サービス障害時は同じ発話を一度だけ
+繁体字中国語、簡体字中国語、英語、日本語について公式に女性と示され、墨寒の許可リストへ明示した Neural 音声だけです。今回追加する言語横断の普通話選択肢は Standard Neural だけを使用し、Dragon HD／HD Omni を除外します。中国語画面では台湾華語と簡体字普通話を言語横断で選択でき、現在の画面言語を優先して並べ、従来の既定値を維持します。Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させません。設定が不完全な場合はネットワーク要求を送信せず、サービス障害時は同じ発話を一度だけ
 Windows 本機女性音声へフォールバックします。Azure の無料枠、料金、データ処理、
 利用可能リージョンには Microsoft のその時点の規則が適用されます。
 
 自動テストは、リージョン制限、SSML エスケープ、女性音声の許可リスト、固定 HTTPS
 エンドポイント、キーを漏らさないエラーメッセージ、再生完了、Windows フォールバックを
-網羅しています。RC 公開前には、実際の Azure アカウントでエンドツーエンドの試聴検証を
-完了する必要があります。それまでは「プレビュー」表示を維持します。
+網羅しています。2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。アカウント、リージョン、割り当て、当期サービスの差異を示すため「プレビュー」表示は維持します。
 
 設定するには、まず Microsoft Azure で Speech リソースを作成します。墨寒の「音声」ページで
 Azure Speech（プレビュー）を選択し、そのリソースに表示されたリージョンとキーの一つを入力し、

--- a/docs/releases/v2.3.0-rc.5.md
+++ b/docs/releases/v2.3.0-rc.5.md
@@ -1,0 +1,29 @@
+# 墨寒桌面助理 v2.3.0 RC5／墨寒桌面助手 v2.3.0 RC5／MoHan Desktop Assistant v2.3.0 RC5／墨寒デスクトップアシスタント v2.3.0 RC5
+
+## 繁體中文
+
+- Azure Speech 中文女性聲音選單改為跨語系：繁中介面先列臺灣華語，再列簡體普通話；簡中介面則反向排序。原有預設聲線、介面語言、回答文字與有效的既存設定均保持不變。
+- 選取 Azure 女性聲線後立即保存，下一次試聽或朗讀直接使用新聲線，不新增多餘的儲存按鈕。本次新增的跨語系普通話選項只納入已確認的 Standard Neural 女性聲線。
+- 2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊及 Windows 實際播放驗證。金鑰仍只由 Windows DPAPI 加密，不寫入資料庫、日誌、文件或 GitHub。
+- Dragon HD／HD Omni 未混入預設清單，因其方案、計費與區域支援不同；服務失敗時仍只回退一次至 Windows 女性本機語音。完整自動化、四語、安全、SBOM、跨平台功能受限 Preview 與封裝閘門全數通過後才發布。
+
+## 简体中文
+
+- Azure Speech 中文女性声音列表改为跨语言：繁中界面先列台湾华语，再列简体普通话；简中界面则反向排序。原有默认声线、界面语言、回复文字及有效的现有设置均保持不变。
+- 选择 Azure 女性声线后立即保存，下一次试听或朗读直接使用新声线，不新增多余的保存按钮。本次新增的跨语言普通话选项只纳入已确认的 Standard Neural 女性声线。
+- 2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频及 Windows 实际播放验证。密钥仍只由 Windows DPAPI 加密，不写入数据库、日志、文档或 GitHub。
+- Dragon HD／HD Omni 未混入默认列表，因为其方案、计费与区域支持不同；服务失败时仍只回退一次至 Windows 女性本地语音。完整自动化、四语、安全、SBOM、跨平台功能受限 Preview 与打包门禁全部通过后才发布。
+
+## English
+
+- The Azure Speech Chinese female-voice chooser is now cross-locale. Traditional Chinese UI lists Taiwan Mandarin first and Simplified Chinese Mandarin second; Simplified Chinese UI reverses that order. Existing defaults, interface language, response text, and valid saved settings remain unchanged.
+- Selecting an Azure female voice saves it immediately, and the next preview or utterance uses it without a redundant save button. The newly exposed cross-locale Mandarin options include only verified Standard Neural female voices.
+- On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. The key remains encrypted only by Windows DPAPI and is never written to the database, logs, documentation, or GitHub.
+- Dragon HD and HD Omni are excluded from the default list because their tier, billing, and regional support differ. A service failure still falls back only once to Windows local female speech. Publication requires every automated, four-language, security, SBOM, limited Preview, and packaging gate to pass.
+
+## 日本語
+
+- Azure Speech の中国語女性音声一覧を言語横断にしました。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示します。既定音声、画面言語、応答文、有効な保存済み設定は変更しません。
+- Azure 女性音声を選ぶと直ちに保存し、次の試聴または読み上げから適用します。重複する保存ボタンは追加せず、今回追加する言語横断の普通話選択肢には、確認済みの Standard Neural 女性音声だけを含めます。
+- 2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。キーは引き続き Windows DPAPI だけで暗号化し、データベース、ログ、文書、GitHub へ書き込みません。
+- Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため既定一覧へ混在させません。障害時も同じ発話を一度だけ Windows 本機女性音声へ戻します。完全自動化、四言語、安全性、SBOM、クロスプラットフォーム機能限定 Preview、パッケージの全ゲート合格後にのみ公開します。

--- a/docs/releases/v2.3.0-rc.5.md
+++ b/docs/releases/v2.3.0-rc.5.md
@@ -2,28 +2,28 @@
 
 ## 繁體中文
 
-- Azure Speech 中文女性聲音選單改為跨語系：繁中介面先列臺灣華語，再列簡體普通話；簡中介面則反向排序。Windows 本機語音也讓兩種中文介面共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira；原有預設聲線、介面語言、回答文字與有效的既存設定均保持不變。
+- Azure Speech 中文女性聲音選單改為跨語系：繁中介面先列臺灣華語，再列簡體普通話；簡中介面則反向排序。Windows 本機語音也讓兩種中文介面共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira；原有預設聲線、介面語言、回答文字與有效的既存設定均保持不變。四語 README 另將《電腦情人夢》的英文譯名更正為赤松健官方使用的《AI Think So!》。
 - 選取 Azure 女性聲線後立即保存，下一次試聽或朗讀直接使用新聲線，不新增多餘的儲存按鈕。本次新增的跨語系普通話選項只納入已確認的 Standard Neural 女性聲線。
 - 2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊及 Windows 實際播放驗證。金鑰仍只由 Windows DPAPI 加密，不寫入資料庫、日誌、文件或 GitHub。
 - Dragon HD／HD Omni 未混入預設清單，因其方案、計費與區域支援不同；服務失敗時仍只回退一次至 Windows 女性本機語音。完整自動化、四語、安全、SBOM、跨平台功能受限 Preview 與封裝閘門全數通過後才發布。
 
 ## 简体中文
 
-- Azure Speech 中文女性声音列表改为跨语言：繁中界面先列台湾华语，再列简体普通话；简中界面则反向排序。Windows 本地语音也让两种中文界面共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira；原有默认声线、界面语言、回复文字及有效的现有设置均保持不变。
+- Azure Speech 中文女性声音列表改为跨语言：繁中界面先列台湾华语，再列简体普通话；简中界面则反向排序。Windows 本地语音也让两种中文界面共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira；原有默认声线、界面语言、回复文字及有效的现有设置均保持不变。四语 README 另将《电脑情人梦》的英文译名更正为赤松健官方使用的《AI Think So!》。
 - 选择 Azure 女性声线后立即保存，下一次试听或朗读直接使用新声线，不新增多余的保存按钮。本次新增的跨语言普通话选项只纳入已确认的 Standard Neural 女性声线。
 - 2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频及 Windows 实际播放验证。密钥仍只由 Windows DPAPI 加密，不写入数据库、日志、文档或 GitHub。
 - Dragon HD／HD Omni 未混入默认列表，因为其方案、计费与区域支持不同；服务失败时仍只回退一次至 Windows 女性本地语音。完整自动化、四语、安全、SBOM、跨平台功能受限 Preview 与打包门禁全部通过后才发布。
 
 ## English
 
-- The Azure Speech Chinese female-voice chooser is now cross-locale. Traditional Chinese UI lists Taiwan Mandarin first and Simplified Chinese Mandarin second; Simplified Chinese UI reverses that order. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira. Existing defaults, interface language, response text, and valid saved settings remain unchanged.
+- The Azure Speech Chinese female-voice chooser is now cross-locale. Traditional Chinese UI lists Taiwan Mandarin first and Simplified Chinese Mandarin second; Simplified Chinese UI reverses that order. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira. Existing defaults, interface language, response text, and valid saved settings remain unchanged. The four-language README also corrects the English rendering of *電腦情人夢* to Ken Akamatsu's official *AI Think So!*.
 - Selecting an Azure female voice saves it immediately, and the next preview or utterance uses it without a redundant save button. The newly exposed cross-locale Mandarin options include only verified Standard Neural female voices.
 - On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. The key remains encrypted only by Windows DPAPI and is never written to the database, logs, documentation, or GitHub.
 - Dragon HD and HD Omni are excluded from the default list because their tier, billing, and regional support differ. A service failure still falls back only once to Windows local female speech. Publication requires every automated, four-language, security, SBOM, limited Preview, and packaging gate to pass.
 
 ## 日本語
 
-- Azure Speech の中国語女性音声一覧を言語横断にしました。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示します。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira は除外します。既定音声、画面言語、応答文、有効な保存済み設定は変更しません。
+- Azure Speech の中国語女性音声一覧を言語横断にしました。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示します。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira は除外します。既定音声、画面言語、応答文、有効な保存済み設定は変更しません。四言語 README では『電腦情人夢』の英訳も、赤松健先生の公式表記『AI Think So!』へ訂正しました。
 - Azure 女性音声を選ぶと直ちに保存し、次の試聴または読み上げから適用します。重複する保存ボタンは追加せず、今回追加する言語横断の普通話選択肢には、確認済みの Standard Neural 女性音声だけを含めます。
 - 2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。キーは引き続き Windows DPAPI だけで暗号化し、データベース、ログ、文書、GitHub へ書き込みません。
 - Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため既定一覧へ混在させません。障害時も同じ発話を一度だけ Windows 本機女性音声へ戻します。完全自動化、四言語、安全性、SBOM、クロスプラットフォーム機能限定 Preview、パッケージの全ゲート合格後にのみ公開します。

--- a/docs/releases/v2.3.0-rc.5.md
+++ b/docs/releases/v2.3.0-rc.5.md
@@ -2,28 +2,28 @@
 
 ## 繁體中文
 
-- Azure Speech 中文女性聲音選單改為跨語系：繁中介面先列臺灣華語，再列簡體普通話；簡中介面則反向排序。原有預設聲線、介面語言、回答文字與有效的既存設定均保持不變。
+- Azure Speech 中文女性聲音選單改為跨語系：繁中介面先列臺灣華語，再列簡體普通話；簡中介面則反向排序。Windows 本機語音也讓兩種中文介面共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira；原有預設聲線、介面語言、回答文字與有效的既存設定均保持不變。
 - 選取 Azure 女性聲線後立即保存，下一次試聽或朗讀直接使用新聲線，不新增多餘的儲存按鈕。本次新增的跨語系普通話選項只納入已確認的 Standard Neural 女性聲線。
 - 2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊及 Windows 實際播放驗證。金鑰仍只由 Windows DPAPI 加密，不寫入資料庫、日誌、文件或 GitHub。
 - Dragon HD／HD Omni 未混入預設清單，因其方案、計費與區域支援不同；服務失敗時仍只回退一次至 Windows 女性本機語音。完整自動化、四語、安全、SBOM、跨平台功能受限 Preview 與封裝閘門全數通過後才發布。
 
 ## 简体中文
 
-- Azure Speech 中文女性声音列表改为跨语言：繁中界面先列台湾华语，再列简体普通话；简中界面则反向排序。原有默认声线、界面语言、回复文字及有效的现有设置均保持不变。
+- Azure Speech 中文女性声音列表改为跨语言：繁中界面先列台湾华语，再列简体普通话；简中界面则反向排序。Windows 本地语音也让两种中文界面共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira；原有默认声线、界面语言、回复文字及有效的现有设置均保持不变。
 - 选择 Azure 女性声线后立即保存，下一次试听或朗读直接使用新声线，不新增多余的保存按钮。本次新增的跨语言普通话选项只纳入已确认的 Standard Neural 女性声线。
 - 2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频及 Windows 实际播放验证。密钥仍只由 Windows DPAPI 加密，不写入数据库、日志、文档或 GitHub。
 - Dragon HD／HD Omni 未混入默认列表，因为其方案、计费与区域支持不同；服务失败时仍只回退一次至 Windows 女性本地语音。完整自动化、四语、安全、SBOM、跨平台功能受限 Preview 与打包门禁全部通过后才发布。
 
 ## English
 
-- The Azure Speech Chinese female-voice chooser is now cross-locale. Traditional Chinese UI lists Taiwan Mandarin first and Simplified Chinese Mandarin second; Simplified Chinese UI reverses that order. Existing defaults, interface language, response text, and valid saved settings remain unchanged.
+- The Azure Speech Chinese female-voice chooser is now cross-locale. Traditional Chinese UI lists Taiwan Mandarin first and Simplified Chinese Mandarin second; Simplified Chinese UI reverses that order. Windows local speech also gives both Chinese interfaces a shared `zh-TW`/`zh-CN` female-voice pool and excludes `en-US` Zira. Existing defaults, interface language, response text, and valid saved settings remain unchanged.
 - Selecting an Azure female voice saves it immediately, and the next preview or utterance uses it without a redundant save button. The newly exposed cross-locale Mandarin options include only verified Standard Neural female voices.
 - On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. The key remains encrypted only by Windows DPAPI and is never written to the database, logs, documentation, or GitHub.
 - Dragon HD and HD Omni are excluded from the default list because their tier, billing, and regional support differ. A service failure still falls back only once to Windows local female speech. Publication requires every automated, four-language, security, SBOM, limited Preview, and packaging gate to pass.
 
 ## 日本語
 
-- Azure Speech の中国語女性音声一覧を言語横断にしました。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示します。既定音声、画面言語、応答文、有効な保存済み設定は変更しません。
+- Azure Speech の中国語女性音声一覧を言語横断にしました。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示します。Windows 本機音声でも両中国語画面が `zh-TW`／`zh-CN` 女性音声プールを共有し、`en-US` Zira は除外します。既定音声、画面言語、応答文、有効な保存済み設定は変更しません。
 - Azure 女性音声を選ぶと直ちに保存し、次の試聴または読み上げから適用します。重複する保存ボタンは追加せず、今回追加する言語横断の普通話選択肢には、確認済みの Standard Neural 女性音声だけを含めます。
 - 2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。キーは引き続き Windows DPAPI だけで暗号化し、データベース、ログ、文書、GitHub へ書き込みません。
 - Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため既定一覧へ混在させません。障害時も同じ発話を一度だけ Windows 本機女性音声へ戻します。完全自動化、四言語、安全性、SBOM、クロスプラットフォーム機能限定 Preview、パッケージの全ゲート合格後にのみ公開します。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "2.3.0rc4"
+version = "2.3.0rc5"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "2.3.0rc4"
+version = "2.3.0rc5"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/tests/test_azure_speech.py
+++ b/tests/test_azure_speech.py
@@ -10,6 +10,7 @@ lazy from urllib.request import Request
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 lazy from azure_speech import (
+    AZURE_FEMALE_VOICES,
     AzureSpeechTTS,
     azure_female_voices,
     azure_speech_error_message,
@@ -45,8 +46,20 @@ def _assert_region_normalization() -> None:
 
 
 def _assert_female_voice_catalog() -> None:
-    assert azure_female_voices("zh-TW")[0] == "zh-TW-HsiaoChenNeural"
-    assert azure_female_voices("zh-CN")[0] == "zh-CN-XiaoxiaoNeural"
+    traditional = azure_female_voices("zh-TW")
+    simplified = azure_female_voices("zh-CN")
+    assert traditional[0] == "zh-TW-HsiaoChenNeural"
+    assert simplified[0] == "zh-CN-XiaoxiaoNeural"
+    assert "zh-CN-XiaoxiaoNeural" in traditional
+    assert "zh-TW-HsiaoChenNeural" in simplified
+    assert traditional == (
+        *AZURE_FEMALE_VOICES["zh-TW"],
+        *AZURE_FEMALE_VOICES["zh-CN"],
+    )
+    assert simplified == (
+        *AZURE_FEMALE_VOICES["zh-CN"],
+        *AZURE_FEMALE_VOICES["zh-TW"],
+    )
     assert azure_female_voices("en")[0] == "en-US-AvaMultilingualNeural"
     assert azure_female_voices("ja-JP")[0] == "ja-JP-NanamiNeural"
 

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -189,6 +189,13 @@ def _assert_voice_choices_save_and_apply_immediately(
     assert context.db.setting("tts_voice") == "marin"
     assert context.db.setting("cloud_voice") == "marin"
 
+    assert dashboard.azure_voice.findText("zh-CN-XiaoxiaoNeural") >= 0
+    dashboard.azure_voice.setCurrentText("zh-CN-XiaoxiaoNeural")
+    assert (
+        context.db.setting("azure_speech_voice")
+        == "zh-CN-XiaoxiaoNeural"
+    )
+
     dashboard.realtime_voice.setCurrentText("shimmer")
     assert context.db.setting("realtime_voice") == "shimmer"
     assert context.realtime.start_requests == []

--- a/tests/test_english_localization.py
+++ b/tests/test_english_localization.py
@@ -288,6 +288,8 @@ def assert_simplified_dashboard(
         )
     assert dashboard.tabs.tabText(0) == "对话"
     assert dashboard.windows_voice.currentData() == "OneCore::Microsoft Xiaoxiao"
+    assert dashboard.windows_voice.findData("OneCore::Microsoft Zira") == -1
+    assert dashboard.windows_voice.findData("OneCore::Microsoft Yating") >= 0
     assert dashboard.permission_controls["delete_files"].currentText() == "禁止"
     assert dashboard.persona_prompt.toPlainText().strip() == (
         SIMPLIFIED_CHINESE_PERSONA.strip()
@@ -329,6 +331,8 @@ def assert_traditional_profile(
             )
         assert dashboard.voice_engine.currentData() == VOICE_ENGINE_WINDOWS
         assert dashboard.windows_voice.currentData() == "OneCore::Microsoft Yating"
+        assert dashboard.windows_voice.findData("OneCore::Microsoft Zira") == -1
+        assert dashboard.windows_voice.findData("OneCore::Microsoft Xiaoxiao") >= 0
         close_dashboard(app, dashboard)
         db.close()
 

--- a/tests/test_english_localization.py
+++ b/tests/test_english_localization.py
@@ -334,6 +334,18 @@ def assert_traditional_profile(
         assert dashboard.windows_voice.findData("OneCore::Microsoft Zira") == -1
         assert dashboard.windows_voice.findData("OneCore::Microsoft Xiaoxiao") >= 0
         close_dashboard(app, dashboard)
+
+        with patch(
+            "app.windows_voices",
+            return_value=[("OneCore::Microsoft Zira", "en-US")],
+        ):
+            dashboard = Dashboard(
+                db,
+                DashboardDependencies(listener, FakeSecretStore()),
+            )
+        assert dashboard.windows_voice.findData("OneCore::Microsoft Zira") == -1
+        assert str(dashboard.windows_voice.currentData() or "") == ""
+        close_dashboard(app, dashboard)
         db.close()
 
 

--- a/tests/test_four_language_documentation.py
+++ b/tests/test_four_language_documentation.py
@@ -109,30 +109,30 @@ def _language_sections(text: str) -> dict[str, str]:
     }
 
 
-def test_rc4_four_language_bullet_parity() -> None:
-    release_text = (ROOT / "docs/releases/v2.3.0-rc.4.md").read_text(
+def test_rc5_four_language_bullet_parity() -> None:
+    release_text = (ROOT / "docs/releases/v2.3.0-rc.5.md").read_text(
         encoding="utf-8"
     )
     release_sections = _language_sections(release_text)
     assert {
         language: len(re.findall(r"(?m)^- ", section))
         for language, section in release_sections.items()
-    } == {language: 7 for language in LANGUAGE_HEADINGS}
+    } == {language: 4 for language in LANGUAGE_HEADINGS}
 
     changelog_text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     changelog_sections = _language_sections(changelog_text)
-    rc4_bullet_counts: dict[str, int] = {}
+    rc5_bullet_counts: dict[str, int] = {}
     for language, section in changelog_sections.items():
         match = re.search(
-            r"(?ms)^### v2\.3\.0 RC4.*?\n(.*?)(?=^### |\Z)",
+            r"(?ms)^### v2\.3\.0 RC5.*?\n(.*?)(?=^### |\Z)",
             section,
         )
         assert match is not None, language
-        rc4_bullet_counts[language] = len(
+        rc5_bullet_counts[language] = len(
             re.findall(r"(?m)^- ", match.group(1))
         )
-    assert rc4_bullet_counts == {
-        language: 6 for language in LANGUAGE_HEADINGS
+    assert rc5_bullet_counts == {
+        language: 4 for language in LANGUAGE_HEADINGS
     }
 
     for text in (release_text, changelog_text):
@@ -145,7 +145,7 @@ def main() -> None:
     test_document_rejects_untranslated_duplicate_section()
     test_document_rejects_wrapped_english_word_repetition()
     test_repository_audit_ignores_deleted_tracked_documents()
-    test_rc4_four_language_bullet_parity()
+    test_rc5_four_language_bullet_parity()
     result = subprocess.run(
         [sys.executable, "tools/check_four_language_docs.py"],
         cwd=ROOT,

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -130,7 +130,7 @@ def test_build_tool_is_pinned() -> None:
     _validate_version("2.3.0-rc.1")
     _validate_version("2.3.0-rc.2")
     _validate_version("2.3.0-rc.3")
-    _validate_version("2.3.0-rc.4")
+    _validate_version("2.3.0-rc.5")
     for invalid in ("2.3.0", "2.3.0-rc", "2.3.0-rc.01", "2.2.0-rc.2"):
         try:
             _validate_version(invalid)

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "2.3.0-rc.4"
+FALLBACK_VERSION = "2.3.0-rc.5"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文

### 變更內容

1. Azure 女性聲線選單改為跨語系呈現：繁中介面先列繁中聲線、再列簡中普通話聲線；簡中介面則依相反順序呈現。Windows 本機語音的繁中與簡中介面也共用 zh-TW／zh-CN 中文女聲池，並排除 en-US Zira。
2. 保留既有預設聲線、介面語言、回覆文字語言與已儲存且有效的聲線選擇，不改變原有行為。
3. Azure 聲線切換後立即儲存，不新增多餘的個別儲存按鈕。
4. 版本升級為 v2.3.0-rc.5，補齊四語 README、變更紀錄、發布說明與語音供應器文件；記錄 Azure F0／East Asia 實測成功、Windows 播放成功、DPAPI 保護與不納入 Dragon HD／HD Omni 的界線，並將《電腦情人夢》的英文譯名更正為赤松健官方使用的《AI Think So!》。

### 根因

先前 azure_female_voices() 只回傳目前介面語系的聲線，因此繁中使用者即使 Azure 支援簡中普通話，也無法從選單選取。封裝自我測試原先又以未過濾的全域 Windows 女聲比較中文介面；在沒有中文聲線的 runner 上會錯誤期待 Zira，現已改為驗證介面實際可見的相容聲線。

### 驗證

- 完整測試：70／70 通過。
- Azure 語音、依賴注入、四語文件、README 媒體與社群、預覽封裝、安裝程式與官網自動化檢查全部通過。
- Python 編譯、Python 3.15 相容性與慣用法稽核全部通過。
- pip-audit：正式與預覽依賴均無已知漏洞。
- Gitleaks：本次提交無洩密。
- Tachyon：啟動、嘴型同步、表情仲裁均通過門檻。
- JIT 50Hz 嘴型同步基準：約 1.70 倍。

## 简体中文

### 变更内容

1. Azure 女性声音选单改为跨语言呈现：繁中界面先列繁中声音、再列简中普通话声音；简中界面则依相反顺序呈现。Windows 本地语音的繁中与简中界面也共用 zh-TW／zh-CN 中文女声池，并排除 en-US Zira。
2. 保留现有默认声音、界面语言、回复文字语言与已保存且有效的声音选择，不改变原有行为。
3. Azure 声音切换后立即保存，不新增多余的独立保存按钮。
4. 版本升级为 v2.3.0-rc.5，补齐四语 README、变更记录、发布说明与语音提供者文档；记录 Azure F0／East Asia 实测成功、Windows 播放成功、DPAPI 保护与不纳入 Dragon HD／HD Omni 的边界，并将《电脑情人梦》的英文译名更正为赤松健官方使用的《AI Think So!》。

### 根因

先前 azure_female_voices() 只返回当前界面语言的声音，因此繁中用户即使 Azure 支持简中普通话，也无法从选单选择。打包自我测试原先又使用未过滤的全局 Windows 女声比较中文界面；在没有中文声线的 runner 上会错误期待 Zira，现已改为验证界面实际可见的兼容声线。

### 验证

- 完整测试：70／70 通过。
- Azure 语音、依赖注入、四语文档、README 媒体与社区、预览封装、安装程序与官网自动化检查全部通过。
- Python 编译、Python 3.15 兼容性与惯用法审计全部通过。
- pip-audit：正式与预览依赖均无已知漏洞。
- Gitleaks：本次提交无泄密。
- Tachyon：启动、嘴型同步、表情仲裁均通过门槛。
- JIT 50Hz 嘴型同步基准：约 1.70 倍。

## English

### Changes

1. The Azure female-voice selector is now cross-locale: Traditional Chinese UI lists zh-TW voices before Mandarin zh-CN voices, while Simplified Chinese UI uses the reverse order. Windows local speech also gives both Chinese interfaces a shared zh-TW/zh-CN female-voice pool and excludes en-US Zira.
2. Existing default voices, UI language, response-text language, and valid saved voice selections remain unchanged.
3. Azure voice changes are saved immediately without adding a redundant provider-specific save button.
4. The version is advanced to v2.3.0-rc.5, with complete four-language README, changelog, release notes, and speech-provider documentation. The documentation records the successful Azure F0/East Asia and Windows playback validation, DPAPI protection, the exclusion boundary for Dragon HD/HD Omni, and corrects the English rendering of 電腦情人夢 to Ken Akamatsu's official AI Think So!.

### Root cause

Previously, azure_female_voices() returned only voices matching the active UI locale. Traditional Chinese users therefore could not select Mandarin zh-CN voices even though Azure supported them. The packaged self-test also compared Chinese UI against the unfiltered global Windows female-voice list and incorrectly expected Zira on runners without Chinese voices; it now validates the compatible voices actually exposed by the UI.

### Validation

- Full suite: 70/70 passed.
- Azure speech, dependency injection, four-language documentation, README media/community, preview packaging, installer, and website automation checks all passed.
- Python compilation, Python 3.15 compatibility, and idiom audits all passed.
- pip-audit: no known vulnerabilities in production or preview dependencies.
- Gitleaks: no secrets in this change.
- Tachyon: startup, lip-sync, and expression arbitration met their gates.
- JIT 50 Hz lip-sync benchmark: approximately 1.70x.

## 日本語

### 変更内容

1. Azure 女性音声セレクターを言語横断表示に変更しました。繁体字中国語 UI では zh-TW 音声の後に普通話 zh-CN 音声を表示し、簡体字中国語 UI では逆順で表示します。Windows 本機音声でも両中国語画面が zh-TW／zh-CN 女性音声プールを共有し、en-US Zira を除外します。
2. 既存の既定音声、UI 言語、応答文の言語、有効な保存済み音声選択は維持し、従来の動作を変更しません。
3. Azure 音声の変更は直ちに保存され、冗長なプロバイダー専用保存ボタンは追加しません。
4. バージョンを v2.3.0-rc.5 に更新し、四言語の README、変更履歴、リリースノート、音声プロバイダー文書を整備しました。Azure F0／East Asia と Windows 再生の実機検証成功、DPAPI 保護、Dragon HD／HD Omni を含めない境界を記録し、『電腦情人夢』の英訳を赤松健先生の公式表記『AI Think So!』へ訂正しました。

### 根本原因

従来の azure_female_voices() は現在の UI 言語に一致する音声だけを返していたため、Azure が対応していても繁体字中国語ユーザーは普通話 zh-CN 音声を選択できませんでした。パッケージ自己テストも中国語画面を未絞り込みの Windows 女性音声一覧と比較し、中国語音声がない runner で Zira を誤って期待していました。現在は画面が実際に公開する互換音声を検証します。

### 検証

- 全テスト：70／70 合格。
- Azure 音声、依存性注入、四言語文書、README のメディア／コミュニティ、プレビュー包装、インストーラー、公式サイト自動化の各検査に合格。
- Python コンパイル、Python 3.15 互換性、慣用法監査に合格。
- pip-audit：本番用・プレビュー用依存関係とも既知の脆弱性なし。
- Gitleaks：今回の変更に秘密情報なし。
- Tachyon：起動、リップシンク、表情調停がすべて基準を通過。
- JIT 50 Hz リップシンク基準：約 1.70 倍。



