### PR TITLE
發布墨寒 v3.0.0 正式版／发布墨寒 v3.0.0 正式版／Publish MoHan v3.0.0 Stable／墨寒 v3.0.0 正式版を公開

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,15 @@ env:
 on:
   push:
     tags:
-      - "v2.3.0-rc.*"
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing v2.3.0-rc.N tag to package"
+        description: "Existing immutable vN.N.N or vN.N.N-rc.N tag to package"
         required: true
         type: string
       publish:
-        description: "Publish a new pre-release after verification"
+        description: "Publish a new stable release or pre-release after verification"
         required: true
         default: false
         type: boolean
@@ -25,12 +25,13 @@ permissions:
 
 jobs:
   resolve-release:
-    name: validate-preview-tag
+    name: validate-release-tag
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
       commit: ${{ steps.source.outputs.commit }}
     steps:
       - name: Resolve and restrict release tag
@@ -46,12 +47,17 @@ jobs:
           else
             tag="$REF_NAME"
           fi
-          if [[ ! "$tag" =~ ^v2\.3\.0-rc\.[1-9][0-9]*$ ]]; then
-            echo "Only immutable v2.3.0-rc.N preview tags are accepted: $tag" >&2
+          if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]]; then
+            prerelease=true
+          elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            prerelease=false
+          else
+            echo "Only immutable vN.N.N or vN.N.N-rc.N tags are accepted: $tag" >&2
             exit 2
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
       - name: Check out complete tagged history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -90,6 +96,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_INPUT: ${{ inputs.publish }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          EXPECTED_PRERELEASE: ${{ steps.release.outputs.prerelease }}
         run: |
           set -euo pipefail
           releases_api="repos/${{ github.repository }}/releases"
@@ -102,12 +109,12 @@ jobs:
               echo "Expected an existing Release for verification before packaging: $RELEASE_TAG" >&2
               exit 7
             }
-            release_is_pre_release="$(
+            release_mode_matches="$(
               gh api "$releases_api/$release_id" \
-                --jq '.draft == false and .prerelease == true'
+                --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE"
             )"
-            [[ "$release_is_pre_release" == true ]] || {
-              echo "Existing Release must be a published pre-release: $RELEASE_TAG" >&2
+            [[ "$release_mode_matches" == true ]] || {
+              echo "Existing Release maturity does not match its tag: $RELEASE_TAG" >&2
               exit 7
             }
           elif [[ -n "$release_id" ]]; then
@@ -636,11 +643,12 @@ jobs:
             exit 4
           fi
 
-      - name: Verify existing pre-release without modifying it
+      - name: Verify existing release without modifying it
         if: ${{ github.event_name == 'workflow_dispatch' && !inputs.publish }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
         run: |
           set -euo pipefail
           tag="${{ needs.resolve-release.outputs.tag }}"
@@ -649,7 +657,7 @@ jobs:
             echo "Expected an existing Release for verification: $tag" >&2
             exit 7
           }
-          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq '.draft == false and .prerelease == true')" == true ]]
+          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE")" == true ]]
           mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
           mapfile -t expected_assets < <(find release-artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
           [[ "$(printf '%s\n' "${actual_assets[@]}")" == "$(printf '%s\n' "${expected_assets[@]}")" ]] || {
@@ -658,11 +666,12 @@ jobs:
           }
           echo "Release $tag is unchanged and matches the verified artifact set."
 
-      - name: Publish one GitHub pre-release
+      - name: Publish one GitHub release
         if: ${{ github.event_name == 'push' || inputs.publish }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
         run: |
           set -euo pipefail
           tag="${{ needs.resolve-release.outputs.tag }}"
@@ -683,13 +692,18 @@ jobs:
             exit "$status"
           }
           trap cleanup_failed_draft EXIT
-          gh release create "$tag" "${assets[@]}" \
-            --repo "${{ github.repository }}" \
-            --verify-tag \
-            --draft \
-            --prerelease \
-            --title "墨寒桌面助理 $tag／墨寒桌面助手 $tag／MoHan Desktop Assistant $tag／墨寒デスクトップアシスタント $tag" \
+          release_args=(
+            "$tag" "${assets[@]}"
+            --repo "${{ github.repository }}"
+            --verify-tag
+            --draft
+            --title "墨寒桌面助理 $tag／墨寒桌面助手 $tag／MoHan Desktop Assistant $tag／墨寒デスクトップアシスタント $tag"
             --notes-file "docs/releases/$tag.md"
+          )
+          if [[ "$EXPECTED_PRERELEASE" == true ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${release_args[@]}"
           release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\" and .draft == true) | .id" | head -n 1)"
           [[ "$release_id" =~ ^[0-9]+$ ]]
           mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
@@ -699,7 +713,7 @@ jobs:
             exit 8
           }
           gh api --method PATCH "repos/${{ github.repository }}/releases/$release_id" \
-            -F draft=false -F prerelease=true >/dev/null
-          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq '.draft == false and .prerelease == true')" == true ]]
+            -F draft=false -F prerelease="$EXPECTED_PRERELEASE" >/dev/null
+          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE")" == true ]]
           published=true
           trap - EXIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### v3.0.0 — 2026-08-11
+
+- 專案擁有者親自認可的第一個正式穩定版本，也是由 v2.3.0 候選系列完整驗證後升格的第三代里程碑。
+- 托腮嘴型改為完整更新左右嘴角；50 Hz 音訊取樣搭配三影格母音確認與 50 毫秒插值，降低嘴型搶拍、跳動及殘留嘴角。
+- 語音呼吸、衣袖與頭髮平順銜接待機呼吸，消除講話結束瞬間的單次身體抖動。
+- Windows 捷徑與原生視窗統一使用 EXE 內嵌半身像，並阻止本機安裝測試污染真實桌面及工作列圖示來源；OpenAI TTS 與 Realtime 也改由單一權威順序產生共同聲線清單。
+
 ### v2.3.0 RC5 — 2026-08-11
 
 - Azure Speech 中文女性聲音選單支援繁中與簡中跨語系選擇，並依目前介面語言優先排列；Windows 本機語音的兩種中文介面也共用 `zh-TW`／`zh-CN` 女聲池並排除 `en-US` Zira，既有預設及有效設定不變。四語 README 同步將《電腦情人夢》的英文譯名更正為《AI Think So!》。
@@ -170,6 +177,13 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### v3.0.0 — 2026-08-11
+
+- 项目所有者亲自认可的第一个正式稳定版本，也是由 v2.3.0 候选系列完整验证后升级的第三代里程碑。
+- 托腮嘴形改为完整更新左右嘴角；50 Hz 音频采样配合三帧元音确认及 50 毫秒插值，降低嘴形抢拍、跳动和残留嘴角。
+- 语音呼吸、衣袖与头发平滑衔接待机呼吸，消除说话结束瞬间的一次身体抖动。
+- Windows 快捷方式与原生窗口统一使用 EXE 内嵌半身像，并阻止本地安装测试污染真实桌面及任务栏图标来源；OpenAI TTS 与 Realtime 也改由唯一权威顺序生成共同声线列表。
+
 ### v2.3.0 RC5 — 2026-08-11
 
 - Azure Speech 中文女性声音列表支持繁中与简中跨语言选择，并按当前界面语言优先排列；Windows 本地语音的两种中文界面也共用 `zh-TW`／`zh-CN` 女声池并排除 `en-US` Zira，现有默认值及有效设置不变。四语 README 同步将《电脑情人梦》的英文译名更正为《AI Think So!》。
@@ -334,6 +348,13 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v3.0.0 — 2026-08-11
+
+- The first stable release personally approved by the project owner and the third-generation milestone promoted after the complete v2.3.0 release-candidate series.
+- Chin-rest visemes now update both mouth corners. Three-frame vowel confirmation and 50 ms interpolation retain 50 Hz analysis while preventing rushed motion, jumps, and stranded corners.
+- Speech-driven breathing, sleeves, and hair ease into idle breathing, removing the one-frame body twitch when an utterance ends.
+- Windows shortcuts and native windows share the executable's embedded half-body icon, local installer tests cannot pollute real desktop or taskbar icon sources, and OpenAI TTS and Realtime derive shared voices from one canonical order.
 
 ### v2.3.0 RC5 — 2026-08-11
 
@@ -539,6 +560,13 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v3.0.0 — 2026-08-11
+
+- プロジェクト所有者が自ら認定した初の正式安定版であり、v2.3.0 候補系列の完全検証後に昇格した第三世代の節目です。
+- 頬杖姿勢の口形は左右の口角まで更新します。50 Hz 解析を保ちながら、母音の三フレーム確認と 50 ミリ秒補間で先走り、跳ね、残留口角を防ぎます。
+- 発話連動の呼吸、袖、髪を待機呼吸へ滑らかにつなぎ、発話終了時の一フレームだけの身体揺れを解消しました。
+- Windows ショートカットとネイティブウィンドウは EXE 内蔵の半身アイコンを共用し、本機インストーラーテストによる実デスクトップやタスクバーのアイコン参照元の汚染を禁止しました。OpenAI TTS と Realtime の共通音声も一つの正規順序から生成します。
 
 ### v2.3.0 RC5 — 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "2.3.0-rc.5"
-date-released: "2026-08-10"
+version: "3.0.0"
+date-released: "2026-08-11"
 license: MIT
 abstract: >-
   A configurable Windows AI desktop companion and permission-gated

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,17 +38,17 @@ open-source
 
 ### 已準備的公開預發行版
 
-- 標籤：`v2.3.0-rc.5`
-- 標題：`MoHan Desktop Assistant v2.3.0 RC5`
+- 標籤：`v3.0.0`
+- 標題：`MoHan Desktop Assistant v3.0.0`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
 ### 後續發行系列
 
-- 可接受的發行標籤只能是不可變的 `v2.3.0-rc.N`，其中 `N` 必須是正整數；其他標籤必須在封裝或發布前失敗。
+- 可接受的發行標籤只能是不可變的 `vN.N.N` 正式版或 `vN.N.N-rc.N` 候選版，其中 RC 編號必須是正整數；其他標籤必須在封裝或發布前失敗。
 - Windows 維持正式且完整的產品範圍，並保留已驗證的 x64 ZIP、EXE、MSI 及 MSI 語言轉換檔。
 - macOS 分別提供原生 Apple Silicon（arm64）與 Intel（x86_64）`.dmg`，各自包含架構相符的 `.app`；Linux x86_64 提供 `.AppImage`。這些套件都必須明確標示為功能受限的 Preview：只驗證啟動、四語顯示、每位使用者路徑與安全失效關閉的平台邊界，不代表與 Windows 功能相同。
-- Pull Request 只能為套件測試建立短期 CI 產物，不得建立 GitHub Release；只有既存的 `v2.3.0-rc.N` 標籤能進入發布工作流程。
+- Pull Request 只能為套件測試建立短期 CI 產物，不得建立 GitHub Release；只有既存且符合規則的正式版或候選版標籤能進入發布工作流程。
 - Release 說明必須來自人工整理的四語檔案 `docs/releases/<tag>.md`，不能只使用自動產生的說明。
 
 ### 歷史首發版本
@@ -99,7 +99,7 @@ GitHub 自動化必須使用一條可預測的憑證路徑。Pull Request 的讀
 
 ### 自動化後續發行
 
-在本次遷移期間，只有 `v2.3.0-rc.N` 標籤能觸發 `.github/workflows/release.yml`。工作流程會驗證精確標籤、簽出該不可變的來源修訂，然後依序：
+只有符合 `vN.N.N` 或 `vN.N.N-rc.N` 的標籤能觸發 `.github/workflows/release.yml`。工作流程會驗證精確標籤、簽出該不可變的來源修訂，然後依序：
 
 任何平台封裝開始前，快速閘門必須先確認標籤、版本與 `main` 歷史一致，檢查本次模式所要求的 Release 存在或不存在，並以 Python 3.15 驗證人工整理的四語 Release 說明。這些便宜且具決定性的檢查不得延後到長時間建置之後；發布前仍須再次驗證標籤、產物與 Release 狀態，以防執行期間發生漂移。
 
@@ -119,7 +119,7 @@ GitHub 自動化必須使用一條可預測的憑證路徑。Pull Request 的讀
 14. 為每個發布檔案建立 GitHub 產物來源證明；
 15. 要求並發布人工整理的四語 Release 說明。
 
-此發行系列的每個標籤都必須發布為預發行版。不得重複使用或移動已發布的標籤；必須建立新的 `v2.3.0-rc.N` 標籤。未來穩定版需要另外經過審查的政策變更，不能默默放寬此閘門。
+`vN.N.N-rc.N` 必須發布為 Pre-release，純 `vN.N.N` 必須發布為 Stable Release；工作流程會阻擋標籤與成熟度不一致。不得重複使用或移動任何已發布標籤。
 
 發布中繼資料工作必須以已保存的 Python 3.15 執行路徑執行所有墨寒專案工具。隔離的 Python 3.14 只能用於尚未支援 3.15 的第三方 SBOM 工具鏈，不得透過 `PATH` 改變後續專案工具的執行環境。
 
@@ -203,17 +203,17 @@ open-source
 
 ### 已准备的公开预发布版
 
-- 标签：`v2.3.0-rc.5`
-- 标题：`MoHan Desktop Assistant v2.3.0 RC5`
+- 标签：`v3.0.0`
+- 标题：`MoHan Desktop Assistant v3.0.0`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
 ### 后续发布系列
 
-- 可接受的发布标签只能是不可变的 `v2.3.0-rc.N`，其中 `N` 必须是正整数；其他标签必须在打包或发布前失败。
+- 可接受的发布标签只能是不可变的 `vN.N.N` 正式版或 `vN.N.N-rc.N` 候选版，其中 RC 编号必须是正整数；其他标签必须在打包或发布前失败。
 - Windows 维持正式且完整的产品范围，并保留已验证的 x64 ZIP、EXE、MSI 及 MSI 语言转换文件。
 - macOS 分别提供原生 Apple Silicon（arm64）与 Intel（x86_64）`.dmg`，各自包含架构相符的 `.app`；Linux x86_64 提供 `.AppImage`。这些软件包都必须明确标示为功能受限的 Preview：只验证启动、四语显示、按用户路径与安全失效关闭的平台边界，不代表与 Windows 功能相同。
-- Pull Request 只能为软件包测试建立短期 CI 产物，不得建立 GitHub Release；只有现有的 `v2.3.0-rc.N` 标签能进入发布工作流。
+- Pull Request 只能为软件包测试建立短期 CI 产物，不得建立 GitHub Release；只有现有且符合规则的正式版或候选版标签能进入发布工作流。
 - Release 说明必须来自人工整理的四语文件 `docs/releases/<tag>.md`，不能只使用自动生成的说明。
 
 ### 历史首发版本
@@ -264,7 +264,7 @@ GitHub 自动化必须使用一条可预测的凭证路径。Pull Request 的读
 
 ### 自动化后续发布
 
-在本次迁移期间，只有 `v2.3.0-rc.N` 标签能触发 `.github/workflows/release.yml`。工作流会验证精确标签、检出该不可变的源修订，然后依次：
+只有符合 `vN.N.N` 或 `vN.N.N-rc.N` 的标签能触发 `.github/workflows/release.yml`。工作流会验证精确标签、检出该不可变的源修订，然后依次：
 
 任何平台打包开始前，快速关卡必须先确认标签、版本与 `main` 历史一致，检查本次模式所要求的 Release 存在或不存在，并使用 Python 3.15 验证人工整理的四语 Release 说明。这些低成本且具有决定性的检查不得延后到长时间构建之后；发布前仍须再次验证标签、产物与 Release 状态，以防运行期间发生漂移。
 
@@ -284,7 +284,7 @@ GitHub 自动化必须使用一条可预测的凭证路径。Pull Request 的读
 14. 为每个发布文件建立 GitHub 产物来源证明；
 15. 要求并发布人工整理的四语 Release 说明。
 
-此发布系列的每个标签都必须发布为预发布版。不得重复使用或移动已发布的标签；必须建立新的 `v2.3.0-rc.N` 标签。未来稳定版需要另行通过评审的政策变更，不能默默放宽此关卡。
+`vN.N.N-rc.N` 必须发布为预发布版，纯 `vN.N.N` 必须发布为正式稳定版；工作流会阻止标签与成熟度不一致。不得重复使用或移动任何已发布标签。
 
 发布元数据工作必须使用已保存的 Python 3.15 执行路径运行所有墨寒项目工具。隔离的 Python 3.14 只能用于尚未支持 3.15 的第三方 SBOM 工具链，不得通过 `PATH` 改变后续项目工具的运行环境。
 
@@ -368,17 +368,17 @@ open-source
 
 ### Prepared public pre-release
 
-- Tag: `v2.3.0-rc.5`
-- Title: `MoHan Desktop Assistant v2.3.0 RC5`
+- Tag: `v3.0.0`
+- Title: `MoHan Desktop Assistant v3.0.0`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
 ### Next release line
 
-- Accepted release tags are immutable `v2.3.0-rc.N` tags where `N` is a positive integer; every other tag must fail before packaging or publication.
+- Accepted release tags are immutable stable `vN.N.N` or candidate `vN.N.N-rc.N` tags, with a positive RC number; every other tag must fail before packaging or publication.
 - Windows remains the formal, complete product surface and retains its verified x64 ZIP, EXE, MSI, and MSI language transforms.
 - macOS receives separate native Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`; Linux x86_64 receives an `.AppImage`. All must be explicitly labeled as limited Preview packages: they validate launch, four-language rendering, per-user paths, and fail-closed platform boundaries, not feature parity with Windows.
-- Pull Requests may build short-lived CI artifacts for package testing only and cannot create a GitHub Release; only an existing `v2.3.0-rc.N` tag can enter the publication workflow.
+- Pull Requests may build short-lived CI artifacts for package testing only and cannot create a GitHub Release; only an existing valid stable or candidate tag can enter the publication workflow.
 - The Release description must come from the curated four-language file `docs/releases/<tag>.md`; generated notes alone are not accepted.
 
 ### Historical initial release
@@ -429,7 +429,7 @@ GitHub automation must use one predictable credential path. Prefer the connected
 
 ### Automated future releases
 
-During this migration, only `v2.3.0-rc.N` tags trigger `.github/workflows/release.yml`. The workflow validates the exact tag, checks out that immutable source revision, and then:
+Only `vN.N.N` or `vN.N.N-rc.N` tags trigger `.github/workflows/release.yml`. The workflow validates the exact tag, checks out that immutable source revision, and then:
 
 Before any platform package starts, the fast gate must confirm that the tag, version, and `main` history agree, require the Release to exist or not exist as dictated by the selected mode, and validate the curated four-language Release notes with Python 3.15. These cheap, decisive checks must not be deferred until after long builds. The tag, artifacts, and Release state are still revalidated immediately before publication to detect in-flight drift.
 
@@ -449,7 +449,7 @@ Before any platform package starts, the fast gate must confirm that the tag, ver
 14. creates GitHub artifact provenance attestations for every published file;
 15. requires and publishes the curated four-language Release description.
 
-Every tag in this release line is published as a pre-release. Never reuse or move a published tag; create a new `v2.3.0-rc.N` tag instead. A future stable release requires a separate, reviewed policy change rather than silently broadening this gate.
+Every `vN.N.N-rc.N` tag must publish as a pre-release, while a plain `vN.N.N` tag must publish as a stable release. The workflow rejects a tag/maturity mismatch. Never reuse or move any published tag.
 
 The release metadata job must run every MoHan-owned tool with the saved Python 3.15 executable. The isolated Python 3.14 runtime is restricted to third-party SBOM tooling that does not yet support 3.15 and must never change later project-tool execution through `PATH`.
 
@@ -533,17 +533,17 @@ open-source
 
 ### 準備済みの公開プレリリース
 
-- タグ：`v2.3.0-rc.5`
-- タイトル：`MoHan Desktop Assistant v2.3.0 RC5`
+- タグ：`v3.0.0`
+- タイトル：`MoHan Desktop Assistant v3.0.0`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 
 ### 次のリリース系列
 
-- 受け付けるリリースタグは、`N` が正の整数である不変の `v2.3.0-rc.N` だけです。それ以外のタグはパッケージ化または公開前に失敗しなければなりません。
+- 受け付けるリリースタグは、不変の正式版 `vN.N.N` または候補版 `vN.N.N-rc.N` だけで、RC 番号は正の整数でなければなりません。それ以外のタグはパッケージ化または公開前に失敗します。
 - Windows は正式かつ完全な製品範囲を維持し、検証済みの x64 ZIP、EXE、MSI、MSI 言語変換ファイルを保持します。
 - macOS には Apple Silicon（arm64）用と Intel（x86_64）用のネイティブ `.dmg` を個別に提供し、それぞれ対応する `.app` を収録します。Linux x86_64 には `.AppImage` を提供します。いずれも機能限定 Preview と明記し、起動、四言語表示、ユーザー単位パス、安全に失敗停止するプラットフォーム境界だけを検証するもので、Windows との機能同等性を示すものではありません。
-- Pull Request はパッケージ検査用の短期 CI 成果物だけを作成でき、GitHub Release は作成できません。既存の `v2.3.0-rc.N` タグだけが公開ワークフローへ進めます。
+- Pull Request はパッケージ検査用の短期 CI 成果物だけを作成でき、GitHub Release は作成できません。既存かつ有効な正式版または候補版タグだけが公開ワークフローへ進めます。
 - Release 説明は、人手で整備した四言語ファイル `docs/releases/<tag>.md` を使用しなければならず、自動生成ノートだけでは認められません。
 
 ### 過去の初回リリース
@@ -594,7 +594,7 @@ GitHub 自動化では、予測可能な認証経路を一つだけ使用しま�
 
 ### 今後の自動リリース
 
-この移行期間中、`.github/workflows/release.yml` を起動できるのは `v2.3.0-rc.N` タグだけです。ワークフローは正確なタグを検証し、その不変のソースリビジョンを checkout してから、次を順に実行します。
+`.github/workflows/release.yml` を起動できるのは `vN.N.N` または `vN.N.N-rc.N` タグだけです。ワークフローは正確なタグを検証し、その不変のソースリビジョンを checkout してから、次を順に実行します。
 
 どのプラットフォームのパッケージ化も始める前に、高速ゲートでタグ、バージョン、`main` 履歴の一致を確認し、選択したモードに応じて Release が存在すること、または存在しないことを要求し、Python 3.15 で人手整備の四言語 Release 説明を検証します。低コストで決定的な検査を長時間ビルドの後まで遅らせてはなりません。実行中の変化を検出するため、公開直前にもタグ、成果物、Release 状態を再検証します。
 
@@ -614,7 +614,7 @@ GitHub 自動化では、予測可能な認証経路を一つだけ使用しま�
 14. 公開する全ファイルに GitHub 成果物由来証明を作成します。
 15. 人手で整備した四言語 Release 説明を必須とし、その説明を公開します。
 
-このリリース系列の全タグはプレリリースとして公開します。公開済みタグを再利用または移動せず、新しい `v2.3.0-rc.N` タグを作成します。将来の安定版には、別途レビュー済みのポリシー変更が必要であり、このゲートを暗黙に緩和してはなりません。
+`vN.N.N-rc.N` は Pre-release、純粋な `vN.N.N` は Stable Release として公開し、タグと成熟度が一致しなければワークフローが拒否します。公開済みタグは再利用も移動もしません。
 
 リリースメタデータジョブでは、保存済みの Python 3.15 実行パスを使って墨寒所有の全ツールを実行しなければなりません。隔離した Python 3.14 は、まだ 3.15 をサポートしていない第三者 SBOM ツールチェーンだけに限定し、`PATH` を通じて後続のプロジェクトツール実行環境を変更してはなりません。
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`。
+2. 執行 `MoHan-Desktop-Assistant-3.0.0.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -23,7 +23,7 @@ Microsoft、GitHub 與 Home Assistant 屬於尚未完成真實環境端到端驗
 
 ### macOS／Linux 功能受限 Preview
 
-`v2.3.0-rc.N` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
+`v3.0.0` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
 （內含 `.app`），以及 Linux x86_64 AppImage，只用於
 啟動、四語介面、平台路徑及安全停用驗證。請先核對 SHA256SUMS 與 Artifact
 Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角色、完整聊天／
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`。
+2. 运行 `MoHan-Desktop-Assistant-3.0.0.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -52,7 +52,7 @@ Microsoft、GitHub 与 Home Assistant 仍属于尚未完成真实环境端到端
 
 ### macOS／Linux 功能受限 Preview
 
-`v2.3.0-rc.N` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
+`v3.0.0` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
 （内含 `.app`），以及 Linux x86_64 AppImage，只用于
 验证启动、四语界面、平台路径与安全停用。请核对 SHA256SUMS 与 Artifact
 Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色、完整聊天／工作
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-2.3.0-rc.5.exe`.
+2. Run `MoHan-Desktop-Assistant-3.0.0.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -81,7 +81,7 @@ See [README.md](README.md) for complete setup, OAuth, safety, and privacy notes.
 
 ### Limited macOS/Linux Preview
 
-The `v2.3.0-rc.N` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
+The `v3.0.0` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
 (each containing a `.app`) and Linux x86_64 AppImage
 validate startup, four-language UI, platform paths, and fail-closed boundaries
 only. Verify SHA256SUMS and the Artifact Attestation first. These packages have
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-2.3.0-rc.5.exe` を実行します。
+2. `MoHan-Desktop-Assistant-3.0.0.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う
@@ -114,7 +114,7 @@ Microsoft、GitHub、Home Assistant は、実環境でのエンドツーエン�
 
 ### macOS／Linux 機能限定 Preview
 
-`v2.3.0-rc.N` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
+`v3.0.0` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
 （各 `.app` 同梱）、および Linux x86_64 AppImage は、
 起動、四言語画面、OS ごとの保存先、安全な無効化だけを確認します。先に
 SHA256SUMS と Artifact Attestation を確認してください。API キー入力、音声、

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。macOS／Linux 目前具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI。`v2.3.0-rc.N` 發行線另提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.0.0 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -32,7 +31,7 @@
 
 <p align="center">
   <strong>軟體作者：CHOU MING HUA</strong><br>
-  準備發布的公開預覽版：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
+  正式版與發行候選版資訊：請見 <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -246,11 +245,11 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-`v2.3.0-rc.N` 發行線另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.0.0 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
-只有不可變的 `v2.3.0-rc.N` 標籤可發布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證，才會進入同一個 GitHub 預發行版。Pull Request 只保存短期測試產物，不會建立 Release。
+只有不可變且符合 `vN.N.N` 或 `vN.N.N-rc.N` 的標籤可發布；正式標籤建立 Stable Release，RC 標籤建立 Pre-release。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證。Pull Request 只保存短期測試產物，不會建立 Release。
 
 正式發布檔案同時包含 SHA256SUMS、分別通過 CycloneDX 1.7 結構／授權／依賴圖驗證的 Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、Windows 更新清單、Artifact Attestation，以及依序為繁中、簡中、英文、日文的完整 Release 說明。
 
@@ -357,7 +356,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.5"
+.\build.ps1 -Version "3.0.0"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
@@ -397,14 +396,13 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。macOS／Linux 目前具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI。`v2.3.0-rc.N` 发布线另提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.0.0 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -421,7 +419,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>软件作者：CHOU MING HUA</strong><br>
-  准备发布的公开预览版：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
+  正式版与候选发布版信息：请参阅 <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
   Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -635,11 +633,11 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-`v2.3.0-rc.N` 发布线另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.0.0 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
-只有不可变的 `v2.3.0-rc.N` 标签可发布此系列。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证，才会进入同一个 GitHub 预发布版。Pull Request 只保存短期测试产物，不会创建 Release。
+只有不可变且符合 `vN.N.N` 或 `vN.N.N-rc.N` 的标签可以发布；正式标签创建 Stable Release，RC 标签创建 Pre-release。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证。Pull Request 只保存短期测试产物，不会创建 Release。
 
 正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 结构／许可证／依赖图验证的 Windows／Preview SBOM、去标识化 Tachyon 性能证据与摘要、Windows 更新清单、Artifact Attestation，以及依次为繁中、简中、英文、日文的完整 Release 说明。
 
@@ -746,7 +744,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.5"
+.\build.ps1 -Version "3.0.0"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
@@ -786,14 +784,13 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. macOS/Linux currently have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen. The `v2.3.0-rc.N` line also provides launchable, four-language, deliberately limited DMG/AppImage Previews; CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.0.0 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -810,7 +807,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>Author: CHOU MING HUA</strong><br>
-  Prepared public preview: v2.3.0 RC5 (`v2.3.0-rc.5`)<br>
+  Stable and release-candidate information: see <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
   Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -1024,11 +1021,11 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-The `v2.3.0-rc.N` line also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+v3.0.0 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
-Only immutable `v2.3.0-rc.N` tags may publish this line. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI before entering one GitHub pre-release. Pull Requests retain only short-lived test artifacts and never create a Release.
+Only immutable tags matching `vN.N.N` or `vN.N.N-rc.N` may publish. Stable tags create Stable Releases, while RC tags create Pre-releases. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI. Pull Requests retain only short-lived test artifacts and never create a Release.
 
 Published files also include SHA256SUMS; separately validated Windows/Preview SBOMs that pass CycloneDX 1.7 structure, license, and dependency-graph checks; sanitized Tachyon performance evidence and summaries; a Windows update manifest; Artifact Attestations; and complete Release notes ordered as Traditional Chinese, Simplified Chinese, English, and Japanese.
 
@@ -1135,7 +1132,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.5"
+.\build.ps1 -Version "3.0.0"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
@@ -1175,14 +1172,13 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <img alt="Development Version v2.3.0-rc.5" src="https://img.shields.io/badge/development_version-v2.3.0--rc.5-5c6ac4.svg">
   <a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/hitoshic1982/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
   <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。macOS／Linux には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があります。`v2.3.0-rc.N` 系列では、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.0.0 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
@@ -1199,7 +1195,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 <p align="center">
   <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
-  公開準備中のプレビュー：v2.3.0 RC5（`v2.3.0-rc.5`）<br>
+  正式版とリリース候補版の情報：<a href="https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases">Releases</a> をご覧ください<br>
   Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
 </p>
 
@@ -1413,11 +1409,11 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-`v2.3.0-rc.N` 系列は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.0.0 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 
-この系列を公開できるのは不変の `v2.3.0-rc.N` タグだけです。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格してから、同じ GitHub プレリリースへ入ります。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
+公開できるのは `vN.N.N` または `vN.N.N-rc.N` に一致する不変タグだけです。正式タグは Stable Release、RC タグは Pre-release を作成します。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格しなければなりません。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
 
 公開ファイルには SHA256SUMS、CycloneDX 1.7 の構造／ライセンス／依存関係グラフ検証に合格した Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と要約、Windows 更新マニフェスト、Artifact Attestation、繁体字中国語、簡体字中国語、英語、日本語の順で整備した完全な Release 説明も含みます。
 
@@ -1524,7 +1520,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "2.3.0-rc.5"
+.\build.ps1 -Version "3.0.0"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。

--- a/app.py
+++ b/app.py
@@ -586,11 +586,6 @@ EXPRESSION_SPEECH_MOUTH_RECTS = frozendict({
 })
 CHEEK_SPEECH_CLOSED_EXPRESSION = "idle_speech_neutral"
 HAPPY_SPEECH_CLOSED_EXPRESSION = "happy_speech_neutral"
-# Keep the photographed cheek-rest mouth corners outside the animated region.
-# At the runtime 465 px canvas, the visible central lips occupy roughly
-# x=184..207; widening this mask reaches both smile corners and recreates the
-# Joker-like corner flutter reported in rapid A/I/U/E/O transitions.
-CHEEK_SPEECH_CENTRAL_MOUTH_RECT = QRect(184, 198, 24, 34)
 GESTURE_SPEECH_MOUTH_RECTS = frozendict({
     expression: EXPRESSION_SPEECH_MOUTH_RECTS[expression]
     for expression in GESTURE_SPEECH_EXPRESSIONS
@@ -731,34 +726,29 @@ VOICE_ENGINE_OPENAI = OPENAI_SPEECH_PROVIDER
 VOICE_ENGINE_REALTIME = OPENAI_REALTIME_PROVIDER
 VOICE_ENGINE_AZURE = AZURE_SPEECH_PROVIDER
 
-REALTIME_VOICES = (
+OPENAI_VOICE_ORDER = (
     "coral",
     "marin",
-    "shimmer",
     "cedar",
+    "shimmer",
     "sage",
     "verse",
     "alloy",
     "ash",
     "ballad",
     "echo",
-)
-
-TTS_VOICES = (
-    "coral",
-    "marin",
-    "cedar",
-    "shimmer",
     "nova",
-    "sage",
-    "alloy",
-    "ash",
-    "ballad",
-    "echo",
     "fable",
     "onyx",
-    "verse",
 )
+
+REALTIME_UNSUPPORTED_TTS_VOICES = frozenset({"nova", "fable", "onyx"})
+REALTIME_VOICES = tuple(
+    voice
+    for voice in OPENAI_VOICE_ORDER
+    if voice not in REALTIME_UNSUPPORTED_TTS_VOICES
+)
+TTS_VOICES = OPENAI_VOICE_ORDER
 
 
 def migrate_voice_defaults(db: StudioDB) -> None:
@@ -6168,6 +6158,9 @@ class CompanionWindow(QMainWindow):
             | Qt.WindowStaysOnTopHint
             | Qt.Tool
         )
+        # Keep every native MoHan window on the same icon contract. Windows
+        # can use this hidden tool window while resolving the taskbar group.
+        self.setWindowIcon(application_icon())
         self.setAttribute(Qt.WA_TranslucentBackground)
         self.setAttribute(Qt.WA_ShowWithoutActivating)
         self.character_topmost_active = True
@@ -6644,7 +6637,10 @@ class CompanionWindow(QMainWindow):
         self._ensure_idle_mouth_closed()
         self.idle_phase = (self.idle_phase + 1) % 720
         breath = (math.sin(self.idle_phase * math.tau / 72.0) + 1.0) / 2.0
-        self.current_breath = breath
+        # Speech volume and idle breathing share one continuous body layer.
+        # Ease between them so the first idle frame cannot snap the sleeves
+        # and hair after the final spoken viseme.
+        self.current_breath += (breath - self.current_breath) * 0.22
         sway = math.sin(self.idle_phase * math.tau / 210.0)
         self.ambient_motion_target_y = breath * 2.0
         self.ambient_motion_target_x = sway * 0.7
@@ -7567,33 +7563,10 @@ class CompanionWindow(QMainWindow):
             for suffix, mouth_clip in mouth_clips.items()
         }
         self.viseme_mouth_masks = dict(self.mouth_masks)
-        self.viseme_mouth_masks[""] = self._soft_rounded_mask(
-            (CHEEK_SPEECH_CENTRAL_MOUTH_RECT,),
-            alpha_steps,
-            9,
-        )
 
     def _build_cheek_neutral_speech_frame(self) -> None:
         cheek_idle = self.expression_pixmaps["idle"]
         cheek_neutral = QPixmap(cheek_idle)
-        painter = QPainter(cheek_neutral)
-        painter.drawPixmap(
-            0,
-            0,
-            self._masked_mouth_patch(
-                self.expression_pixmaps["speaking"],
-                "",
-            ),
-        )
-        painter.drawPixmap(
-            0,
-            0,
-            self._masked_region(
-                cheek_idle,
-                self.viseme_mouth_masks[""],
-            ),
-        )
-        painter.end()
         self.expression_pixmaps[
             CHEEK_SPEECH_CLOSED_EXPRESSION
         ] = cheek_neutral
@@ -9025,16 +8998,6 @@ class CompanionWindow(QMainWindow):
                 mouth_source=mouth_source,
                 mouth_mask=self.gesture_mouth_masks[expression],
                 mouth_rect=EXPRESSION_SPEECH_MOUTH_RECTS[expression],
-            )
-        if (
-            suffix == ""
-            and self.speech_closed_expression
-            == CHEEK_SPEECH_CLOSED_EXPRESSION
-        ):
-            return FaceRenderLayers(
-                mouth_source=mouth_source,
-                mouth_mask=self.viseme_mouth_masks[""],
-                mouth_rect=CHEEK_SPEECH_CENTRAL_MOUTH_RECT,
             )
         return FaceRenderLayers(
             mouth_source=mouth_source,

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,33 @@
+# 墨寒桌面助理 v3.0.0／墨寒桌面助手 v3.0.0／MoHan Desktop Assistant v3.0.0／墨寒デスクトップアシスタント v3.0.0
+
+## 繁體中文
+
+- 這是專案擁有者 CHOU MING HUA 親自認可的第一個正式穩定版本，也是由 v2.3.0 候選系列完整驗證後升格的第三代里程碑；延續已通過的 Python 3.15、參數化分層 2.5D、四語、Azure Speech、安全、SBOM 與跨平台功能受限 Preview 契約。
+- 修正托腮姿態講話時嘴角留在原位：A／I／U／E／O 現在會更新完整嘴部與左右嘴角，不再只替換中央嘴唇；50 Hz 音訊取樣維持不變，母音需連續三個取樣確認，並以 50 毫秒連續插值降低嘴型搶拍與跳動。
+- 修正語音結束瞬間的身體抖動：語音音量驅動的呼吸、衣袖與頭髮會平順銜接待機呼吸，不再於第一個待機影格突然重設。
+- 修正 Windows 桌面捷徑與工作列的空白文件圖示：捷徑與原生視窗統一使用 EXE 內嵌的新版墨寒半身像；安裝整合測試在非拋棄式環境預設拒絕執行，CI 也明確禁止建立桌面捷徑，避免測試覆寫真實使用者的桌面與工作列圖示來源。
+- OpenAI 文字轉語音與 Realtime 對話共用單一權威聲線排序；兩邊共同支援的十個聲線順序完全一致，僅 TTS 支援的 `nova`、`fable`、`onyx` 保留在 TTS 清單末端，不顯示為無法使用的 Realtime 選項。
+
+## 简体中文
+
+- 这是项目所有者 CHOU MING HUA 亲自认可的第一个正式稳定版本，也是由 v2.3.0 候选系列完整验证后升级的第三代里程碑；延续已通过的 Python 3.15、参数化分层 2.5D、四语、Azure Speech、安全、SBOM 及跨平台功能受限 Preview 契约。
+- 修复托腮姿态说话时嘴角留在原位：A／I／U／E／O 现在会更新完整嘴部与左右嘴角，不再只替换中央嘴唇；50 Hz 音频采样保持不变，元音须经连续三个采样确认，并使用 50 毫秒连续插值降低嘴形抢拍与跳动。
+- 修复语音结束瞬间的身体抖动：由语音音量驱动的呼吸、衣袖与头发会平滑衔接待机呼吸，不再在第一个待机帧突然重置。
+- 修复 Windows 桌面快捷方式与任务栏的空白文件图标：快捷方式与原生窗口统一使用 EXE 内嵌的新版墨寒半身像；安装集成测试在非一次性环境中默认拒绝运行，CI 也明确禁止创建桌面快捷方式，避免测试覆盖真实用户的桌面与任务栏图标来源。
+- OpenAI 文字转语音与 Realtime 对话共用唯一的权威声线顺序；两边共同支持的十个声线顺序完全一致，只有 TTS 支持的 `nova`、`fable`、`onyx` 保留在 TTS 列表末端，不显示为无法使用的 Realtime 选项。
+
+## English
+
+- This is the first stable release personally approved by project owner CHOU MING HUA and the third-generation milestone promoted after the complete v2.3.0 release-candidate series. It preserves the validated Python 3.15, parameterized layered 2.5D, four-language, Azure Speech, security, SBOM, and limited cross-platform Preview contracts.
+- Chin-rest speech now moves the complete mouth and both corners for A/I/U/E/O instead of replacing only the central lips. Audio analysis remains at 50 Hz, while vowels require three consecutive samples and use a 50 ms continuous interpolation to prevent rushed or abrupt mouth changes.
+- Speech-driven breathing, sleeves, and hair now ease into idle breathing when an utterance ends, removing the one-frame body twitch caused by an abrupt first idle frame.
+- Windows desktop shortcuts and taskbar windows now share the current MoHan half-body icon embedded in the executable. Installer integration tests fail closed outside disposable environments, and CI explicitly disables desktop-shortcut creation so tests cannot overwrite a real user's desktop or taskbar icon source.
+- OpenAI text-to-speech and Realtime now share one canonical voice order. Their ten mutually supported voices appear in exactly the same order; TTS-only `nova`, `fable`, and `onyx` remain at the end of the TTS list instead of appearing as unusable Realtime choices.
+
+## 日本語
+
+- 本版は、プロジェクト所有者 CHOU MING HUA が自ら認定した初の正式安定版であり、v2.3.0 候補系列の完全検証後に昇格した第三世代の節目です。検証済みの Python 3.15、パラメーター化レイヤー 2.5D、四言語、Azure Speech、セキュリティ、SBOM、機能限定クロスプラットフォーム Preview の契約を維持します。
+- 頬杖姿勢の発話で口角が元の位置に残る問題を修正しました。A／I／U／E／O は中央の唇だけでなく口全体と左右の口角を更新します。音声解析は 50 Hz を維持し、母音は三回連続のサンプルで確定し、50 ミリ秒の連続補間で口形の先走りや跳ねを抑えます。
+- 発話終了時、音量連動の呼吸、袖、髪を待機呼吸へ滑らかにつなぎ、最初の待機フレームで身体が一度だけ揺れる現象を解消しました。
+- Windows のデスクトップショートカットとタスクバーウィンドウは、EXE に埋め込まれた新版墨寒の半身アイコンを共用します。使い捨てでない環境ではインストーラー統合テストを既定で拒否し、CI でもデスクトップショートカット作成を明示的に無効化して、実利用者のデスクトップやタスクバーのアイコン参照元を上書きしません。
+- OpenAI のテキスト読み上げと Realtime 対話は、一つの正規音声順序を共有します。双方が対応する十音声は完全に同じ順序で表示し、TTS 専用の `nova`、`fable`、`onyx` は TTS 一覧の末尾だけに残して、利用不能な Realtime 選択肢として表示しません。

--- a/installer/mohan.iss
+++ b/installer/mohan.iss
@@ -87,8 +87,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\MoHan Desktop Assistant"; Filename: "{app}\{#ExecutableName}"; WorkingDir: "{app}"; IconFilename: "{app}\assets\mohan-halfbody.ico"; AppUserModelID: "FlamebladeStudio.MoHanDesktopAssistant"
-Name: "{autodesktop}\MoHan Desktop Assistant"; Filename: "{app}\{#ExecutableName}"; WorkingDir: "{app}"; IconFilename: "{app}\assets\mohan-halfbody.ico"; AppUserModelID: "FlamebladeStudio.MoHanDesktopAssistant"; Tasks: desktopicon
+Name: "{autoprograms}\MoHan Desktop Assistant"; Filename: "{app}\{#ExecutableName}"; WorkingDir: "{app}"; IconFilename: "{app}\{#ExecutableName}"; AppUserModelID: "FlamebladeStudio.MoHanDesktopAssistant"
+Name: "{autodesktop}\MoHan Desktop Assistant"; Filename: "{app}\{#ExecutableName}"; WorkingDir: "{app}"; IconFilename: "{app}\{#ExecutableName}"; AppUserModelID: "FlamebladeStudio.MoHanDesktopAssistant"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\{#ExecutableName}"; Description: "{cm:LaunchMoHan}"; Flags: nowait postinstall skipifsilent

--- a/installer/test_installers.ps1
+++ b/installer/test_installers.ps1
@@ -4,6 +4,16 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+if (
+    $env:GITHUB_ACTIONS -ne "true" -and
+    $env:MOHAN_ALLOW_INSTALLER_MUTATION -ne "1"
+) {
+    throw (
+        "Installer integration tests modify per-user installation state. " +
+        "Run them on GitHub Actions or set MOHAN_ALLOW_INSTALLER_MUTATION=1 " +
+        "only inside a disposable Windows account or virtual machine."
+    )
+}
 $ResolvedArtifacts = (Resolve-Path $ArtifactsDir).Path
 $ExeInstaller = Get-Item (Join-Path $ResolvedArtifacts "*Setup.exe")
 $MsiInstaller = Get-Item (Join-Path $ResolvedArtifacts "*.msi")
@@ -24,7 +34,8 @@ $env:MOHAN_DATA_DIR = Join-Path $env:RUNNER_TEMP "mohan-installer-profile"
 New-Item -ItemType Directory -Force $env:MOHAN_DATA_DIR | Out-Null
 
 $Process = Start-Process $ExeInstaller.FullName -ArgumentList @(
-    "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/DIR=$ExeInstallDir"
+    "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART",
+    "/MERGETASKS=!desktopicon", "/DIR=$ExeInstallDir"
 ) -Wait -PassThru
 if ($Process.ExitCode -ne 0) { throw "EXE installer failed" }
 $InstalledExe = Join-Path $ExeInstallDir "MoHan-Desktop-Assistant-$Version.exe"
@@ -50,9 +61,7 @@ if (-not (Test-Path -LiteralPath $ExeShortcutPath)) {
 $ExeShortcut = (New-Object -ComObject WScript.Shell).CreateShortcut(
     $ExeShortcutPath
 )
-$ExpectedIconLocation = (
-    Join-Path $ExeInstallDir "assets\mohan-halfbody.ico"
-) + ",0"
+$ExpectedIconLocation = $InstalledExe + ",0"
 if (-not [string]::Equals(
     $ExeShortcut.TargetPath,
     $InstalledExe,

--- a/lip_sync.py
+++ b/lip_sync.py
@@ -20,11 +20,11 @@ VOWEL_FORMANTS = frozendict({
 # the live-audio rate.
 VISEME_CUES_PER_SECOND = 50
 VISEME_CONFIRM_FRAMES = frozendict({
-    "A": 2,
-    "I": 2,
-    "U": 2,
-    "E": 2,
-    "O": 2,
+    "A": 3,
+    "I": 3,
+    "U": 3,
+    "E": 3,
+    "O": 3,
     "CONSONANT": 1,
 })
 VISEME_SILENCE_CONFIRM_FRAMES = 2
@@ -39,7 +39,7 @@ VISEME_MIN_HOLD_SECONDS = frozendict({
 })
 VISEME_OPEN_TRANSITION_SECONDS = 0.055
 VISEME_CLOSE_TRANSITION_SECONDS = 0.050
-VISEME_CHANGE_TRANSITION_SECONDS = 0.040
+VISEME_CHANGE_TRANSITION_SECONDS = 0.050
 VALID_VISEMES = frozenset({
     "A",
     "I",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "2.3.0rc5"
+version = "3.0.0"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "2.3.0rc5"
+version = "3.0.0"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/tests/test_four_language_documentation.py
+++ b/tests/test_four_language_documentation.py
@@ -109,31 +109,32 @@ def _language_sections(text: str) -> dict[str, str]:
     }
 
 
-def test_rc5_four_language_bullet_parity() -> None:
-    release_text = (ROOT / "docs/releases/v2.3.0-rc.5.md").read_text(
+def test_current_release_four_language_bullet_parity() -> None:
+    release_text = (ROOT / "docs/releases/v3.0.0.md").read_text(
         encoding="utf-8"
     )
     release_sections = _language_sections(release_text)
-    assert {
+    release_bullet_counts = {
         language: len(re.findall(r"(?m)^- ", section))
         for language, section in release_sections.items()
-    } == {language: 4 for language in LANGUAGE_HEADINGS}
+    }
+    assert len(set(release_bullet_counts.values())) == 1
+    assert next(iter(release_bullet_counts.values())) > 0
 
     changelog_text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     changelog_sections = _language_sections(changelog_text)
-    rc5_bullet_counts: dict[str, int] = {}
+    changelog_bullet_counts: dict[str, int] = {}
     for language, section in changelog_sections.items():
         match = re.search(
-            r"(?ms)^### v2\.3\.0 RC5.*?\n(.*?)(?=^### |\Z)",
+            r"(?ms)^### v3\.0\.0.*?\n(.*?)(?=^### |\Z)",
             section,
         )
         assert match is not None, language
-        rc5_bullet_counts[language] = len(
+        changelog_bullet_counts[language] = len(
             re.findall(r"(?m)^- ", match.group(1))
         )
-    assert rc5_bullet_counts == {
-        language: 4 for language in LANGUAGE_HEADINGS
-    }
+    assert len(set(changelog_bullet_counts.values())) == 1
+    assert next(iter(changelog_bullet_counts.values())) > 0
 
     for text in (release_text, changelog_text):
         assert "。、" not in text
@@ -145,7 +146,7 @@ def main() -> None:
     test_document_rejects_untranslated_duplicate_section()
     test_document_rejects_wrapped_english_word_repetition()
     test_repository_audit_ignores_deleted_tracked_documents()
-    test_rc5_four_language_bullet_parity()
+    test_current_release_four_language_bullet_parity()
     result = subprocess.run(
         [sys.executable, "tools/check_four_language_docs.py"],
         cwd=ROOT,

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -153,7 +153,7 @@ def test_release_publication_boundary(release: str) -> None:
         "commit: ${{ steps.source.outputs.commit }}",
         "ref: ${{ needs.resolve-release.outputs.commit }}",
         "Release tag changed after validation",
-        "Verify existing pre-release without modifying it",
+        "Verify existing release without modifying it",
         "Existing Release assets differ from the exact verified set.",
         "github.event_name == 'push' || inputs.publish",
         "metadata:",

--- a/tests/test_mouth_dynamics.py
+++ b/tests/test_mouth_dynamics.py
@@ -57,6 +57,8 @@ def run() -> None:
 
         for _ in range(2):
             cue(0.55, "O")
+        assert window.viseme_dynamics.current == "A"
+        cue(0.55, "O")
         assert window.viseme_dynamics.current == "O"
 
         before_release = window.viseme_dynamics.jaw_aperture

--- a/tests/test_mouth_visual_continuity.py
+++ b/tests/test_mouth_visual_continuity.py
@@ -16,7 +16,6 @@ lazy from PySide6.QtGui import QImage
 lazy from PySide6.QtWidgets import QApplication
 
 lazy from app import (
-    CHEEK_SPEECH_CENTRAL_MOUTH_RECT,
     CHEEK_SPEECH_CLOSED_EXPRESSION,
     CompanionWindow,
 )
@@ -80,7 +79,7 @@ def outside_region_changed_pixel_count(
 class MouthReference:
     eye_rect: QRect
     mouth_rect: QRect
-    fixed_corner_strips: dict[str, QRect]
+    corner_regions: dict[str, QRect]
     idle_base: QImage
     neutral_base: QImage
 
@@ -103,18 +102,18 @@ def _configure_window(window: CompanionWindow, app: QApplication) -> None:
     assert not window.eye_overlay.isHidden()
 
 
-def _fixed_corner_strips(mouth_rect: QRect) -> dict[str, QRect]:
+def _corner_regions(mouth_rect: QRect) -> dict[str, QRect]:
     return {
         "left": QRect(
             mouth_rect.left(),
             mouth_rect.top(),
-            CHEEK_SPEECH_CENTRAL_MOUTH_RECT.left() - mouth_rect.left(),
+            24,
             mouth_rect.height(),
         ),
         "right": QRect(
-            CHEEK_SPEECH_CENTRAL_MOUTH_RECT.right() + 1,
+            mouth_rect.right() - 23,
             mouth_rect.top(),
-            mouth_rect.right() - CHEEK_SPEECH_CENTRAL_MOUTH_RECT.right(),
+            24,
             mouth_rect.height(),
         ),
     }
@@ -123,8 +122,8 @@ def _fixed_corner_strips(mouth_rect: QRect) -> dict[str, QRect]:
 def _build_mouth_reference(window: CompanionWindow) -> MouthReference:
     mouth_rect = window.mouth_clips[""]
     assert mouth_rect == QRect(168, 195, 64, 40), (
-        "the chin-rest portrait must provide a stable neutral frame "
-        "for both speech corners"
+        "the chin-rest portrait must animate the complete mouth, including "
+        "both corners"
     )
     assert window.speech_closed_expression == CHEEK_SPEECH_CLOSED_EXPRESSION
     idle_base = (
@@ -137,11 +136,10 @@ def _build_mouth_reference(window: CompanionWindow) -> MouthReference:
         .toImage()
         .convertToFormat(QImage.Format_ARGB32)
     )
-    assert changed_pixel_count(
-        idle_base,
+    assert region_signature(idle_base, mouth_rect) == region_signature(
         neutral_base,
         mouth_rect,
-    ) > mouth_rect.width() * mouth_rect.height() // 12
+    )
     assert outside_region_changed_pixel_count(
         idle_base,
         neutral_base,
@@ -150,7 +148,7 @@ def _build_mouth_reference(window: CompanionWindow) -> MouthReference:
     return MouthReference(
         eye_rect=QRect(160, 135, 95, 48),
         mouth_rect=mouth_rect,
-        fixed_corner_strips=_fixed_corner_strips(mouth_rect),
+        corner_regions=_corner_regions(mouth_rect),
         idle_base=idle_base,
         neutral_base=neutral_base,
     )
@@ -160,7 +158,7 @@ def _assert_speech_expression_layers(
     window: CompanionWindow,
     reference: MouthReference,
 ) -> None:
-    central_signatures: set[tuple[int, ...]] = set()
+    mouth_signatures: set[tuple[int, ...]] = set()
     for expression in (
         "speaking",
         "mouth_mid",
@@ -174,21 +172,20 @@ def _assert_speech_expression_layers(
             .toImage()
             .convertToFormat(QImage.Format_ARGB32)
         )
-        central_signatures.add(
-            region_signature(speech_frame, CHEEK_SPEECH_CENTRAL_MOUTH_RECT)
-        )
-        for side, strip in reference.fixed_corner_strips.items():
-            assert region_signature(speech_frame, strip) == region_signature(
+        mouth_signatures.add(region_signature(speech_frame, reference.mouth_rect))
+        for side, region in reference.corner_regions.items():
+            assert changed_pixel_count(
                 reference.neutral_base,
-                strip,
-            ), f"{expression} changed the fixed {side} speech corner"
+                speech_frame,
+                region,
+            ) >= 12, f"{expression} left the neutral {side} corner behind"
         assert outside_region_changed_pixel_count(
             reference.idle_base,
             speech_frame,
             reference.mouth_rect,
         ) == 0, f"{expression} changed pixels outside the cheek mouth clip"
-    assert len(central_signatures) >= 4, (
-        "fixed corners must not flatten the central A/I/U/E/O shapes"
+    assert len(mouth_signatures) >= 4, (
+        "complete moving corners must not flatten the A/I/U/E/O shapes"
     )
 
 
@@ -236,12 +233,10 @@ def _assert_transition_integrity(
         outside_mouth_signature(frame, reference.mouth_rect) == clean_outside
         for frame in frames
     ), "pixels outside the frozen mouth region changed"
-    for frame in frames:
-        for side, strip in reference.fixed_corner_strips.items():
-            assert region_signature(frame, strip) == region_signature(
-                reference.neutral_base,
-                strip,
-            ), f"transition changed the fixed {side} speech corner"
+    for side, region in reference.corner_regions.items():
+        assert len({region_signature(frame, region) for frame in frames}) >= 4, (
+            f"the {side} speech corner remained fixed during transitions"
+        )
     assert window._active_speech_pose_suffix() == ""
 
 
@@ -260,7 +255,11 @@ def _assert_transition_smoothness(
         for first, second in pairwise(frames)
     ]
     assert direct_difference > 0.5
-    assert max(adjacent) < direct_difference * 0.82
+    assert max(adjacent) < direct_difference * 0.82, (
+        f"largest adjacent transition {max(adjacent):.3f} at frame "
+        f"{adjacent.index(max(adjacent)) + 1} exceeded "
+        f"82% of the direct viseme difference {direct_difference:.3f}"
+    )
     assert sum(value > 0.05 for value in adjacent) >= 8
     assert window.eye_overlay.isHidden()
 

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -131,7 +131,9 @@ def test_build_tool_is_pinned() -> None:
     _validate_version("2.3.0-rc.2")
     _validate_version("2.3.0-rc.3")
     _validate_version("2.3.0-rc.5")
-    for invalid in ("2.3.0", "2.3.0-rc", "2.3.0-rc.01", "2.2.0-rc.2"):
+    _validate_version("2.3.0")
+    _validate_version("3.0.0")
+    for invalid in ("2.3", "2.3.0-rc", "2.3.0-rc.01", "v3.0.0"):
         try:
             _validate_version(invalid)
         except ValueError:
@@ -143,13 +145,16 @@ def test_build_tool_is_pinned() -> None:
 def test_release_gate_is_pinned() -> None:
     release = read(".github/workflows/release.yml")
     preview = read(".github/workflows/preview-packages.yml")
-    assert '"v2.3.0-rc.*"' in release
-    assert "^v2\\.3\\.0-rc\\.[1-9][0-9]*$" in release
+    assert '"v*.*.*"' in release
+    assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in release
+    assert "^v[0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[1-9][0-9]*$" in release
     assert "pull_request:" not in release
     assert "gh release create" in release
     assert "artifact-metadata: write" in release
     assert "--draft" in release
-    assert 'gh release create "$tag" "${assets[@]}"' in release
+    assert 'gh release create "${release_args[@]}"' in release
+    assert 'release_args+=(--prerelease)' in release
+    assert 'prerelease="$EXPECTED_PRERELEASE"' in release
     assert "/releases/tags/$tag" not in release
     assert "and .draft == true" in release
     assert "draft=false" in release
@@ -196,7 +201,10 @@ def test_release_gate_is_pinned() -> None:
 
 
 def test_release_version_has_one_source_of_truth() -> None:
-    assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*", FALLBACK_VERSION)
+    assert re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[1-9][0-9]*)?",
+        FALLBACK_VERSION,
+    )
     tag = f"v{FALLBACK_VERSION}"
     assert (ROOT / "docs" / "releases" / f"{tag}.md").is_file()
     release = read(".github/workflows/release.yml")
@@ -219,7 +227,7 @@ def test_four_language_release_notes_and_boundaries() -> None:
     )
     positions = [notes.index(heading) for heading in expected_headings]
     assert positions == sorted(positions)
-    assert re.search(r"limited\s+Preview", notes)
+    assert re.search(r"limited(?:\s+cross-platform)?\s+Preview", notes)
     for phrase in ("功能受限", "機能限定"):
         assert phrase in notes
     guide = read("docs/PREVIEW-PACKAGES.md")

--- a/tests/test_readme_media.py
+++ b/tests/test_readme_media.py
@@ -6,14 +6,6 @@ lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MEDIA = ROOT / "docs" / "media"
-VERSION_MATCH = re.search(
-    r'^FALLBACK_VERSION = "([^"]+)"$',
-    (ROOT / "version_info.py").read_text(encoding="utf-8"),
-    re.MULTILINE,
-)
-assert VERSION_MATCH, "version_info.py must define one literal FALLBACK_VERSION"
-SOURCE_VERSION = VERSION_MATCH.group(1)
-SHIELD_VERSION = SOURCE_VERSION.replace("-", "--")
 PNG_FILES = {
     "mohan-hero.png": (1600, 900),
     "first-run-wizard.png": None,
@@ -51,13 +43,6 @@ README_BADGES = (
         "Extended Secret Defense / Gitleaks",
         ("https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/"
         "actions/workflows/secret-defense.yml/badge.svg"),
-    ),
-    (
-        f"Development Version v{SOURCE_VERSION}",
-        (
-            "https://img.shields.io/badge/development_version-"
-            f"v{SHIELD_VERSION}-5c6ac4.svg"
-        ),
     ),
     (
         "Latest Published Release",

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -142,9 +142,12 @@ def test_inno_setup_and_artwork_contract() -> None:
     assert inno_script.count(
         'AppUserModelID: "FlamebladeStudio.MoHanDesktopAssistant"'
     ) == 2
-    installed_icon = 'IconFilename: "{app}\\assets\\mohan-halfbody.ico"'
+    installed_icon = 'IconFilename: "{app}\\{#ExecutableName}"'
     assert inno_script.count(installed_icon) == 2
     assert 'IconFilename: "{#IconPath}"' not in inno_script
+    installer_test = read("installer/test_installers.ps1")
+    assert 'MOHAN_ALLOW_INSTALLER_MUTATION -ne "1"' in installer_test
+    assert '"/MERGETASKS=!desktopicon"' in installer_test
 
     canonical = ROOT / "assets/expressions/idle_front.png"
     assert_image(canonical, (1254, 1254))
@@ -225,6 +228,13 @@ def test_windows_taskbar_icon_contract() -> None:
     )[1].split("\n    def ", maxsplit=1)[0]
     assert "QIcon(str(resource_path(APP_ICON_PATH)))" not in app
     assert dashboard_setup.index("self.setWindowFlags(") < dashboard_setup.index(
+        "self.setWindowIcon(application_icon())"
+    )
+    character_setup = app.split(
+        "def _configure_character_window(self) -> None:",
+        maxsplit=1,
+    )[1].split("\n    def ", maxsplit=1)[0]
+    assert character_setup.index("self.setWindowFlags(") < character_setup.index(
         "self.setWindowIcon(application_icon())"
     )
 

--- a/tests/test_sbom_validation.py
+++ b/tests/test_sbom_validation.py
@@ -53,9 +53,10 @@ def runtime_policy(
 
 def test_release_version_and_repository_policy_are_synchronized() -> None:
     assert _release_version("v9.8.7-rc.6") == "9.8.7rc6"
-    for invalid in ("9.8.7-rc.6", "v9.8.7", "v9.8.7-rc.0"):
+    assert _release_version("v9.8.7") == "9.8.7"
+    for invalid in ("9.8.7-rc.6", "v9.8", "v9.8.7-rc.0"):
         message = expect_value_error(lambda value=invalid: _release_version(value))
-        assert "vN.N.N-rc.N" in message
+        assert "vN.N.N or vN.N.N-rc.N" in message
 
     policies = load_policies(ROOT / "sbom" / "components.toml")
     windows = _profile_policies(policies, "windows")

--- a/tests/test_speech_state_machine.py
+++ b/tests/test_speech_state_machine.py
@@ -76,6 +76,18 @@ def _assert_local_speech_completion(
     )
 
 
+def _assert_completion_breath_is_continuous(window: CompanionWindow) -> None:
+    window.state = "speaking"
+    window.current_breath = 0.92
+    window.idle_phase = 53
+    window.set_state("idle", force=True)
+    before_idle_tick = window.current_breath
+    window._idle_tick()
+    assert abs(window.current_breath - before_idle_tick) <= 0.22, (
+        "the first idle breath frame snapped after speech completion"
+    )
+
+
 def _assert_realtime_natural_close(
     app: QApplication,
     window: CompanionWindow,
@@ -193,6 +205,7 @@ def run() -> None:
         app, window = _create_window(temp_dir)
         try:
             _assert_local_speech_completion(app, window)
+            _assert_completion_breath_is_continuous(window)
             _assert_realtime_natural_close(app, window)
             _assert_normal_realtime_answer(app, window)
             _assert_emotion_metadata_hidden(window)

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -725,6 +725,17 @@ def _assert_voice_selection_contract(window: CompanionWindow) -> None:
     assert window.dashboard.cloud_voice.currentText() == "coral"
     assert window.dashboard.tts_voice.currentText() == "coral"
     assert window.dashboard.realtime_voice.currentText() == "coral"
+    tts_voices = [
+        window.dashboard.tts_voice.itemText(index)
+        for index in range(window.dashboard.tts_voice.count())
+    ]
+    realtime_voices = [
+        window.dashboard.realtime_voice.itemText(index)
+        for index in range(window.dashboard.realtime_voice.count())
+    ]
+    assert [voice for voice in tts_voices if voice in realtime_voices] == (
+        realtime_voices
+    )
     local_index = window.dashboard.voice_engine.findData("system-local")
     openai_index = window.dashboard.voice_engine.findData("openai-speech")
     assert local_index >= 0 and openai_index >= 0

--- a/tests/test_viseme_sync_contract.py
+++ b/tests/test_viseme_sync_contract.py
@@ -97,8 +97,10 @@ def _assert_sustain_and_vowel_change(
     vowel_change_started = cue.clock[0]
     cue("O")
     cue("O")
+    assert window.viseme_dynamics.current == "A"
+    cue("O")
     assert window.viseme_dynamics.current == "O"
-    assert cue.clock[0] - vowel_change_started <= 0.041
+    assert cue.clock[0] - vowel_change_started <= 0.061
 
 
 def _assert_consonant_and_close(

--- a/tools/build_preview_package.py
+++ b/tools/build_preview_package.py
@@ -14,7 +14,9 @@ lazy import tempfile
 lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-VERSION_PATTERN = re.compile(r"^2\.3\.0-rc\.(?:0|[1-9][0-9]*)$")
+VERSION_PATTERN = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.(?:0|[1-9][0-9]*))?$"
+)
 APPIMAGETOOL_SOURCE_COMMIT = "8c8c91f762b412a19f4e8d2c4b35afb98f2d7c81"
 APPIMAGETOOL_ASSET_ID = "324406882"
 APPIMAGETOOL_SHA256 = (
@@ -41,7 +43,7 @@ def _sha256(path: Path) -> str:
 def _validate_version(version: str) -> None:
     if not VERSION_PATTERN.fullmatch(version):
         raise ValueError(
-            "Preview packages are restricted to the 2.3.0-rc.N line"
+            "Preview packages require an N.N.N or N.N.N-rc.N version"
         )
 
 

--- a/tools/create_release_metadata.py
+++ b/tools/create_release_metadata.py
@@ -8,7 +8,9 @@ lazy from dataclasses import dataclass
 lazy from pathlib import Path
 lazy from urllib.parse import quote
 
-TAG_PATTERN = re.compile(r"^v2\.3\.0-rc\.[1-9][0-9]*$")
+TAG_PATTERN = re.compile(
+    r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-rc\.[1-9][0-9]*)?$"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,7 +49,7 @@ def _parse_arguments() -> ReleaseArguments:
 
 def _validate_tag(tag: str) -> None:
     if not TAG_PATTERN.fullmatch(tag):
-        raise ValueError("Release metadata is restricted to v2.3.0-rc.N tags")
+        raise ValueError("Release metadata requires a vN.N.N or vN.N.N-rc.N tag")
 
 
 def _package_specs(tag: str) -> tuple[PackageSpec, ...]:

--- a/tools/validate_release_sboms.py
+++ b/tools/validate_release_sboms.py
@@ -13,7 +13,8 @@ lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_TAG = re.compile(
-    r"^v(?P<base>[0-9]+\.[0-9]+\.[0-9]+)-rc\.(?P<rc>[1-9][0-9]*)$"
+    r"^v(?P<base>[0-9]+\.[0-9]+\.[0-9]+)"
+    r"(?:-rc\.(?P<rc>[1-9][0-9]*))?$"
 )
 PINNED_REQUIREMENT = re.compile(
     r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)==(?P<version>[^\s;]+)$"
@@ -183,8 +184,13 @@ def _sha256(path: Path) -> str:
 def _release_version(tag: str) -> str:
     match = RELEASE_TAG.fullmatch(tag)
     if match is None:
-        raise ValueError("SBOM validation is restricted to vN.N.N-rc.N tags.")
-    return f"{match.group('base')}rc{match.group('rc')}"
+        raise ValueError("SBOM validation requires a vN.N.N or vN.N.N-rc.N tag.")
+    rc_number = match.group("rc")
+    return (
+        match.group("base")
+        if rc_number is None
+        else f"{match.group('base')}rc{rc_number}"
+    )
 
 
 def _policy_from_row(row: JsonObject, index: int) -> ComponentPolicy:

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "2.3.0-rc.5"
+FALLBACK_VERSION = "3.0.0"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文

### 變更內容

- 將墨寒升格為專案擁有者認可的首個正式穩定版 v3.0.0，統一程式、套件、SBOM、文件與發布工作流程的版本來源。
- 修正托腮講話時左右嘴角殘留、嘴型搶拍，以及語音結束瞬間的身體抖動。
- 修正 Windows 桌面捷徑與工作列空白圖示，讓捷徑及所有原生視窗共用 EXE 內嵌的新版墨寒半身像。
- 統一 OpenAI 文字轉語音與 Realtime 的共同聲線順序。
- README 改為單一 GitHub 自動發布版本標章，並以不寫死正式版或 RC 的 Releases 說明取代重複版本文字。
- 發布工作流程同時支援不可變的正式版與 RC 標籤，依標籤自動設定 Stable 或 Pre-release，並保留完整供應鏈與發布閘門。

### 根因與影響

托腮姿態過去只替換中央嘴唇，兩側嘴角因此留在原位；語音呼吸在結束時直接切回待機波形，造成單影格身體抖動。舊安裝器捷徑則引用安裝後不存在的圖示路徑，使 Windows 工作列回查 AppUserModelID 時顯示空白文件。這些路徑現已統一修正，且不改變既有 50 Hz 音訊分析契約。

### 驗證

- Python 3.15 完整回歸：70／70 通過。
- 嘴型效能：平均 0.318 ms、P95 0.536 ms、P99 0.635 ms。
- 四語文件、Windows 安裝與捷徑、GitHub 治理、SBOM、更新器、跨平台核心及視覺驗收測試通過。

## 简体中文

### 变更内容

- 将墨寒升级为项目所有者认可的首个正式稳定版 v3.0.0，统一程序、软件包、SBOM、文档和发布工作流的版本来源。
- 修复托腮说话时左右嘴角残留、嘴形抢拍，以及语音结束瞬间的身体抖动。
- 修复 Windows 桌面快捷方式与任务栏空白图标，让快捷方式和所有原生窗口共用 EXE 内嵌的新版墨寒半身像。
- 统一 OpenAI 文字转语音与 Realtime 的共同声线顺序。
- README 改为单一 GitHub 自动发布版本标章，并以不写死正式版或 RC 的 Releases 说明取代重复版本文字。
- 发布工作流同时支持不可变的正式版与 RC 标签，依标签自动设置 Stable 或 Pre-release，并保留完整供应链与发布门禁。

### 根因与影响

托腮姿态过去只替换中央嘴唇，两侧嘴角因此留在原位；语音呼吸在结束时直接切回待机波形，造成单帧身体抖动。旧安装器快捷方式还引用安装后不存在的图标路径，使 Windows 任务栏回查 AppUserModelID 时显示空白文件。这些路径现已统一修复，且不改变原有 50 Hz 音频分析契约。

### 验证

- Python 3.15 完整回归：70／70 通过。
- 嘴形性能：平均 0.318 ms、P95 0.536 ms、P99 0.635 ms。
- 四语文档、Windows 安装与快捷方式、GitHub 治理、SBOM、更新器、跨平台核心及视觉验收测试通过。

## English

### Changes

- Promotes MoHan to v3.0.0, the first stable release approved by the project owner, with one version across runtime, package, SBOM, documentation, and release automation metadata.
- Fixes stranded mouth corners during chin-rest speech, rushed viseme changes, and the one-frame body twitch when speech ends.
- Fixes blank Windows desktop and taskbar icons by making shortcuts and every native window share the current half-body icon embedded in the executable.
- Gives OpenAI text-to-speech and Realtime one canonical order for their shared voices.
- Replaces duplicate, hard-coded README version labels with one automatic GitHub published-release badge and release-neutral guidance that remains valid for stable and RC releases.
- Generalizes the immutable release workflow for stable and RC tags, derives Stable or Pre-release status from the tag, and preserves every supply-chain and publication gate.

### Root cause and impact

The chin-rest renderer replaced only the central lips, leaving both corners behind. Speech-driven breathing also snapped directly to the idle waveform, producing a one-frame body twitch. The previous installer shortcut referenced an icon path that did not exist after installation, so Windows taskbar grouping through AppUserModelID resolved to a blank document. These paths are now unified without changing the existing 50 Hz audio-analysis contract.

### Validation

- Python 3.15 full regression suite: 70／70 passed.
- Mouth rendering: 0.318 ms mean, 0.536 ms P95, 0.635 ms P99.
- Four-language documentation, Windows installer and shortcut, GitHub governance, SBOM, updater, cross-platform core, and visual acceptance tests passed.

## 日本語

### 変更内容

- 墨寒を、プロジェクト所有者が認定する初の正式安定版 v3.0.0 へ昇格し、実行時、パッケージ、SBOM、文書、公開自動化のバージョン情報を統一しました。
- 頬杖姿勢の発話で左右の口角が残る問題、口形の先走り、発話終了時の一フレームだけの身体揺れを修正しました。
- Windows のデスクトップとタスクバーの空白アイコンを修正し、ショートカットとすべてのネイティブウィンドウが EXE 内蔵の新版墨寒半身アイコンを共用します。
- OpenAI テキスト読み上げと Realtime の共通音声順序を一つに統一しました。
- README の重複した固定バージョン表示を、GitHub が自動更新する単一の公開版バッジと、正式版／RC の双方で有効な Releases 案内に置き換えました。
- 不変の正式版タグと RC タグの双方を扱い、タグから Stable／Pre-release を自動判定しながら、すべての供給網・公開ゲートを維持するよう公開ワークフローを拡張しました。

### 原因と影響

頬杖姿勢の描画は中央の唇だけを置換していたため、左右の口角が残っていました。また、発話連動の呼吸が待機波形へ直接切り替わり、一フレームだけ身体が揺れていました。旧インストーラーのショートカットはインストール後に存在しないアイコンを参照し、AppUserModelID を使う Windows のタスクバー表示が空白になっていました。既存の 50 Hz 音声解析契約を変えずに、これらの経路を統一しました。

### 検証

- Python 3.15 完全回帰：70／70 合格。
- 口形描画性能：平均 0.318 ms、P95 0.536 ms、P99 0.635 ms。
- 四言語文書、Windows インストーラーとショートカット、GitHub ガバナンス、SBOM、更新機構、クロスプラットフォーム中核、視覚受入テストに合格。
