### PR TITLE
發布：Azure Dragon HD 預覽版 v3.1.0／发布：Azure Dragon HD 预览版 v3.1.0／Release: Azure Dragon HD Preview v3.1.0／リリース：Azure Dragon HD プレビュー v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### v3.1.0 — 2026-08-11
+
+- 新增預設關閉的 Azure Dragon HD／HD Omni 女性聲線 Preview，以獨立 S0 金鑰、區域與聲線設定運作，不改變既有語音供應器。
+- Azure 區域改為切換後自動儲存的選單；只顯示官方支援的女性 HD 聲線，HD Flash 依區域能力自動隱藏。
+- 三種雲端金鑰統一採密碼遮罩、Windows DPAPI 自動加密與成功後清空輸入框；Dragon HD 失敗時只依序嘗試一般 Azure 與 Windows 本機女聲各一次。
+- Central India S0 已完成真實 Windows 合成與播放驗證；臺灣連線的發話前等待明顯，因此介面與文件保留 Preview、區域延遲及費用警告，嘴型仍由既有 50 Hz 本機音訊分析同步驅動。
+
 ### v3.0.0 — 2026-08-11
 
 - 專案擁有者親自認可的第一個正式穩定版本，也是由 v2.3.0 候選系列完整驗證後升格的第三代里程碑。
@@ -177,6 +184,13 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### v3.1.0 — 2026-08-11
+
+- 新增默认关闭的 Azure Dragon HD／HD Omni 女性声线 Preview，以独立 S0 密钥、区域与声线设置运行，不改变现有语音供应器。
+- Azure 区域改为切换后自动保存的选单；只显示官方支持的女性 HD 声线，HD Flash 按区域能力自动隐藏。
+- 三种云端密钥统一采用密码遮罩、Windows DPAPI 自动加密与成功后清空输入框；Dragon HD 失败时只依次尝试一般 Azure 与 Windows 本地女声各一次。
+- Central India S0 已完成真实 Windows 合成与播放验证；台湾连接的发话前等待明显，因此界面与文档保留 Preview、区域延迟及费用警告，嘴型仍由现有 50 Hz 本地音频分析同步驱动。
+
 ### v3.0.0 — 2026-08-11
 
 - 项目所有者亲自认可的第一个正式稳定版本，也是由 v2.3.0 候选系列完整验证后升级的第三代里程碑。
@@ -348,6 +362,13 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v3.1.0 — 2026-08-11
+
+- Adds a disabled-by-default Azure Dragon HD/HD Omni female-voice Preview with separate S0 key, region, and voice settings, leaving existing speech providers unchanged.
+- Azure regions now use an immediately saved selector; only officially supported female HD voices appear, and HD Flash is hidden according to regional capability.
+- All three cloud-key inputs share password masking, automatic Windows DPAPI encryption, and post-save clearing. Dragon HD failure tries standard Azure and Windows local female speech once each in order.
+- A real Central India S0 resource passed Windows synthesis and playback validation. Taiwan experienced a noticeable wait before speech, so the UI and documentation retain Preview, regional-latency, and cost warnings while existing local 50 Hz audio analysis remains the lip-sync authority.
 
 ### v3.0.0 — 2026-08-11
 
@@ -560,6 +581,13 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v3.1.0 — 2026-08-11
+
+- 初期状態で無効な Azure Dragon HD／HD Omni 女性音声 Preview を追加し、独立した S0 キー、リージョン、音声設定で動作させ、既存の音声プロバイダーを変更しません。
+- Azure リージョンは切替後すぐ保存する選択欄となり、公式対応の女性 HD 音声だけを表示し、HD Flash はリージョン機能に応じて自動的に隠します。
+- 三種のクラウドキー入力は、パスワード表示、Windows DPAPI 自動暗号化、保存成功後の入力欄消去を共用します。Dragon HD 失敗時は通常の Azure と Windows 本機女性音声を順に各一回だけ試します。
+- Central India S0 の実リソースで Windows の合成と再生を検証しました。台湾からは発話開始前の待ち時間が明確なため、画面と文書に Preview、リージョン遅延、料金の注意を残し、口形同期は従来の 50 Hz 本機音声解析を正規情報源として維持します。
 
 ### v3.0.0 — 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "3.0.0"
+version: "3.1.0"
 date-released: "2026-08-11"
 license: MIT
 abstract: >-

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,8 +38,8 @@ open-source
 
 ### 已準備的公開預發行版
 
-- 標籤：`v3.0.0`
-- 標題：`MoHan Desktop Assistant v3.0.0`
+- 標籤：`v3.1.0`
+- 標題：`MoHan Desktop Assistant v3.1.0`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
@@ -203,8 +203,8 @@ open-source
 
 ### 已准备的公开预发布版
 
-- 标签：`v3.0.0`
-- 标题：`MoHan Desktop Assistant v3.0.0`
+- 标签：`v3.1.0`
+- 标题：`MoHan Desktop Assistant v3.1.0`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
@@ -368,8 +368,8 @@ open-source
 
 ### Prepared public pre-release
 
-- Tag: `v3.0.0`
-- Title: `MoHan Desktop Assistant v3.0.0`
+- Tag: `v3.1.0`
+- Title: `MoHan Desktop Assistant v3.1.0`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
@@ -533,8 +533,8 @@ open-source
 
 ### 準備済みの公開プレリリース
 
-- タグ：`v3.0.0`
-- タイトル：`MoHan Desktop Assistant v3.0.0`
+- タグ：`v3.1.0`
+- タイトル：`MoHan Desktop Assistant v3.1.0`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-3.0.0.exe`。
+2. 執行 `MoHan-Desktop-Assistant-3.1.0.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -23,7 +23,7 @@ Microsoft、GitHub 與 Home Assistant 屬於尚未完成真實環境端到端驗
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.0.0` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
+`v3.1.0` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
 （內含 `.app`），以及 Linux x86_64 AppImage，只用於
 啟動、四語介面、平台路徑及安全停用驗證。請先核對 SHA256SUMS 與 Artifact
 Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角色、完整聊天／
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-3.0.0.exe`。
+2. 运行 `MoHan-Desktop-Assistant-3.1.0.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -52,7 +52,7 @@ Microsoft、GitHub 与 Home Assistant 仍属于尚未完成真实环境端到端
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.0.0` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
+`v3.1.0` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
 （内含 `.app`），以及 Linux x86_64 AppImage，只用于
 验证启动、四语界面、平台路径与安全停用。请核对 SHA256SUMS 与 Artifact
 Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色、完整聊天／工作
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-3.0.0.exe`.
+2. Run `MoHan-Desktop-Assistant-3.1.0.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -81,7 +81,7 @@ See [README.md](README.md) for complete setup, OAuth, safety, and privacy notes.
 
 ### Limited macOS/Linux Preview
 
-The `v3.0.0` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
+The `v3.1.0` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
 (each containing a `.app`) and Linux x86_64 AppImage
 validate startup, four-language UI, platform paths, and fail-closed boundaries
 only. Verify SHA256SUMS and the Artifact Attestation first. These packages have
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-3.0.0.exe` を実行します。
+2. `MoHan-Desktop-Assistant-3.1.0.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う
@@ -114,7 +114,7 @@ Microsoft、GitHub、Home Assistant は、実環境でのエンドツーエン�
 
 ### macOS／Linux 機能限定 Preview
 
-`v3.0.0` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
+`v3.1.0` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
 （各 `.app` 同梱）、および Linux x86_64 AppImage は、
 起動、四言語画面、OS ごとの保存先、安全な無効化だけを確認します。先に
 SHA256SUMS と Artifact Attestation を確認してください。API キー入力、音声、

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.0.0 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.0 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -185,6 +185,7 @@ Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責�
 - 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
 - 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
 - 已完成真實連線驗證的 Azure Speech 女性聲線預覽；中文介面可跨語系選擇臺灣華語與簡體普通話，使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
+- 可選的 Azure Dragon HD／HD Omni 女性聲線預覽，使用獨立 S0 金鑰與支援區域；失敗時依序退回一般 Azure Speech 與 Windows 本機女聲。
 - 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
 - 工作、陪伴、勿擾、會議、離開及睡眠模式。
 - 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
@@ -221,6 +222,8 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證。此結果確認墨寒的整合路徑可用，但不保證每個帳號、區域或當期配額皆相同。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
+`v3.1.0` 新增獨立且預設關閉的 Azure Dragon HD／HD Omni 預覽供應器。它使用自己的 S0 金鑰、區域與女性聲線清單；HD Flash 只會在 Microsoft 官方支援的區域顯示。2026 年 8 月 11 日已使用 Central India S0 完成真實 Windows 合成與播放驗證，但臺灣連線的發話前等待明顯，實際延遲取決於網路路由與區域距離。Dragon HD 不提供 viseme 事件，因此墨寒仍以同一套 50 Hz 本機音訊分析驅動嘴型，網路等待不會被硬編碼成嘴型偏移。
+
 ### 整合驗證狀態
 
 > **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
@@ -245,7 +248,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-v3.0.0 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.1.0 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
@@ -356,7 +359,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.0.0"
+.\build.ps1 -Version "3.1.0"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
@@ -402,7 +405,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.0.0 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.0 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -573,6 +576,7 @@ Codex 协助我把想法转译成程序架构与代码；而我始终负责决�
 - 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
 - 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
 - 已完成真实连接验证的 Azure Speech 女性声线预览；中文界面可跨语言选择台湾华语与简体普通话，用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
+- 可选的 Azure Dragon HD／HD Omni 女性声线预览，使用独立 S0 密钥与支持区域；失败时依次回退到一般 Azure Speech 与 Windows 本地女声。
 - 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
 - 工作、陪伴、勿扰、会议、离开及睡眠模式。
 - 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
@@ -609,6 +613,8 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证。此结果确认墨寒的集成路径可用，但不保证每个账号、区域或当前配额都相同。Dragon HD／HD Omni 因方案、计费与区域支持不同，不混入免费默认列表。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
+`v3.1.0` 新增独立且默认关闭的 Azure Dragon HD／HD Omni 预览供应器。它使用自己的 S0 密钥、区域与女性声线列表；HD Flash 只会在 Microsoft 官方支持的区域显示。2026 年 8 月 11 日已使用 Central India S0 完成真实 Windows 合成与播放验证，但台湾连接的发话前等待明显，实际延迟取决于网络路由与区域距离。Dragon HD 不提供 viseme 事件，因此墨寒仍以同一套 50 Hz 本地音频分析驱动嘴型，网络等待不会被硬编码为嘴型偏移。
+
 ### 集成验证状态
 
 > **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
@@ -633,7 +639,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-v3.0.0 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.1.0 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
@@ -744,7 +750,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.0.0"
+.\build.ps1 -Version "3.1.0"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
@@ -790,7 +796,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.0.0 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.0 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -961,6 +967,7 @@ If this project encourages even one person without an engineering background to 
 - Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
 - Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
 - A live-validated Azure Speech female-voice Preview. Chinese UI can select both Taiwan Mandarin and Simplified Chinese Mandarin; users supply their own key and region, with immediate Windows fallback on failure.
+- An optional Azure Dragon HD/HD Omni female-voice Preview with a separate S0 key and supported region; failures fall back to standard Azure Speech and then Windows local female speech.
 - Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
 - Work, companion, do-not-disturb, meeting, away, and sleep modes.
 - A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
@@ -997,6 +1004,8 @@ The interface lists only Traditional Chinese, Simplified Chinese, English, and J
 
 On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. This confirms MoHan's integration path, but does not guarantee identical account, region, or quota behavior. Dragon HD and HD Omni stay out of the free default list because their tier, billing, and regional support differ. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
 
+`v3.1.0` adds a separate, disabled-by-default Azure Dragon HD/HD Omni Preview provider with its own S0 key, region, and female-voice catalog. HD Flash voices appear only in regions officially supported by Microsoft. A real Central India S0 resource completed Windows synthesis and playback validation on August 11, 2026, but Taiwan experienced a noticeable wait before speech; actual latency depends on network routing and region distance. Dragon HD provides no viseme events, so MoHan keeps the same local 50 Hz audio analysis as the lip-sync authority instead of hardcoding network delay as a mouth offset.
+
 ### Integration verification status
 
 > **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
@@ -1021,7 +1030,7 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-v3.0.0 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+v3.1.0 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
@@ -1132,7 +1141,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.0.0"
+.\build.ps1 -Version "3.1.0"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
@@ -1178,7 +1187,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.0.0 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.0 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
@@ -1349,6 +1358,7 @@ Codex は私の思いをアーキテクチャとコードへ翻訳する手助�
 - テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
 - Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
 - 実接続検証済みの任意 Azure Speech 女性音声 Preview。中国語画面では台湾華語と簡体字普通話を言語横断で選択でき、利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻ります。
+- 独立した S0 キーと対応リージョンを使う任意の Azure Dragon HD／HD Omni 女性音声 Preview。失敗時は通常の Azure Speech、Windows 本機女性音声の順に戻ります。
 - 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
 - 仕事、同伴、集中、会議、離席、休眠モード。
 - 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
@@ -1385,6 +1395,8 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。これは墨寒の統合経路を確認する結果であり、すべてのアカウント、リージョン、割り当てで同じ動作を保証するものではありません。Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
 
+`v3.1.0` は、独立して初期状態では無効な Azure Dragon HD／HD Omni Preview 供給元を追加します。専用の S0 キー、リージョン、女性音声一覧を使用し、HD Flash は Microsoft が公式対応するリージョンだけに表示します。2026 年 8 月 11 日、Central India S0 の実リソースで Windows の合成と再生を検証しましたが、台湾からは発話開始前の待ち時間が明確にありました。実際の遅延はネットワーク経路とリージョン間距離に依存します。Dragon HD は viseme イベント非対応のため、墨寒はネットワーク待ち時間を口形オフセットへ固定せず、従来と同じ 50 Hz 本機音声解析を口形同期の正規情報源として維持します。
+
 ### 統合の検証状況
 
 > **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
@@ -1409,7 +1421,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-v3.0.0 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.1.0 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 
@@ -1520,7 +1532,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.0.0"
+.\build.ps1 -Version "3.1.0"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。

--- a/app.py
+++ b/app.py
@@ -95,7 +95,15 @@ lazy from ai_client import (
     AIWorker,
     AIWorkerRequest,
 )
-lazy from azure_speech import azure_female_voices
+lazy from azure_regions import (
+    azure_region_identifiers,
+    azure_region_options,
+    azure_region_supports_hd_flash,
+)
+lazy from azure_speech import (
+    azure_female_voices,
+    azure_hd_female_voices,
+)
 lazy from background_agents import (
     DiagnosticReportWorker,
     ManagerWorkerScheduler,
@@ -114,11 +122,10 @@ lazy from expression_system import (
     parse_internal_emotion,
     plan_wait_expressions,
 )
-lazy from feature_registry import DashboardFeatureRegistry
 lazy from face_assets import validate_face_assets
 lazy from face_motion import FaceMotionController
 lazy from face_renderer import FaceRenderLayers, ParametricFaceRenderer
-lazy from face_rig import FaceMotionFrame
+lazy from feature_registry import DashboardFeatureRegistry
 lazy from flagship_ui import FlagshipControlCenter
 lazy from language_support import (
     english_voice_instructions,
@@ -153,11 +160,12 @@ lazy from realtime_voice import (
 lazy from service_container import CompanionServices, create_default_services
 lazy from speech import (
     SpeechListener,
-    is_known_male_windows_voice,
+    female_windows_voices_for_language,
     preferred_windows_voice,
     windows_voices,
 )
 lazy from speech_providers import (
+    AZURE_HD_SPEECH_PROVIDER,
     AZURE_SPEECH_PROVIDER,
     OPENAI_REALTIME_PROVIDER,
     OPENAI_SPEECH_PROVIDER,
@@ -217,6 +225,44 @@ class SpeechCredentials:
     openai_api_key: str
     azure_api_key: str
     azure_region: str
+    azure_hd_api_key: str
+    azure_hd_region: str
+
+
+@dataclass(frozen=True, slots=True)
+class SecretInputPolicy:
+    saved_key: str
+    saved_fallback: str
+    title_key: str
+    title_fallback: str
+    error_key: str
+    error_fallback: str
+
+
+OPENAI_SECRET_POLICY = SecretInputPolicy(
+    saved_key="api_key_saved",
+    saved_fallback="已安全保存（留空不變）",
+    title_key="api_key",
+    title_fallback="OpenAI API 金鑰",
+    error_key="api_key_save_failed",
+    error_fallback="無法安全保存 OpenAI API 金鑰：{error}",
+)
+AZURE_SECRET_POLICY = SecretInputPolicy(
+    saved_key="azure_key_saved",
+    saved_fallback="已由作業系統安全保存（留空不變）",
+    title_key="azure_key",
+    title_fallback="Azure Speech 金鑰",
+    error_key="azure_key_save_failed",
+    error_fallback="無法安全保存 Azure Speech 金鑰：{error}",
+)
+AZURE_HD_SECRET_POLICY = SecretInputPolicy(
+    saved_key="azure_hd_key_saved",
+    saved_fallback="Dragon HD S0 金鑰已由 Windows 加密保存（留空不變）",
+    title_key="azure_hd_key",
+    title_fallback="Dragon HD S0 金鑰",
+    error_key="azure_hd_key_save_failed",
+    error_fallback="無法安全保存 Dragon HD S0 金鑰：{error}",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -224,6 +270,7 @@ class DashboardDependencies:
     listener: SpeechListenerPort
     secret_store: SecretStorePort
     azure_secret_store: SecretStorePort | None = None
+    azure_hd_secret_store: SecretStorePort | None = None
     secret_store_factory: SecretStoreFactoryPort | None = None
     platform_services: PlatformServicePort | None = None
 
@@ -725,6 +772,7 @@ VOICE_ENGINE_WINDOWS = VOICE_ENGINE_SYSTEM
 VOICE_ENGINE_OPENAI = OPENAI_SPEECH_PROVIDER
 VOICE_ENGINE_REALTIME = OPENAI_REALTIME_PROVIDER
 VOICE_ENGINE_AZURE = AZURE_SPEECH_PROVIDER
+VOICE_ENGINE_AZURE_HD = AZURE_HD_SPEECH_PROVIDER
 
 OPENAI_VOICE_ORDER = (
     "coral",
@@ -1874,6 +1922,7 @@ class Dashboard(QDialog):
         self.listener = dependencies.listener
         self.secret_store = dependencies.secret_store
         self.azure_secret_store = dependencies.azure_secret_store
+        self.azure_hd_secret_store = dependencies.azure_hd_secret_store
         self.secret_store_factory = (
             dependencies.secret_store_factory
         )
@@ -2957,6 +3006,13 @@ class Dashboard(QDialog):
                 VOICE_ENGINE_AZURE,
                 self._t("azure_engine", "Azure Speech（預覽）"),
             ),
+            (
+                VOICE_ENGINE_AZURE_HD,
+                self._t(
+                    "azure_hd_engine",
+                    "Azure Dragon HD（預覽，需 S0）",
+                ),
+            ),
         )
         for key, label in cloud_engines:
             combo.addItem(label, key)
@@ -3013,18 +3069,10 @@ class Dashboard(QDialog):
     ) -> tuple[tuple[str, str], ...]:
         if not capabilities.system_local_speech:
             return ()
-        chinese_interface = self.ui_language.lower() in {
-            "zh",
-            "zh-tw",
-            "zh-cn",
-        }
         return tuple(
-            (name, culture)
-            for name, culture in windows_voices()
-            if not is_known_male_windows_voice(name)
-            and (
-                not chinese_interface
-                or culture.lower().split("-", 1)[0] == "zh"
+            female_windows_voices_for_language(
+                windows_voices(),
+                self.ui_language,
             )
         )
 
@@ -3111,13 +3159,132 @@ class Dashboard(QDialog):
             selected_voice,
         )
         self.azure_voice.setEditable(False)
-        self.azure_region = QLineEdit(
-            str(self.db.setting("azure_speech_region", ""))
-        )
-        self.azure_region.setPlaceholderText(
-            self._t("azure_region_placeholder", "例如：eastasia")
+        self.azure_region = self._azure_region_combo(
+            setting_key="azure_speech_region",
         )
         self._initialize_azure_key_controls(capabilities)
+
+        saved_hd_region = str(
+            self.db.setting("azure_hd_speech_region", "")
+        ).strip().lower()
+        azure_hd_voices = azure_hd_female_voices(
+            self.ui_language,
+            include_flash=azure_region_supports_hd_flash(saved_hd_region),
+        )
+        saved_hd_voice = str(
+            self.db.setting("azure_hd_speech_voice", azure_hd_voices[0])
+        )
+        selected_hd_voice = (
+            saved_hd_voice
+            if saved_hd_voice in azure_hd_voices
+            else azure_hd_voices[0]
+        )
+        if selected_hd_voice != saved_hd_voice:
+            self.db.set_setting(
+                "azure_hd_speech_voice",
+                selected_hd_voice,
+            )
+        self.azure_hd_voice = self._editable_combo(
+            azure_hd_voices,
+            selected_hd_voice,
+        )
+        self.azure_hd_voice.setEditable(False)
+        self.azure_hd_region = self._azure_region_combo(
+            setting_key="azure_hd_speech_region",
+            hd_only=True,
+        )
+        self._initialize_azure_hd_key_controls(capabilities)
+
+    def _azure_region_combo(
+        self,
+        *,
+        setting_key: str,
+        hd_only: bool = False,
+        hd_flash_only: bool = False,
+    ) -> QComboBox:
+        combo = QComboBox()
+        combo.addItem(
+            self._t(
+                "azure_region_choose",
+                "請選擇 Azure 資源建立時所在的區域",
+            ),
+            "",
+        )
+        for label, identifier in azure_region_options(
+            self.ui_language,
+            hd_only=hd_only,
+            hd_flash_only=hd_flash_only,
+        ):
+            combo.addItem(label, identifier)
+
+        saved_region = str(
+            self.db.setting(setting_key, "")
+        ).strip().lower()
+        known_regions = azure_region_identifiers()
+        if (
+            saved_region
+            and saved_region not in known_regions
+            and combo.findData(saved_region) < 0
+        ):
+            combo.addItem(
+                self._t(
+                    "azure_region_saved",
+                    "既有設定 · {region}",
+                    region=saved_region,
+                ),
+                saved_region,
+            )
+        self._select_combo_data(combo, saved_region)
+        return combo
+
+    def _initialize_azure_hd_key_controls(
+        self,
+        capabilities: PlatformCapabilities,
+    ) -> None:
+        self.azure_hd_key_input = QLineEdit()
+        self.azure_hd_key_input.setEchoMode(QLineEdit.Password)
+        self.azure_hd_key_input.setAccessibleName(
+            self._t("azure_hd_key", "Dragon HD S0 金鑰")
+        )
+        self.azure_hd_key_input.setToolTip(
+            self._t(
+                "secret_auto_save_hint",
+                "輸入後按 Enter 或移開游標，即會自動安全保存。",
+            )
+        )
+        secure_storage = capabilities.secure_secret_storage
+        key_saved = bool(
+            secure_storage
+            and self.azure_hd_secret_store
+            and self.azure_hd_secret_store.load()
+        )
+        if secure_storage:
+            placeholder = self._t(
+                "azure_hd_key_saved" if key_saved else "azure_hd_key_missing",
+                (
+                    "Dragon HD S0 金鑰已由 Windows 加密保存（留空不變）"
+                    if key_saved
+                    else "貼上獨立的 Dragon HD S0 資源金鑰"
+                ),
+            )
+        else:
+            placeholder = self._t(
+                "platform_secret_storage_unavailable",
+                f"{capabilities.display_name} 安全金鑰保存尚未完成實機驗證",
+                platform=capabilities.display_name,
+            )
+            self.azure_hd_key_input.setEnabled(False)
+        self.azure_hd_key_input.setPlaceholderText(placeholder)
+        self.azure_hd_key_input.editingFinished.connect(
+            self._save_azure_hd_key_immediately
+        )
+        self.azure_hd_clear_key = QPushButton(
+            self._t("azure_hd_remove_key", "移除 Dragon HD S0 金鑰")
+        )
+        self.azure_hd_clear_key.clicked.connect(
+            self.clear_azure_hd_speech_key
+        )
+        self.azure_hd_clear_key.setEnabled(secure_storage)
 
     def _initialize_azure_key_controls(
         self,
@@ -3125,6 +3292,15 @@ class Dashboard(QDialog):
     ) -> None:
         self.azure_key_input = QLineEdit()
         self.azure_key_input.setEchoMode(QLineEdit.Password)
+        self.azure_key_input.setAccessibleName(
+            self._t("azure_key", "Azure Speech 金鑰")
+        )
+        self.azure_key_input.setToolTip(
+            self._t(
+                "secret_auto_save_hint",
+                "輸入後按 Enter 或移開游標，即會自動安全保存。",
+            )
+        )
         secure_storage = capabilities.secure_secret_storage
         key_saved = bool(
             secure_storage
@@ -3151,6 +3327,9 @@ class Dashboard(QDialog):
             )
             self.azure_key_input.setEnabled(False)
         self.azure_key_input.setPlaceholderText(placeholder)
+        self.azure_key_input.editingFinished.connect(
+            self._save_azure_key_immediately
+        )
         self.azure_clear_key = QPushButton(
             self._t("azure_remove_key", "移除 Azure Speech 金鑰")
         )
@@ -3425,6 +3604,18 @@ class Dashboard(QDialog):
             )
         return self._voice_note(text)
 
+    def _azure_hd_voice_note(self) -> QLabel:
+        return self._voice_note(
+            self._t(
+                "azure_hd_speech_note",
+                "可選預覽功能；請使用獨立的 S0 語音資源、金鑰與相符區域。"
+                "Dragon HD 不提供 viseme，因此墨寒會使用既有音訊分析維持"
+                "嘴型同步。發話前等待時間取決於網路與區域距離。若 HD 失敗，"
+                "依序退回一般 Azure，再退回 Windows "
+                "本機語音；每一層只嘗試一次，避免重複計費。",
+            )
+        )
+
     def _model_access_note(self) -> QLabel:
         return self._voice_note(
             self._t(
@@ -3533,6 +3724,20 @@ class Dashboard(QDialog):
         )
         form.addRow("", self.azure_clear_key)
         form.addRow("", self._azure_voice_note(capabilities))
+        form.addRow(
+            self._t("azure_hd_voice", "Dragon HD 女性聲線"),
+            self.azure_hd_voice,
+        )
+        form.addRow(
+            self._t("azure_hd_region", "Dragon HD S0 區域"),
+            self.azure_hd_region,
+        )
+        form.addRow(
+            self._t("azure_hd_key", "Dragon HD S0 金鑰"),
+            self.azure_hd_key_input,
+        )
+        form.addRow("", self.azure_hd_clear_key)
+        form.addRow("", self._azure_hd_voice_note())
 
     def _add_realtime_rows(self, form: QFormLayout) -> None:
         form.addRow(
@@ -3626,6 +3831,15 @@ class Dashboard(QDialog):
         )
         self.azure_voice.currentTextChanged.connect(
             self._azure_voice_changed
+        )
+        self.azure_region.currentIndexChanged.connect(
+            self._azure_region_changed
+        )
+        self.azure_hd_voice.currentTextChanged.connect(
+            self._azure_hd_voice_changed
+        )
+        self.azure_hd_region.currentIndexChanged.connect(
+            self._azure_hd_region_changed
         )
         self.realtime_voice.currentTextChanged.connect(
             self._realtime_voice_changed
@@ -4139,6 +4353,9 @@ class Dashboard(QDialog):
             capabilities,
             key_saved,
         )
+        self.api_key_input.editingFinished.connect(
+            self._save_api_key_if_provided
+        )
         self.ai_model = self._editable_combo(
             TEXT_MODELS,
             str(self.db.setting("ai_model", DEFAULT_TEXT_MODEL)),
@@ -4175,6 +4392,15 @@ class Dashboard(QDialog):
     ) -> QLineEdit:
         key_input = QLineEdit()
         key_input.setEchoMode(QLineEdit.Password)
+        key_input.setAccessibleName(
+            self._t("api_key", "OpenAI API 金鑰")
+        )
+        key_input.setToolTip(
+            self._t(
+                "secret_auto_save_hint",
+                "輸入後按 Enter 或移開游標，即會自動安全保存。",
+            )
+        )
         if capabilities.secure_secret_storage:
             placeholder = (
                 self._t(
@@ -5439,6 +5665,40 @@ class Dashboard(QDialog):
             return
         self.db.set_setting("azure_speech_voice", selected_voice)
 
+    def _azure_region_changed(self, _index: int) -> None:
+        self.db.set_setting(
+            "azure_speech_region",
+            str(self.azure_region.currentData() or ""),
+        )
+
+    def _azure_hd_voice_changed(self, voice: str) -> None:
+        selected_voice = voice.strip()
+        if not selected_voice:
+            return
+        self.db.set_setting("azure_hd_speech_voice", selected_voice)
+
+    def _azure_hd_region_changed(self, _index: int) -> None:
+        region = str(self.azure_hd_region.currentData() or "")
+        self.db.set_setting(
+            "azure_hd_speech_region",
+            region,
+        )
+        self._refresh_azure_hd_voice_options(region)
+
+    def _refresh_azure_hd_voice_options(self, region: str) -> None:
+        voices = azure_hd_female_voices(
+            self.ui_language,
+            include_flash=azure_region_supports_hd_flash(region),
+        )
+        current_voice = self.azure_hd_voice.currentText().strip()
+        selected_voice = current_voice if current_voice in voices else voices[0]
+        self.azure_hd_voice.blockSignals(True)
+        self.azure_hd_voice.clear()
+        self.azure_hd_voice.addItems(voices)
+        self.azure_hd_voice.setCurrentText(selected_voice)
+        self.azure_hd_voice.blockSignals(False)
+        self.db.set_setting("azure_hd_speech_voice", selected_voice)
+
     def _realtime_voice_changed(self, voice: str) -> None:
         selected_voice = voice.strip()
         if not selected_voice:
@@ -5465,6 +5725,29 @@ class Dashboard(QDialog):
                 self._t(
                     "azure_key_missing",
                     "貼上 Azure Speech 資源金鑰",
+                )
+            )
+
+    def clear_azure_hd_speech_key(self) -> None:
+        if self.azure_hd_secret_store is None:
+            return
+        platform = self.platform_services.capabilities
+        answer = QMessageBox.question(
+            self,
+            self._t("azure_hd_remove_key", "移除 Dragon HD S0 金鑰"),
+            self._t(
+                "azure_hd_remove_key_confirm",
+                "確定移除由 {platform} 安全保存的 Dragon HD S0 金鑰嗎？",
+                platform=platform.display_name,
+            ),
+        )
+        if answer == QMessageBox.Yes:
+            self.azure_hd_secret_store.clear()
+            self.azure_hd_key_input.clear()
+            self.azure_hd_key_input.setPlaceholderText(
+                self._t(
+                    "azure_hd_key_missing",
+                    "貼上獨立的 Dragon HD S0 資源金鑰",
                 )
             )
 
@@ -5534,30 +5817,18 @@ class Dashboard(QDialog):
         )
         self.db.set_setting(
             "azure_speech_region",
-            self.azure_region.text().strip().lower(),
+            str(self.azure_region.currentData() or ""),
         )
-        azure_key = self.azure_key_input.text().strip()
-        if azure_key and self.azure_secret_store is not None:
-            try:
-                self.azure_secret_store.save(azure_key)
-                self.azure_key_input.clear()
-                self.azure_key_input.setPlaceholderText(
-                    self._t(
-                        "azure_key_saved",
-                        "已由作業系統安全保存（留空不變）",
-                    )
-                )
-            except OSError as exc:
-                if not silent:
-                    QMessageBox.warning(
-                        self,
-                        "Azure Speech",
-                        self._t(
-                            "azure_key_save_failed",
-                            "無法安全保存 Azure Speech 金鑰：{error}",
-                            error=exc,
-                        ),
-                    )
+        self.db.set_setting(
+            "azure_hd_speech_voice",
+            self.azure_hd_voice.currentText(),
+        )
+        self.db.set_setting(
+            "azure_hd_speech_region",
+            str(self.azure_hd_region.currentData() or ""),
+        )
+        self._persist_azure_key(silent=silent)
+        self._persist_azure_hd_key(silent=silent)
         self.db.set_setting("realtime_model", self.realtime_model.currentText())
         self.db.set_setting(
             "realtime_transcription_model",
@@ -5592,6 +5863,59 @@ class Dashboard(QDialog):
                 self._t("voice_settings_saved", "聲音設定已保存。"),
                 "happy",
             )
+
+    def _save_azure_key_immediately(self) -> None:
+        self._persist_azure_key(silent=False)
+
+    def _save_azure_hd_key_immediately(self) -> None:
+        self._persist_azure_hd_key(silent=False)
+
+    def _persist_azure_key(self, *, silent: bool) -> None:
+        self._persist_secret_input(
+            self.azure_key_input,
+            self.azure_secret_store,
+            AZURE_SECRET_POLICY,
+            silent=silent,
+        )
+
+    def _persist_azure_hd_key(self, *, silent: bool) -> None:
+        self._persist_secret_input(
+            self.azure_hd_key_input,
+            self.azure_hd_secret_store,
+            AZURE_HD_SECRET_POLICY,
+            silent=silent,
+        )
+
+    def _persist_secret_input(
+        self,
+        key_input: QLineEdit,
+        secret_store: SecretStorePort | None,
+        policy: SecretInputPolicy,
+        *,
+        silent: bool,
+    ) -> bool:
+        secret = key_input.text().strip()
+        if not secret or secret_store is None:
+            return False
+        try:
+            secret_store.save(secret)
+        except OSError as exc:
+            if not silent:
+                QMessageBox.warning(
+                    self,
+                    self._t(policy.title_key, policy.title_fallback),
+                    self._t(
+                        policy.error_key,
+                        policy.error_fallback,
+                        error=exc,
+                    ),
+                )
+            return False
+        key_input.clear()
+        key_input.setPlaceholderText(
+            self._t(policy.saved_key, policy.saved_fallback)
+        )
+        return True
 
     def set_realtime_status(self, status: str, active: bool | None = None) -> None:
         self.realtime_status.setText(f"Realtime：{status}")
@@ -5899,21 +6223,19 @@ class Dashboard(QDialog):
             self.db.set_setting(key, control.isChecked())
 
     def _save_api_key_if_provided(self) -> None:
-        key = self.api_key_input.text().strip()
-        if not key:
-            return
-        try:
-            self.secret_store.save(key)
-        except OSError as exc:
-            QMessageBox.warning(
-                self,
-                "API 金鑰",
-                f"無法安全保存金鑰：{exc}",
+        saved = self._persist_secret_input(
+            self.api_key_input,
+            self.secret_store,
+            OPENAI_SECRET_POLICY,
+            silent=False,
+        )
+        if saved:
+            self.api_status.setText(
+                self._t(
+                    "api_status_saved",
+                    "OpenAI API：金鑰已由作業系統安全保存",
+                )
             )
-            return
-        self.api_key_input.clear()
-        self.api_key_input.setPlaceholderText("已安全保存（留空不變）")
-        self.api_status.setText("OpenAI API：金鑰已由作業系統安全保存")
 
     def _save_autostart_setting(self) -> None:
         if not self.platform_services.capabilities.desktop_autostart:
@@ -5963,14 +6285,28 @@ class Dashboard(QDialog):
         platform = self.platform_services.capabilities
         answer = QMessageBox.question(
             self,
-            "移除 API 金鑰",
-            f"確定要移除由 {platform.display_name} 安全保存的 OpenAI API 金鑰嗎？",
+            self._t("remove_api_key", "移除已保存的 API 金鑰"),
+            self._t(
+                "remove_api_key_confirm",
+                "確定要移除由 {platform} 安全保存的 OpenAI API 金鑰嗎？",
+                platform=platform.display_name,
+            ),
         )
         if answer == QMessageBox.Yes:
             self.secret_store.clear()
             self.api_key_input.clear()
-            self.api_key_input.setPlaceholderText("貼上新的 OpenAI Project API Key")
-            self.api_status.setText("OpenAI API：未設定，使用離線人設")
+            self.api_key_input.setPlaceholderText(
+                self._t(
+                    "api_key_missing",
+                    "貼上 sk- 開頭的 OpenAI Project API Key",
+                )
+            )
+            self.api_status.setText(
+                self._t(
+                    "api_status_offline",
+                    "OpenAI API：未設定，使用離線人設",
+                )
+            )
 
     def open_work_folder(self) -> None:
         value = self.work_folder.text().strip()
@@ -6025,16 +6361,19 @@ class CompanionWindow(QMainWindow):
         self.backup_manager = services.backup_manager
         self.secret_store = services.secret_store
         self.azure_secret_store = services.azure_secret_store
+        self.azure_hd_secret_store = services.azure_hd_secret_store
         self.secret_store_factory = services.secret_store_factory
         self.tts = services.local_tts
         self.cloud_tts = services.cloud_tts
         self.azure_tts = services.azure_speech
+        self.azure_hd_tts = services.azure_hd_speech
         self.speech_providers = (
             services.speech_providers
             or create_builtin_speech_registry(
                 self.tts,
                 self.cloud_tts,
                 self.azure_tts,
+                self.azure_hd_tts,
             )
         )
         self.realtime = services.realtime
@@ -6064,6 +6403,7 @@ class CompanionWindow(QMainWindow):
                 listener=self.listener,
                 secret_store=self.secret_store,
                 azure_secret_store=self.azure_secret_store,
+                azure_hd_secret_store=self.azure_hd_secret_store,
                 secret_store_factory=self.secret_store_factory,
                 platform_services=self.platform_services,
             ),
@@ -6119,6 +6459,10 @@ class CompanionWindow(QMainWindow):
             self.azure_tts.finished.connect(self._speech_audio_finished)
             self.azure_tts.failed.connect(self._azure_voice_failed)
             self.azure_tts.viseme_cue.connect(self._audio_viseme_cue)
+        if self.azure_hd_tts is not None:
+            self.azure_hd_tts.finished.connect(self._speech_audio_finished)
+            self.azure_hd_tts.failed.connect(self._azure_hd_voice_failed)
+            self.azure_hd_tts.viseme_cue.connect(self._audio_viseme_cue)
         self.realtime.status_changed.connect(self._realtime_status)
         self.realtime.user_transcript.connect(
             self._realtime_user_text
@@ -6145,6 +6489,7 @@ class CompanionWindow(QMainWindow):
         self.active_speech_text = ""
         self.active_speech_engine = ""
         self.cloud_fallback_active = False
+        self.speech_fallback_attempts: set[str] = set()
         self.drag_offset: QPoint | None = None
         self.last_overwork_notice = ""
         self._startup_speech_requested = startup_speech
@@ -9327,6 +9672,7 @@ class CompanionWindow(QMainWindow):
         self.active_speech_text = queued.text
         self.active_speech_engine = ""
         self.cloud_fallback_active = False
+        self.speech_fallback_attempts.clear()
         self._show_bubble(queued.text)
         state = self._accepted_speech_state(queued)
         self.after_speech_state = state if state != "speaking" else "idle"
@@ -9397,11 +9743,20 @@ class CompanionWindow(QMainWindow):
             if self.azure_secret_store is not None
             else ""
         )
+        azure_hd_api_key = (
+            self.azure_hd_secret_store.load()
+            if self.azure_hd_secret_store is not None
+            else ""
+        )
         return SpeechCredentials(
             openai_api_key=self.secret_store.load(),
             azure_api_key=azure_api_key,
             azure_region=str(
                 self.db.setting("azure_speech_region", "")
+            ).strip(),
+            azure_hd_api_key=azure_hd_api_key,
+            azure_hd_region=str(
+                self.db.setting("azure_hd_speech_region", "")
             ).strip(),
         )
 
@@ -9418,6 +9773,13 @@ class CompanionWindow(QMainWindow):
             (
                 VOICE_ENGINE_AZURE,
                 bool(credentials.azure_api_key and credentials.azure_region),
+            ),
+            (
+                VOICE_ENGINE_AZURE_HD,
+                bool(
+                    credentials.azure_hd_api_key
+                    and credentials.azure_hd_region
+                ),
             ),
         )
         return tuple(
@@ -9441,6 +9803,7 @@ class CompanionWindow(QMainWindow):
         )
         self._report_azure_fallback(selected_provider_id, provider_id)
         self.active_speech_engine = provider_id
+        self.speech_fallback_attempts.add(provider_id)
         voice, api_key = self._speech_voice_and_key(provider_id, credentials)
         request = SpeechRequest(
             text=text,
@@ -9453,7 +9816,13 @@ class CompanionWindow(QMainWindow):
                     VOICE_GENERATION_PROMPT,
                 )
             ),
-            options={"region": credentials.azure_region},
+            options={
+                "region": (
+                    credentials.azure_hd_region
+                    if provider_id == VOICE_ENGINE_AZURE_HD
+                    else credentials.azure_region
+                )
+            },
         )
         self.speech_providers.provider(provider_id).speak(request)
 
@@ -9463,12 +9832,13 @@ class CompanionWindow(QMainWindow):
         provider_id: str,
     ) -> None:
         if (
-            selected_provider_id != VOICE_ENGINE_AZURE
-            or provider_id == VOICE_ENGINE_AZURE
+            selected_provider_id
+            not in {VOICE_ENGINE_AZURE, VOICE_ENGINE_AZURE_HD}
+            or provider_id == selected_provider_id
         ):
             return
         fallback_available = (
-            self.speech_providers.fallback_provider_id(VOICE_ENGINE_AZURE)
+            self.speech_providers.fallback_provider_id(selected_provider_id)
             is not None
         )
         message_key = (
@@ -9477,8 +9847,8 @@ class CompanionWindow(QMainWindow):
             else "azure_missing_no_local_fallback"
         )
         default_message = (
-            "Azure Speech 尚未完成設定；已直接使用 Windows "
-            "女性語音，未送出雲端請求。"
+            "所選 Azure 語音尚未完成設定；已直接使用可用的備援"
+            "語音，未送出該項雲端請求。"
             if fallback_available
             else "Azure Speech 尚未完成設定，且此平台沒有已驗證的"
             "本機語音；本次不會播放，也不會送出雲端請求。"
@@ -9502,6 +9872,9 @@ class CompanionWindow(QMainWindow):
         elif provider_id == VOICE_ENGINE_AZURE:
             voice = str(self.db.setting("azure_speech_voice", ""))
             api_key = credentials.azure_api_key
+        elif provider_id == VOICE_ENGINE_AZURE_HD:
+            voice = str(self.db.setting("azure_hd_speech_voice", ""))
+            api_key = credentials.azure_hd_api_key
         else:
             voice = str(
                 self.db.setting(
@@ -9549,6 +9922,8 @@ class CompanionWindow(QMainWindow):
         engines = [self.tts, self.cloud_tts, self.realtime]
         if self.azure_tts is not None:
             engines.append(self.azure_tts)
+        if self.azure_hd_tts is not None:
+            engines.append(self.azure_hd_tts)
         for engine in engines:
             engine.set_volume(volume_percent, muted)
 
@@ -9891,19 +10266,43 @@ class CompanionWindow(QMainWindow):
             message,
         )
 
+    def _azure_hd_voice_failed(self, message: str) -> None:
+        self._online_voice_failed(
+            VOICE_ENGINE_AZURE_HD,
+            "Azure Dragon HD",
+            message,
+        )
+
     def _online_voice_failed(
         self,
         failed_provider_id: str,
         provider_label: str,
         message: str,
     ) -> None:
-        fallback_provider_id = self.speech_providers.fallback_provider_id(
-            failed_provider_id
+        credentials = self._speech_credentials()
+        configured = set(self._configured_speech_providers(credentials))
+        candidates = (
+            (VOICE_ENGINE_AZURE, VOICE_ENGINE_SYSTEM)
+            if failed_provider_id == VOICE_ENGINE_AZURE_HD
+            else (VOICE_ENGINE_SYSTEM,)
+        )
+        fallback_provider_id = next(
+            (
+                provider_id
+                for provider_id in candidates
+                if provider_id in configured
+                and provider_id not in self.speech_fallback_attempts
+            ),
+            None,
         )
         if fallback_provider_id is not None:
-            local_name = self.platform_services.capabilities.display_name
+            fallback_label = (
+                "Azure Speech"
+                if fallback_provider_id == VOICE_ENGINE_AZURE
+                else f"{self.platform_services.capabilities.display_name} 本機女聲"
+            )
             self.dashboard.set_api_status(
-                f"{provider_label}失敗，已切換 {local_name} 本機女聲："
+                f"{provider_label}失敗，已切換 {fallback_label}："
                 f"{message[:50]}"
             )
         else:
@@ -9914,7 +10313,6 @@ class CompanionWindow(QMainWindow):
         if (
             self.speech_playing
             and self.active_speech_engine == failed_provider_id
-            and not self.cloud_fallback_active
             and self.active_speech_text.strip()
         ):
             if fallback_provider_id is None:
@@ -9922,11 +10320,30 @@ class CompanionWindow(QMainWindow):
                 return
             self.cloud_fallback_active = True
             self.active_speech_engine = fallback_provider_id
+            self.speech_fallback_attempts.add(fallback_provider_id)
+            voice, api_key = self._speech_voice_and_key(
+                fallback_provider_id,
+                credentials,
+            )
             self.speech_providers.provider(fallback_provider_id).speak(
                 SpeechRequest(
                     text=self.active_speech_text,
-                    voice=str(self.db.setting("windows_voice", "")),
+                    voice=voice,
                     rate=int(self.db.setting("voice_rate", -1)),
+                    api_key=api_key,
+                    instructions=str(
+                        self.db.setting(
+                            "voice_instructions",
+                            VOICE_GENERATION_PROMPT,
+                        )
+                    ),
+                    options={
+                        "region": (
+                            credentials.azure_region
+                            if fallback_provider_id == VOICE_ENGINE_AZURE
+                            else ""
+                        )
+                    },
                 )
             )
             return
@@ -9979,6 +10396,7 @@ class CompanionWindow(QMainWindow):
         self.active_speech_text = ""
         self.active_speech_engine = ""
         self.cloud_fallback_active = False
+        self.speech_fallback_attempts.clear()
         if self.speech_queue:
             QTimer.singleShot(120, self._start_next_speech)
         else:

--- a/azure_regions.py
+++ b/azure_regions.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+lazy from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AzureSpeechRegion:
+    identifier: str
+    traditional_chinese: str
+    simplified_chinese: str
+    english: str
+    japanese: str
+    supports_hd: bool = False
+    supports_hd_flash: bool = False
+
+    def label(self, language: str) -> str:
+        normalized = str(language or "").strip().lower()
+        if normalized == "zh-cn":
+            name = self.simplified_chinese
+        elif normalized in {"en", "en-us"}:
+            name = self.english
+        elif normalized in {"ja", "ja-jp"}:
+            name = self.japanese
+        else:
+            name = self.traditional_chinese
+        return f"{name} · {self.identifier}"
+
+
+AZURE_SPEECH_REGIONS: tuple[AzureSpeechRegion, ...] = (
+    AzureSpeechRegion("eastasia", "東亞", "东亚", "East Asia", "東アジア"),
+    AzureSpeechRegion(
+        "southeastasia",
+        "東南亞",
+        "东南亚",
+        "Southeast Asia",
+        "東南アジア",
+        True,
+        True,
+    ),
+    AzureSpeechRegion(
+        "australiaeast",
+        "澳洲東部",
+        "澳大利亚东部",
+        "Australia East",
+        "オーストラリア東部",
+    ),
+    AzureSpeechRegion(
+        "centralindia",
+        "印度中部",
+        "印度中部",
+        "Central India",
+        "インド中部",
+        True,
+    ),
+    AzureSpeechRegion(
+        "japaneast", "日本東部", "日本东部", "Japan East", "東日本"
+    ),
+    AzureSpeechRegion(
+        "japanwest", "日本西部", "日本西部", "Japan West", "西日本"
+    ),
+    AzureSpeechRegion(
+        "koreacentral",
+        "韓國中部",
+        "韩国中部",
+        "Korea Central",
+        "韓国中部",
+    ),
+    AzureSpeechRegion(
+        "southafricanorth",
+        "南非北部",
+        "南非北部",
+        "South Africa North",
+        "南アフリカ北部",
+    ),
+    AzureSpeechRegion(
+        "canadacentral",
+        "加拿大中部",
+        "加拿大中部",
+        "Canada Central",
+        "カナダ中部",
+        True,
+    ),
+    AzureSpeechRegion(
+        "canadaeast",
+        "加拿大東部",
+        "加拿大东部",
+        "Canada East",
+        "カナダ東部",
+    ),
+    AzureSpeechRegion(
+        "northeurope", "北歐", "北欧", "North Europe", "北ヨーロッパ"
+    ),
+    AzureSpeechRegion(
+        "westeurope", "西歐", "西欧", "West Europe", "西ヨーロッパ", True, True
+    ),
+    AzureSpeechRegion(
+        "francecentral",
+        "法國中部",
+        "法国中部",
+        "France Central",
+        "フランス中部",
+        True,
+    ),
+    AzureSpeechRegion(
+        "germanywestcentral",
+        "德國中西部",
+        "德国中西部",
+        "Germany West Central",
+        "ドイツ中西部",
+    ),
+    AzureSpeechRegion(
+        "italynorth",
+        "義大利北部",
+        "意大利北部",
+        "Italy North",
+        "イタリア北部",
+    ),
+    AzureSpeechRegion(
+        "norwayeast",
+        "挪威東部",
+        "挪威东部",
+        "Norway East",
+        "ノルウェー東部",
+    ),
+    AzureSpeechRegion(
+        "swedencentral",
+        "瑞典中部",
+        "瑞典中部",
+        "Sweden Central",
+        "スウェーデン中部",
+        True,
+    ),
+    AzureSpeechRegion(
+        "switzerlandnorth",
+        "瑞士北部",
+        "瑞士北部",
+        "Switzerland North",
+        "スイス北部",
+    ),
+    AzureSpeechRegion(
+        "switzerlandwest",
+        "瑞士西部",
+        "瑞士西部",
+        "Switzerland West",
+        "スイス西部",
+    ),
+    AzureSpeechRegion(
+        "uksouth", "英國南部", "英国南部", "UK South", "英国南部"
+    ),
+    AzureSpeechRegion(
+        "ukwest", "英國西部", "英国西部", "UK West", "英国西部"
+    ),
+    AzureSpeechRegion(
+        "uaenorth",
+        "阿拉伯聯合大公國北部",
+        "阿拉伯联合酋长国北部",
+        "UAE North",
+        "アラブ首長国連邦北部",
+    ),
+    AzureSpeechRegion(
+        "brazilsouth",
+        "巴西南部",
+        "巴西南部",
+        "Brazil South",
+        "ブラジル南部",
+    ),
+    AzureSpeechRegion(
+        "qatarcentral",
+        "卡達中部",
+        "卡塔尔中部",
+        "Qatar Central",
+        "カタール中部",
+    ),
+    AzureSpeechRegion(
+        "centralus", "美國中部", "美国中部", "Central US", "米国中部"
+    ),
+    AzureSpeechRegion(
+        "eastus", "美國東部", "美国东部", "East US", "米国東部", True, True
+    ),
+    AzureSpeechRegion(
+        "eastus2", "美國東部 2", "美国东部 2", "East US 2", "米国東部 2", True
+    ),
+    AzureSpeechRegion(
+        "northcentralus",
+        "美國中北部",
+        "美国中北部",
+        "North Central US",
+        "米国中北部",
+    ),
+    AzureSpeechRegion(
+        "southcentralus",
+        "美國中南部",
+        "美国中南部",
+        "South Central US",
+        "米国中南部",
+    ),
+    AzureSpeechRegion(
+        "westcentralus",
+        "美國中西部",
+        "美国中西部",
+        "West Central US",
+        "米国中西部",
+    ),
+    AzureSpeechRegion(
+        "westus", "美國西部", "美国西部", "West US", "米国西部"
+    ),
+    AzureSpeechRegion(
+        "westus2", "美國西部 2", "美国西部 2", "West US 2", "米国西部 2", True
+    ),
+    AzureSpeechRegion(
+        "westus3", "美國西部 3", "美国西部 3", "West US 3", "米国西部 3"
+    ),
+)
+
+
+def azure_region_options(
+    language: str,
+    *,
+    hd_only: bool = False,
+    hd_flash_only: bool = False,
+) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (region.label(language), region.identifier)
+        for region in AZURE_SPEECH_REGIONS
+        if (not hd_only or region.supports_hd)
+        and (not hd_flash_only or region.supports_hd_flash)
+    )
+
+
+def azure_region_identifiers(
+    *,
+    hd_only: bool = False,
+    hd_flash_only: bool = False,
+) -> tuple[str, ...]:
+    return tuple(
+        region.identifier
+        for region in AZURE_SPEECH_REGIONS
+        if (not hd_only or region.supports_hd)
+        and (not hd_flash_only or region.supports_hd_flash)
+    )
+
+
+def azure_region_supports_hd_flash(identifier: str) -> bool:
+    normalized = str(identifier or "").strip().lower()
+    return any(
+        region.identifier == normalized and region.supports_hd_flash
+        for region in AZURE_SPEECH_REGIONS
+    )

--- a/azure_speech.py
+++ b/azure_speech.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 lazy import re
 lazy import threading
+lazy import time
 lazy from urllib.error import HTTPError, URLError
 lazy from urllib.request import Request, urlopen
 lazy from xml.sax.saxutils import escape, quoteattr
@@ -40,10 +41,43 @@ AZURE_FEMALE_VOICES: frozendict[str, tuple[str, ...]] = frozendict({
         "ja-JP-ShioriNeural",
     ),
 })
-_VOICE_LOCALE = frozendict({
-    **{voice: locale for voice in voices}
-    for locale, voices in AZURE_FEMALE_VOICES.items()
+AZURE_HD_FEMALE_VOICES: frozendict[str, tuple[str, ...]] = frozendict({
+    "zh-CN": (
+        "zh-CN-Xiaochen:DragonHDLatestNeural",
+        "zh-CN-Xiaoyue:DragonHDOmniLatestNeural",
+        "zh-CN-Maroonallegro:DragonHDOmniLatestNeural",
+        "zh-CN-Xiaoxiao:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaoxiao2:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaochen:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaoyi:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaoyu:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaohan:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaoshuang:DragonHDFlashLatestNeural",
+        "zh-CN-Xiaoyou:DragonHDFlashLatestNeural",
+    ),
+    "en-US": (
+        "en-US-Ava:DragonHDLatestNeural",
+        "en-US-Aria:DragonHDLatestNeural",
+        "en-US-Emma:DragonHDLatestNeural",
+        "en-US-Emma2:DragonHDLatestNeural",
+        "en-US-Jenny:DragonHDLatestNeural",
+        "en-US-Nova:DragonHDLatestNeural",
+        "en-US-Phoebe:DragonHDLatestNeural",
+        "en-US-Serena:DragonHDLatestNeural",
+    ),
+    "ja-JP": ("ja-JP-Nanami:DragonHDLatestNeural",),
 })
+
+
+def _build_voice_locale_index() -> frozendict[str, str]:
+    index: dict[str, str] = {}
+    for catalog in (AZURE_FEMALE_VOICES, AZURE_HD_FEMALE_VOICES):
+        for locale, voices in catalog.items():
+            index.update(dict.fromkeys(voices, locale))
+    return frozendict(index)
+
+
+_VOICE_LOCALE = _build_voice_locale_index()
 _REGION_PATTERN = re.compile(r"^[a-z0-9-]{2,32}$")
 _MESSAGES = deep_freeze({
     "zh-TW": {
@@ -126,14 +160,48 @@ def azure_female_voices(language: str) -> tuple[str, ...]:
     )
 
 
+def azure_hd_female_voices(
+    language: str,
+    *,
+    include_flash: bool = True,
+) -> tuple[str, ...]:
+    normalized = str(language or "").strip().lower()
+    if normalized in {"en", "en-us"}:
+        voices = AZURE_HD_FEMALE_VOICES["en-US"]
+    elif normalized in {"ja", "ja-jp"}:
+        voices = AZURE_HD_FEMALE_VOICES["ja-JP"]
+    else:
+        voices = AZURE_HD_FEMALE_VOICES["zh-CN"]
+    if include_flash:
+        return voices
+    return tuple(voice for voice in voices if not azure_hd_voice_uses_flash(voice))
+
+
+def azure_hd_voice_uses_flash(voice: str) -> bool:
+    return ":DragonHDFlash" in str(voice)
+
+
+def is_azure_hd_voice(voice: str) -> bool:
+    return voice in {
+        *AZURE_HD_FEMALE_VOICES["zh-CN"],
+        *AZURE_HD_FEMALE_VOICES["en-US"],
+        *AZURE_HD_FEMALE_VOICES["ja-JP"],
+    }
+
+
 def build_azure_ssml(text: str, voice: str) -> bytes:
     locale = _VOICE_LOCALE.get(voice)
     if locale is None:
         raise ValueError("unsupported_voice")
+    parameters = (
+        " parameters='temperature=0.8'"
+        if is_azure_hd_voice(voice)
+        else ""
+    )
     body = (
         f"<speak version='1.0' xml:lang={quoteattr(locale)}>"
         f"<voice xml:lang={quoteattr(locale)} xml:gender='Female' "
-        f"name={quoteattr(voice)}>{escape(text)}</voice></speak>"
+        f"name={quoteattr(voice)}{parameters}>{escape(text)}</voice></speak>"
     )
     return body.encode("utf-8")
 
@@ -156,12 +224,14 @@ def azure_speech_error_message(
 class AzureSpeechTTS(QObject):
     failed = Signal(str)
     finished = Signal()
+    synthesis_latency_measured = Signal(float)
     viseme_cue = Signal(float, str)
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
         self.volume_percent = 125
         self.muted = False
+        self.last_synthesis_latency_ms: float | None = None
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
@@ -216,8 +286,19 @@ class AzureSpeechTTS(QObject):
             method="POST",
         )
         try:
+            request_started = time.perf_counter()
             with urlopen(request, timeout=60) as response:
                 audio = response.read()
+            self.last_synthesis_latency_ms = max(
+                0.0,
+                (time.perf_counter() - request_started) * 1_000.0,
+            )
+            self.synthesis_latency_measured.emit(
+                self.last_synthesis_latency_ms
+            )
+            # Azure audio is fully buffered before playback. Regional network
+            # latency delays speech onset but must never offset the local
+            # 50 Hz viseme clock from the audio that it analyzes.
             play_wave_with_visemes(
                 audio,
                 self.volume_percent,

--- a/docs/PLUGGABLE-SPEECH-PROVIDERS.md
+++ b/docs/PLUGGABLE-SPEECH-PROVIDERS.md
@@ -20,6 +20,15 @@ Azure Speech 預覽必須由使用者自行申請 Azure Speech 資源，輸入�
 同一句話只回退一次到 Windows 女性本機語音。Azure 免費額度、費率、資料處理與
 可用區域以 Microsoft 當期規則為準。
 
+`v3.1.0` 將 Dragon HD／HD Omni 公開為另一個預設關閉的可選 Preview 供應器，
+不與一般 Azure Speech 共用金鑰、區域或聲線設定。它要求使用者自行建立 S0 資源，
+只顯示官方標示的女性聲線，並依所選區域隱藏不支援的 HD Flash。HD 失敗時，
+同一句話依序只嘗試一次一般 Azure Speech 與 Windows 本機女聲，避免循環與重複計費。
+Dragon HD 不提供 viseme 事件；Azure WAV 完整緩衝後，播放與既有 50 Hz 本機音訊
+分析同步開始，因此區域網路延遲只增加發話前等待，不得硬編碼為嘴型偏移。
+Central India S0 已完成真實 Windows 合成與播放驗證，但臺灣連線等待明顯；
+使用者應優先選擇實際延遲可接受且支援所需聲線的區域。
+
 自動測試已涵蓋區域限制、SSML 跳脫、女性聲線白名單、固定 HTTPS 端點、錯誤訊息
 不洩漏金鑰、播放完成與 Windows 回退。2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證；預覽標示仍保留，以反映各帳號、區域、配額及當期服務差異。
 
@@ -39,6 +48,7 @@ Sherpa-ONNX、Piper、Kokoro 等本地方案。加入任何候選前都必須逐
 - [Speech 服務區域](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
 - [文字轉語音 REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
 - [語言與聲線支援](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
+- [Dragon HD／HD Omni 官方說明](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices)
 
 ## 简体中文
 
@@ -60,6 +70,15 @@ Azure Speech 预览要求用户自行申请 Azure Speech 资源，并输入资�
 同一句话只回退一次到 Windows 女性本地语音。Azure 免费额度、费率、数据处理与
 可用区域以 Microsoft 当期规则为准。
 
+`v3.1.0` 将 Dragon HD／HD Omni 公开为另一个默认关闭的可选 Preview 供应器，
+不与一般 Azure Speech 共用密钥、区域或声线设置。它要求用户自行建立 S0 资源，
+只显示官方标示的女性声线，并按所选区域隐藏不支持的 HD Flash。HD 失败时，
+同一句话依次只尝试一次一般 Azure Speech 与 Windows 本地女声，避免循环与重复计费。
+Dragon HD 不提供 viseme 事件；Azure WAV 完整缓冲后，播放与现有 50 Hz 本地音频
+分析同步开始，因此区域网络延迟只增加发话前等待，不得硬编码为嘴型偏移。
+Central India S0 已完成真实 Windows 合成与播放验证，但台湾连接等待明显；
+用户应优先选择实际延迟可接受且支持所需声线的区域。
+
 自动测试已经覆盖区域限制、SSML 转义、女性声线白名单、固定 HTTPS 端点、错误信息
 不泄漏密钥、播放完成与 Windows 回退。2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证；仍保留“预览”标示，以反映不同账号、区域、配额及当前服务的差异。
 
@@ -79,6 +98,7 @@ Sherpa-ONNX、Piper、Kokoro 等本地方案。加入任何候选前都必须逐
 - [Speech 服务区域](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
 - [文字转语音 REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
 - [语言与声线支持](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
+- [Dragon HD／HD Omni 官方说明](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices)
 
 ## English
 
@@ -105,6 +125,18 @@ cause no network request; a service failure falls back once for the same utteran
 local female speech. Current Microsoft rules govern Azure free quotas, pricing, data handling,
 and regional availability.
 
+`v3.1.0` publishes Dragon HD/HD Omni as another optional Preview provider that is
+disabled by default and does not share its key, region, or voice setting with standard
+Azure Speech. Users create their own S0 resource; the UI lists only officially identified
+female voices and hides HD Flash where the selected region does not support it. For one
+utterance, HD failure falls back once to standard Azure Speech and then once to Windows
+local female speech, preventing loops and duplicate charges. Dragon HD provides no viseme
+events. After the Azure WAV is fully buffered, playback and the existing local 50 Hz audio
+analysis start together, so regional latency delays speech onset and must not become a
+hardcoded mouth offset. A real Central India S0 resource passed Windows synthesis and
+playback validation, but Taiwan experienced a noticeable wait; users should prefer a
+supported region with acceptable measured latency.
+
 Automated tests cover region restrictions, SSML escaping, the female-voice allowlist, the fixed
 HTTPS endpoint, secret-safe error messages, playback completion, and Windows fallback. On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. The Preview label remains to reflect account, region, quota, and current-service differences.
 
@@ -126,6 +158,7 @@ software license and voice-model license separately.
 - [Speech service regions](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
 - [Text-to-speech REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
 - [Language and voice support](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
+- [Official Dragon HD/HD Omni guide](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices)
 
 ## 日本語
 
@@ -150,6 +183,17 @@ Azure Speech プレビューを使うには、利用者自身が Azure Speech �
 Windows 本機女性音声へフォールバックします。Azure の無料枠、料金、データ処理、
 利用可能リージョンには Microsoft のその時点の規則が適用されます。
 
+`v3.1.0` は Dragon HD／HD Omni を、初期状態で無効かつ任意の別 Preview
+プロバイダーとして公開します。通常の Azure Speech とはキー、リージョン、音声設定を
+共有しません。利用者自身の S0 リソースを必要とし、公式に女性と示された音声だけを
+表示し、選択リージョンが非対応の HD Flash は隠します。HD 失敗時、同じ発話は通常の
+Azure Speech、Windows 本機女性音声の順に各一回だけ切り替え、循環と重複課金を防ぎます。
+Dragon HD は viseme イベント非対応です。Azure WAV を完全にバッファした後、再生と
+既存の 50 Hz 本機音声解析を同時開始するため、リージョン遅延は発話開始前の待ち時間だけを
+増やし、固定の口形オフセットにしてはなりません。Central India S0 の実リソースで
+Windows の合成と再生を検証しましたが、台湾からは明確な待ち時間がありました。利用者は
+必要な音声に対応し、実測遅延を許容できるリージョンを優先してください。
+
 自動テストは、リージョン制限、SSML エスケープ、女性音声の許可リスト、固定 HTTPS
 エンドポイント、キーを漏らさないエラーメッセージ、再生完了、Windows フォールバックを
 網羅しています。2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。アカウント、リージョン、割り当て、当期サービスの差異を示すため「プレビュー」表示は維持します。
@@ -172,3 +216,4 @@ Sherpa-ONNX、Piper、Kokoro などがあります。候補を追加する前に
 - [Speech サービスのリージョン](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/regions)
 - [テキスト読み上げ REST API](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/rest-text-to-speech)
 - [対応言語と音声](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/language-support)
+- [Dragon HD／HD Omni 公式ガイド](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/high-definition-voices)

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -1,0 +1,41 @@
+# 墨寒桌面助理 v3.1.0／墨寒桌面助手 v3.1.0／MoHan Desktop Assistant v3.1.0／墨寒デスクトップアシスタント v3.1.0
+
+## 繁體中文
+
+- 新增預設關閉、由使用者自行啟用的 Azure Dragon HD／HD Omni 女性聲線 Preview；它使用獨立的 S0 Speech 資源、金鑰、區域與聲線設定，不影響既有 Windows 本機語音、OpenAI 文字轉語音、Realtime 語音或一般 Azure Speech。
+- Azure 區域改為可搜尋且切換後自動儲存的選單。Dragon HD 只列 Microsoft 官方支援區域與女性聲線；HD Flash 僅在官方支援的區域顯示。Central India 的簡體中文女性高階聲線包含 Xiaochen DragonHD，以及 Xiaoyue、Maroonallegro Dragon HD Omni。
+- OpenAI、一般 Azure Speech 與 Dragon HD 金鑰統一使用同一套安全輸入流程：密碼遮罩、離開欄位即由 Windows DPAPI 加密儲存、成功後清空輸入框；金鑰不進入 SQLite、log、可攜設定檔、Git 或安裝包。
+- Dragon HD 設定缺漏或合成失敗時，同一句話依序只嘗試一次一般 Azure Speech 與 Windows 本機女性語音，避免無限循環、重複請求與不必要的雲端費用。
+- Dragon HD 不提供 viseme 事件。墨寒會先完整緩衝 Azure WAV，再讓音訊播放與既有 50 Hz 本機音訊嘴型分析同步開始；區域網路延遲只影響發話前等待，不會被硬編碼為嘴型偏移。
+- 2026 年 8 月 11 日已使用真實 Central India S0 資源在 Windows 完成金鑰儲存、區域與聲線切換、Dragon HD／HD Omni 合成及播放驗證。臺灣連線至 Central India 的發話前等待明顯；實際延遲、可用聲線、費率與區域能力依使用者網路及 Microsoft 當期服務而異，因此本功能維持 Preview 標示。
+- Python 3.15 完整回歸測試 `70/70`、程式碼檢查、封裝後自我測試、JIT 預設啟用與 Qt 事件循環均通過；Windows 仍是唯一完成真實功能驗證的完整平台，macOS／Linux 仍為功能受限 Preview。
+
+## 简体中文
+
+- 新增默认关闭、由用户自行启用的 Azure Dragon HD／HD Omni 女性声线 Preview；它使用独立的 S0 Speech 资源、密钥、区域与声线设置，不影响现有 Windows 本地语音、OpenAI 文字转语音、Realtime 语音或一般 Azure Speech。
+- Azure 区域改为可搜索且切换后自动保存的选单。Dragon HD 只列 Microsoft 官方支持区域与女性声线；HD Flash 仅在官方支持的区域显示。Central India 的简体中文女性高阶声线包括 Xiaochen DragonHD，以及 Xiaoyue、Maroonallegro Dragon HD Omni。
+- OpenAI、一般 Azure Speech 与 Dragon HD 密钥统一使用同一套安全输入流程：密码遮罩、离开字段即由 Windows DPAPI 加密保存、成功后清空输入框；密钥不会进入 SQLite、日志、可移植配置文件、Git 或安装包。
+- Dragon HD 设置缺失或合成失败时，同一句话依次只尝试一次一般 Azure Speech 与 Windows 本地女性语音，避免无限循环、重复请求与不必要的云端费用。
+- Dragon HD 不提供 viseme 事件。墨寒会先完整缓冲 Azure WAV，再让音频播放与现有 50 Hz 本地音频嘴型分析同步开始；区域网络延迟只影响发话前等待，不会被硬编码为嘴型偏移。
+- 2026 年 8 月 11 日已使用真实 Central India S0 资源在 Windows 完成密钥保存、区域与声线切换、Dragon HD／HD Omni 合成及播放验证。台湾连接至 Central India 的发话前等待明显；实际延迟、可用声线、费率与区域能力会因用户网络及 Microsoft 当前服务而异，因此本功能保留 Preview 标示。
+- Python 3.15 完整回归测试 `70/70`、代码检查、打包后自检、JIT 默认启用与 Qt 事件循环均已通过；Windows 仍是唯一完成真实功能验证的完整平台，macOS／Linux 仍为功能受限 Preview。
+
+## English
+
+- Adds an Azure Dragon HD/HD Omni female-voice Preview that is disabled by default and enabled only by the user. It uses a separate S0 Speech resource, key, region, and voice setting without changing existing Windows local speech, OpenAI text-to-speech, Realtime voice, or standard Azure Speech.
+- Azure regions now use a searchable selector that saves immediately after a change. Dragon HD lists only Microsoft-supported regions and female voices, while HD Flash appears only where officially supported. Central India provides the Simplified Chinese female high-definition voices Xiaochen DragonHD plus Xiaoyue and Maroonallegro Dragon HD Omni.
+- OpenAI, standard Azure Speech, and Dragon HD keys now share one secure input workflow: password masking, Windows DPAPI encryption when the field loses focus, and input clearing after success. Keys never enter SQLite, logs, portable profiles, Git, or installers.
+- If Dragon HD configuration is incomplete or synthesis fails, the same utterance tries standard Azure Speech once and Windows local female speech once, preventing infinite loops, duplicate requests, and unnecessary cloud charges.
+- Dragon HD provides no viseme events. MoHan fully buffers the Azure WAV before starting audio playback and the existing local 50 Hz audio-driven lip analysis together. Regional network latency delays speech onset only and is never hardcoded as a mouth offset.
+- On August 11, 2026, a real Central India S0 resource completed Windows validation for key storage, region and voice switching, and Dragon HD/HD Omni synthesis and playback. Taiwan experienced a noticeable wait before speech with Central India. Actual latency, voices, pricing, and regional capabilities vary with the user's network and Microsoft's current service, so the feature retains its Preview label.
+- The complete Python 3.15 regression suite `70/70`, code checks, packaged self-test, default-enabled JIT verification, and Qt event-loop smoke test passed. Windows remains the only full platform with real feature validation; macOS and Linux remain limited Previews.
+
+## 日本語
+
+- 初期状態で無効で、利用者が明示的に有効化する Azure Dragon HD／HD Omni 女性音声 Preview を追加します。独立した S0 Speech リソース、キー、リージョン、音声設定を使用し、既存の Windows 本機音声、OpenAI テキスト読み上げ、Realtime 音声、通常の Azure Speech を変更しません。
+- Azure リージョンは検索可能な選択欄となり、切替後すぐに自動保存します。Dragon HD は Microsoft 公式対応リージョンと女性音声だけを表示し、HD Flash は公式対応リージョンだけに表示します。Central India の簡体字中国語女性 HD 音声には Xiaochen DragonHD と、Xiaoyue、Maroonallegro Dragon HD Omni があります。
+- OpenAI、通常の Azure Speech、Dragon HD のキーは一つの安全入力手順を共有します。パスワード表示、欄から離れた時点での Windows DPAPI 暗号化、成功後の入力欄消去を行い、キーを SQLite、ログ、可搬プロファイル、Git、インストーラーへ入れません。
+- Dragon HD の設定不足または合成失敗時、同じ発話は通常の Azure Speech と Windows 本機女性音声を各一回だけ試し、無限循環、重複要求、不要なクラウド費用を防ぎます。
+- Dragon HD は viseme イベント非対応です。墨寒は Azure WAV を完全にバッファした後、音声再生と既存の 50 Hz 本機音声駆動口形解析を同時開始します。リージョン間のネットワーク遅延は発話開始前の待ち時間だけに影響し、固定の口形オフセットにはしません。
+- 2026 年 8 月 11 日、実際の Central India S0 リソースを使い、Windows でキー保存、リージョンと音声切替、Dragon HD／HD Omni の合成と再生を検証しました。台湾から Central India では発話開始前の待ち時間が明確でした。実際の遅延、音声、料金、リージョン機能は利用者のネットワークと Microsoft の当期サービスにより異なるため、本機能は Preview 表示を維持します。
+- Python 3.15 完全回帰テスト `70/70`、コード検査、パッケージ化後セルフテスト、JIT 既定有効化検証、Qt イベントループ smoke test に合格しました。実機機能検証済みの完全対応プラットフォームは引き続き Windows のみで、macOS／Linux は機能限定 Preview です。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "3.0.0"
+version = "3.1.0"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "3.0.0"
+version = "3.1.0"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/service_container.py
+++ b/service_container.py
@@ -52,7 +52,9 @@ class CompanionServices:
     backup_manager: BackupManager | None = None
     speech_providers: SpeechProviderRegistryPort | None = None
     azure_speech: AzureSpeechEnginePort | None = None
+    azure_hd_speech: AzureSpeechEnginePort | None = None
     azure_secret_store: SecretStorePort | None = None
+    azure_hd_secret_store: SecretStorePort | None = None
     secret_store_factory: SecretStoreFactoryPort | None = None
     platform_services: PlatformServicePort | None = None
 
@@ -85,6 +87,10 @@ def create_default_services(
     azure_secret_store = secret_factory(
         data_path / "azure-speech-key.dpapi",
         "MoHan Azure Speech key",
+    )
+    azure_hd_secret_store = secret_factory(
+        data_path / "azure-dragon-hd-key.dpapi",
+        "MoHan Azure Dragon HD Speech key",
     )
     listener = SpeechListener(
         listener_script,
@@ -146,6 +152,7 @@ def create_default_services(
         )
     cloud_tts = OpenAITTS(parent)
     azure_tts = AzureSpeechTTS(parent)
+    azure_hd_tts = AzureSpeechTTS(parent)
     system_capabilities = SpeechProviderCapabilities(
         provider_id=SYSTEM_LOCAL_PROVIDER,
         offline=runtime_platform.capabilities.system_local_speech,
@@ -172,10 +179,13 @@ def create_default_services(
             local_tts,
             cloud_tts,
             azure_tts,
+            azure_hd_tts,
             system_capabilities=system_capabilities,
         ),
         azure_speech=azure_tts,
+        azure_hd_speech=azure_hd_tts,
         azure_secret_store=azure_secret_store,
+        azure_hd_secret_store=azure_hd_secret_store,
         secret_store_factory=secret_factory,
         platform_services=runtime_platform,
     )

--- a/speech.py
+++ b/speech.py
@@ -554,6 +554,20 @@ def windows_voices() -> list[tuple[str, str]]:
     return [(voice.name, voice.culture) for voice in windows_voice_catalog()]
 
 
+def female_windows_voices_for_language(
+    voices: list[tuple[str, str]],
+    target_language: str,
+) -> list[tuple[str, str]]:
+    target = str(target_language or "").strip().lower()
+    family = target.split("-", 1)[0]
+    return [
+        (name, culture)
+        for name, culture in voices
+        if not is_known_male_windows_voice(name)
+        and culture.lower().split("-", 1)[0] == family
+    ]
+
+
 def preferred_windows_voice(
     voices: list[tuple[str, str]],
     saved: str = "",

--- a/speech_providers.py
+++ b/speech_providers.py
@@ -18,6 +18,7 @@ LEGACY_WINDOWS_LOCAL_PROVIDER = "windows-local"
 OPENAI_SPEECH_PROVIDER = "openai-speech"
 OPENAI_REALTIME_PROVIDER = "openai-realtime"
 AZURE_SPEECH_PROVIDER = "azure-speech"
+AZURE_HD_SPEECH_PROVIDER = "azure-speech-hd"
 
 
 _LEGACY_PROVIDER_IDS = {
@@ -43,6 +44,15 @@ _LEGACY_PROVIDER_IDS = {
     "Azure Speech（預覽）": AZURE_SPEECH_PROVIDER,
     "Azure Speech（预览）": AZURE_SPEECH_PROVIDER,
     "Azure Speech (Preview)": AZURE_SPEECH_PROVIDER,
+    AZURE_HD_SPEECH_PROVIDER: AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（私下測試）": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（私下测试）": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD (Private Preview)": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（非公開テスト）": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（預覽，需 S0）": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（预览，需 S0）": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD (Preview, requires S0)": AZURE_HD_SPEECH_PROVIDER,
+    "Azure Dragon HD（プレビュー、S0 必須）": AZURE_HD_SPEECH_PROVIDER,
 }
 
 
@@ -170,6 +180,17 @@ class AzureSpeechProvider:
         )
 
 
+class AzureHDSpeechProvider(AzureSpeechProvider):
+    capabilities = SpeechProviderCapabilities(
+        provider_id=AZURE_HD_SPEECH_PROVIDER,
+        offline=False,
+        requires_api_key=True,
+        verified_female_catalog=True,
+        supports_streaming=False,
+        supported_languages=("multilingual",),
+    )
+
+
 class SpeechProviderRegistry:
     """Explicit registry for replaceable speech engines.
 
@@ -233,10 +254,21 @@ class SpeechProviderRegistry:
         configured.add(SYSTEM_LOCAL_PROVIDER)
         if selected in self._providers and selected in configured:
             return selected
+        if (
+            selected == AZURE_HD_SPEECH_PROVIDER
+            and AZURE_SPEECH_PROVIDER in self._providers
+            and AZURE_SPEECH_PROVIDER in configured
+        ):
+            return AZURE_SPEECH_PROVIDER
         return SYSTEM_LOCAL_PROVIDER
 
     def fallback_provider_id(self, failed_provider_id: object) -> str | None:
         failed = normalize_speech_provider_id(failed_provider_id)
+        if (
+            failed == AZURE_HD_SPEECH_PROVIDER
+            and AZURE_SPEECH_PROVIDER in self._providers
+        ):
+            return AZURE_SPEECH_PROVIDER
         local = self._providers.get(SYSTEM_LOCAL_PROVIDER)
         if (
             failed != SYSTEM_LOCAL_PROVIDER
@@ -251,6 +283,7 @@ def create_builtin_speech_registry(
     local_engine: LocalSpeechEnginePort,
     cloud_engine: CloudSpeechEnginePort,
     azure_engine: AzureSpeechEnginePort | None = None,
+    azure_hd_engine: AzureSpeechEnginePort | None = None,
     *,
     system_capabilities: SpeechProviderCapabilities | None = None,
 ) -> SpeechProviderRegistry:
@@ -260,4 +293,6 @@ def create_builtin_speech_registry(
     ]
     if azure_engine is not None:
         providers.append(AzureSpeechProvider(azure_engine))
+    if azure_hd_engine is not None:
+        providers.append(AzureHDSpeechProvider(azure_hd_engine))
     return SpeechProviderRegistry(tuple(providers))

--- a/tests/test_azure_speech.py
+++ b/tests/test_azure_speech.py
@@ -9,10 +9,16 @@ lazy from urllib.request import Request
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+lazy from azure_regions import (
+    azure_region_identifiers,
+    azure_region_options,
+    azure_region_supports_hd_flash,
+)
 lazy from azure_speech import (
     AZURE_FEMALE_VOICES,
     AzureSpeechTTS,
     azure_female_voices,
+    azure_hd_female_voices,
     azure_speech_error_message,
     build_azure_ssml,
     normalize_azure_region,
@@ -45,6 +51,31 @@ def _assert_region_normalization() -> None:
             raise AssertionError(f"Invalid region accepted: {invalid!r}")
 
 
+def _assert_region_catalog() -> None:
+    all_regions = azure_region_identifiers()
+    hd_regions = azure_region_identifiers(hd_only=True)
+    assert len(all_regions) == len(set(all_regions)) == 33
+    assert "eastasia" in all_regions
+    assert "eastasia" not in hd_regions
+    assert "southeastasia" in hd_regions
+    assert (
+        "東南亞 · southeastasia",
+        "southeastasia",
+    ) in azure_region_options("zh-TW", hd_only=True)
+    assert (
+        "东南亚 · southeastasia",
+        "southeastasia",
+    ) in azure_region_options("zh-CN", hd_only=True)
+    assert (
+        "Southeast Asia · southeastasia",
+        "southeastasia",
+    ) in azure_region_options("en", hd_only=True)
+    assert (
+        "東南アジア · southeastasia",
+        "southeastasia",
+    ) in azure_region_options("ja-JP", hd_only=True)
+
+
 def _assert_female_voice_catalog() -> None:
     traditional = azure_female_voices("zh-TW")
     simplified = azure_female_voices("zh-CN")
@@ -62,6 +93,37 @@ def _assert_female_voice_catalog() -> None:
     )
     assert azure_female_voices("en")[0] == "en-US-AvaMultilingualNeural"
     assert azure_female_voices("ja-JP")[0] == "ja-JP-NanamiNeural"
+    all_hd_voices = azure_hd_female_voices("zh-TW")
+    non_flash_hd_voices = azure_hd_female_voices(
+        "zh-TW",
+        include_flash=False,
+    )
+    assert non_flash_hd_voices == (
+        "zh-CN-Xiaochen:DragonHDLatestNeural",
+        "zh-CN-Xiaoyue:DragonHDOmniLatestNeural",
+        "zh-CN-Maroonallegro:DragonHDOmniLatestNeural",
+    )
+    assert all(":DragonHD" in voice for voice in all_hd_voices)
+    assert all("Flash" not in voice for voice in non_flash_hd_voices)
+    assert len(non_flash_hd_voices) < len(all_hd_voices)
+    assert all(
+        voice.startswith("zh-CN-")
+        for voice in azure_hd_female_voices("zh-TW")
+    )
+    assert all(
+        voice.startswith("zh-CN-")
+        for voice in azure_hd_female_voices("zh-CN")
+    )
+    assert all(
+        voice.startswith("en-US-")
+        for voice in azure_hd_female_voices("en")
+    )
+    assert all(
+        voice.startswith("ja-JP-")
+        for voice in azure_hd_female_voices("ja-JP")
+    )
+    assert azure_region_supports_hd_flash("southeastasia")
+    assert not azure_region_supports_hd_flash("centralindia")
 
 
 def _assert_ssml_safety() -> None:
@@ -99,6 +161,21 @@ def _assert_localized_errors_and_ui() -> None:
     )
     assert ui_text("zh-CN", "azure_remove_key", "fallback") == (
         "移除 Azure Speech 密钥"
+    )
+    assert "automatically" in ui_text(
+        "en",
+        "secret_auto_save_hint",
+        "fallback",
+    )
+    assert "自动安全保存" in ui_text(
+        "zh-CN",
+        "secret_auto_save_hint",
+        "fallback",
+    )
+    assert "自動的に安全に保存" in ui_text(
+        "ja-JP",
+        "secret_auto_save_hint",
+        "fallback",
     )
 
 
@@ -147,6 +224,8 @@ def _assert_successful_synthesis(
 ) -> Request:
     captured_requests: list[Request] = []
     captured_timeouts: list[float] = []
+    measured_latencies: list[float] = []
+    engine.synthesis_latency_measured.connect(measured_latencies.append)
 
     def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
         captured_requests.append(request)
@@ -177,6 +256,8 @@ def _assert_successful_synthesis(
     playback.assert_called_once()
     assert finished == [True]
     assert not failures
+    assert engine.last_synthesis_latency_ms is not None
+    assert measured_latencies == [engine.last_synthesis_latency_ms]
     return request
 
 
@@ -208,6 +289,7 @@ def _assert_http_error_redacts_key(
 
 def run() -> None:
     _assert_region_normalization()
+    _assert_region_catalog()
     _assert_female_voice_catalog()
     _assert_ssml_safety()
     _assert_localized_errors_and_ui()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,6 +33,7 @@ lazy from speech import (
     SpeechListener,
     WindowsTTS,
     apply_wav_volume,
+    female_windows_voices_for_language,
     preferred_windows_voice,
     windows_voices,
 )
@@ -424,6 +425,7 @@ def _assert_windows_voice_selection() -> None:
         ("OneCore::Microsoft Zhiwei", "zh-TW"),
         ("Microsoft Hanhan Desktop", "zh-TW"),
         ("OneCore::Microsoft Yating", "zh-TW"),
+        ("OneCore::Microsoft Ayumi", "ja-JP"),
     ]
     assert preferred_windows_voice(voices) == "OneCore::Microsoft Yating"
     assert (
@@ -434,6 +436,20 @@ def _assert_windows_voice_selection() -> None:
         preferred_windows_voice(voices, "OneCore::Microsoft Zhiwei")
         == "OneCore::Microsoft Yating"
     )
+    assert female_windows_voices_for_language(voices, "zh-TW") == [
+        ("Microsoft Hanhan Desktop", "zh-TW"),
+        ("OneCore::Microsoft Yating", "zh-TW"),
+    ]
+    assert female_windows_voices_for_language(voices, "zh-CN") == [
+        ("Microsoft Hanhan Desktop", "zh-TW"),
+        ("OneCore::Microsoft Yating", "zh-TW"),
+    ]
+    assert female_windows_voices_for_language(voices, "en") == [
+        ("Microsoft Zira Desktop", "en-US"),
+    ]
+    assert female_windows_voices_for_language(voices, "ja-JP") == [
+        ("OneCore::Microsoft Ayumi", "ja-JP"),
+    ]
     installed = windows_voices()
     # GitHub's clean Windows runners do not guarantee that optional language
     # packs are installed.  The deterministic list above verifies that Yating

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -10,7 +10,7 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 lazy from PySide6.QtCore import QObject, Signal
-lazy from PySide6.QtWidgets import QApplication
+lazy from PySide6.QtWidgets import QApplication, QLineEdit
 
 lazy from app import CompanionWindow
 lazy from db import StudioDB
@@ -19,8 +19,8 @@ lazy from service_container import CompanionServices
 
 
 class FakeSecretStore:
-    def __init__(self) -> None:
-        self.value = "test-key"
+    def __init__(self, value: str = "test-key") -> None:
+        self.value = value
 
     def load(self) -> str:
         return self.value
@@ -99,9 +99,11 @@ class InjectedTestContext:
     db: StudioDB
     secret_store: FakeSecretStore
     azure_secret_store: FakeSecretStore
+    azure_hd_secret_store: FakeSecretStore
     local_tts: FakeSpeechEngine
     cloud_tts: FakeSpeechEngine
     azure_tts: FakeSpeechEngine
+    azure_hd_tts: FakeSpeechEngine
     realtime: FakeRealtime
     listener: FakeListener
     window: CompanionWindow
@@ -116,9 +118,11 @@ def _create_injected_context(temp_dir: str) -> InjectedTestContext:
     db.set_setting("voice_muted", False)
     secret_store = FakeSecretStore()
     azure_secret_store = FakeSecretStore()
+    azure_hd_secret_store = FakeSecretStore("test-hd-key")
     local_tts = FakeSpeechEngine()
     cloud_tts = FakeSpeechEngine()
     azure_tts = FakeSpeechEngine()
+    azure_hd_tts = FakeSpeechEngine()
     realtime = FakeRealtime()
     listener = FakeListener()
     services = CompanionServices(
@@ -129,7 +133,9 @@ def _create_injected_context(temp_dir: str) -> InjectedTestContext:
         realtime=realtime,
         listener=listener,
         azure_speech=azure_tts,
+        azure_hd_speech=azure_hd_tts,
         azure_secret_store=azure_secret_store,
+        azure_hd_secret_store=azure_hd_secret_store,
     )
     window = CompanionWindow(startup_speech=False, services=services)
     return InjectedTestContext(
@@ -137,9 +143,11 @@ def _create_injected_context(temp_dir: str) -> InjectedTestContext:
         db=db,
         secret_store=secret_store,
         azure_secret_store=azure_secret_store,
+        azure_hd_secret_store=azure_hd_secret_store,
         local_tts=local_tts,
         cloud_tts=cloud_tts,
         azure_tts=azure_tts,
+        azure_hd_tts=azure_hd_tts,
         realtime=realtime,
         listener=listener,
         window=window,
@@ -152,11 +160,16 @@ def _assert_dependencies_are_injected(context: InjectedTestContext) -> None:
     assert context.window.tts is context.local_tts
     assert context.window.cloud_tts is context.cloud_tts
     assert context.window.azure_tts is context.azure_tts
+    assert context.window.azure_hd_tts is context.azure_hd_tts
+    assert context.window.azure_hd_secret_store is (
+        context.azure_hd_secret_store
+    )
     assert context.window.realtime is context.realtime
     assert context.window.listener is context.listener
     assert context.local_tts.volume_calls[-1] == (137, False)
     assert context.cloud_tts.volume_calls[-1] == (137, False)
     assert context.azure_tts.volume_calls[-1] == (137, False)
+    assert context.azure_hd_tts.volume_calls[-1] == (137, False)
     assert context.realtime.volume_calls[-1] == (137, False)
 
 
@@ -196,6 +209,28 @@ def _assert_voice_choices_save_and_apply_immediately(
         == "zh-CN-XiaoxiaoNeural"
     )
 
+    southeast_asia = dashboard.azure_region.findData("southeastasia")
+    assert southeast_asia >= 0
+    dashboard.azure_region.setCurrentIndex(southeast_asia)
+    assert context.db.setting("azure_speech_region") == "southeastasia"
+
+    hd_southeast_asia = dashboard.azure_hd_region.findData("southeastasia")
+    hd_central_india = dashboard.azure_hd_region.findData("centralindia")
+    assert hd_southeast_asia >= 0 and hd_central_india >= 0
+    dashboard.azure_hd_region.setCurrentIndex(hd_southeast_asia)
+    flash_voice = "zh-CN-Xiaoxiao:DragonHDFlashLatestNeural"
+    assert dashboard.azure_hd_voice.findText(flash_voice) >= 0
+    dashboard.azure_hd_voice.setCurrentText(flash_voice)
+    assert context.db.setting("azure_hd_speech_voice") == flash_voice
+
+    dashboard.azure_hd_region.setCurrentIndex(hd_central_india)
+    assert context.db.setting("azure_hd_speech_region") == "centralindia"
+    assert dashboard.azure_hd_voice.findText(flash_voice) == -1
+    assert "Flash" not in dashboard.azure_hd_voice.currentText()
+    assert context.db.setting("azure_hd_speech_voice") == (
+        dashboard.azure_hd_voice.currentText()
+    )
+
     dashboard.realtime_voice.setCurrentText("shimmer")
     assert context.db.setting("realtime_voice") == "shimmer"
     assert context.realtime.start_requests == []
@@ -206,6 +241,42 @@ def _assert_voice_choices_save_and_apply_immediately(
     assert context.db.setting("realtime_voice") == "coral"
     assert context.realtime.stop_calls == 1
     assert context.realtime.start_requests[-1].session.voice == "coral"
+
+
+def _assert_secret_fields_save_consistently_and_securely(
+    context: InjectedTestContext,
+) -> None:
+    dashboard = context.window.dashboard
+    fields = (
+        (dashboard.api_key_input, context.secret_store, "sk-openai-test"),
+        (
+            dashboard.azure_key_input,
+            context.azure_secret_store,
+            "azure-standard-test",
+        ),
+        (
+            dashboard.azure_hd_key_input,
+            context.azure_hd_secret_store,
+            "azure-dragon-hd-test",
+        ),
+    )
+    for key_input, secret_store, secret in fields:
+        assert key_input.echoMode() == QLineEdit.Password
+        assert key_input.isEnabled()
+        assert key_input.accessibleName()
+        assert "自動安全保存" in key_input.toolTip()
+        secret_store.clear()
+        key_input.setText(secret)
+        key_input.editingFinished.emit()
+        assert secret_store.load() == secret
+        assert key_input.text() == ""
+        assert "保存" in key_input.placeholderText()
+
+    database_text = "\n".join(
+        str(row["value"])
+        for row in context.db.conn.execute("SELECT value FROM settings")
+    )
+    assert all(secret not in database_text for *_prefix, secret in fields)
 
 def _assert_cloud_failure_uses_local_tts(
     context: InjectedTestContext,
@@ -270,7 +341,8 @@ def _assert_missing_azure_settings_fail_locally(
         "OneCore::Microsoft Yating",
         -1,
     )
-    assert "未送出雲端請求" in context.window.dashboard.api_status.text()
+    status = context.window.dashboard.api_status.text()
+    assert "未送出" in status and "雲端請求" in status, status
 
 
 def _assert_controls_and_shutdown(context: InjectedTestContext) -> None:
@@ -291,6 +363,7 @@ def run() -> None:
         _assert_cloud_failure_uses_local_tts(context)
         _assert_azure_failure_uses_local_tts(context)
         _assert_missing_azure_settings_fail_locally(context)
+        _assert_secret_fields_save_consistently_and_securely(context)
         _assert_controls_and_shutdown(context)
     print("DEPENDENCY_INJECTION_OK")
 

--- a/tests/test_four_language_documentation.py
+++ b/tests/test_four_language_documentation.py
@@ -110,7 +110,7 @@ def _language_sections(text: str) -> dict[str, str]:
 
 
 def test_current_release_four_language_bullet_parity() -> None:
-    release_text = (ROOT / "docs/releases/v3.0.0.md").read_text(
+    release_text = (ROOT / "docs/releases/v3.1.0.md").read_text(
         encoding="utf-8"
     )
     release_sections = _language_sections(release_text)
@@ -126,7 +126,7 @@ def test_current_release_four_language_bullet_parity() -> None:
     changelog_bullet_counts: dict[str, int] = {}
     for language, section in changelog_sections.items():
         match = re.search(
-            r"(?ms)^### v3\.0\.0.*?\n(.*?)(?=^### |\Z)",
+            r"(?ms)^### v3\.1\.0.*?\n(.*?)(?=^### |\Z)",
             section,
         )
         assert match is not None, language

--- a/ui_localization.py
+++ b/ui_localization.py
@@ -89,10 +89,12 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
     "openai_engine": "OpenAI natural voice",
     "realtime_engine": "Realtime voice",
     "azure_engine": "Azure Speech (Preview)",
+    "azure_hd_engine": "Azure Dragon HD (Preview, requires S0)",
     "azure_voice": "Azure Speech female voice",
     "azure_region": "Azure Speech region",
     "azure_key": "Azure Speech key",
-    "azure_region_placeholder": "For example: eastasia",
+    "azure_region_choose": "Choose the region where the Azure resource was created",
+    "azure_region_saved": "Existing setting · {region}",
     "azure_key_saved": "Encrypted by Windows; leave blank to keep it",
     "azure_key_missing": "Paste the Azure Speech resource key",
     "azure_remove_key": "Remove Azure Speech key",
@@ -101,6 +103,25 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
     ),
     "azure_key_save_failed": (
         "Could not securely save the Azure Speech key: {error}"
+    ),
+    "azure_hd_voice": "Dragon HD female voice",
+    "azure_hd_region": "Dragon HD resource region",
+    "azure_hd_key": "Dragon HD S0 resource key",
+    "azure_hd_key_saved": "Dragon HD S0 key encrypted by Windows; leave blank to keep it",
+    "azure_hd_key_missing": "Paste the separate Dragon HD S0 resource key",
+    "azure_hd_remove_key": "Remove Dragon HD S0 key",
+    "azure_hd_remove_key_confirm": (
+        "Remove the Dragon HD S0 key securely stored by {platform}?"
+    ),
+    "azure_hd_key_save_failed": (
+        "Could not securely save the Dragon HD S0 key: {error}"
+    ),
+    "azure_hd_speech_note": (
+        "Optional Preview. Use a separate S0 Speech resource, key, and "
+        "matching supported region. Dragon HD has no viseme events, so "
+        "MoHan retains audio-driven lip sync. Speech-start delay depends on "
+        "network and region distance. Failures fall back once each to "
+        "standard Azure Speech and then Windows local speech."
     ),
     "azure_speech_note": (
         "Preview feature. Bring your own Azure Speech resource key and its "
@@ -216,9 +237,16 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
     "text_model": "Text model",
     "persona_prompt": "AI persona prompt",
     "remove_api_key": "Remove saved API key",
+    "remove_api_key_confirm": (
+        "Remove the OpenAI API key stored securely by {platform}?"
+    ),
     "save_settings": "Save settings",
     "api_key_saved": "Safely stored; leave blank to keep it unchanged",
     "api_key_missing": "Paste an OpenAI Project API key beginning with sk-",
+    "api_key_save_failed": "Could not store the OpenAI API key securely: {error}",
+    "secret_auto_save_hint": (
+        "Press Enter or leave the field to store the key securely and automatically."
+    ),
     "api_status_saved": "OpenAI API: Key encrypted by Windows",
     "api_status_environment": "OpenAI API: Key supplied by an environment variable",
     "api_status_secret_unavailable": (
@@ -326,10 +354,12 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
     "openai_engine": "OpenAI 自然语音",
     "realtime_engine": "Realtime 即时语音",
     "azure_engine": "Azure Speech（预览）",
+    "azure_hd_engine": "Azure Dragon HD（预览，需 S0）",
     "azure_voice": "Azure Speech 女性声线",
     "azure_region": "Azure Speech 区域",
     "azure_key": "Azure Speech 密钥",
-    "azure_region_placeholder": "例如：eastasia",
+    "azure_region_choose": "请选择创建 Azure 资源时所在的区域",
+    "azure_region_saved": "现有设置 · {region}",
     "azure_key_saved": "已由 Windows 加密保存；留空即可保留",
     "azure_key_missing": "贴上 Azure Speech 资源密钥",
     "azure_remove_key": "移除 Azure Speech 密钥",
@@ -337,6 +367,23 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
         "确定移除由 Windows 加密保存的 Azure Speech 密钥吗？"
     ),
     "azure_key_save_failed": "无法安全保存 Azure Speech 密钥：{error}",
+    "azure_hd_voice": "Dragon HD 女性声线",
+    "azure_hd_region": "Dragon HD 资源区域",
+    "azure_hd_key": "Dragon HD S0 资源密钥",
+    "azure_hd_key_saved": "Dragon HD S0 密钥已由 Windows 加密保存；留空即可保留",
+    "azure_hd_key_missing": "贴上独立的 Dragon HD S0 资源密钥",
+    "azure_hd_remove_key": "移除 Dragon HD S0 密钥",
+    "azure_hd_remove_key_confirm": (
+        "确定移除由 {platform} 安全保存的 Dragon HD S0 密钥吗？"
+    ),
+    "azure_hd_key_save_failed": "无法安全保存 Dragon HD S0 密钥：{error}",
+    "azure_hd_speech_note": (
+        "可选预览功能；请使用独立的 S0 语音资源、密钥与相符区域。"
+        "Dragon HD 不提供 viseme，因此墨寒会沿用音频分析维持嘴型同步。"
+        "发话前等待时间取决于网络与区域距离。若 HD 失败，会依序退回一般 "
+        "Azure 与 Windows 本机语音，"
+        "每一层只尝试一次，避免重复计费。"
+    ),
     "azure_speech_note": (
         "预览功能；需自备 Azure Speech 资源密钥与相符区域。仅列出已确认的"
         "女性声线；设定不完整或服务失败时会立即切换到 Windows 女性语音。"
@@ -437,9 +484,12 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
     "text_model": "文字模型",
     "persona_prompt": "AI 人格提示词",
     "remove_api_key": "删除已保存的 API 密钥",
+    "remove_api_key_confirm": "确定移除由 {platform} 安全保存的 OpenAI API 密钥吗？",
     "save_settings": "保存设置",
     "api_key_saved": "已安全保存；留空则保持不变",
     "api_key_missing": "粘贴以 sk- 开头的 OpenAI Project API Key",
+    "api_key_save_failed": "无法安全保存 OpenAI API 密钥：{error}",
+    "secret_auto_save_hint": "输入后按 Enter 或移开焦点，即会自动安全保存。",
     "api_status_saved": "OpenAI API：密钥已由 Windows 加密保存",
     "api_status_environment": "OpenAI API：使用环境变量提供的密钥",
     "api_status_secret_unavailable": (

--- a/ui_localization_ja.py
+++ b/ui_localization_ja.py
@@ -82,10 +82,12 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
     "openai_engine": "OpenAI 自然音声",
     "realtime_engine": "Realtime 音声",
     "azure_engine": "Azure Speech（プレビュー）",
+    "azure_hd_engine": "Azure Dragon HD（プレビュー、S0 必須）",
     "azure_voice": "Azure Speech 女性音声",
     "azure_region": "Azure Speech リージョン",
     "azure_key": "Azure Speech キー",
-    "azure_region_placeholder": "例：japaneast",
+    "azure_region_choose": "Azure リソースを作成したリージョンを選択",
+    "azure_region_saved": "既存の設定 · {region}",
     "azure_key_saved": "Windows で暗号化済み（空欄なら保持）",
     "azure_key_missing": "Azure Speech リソースキーを貼り付け",
     "azure_remove_key": "Azure Speech キーを削除",
@@ -93,6 +95,23 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
         "Windows で暗号化保存した Azure Speech キーを削除しますか？"
     ),
     "azure_key_save_failed": "Azure Speech キーを安全に保存できません：{error}",
+    "azure_hd_voice": "Dragon HD 女性音声",
+    "azure_hd_region": "Dragon HD リソースのリージョン",
+    "azure_hd_key": "Dragon HD S0 リソースキー",
+    "azure_hd_key_saved": "Dragon HD S0 キーは Windows で暗号化済み（空欄なら保持）",
+    "azure_hd_key_missing": "独立した Dragon HD S0 リソースキーを貼り付け",
+    "azure_hd_remove_key": "Dragon HD S0 キーを削除",
+    "azure_hd_remove_key_confirm": (
+        "{platform} で安全に保存した Dragon HD S0 キーを削除しますか？"
+    ),
+    "azure_hd_key_save_failed": "Dragon HD S0 キーを安全に保存できません：{error}",
+    "azure_hd_speech_note": (
+        "任意のプレビュー機能です。独立した S0 音声リソース、キー、対応リージョンを"
+        "使用してください。Dragon HD は viseme イベント非対応のため、墨寒は"
+        "既存の音声解析で口形同期を保ちます。発話開始前の待ち時間はネットワークと"
+        "リージョン間距離に依存します。失敗時は通常の Azure、Windows "
+        "本機音声の順に各一回だけ切り替え、重複課金を防ぎます。"
+    ),
     "azure_speech_note": (
         "プレビュー機能です。ご自身の Azure Speech リソースキーと対応する"
         "リージョンが必要です。確認済みの女性音声だけを表示し、設定不足または"
@@ -195,9 +214,16 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
     "text_model": "テキストモデル",
     "persona_prompt": "AI 人格プロンプト",
     "remove_api_key": "保存済み API キーを削除",
+    "remove_api_key_confirm": (
+        "{platform} で安全に保存された OpenAI API キーを削除しますか？"
+    ),
     "save_settings": "設定を保存",
     "api_key_saved": "安全に保存済み（空欄なら変更しません）",
     "api_key_missing": "sk- で始まる OpenAI Project API キーを貼り付け",
+    "api_key_save_failed": "OpenAI API キーを安全に保存できません：{error}",
+    "secret_auto_save_hint": (
+        "Enter キーを押すかフォーカスを移すと、自動的に安全に保存されます。"
+    ),
     "api_status_saved": "OpenAI API：キーは Windows で暗号化済み",
     "api_status_environment": "OpenAI API：環境変数からキーを使用中",
     "api_status_secret_unavailable": (

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "3.0.0"
+FALLBACK_VERSION = "3.1.0"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文

### 摘要
- 發布版本更新為 **v3.1.0**，公開提供可選用、預設關閉的 **Azure Speech Dragon HD Preview（需要 S0）**。
- 一般 Azure Speech 與 Dragon HD 使用各自獨立的金鑰、區域及聲音設定；所有金鑰沿用一致的安全儲存、遮蔽與清除流程。
- Azure 區域可自由選擇並立即自動儲存；Dragon HD Flash 女聲只在微軟官方支援區域顯示，不將開發者配置寫死。
- Dragon HD 失效時依序退回一般 Azure Neural，再退回 Windows 本機語音。
- 保留供應器無關的 50 Hz 本機嘴型同步，不以固定網路延遲參數掩蓋區域差異。
- 四語介面只列出對應語系家族的女性聲音；繁中與簡中可互選華語女聲。
- 已在臺灣連線 Central India S0 實機驗證功能正常；跨區延遲明顯，因此介面與文件均標示 Preview 與區域延遲提醒。

### 驗證
- Python 3.15 完整回歸測試：**70/70**
- Ruff、四語文件完整性、公開發布安全稽核：通過
- 封裝後自我測試、JIT 預設啟用與 Qt 事件迴圈 smoke test：通過
- 嘴型效能：平均 0.352 ms、p95 0.587 ms、p99 0.769 ms
- 本機 Inno Setup 7 EXE：成功
- 本機 WiX 7 MSI 已編譯；繁中 Windows 上 ICE 外部記錄器無法解析系統服務訊息，故以 PR 的 Windows Runner 完整 MSI 驗證、安裝、自我測試與解除安裝作為合併前必要門檻
- 未提交、封裝或公開任何金鑰與個人設定

## 简体中文

### 摘要
- 发布版本更新为 **v3.1.0**，公开提供可选、默认关闭的 **Azure Speech Dragon HD Preview（需要 S0）**。
- 普通 Azure Speech 与 Dragon HD 使用各自独立的密钥、区域及声音设置；所有密钥沿用统一的安全存储、遮蔽与清除流程。
- Azure 区域可自由选择并立即自动保存；Dragon HD Flash 女声只在微软官方支持区域显示，不将开发者配置写死。
- Dragon HD 失效时依次回退至普通 Azure Neural，再回退至 Windows 本地语音。
- 保留与供应商无关的 50 Hz 本地口型同步，不用固定网络延迟参数掩盖区域差异。
- 四语界面只显示对应语言家族的女性声音；繁中与简中可互选中文女声。
- 已从台湾连接 Central India S0 完成实机验证，功能正常；跨区延迟明显，因此界面与文档均标示 Preview 与区域延迟提醒。

### 验证
- Python 3.15 完整回归测试：**70/70**
- Ruff、四语文档完整性、公开发布安全审计：通过
- 打包后自检、JIT 默认启用与 Qt 事件循环 smoke test：通过
- 口型性能：平均 0.352 ms、p95 0.587 ms、p99 0.769 ms
- 本机 Inno Setup 7 EXE：成功
- 本机 WiX 7 MSI 已编译；繁中 Windows 上 ICE 外部日志器无法解析系统服务消息，因此 PR 的 Windows Runner 完整 MSI 验证、安装、自检与卸载是合并前的必要门槛
- 未提交、打包或公开任何密钥与个人设置

## English

### Summary
- Advances the release to **v3.1.0** and publicly introduces an optional, disabled-by-default **Azure Speech Dragon HD Preview (S0 required)**.
- Standard Azure Speech and Dragon HD have separate keys, regions, and voice settings, while all credentials share one consistent secure storage, masking, and clearing flow.
- Azure regions are freely selectable and auto-saved immediately. Dragon HD Flash voices appear only in Microsoft-supported regions; no developer-specific deployment is hard-coded.
- Dragon HD failures fall back to standard Azure Neural and then Windows local speech.
- Provider-neutral local 50 Hz lip sync remains intact; regional latency is not hidden behind fixed timing offsets.
- Each of the four UI languages exposes female voices from its language family; Traditional and Simplified Chinese users can cross-select Mandarin female voices.
- A real Taiwan-to-Central India S0 test confirmed correct operation. Because cross-region latency is noticeable, the UI and documentation clearly label the feature Preview and warn about region latency.

### Validation
- Complete Python 3.15 regression suite: **70/70**
- Ruff, four-language documentation completeness, and public-release security audit: passed
- Packaged self-test, JIT-default verification, and Qt event-loop smoke test: passed
- Lip-sync performance: mean 0.352 ms, p95 0.587 ms, p99 0.769 ms
- Local Inno Setup 7 EXE: passed
- The local WiX 7 MSI compiled successfully. On Traditional Chinese Windows, the ICE external logger could not parse a system-service message, so the PR Windows runner's complete MSI validation, installation, self-test, and uninstall remain mandatory before merge
- No credentials or personal settings are committed, packaged, or published

## 日本語

### 概要
- リリースを **v3.1.0** に更新し、任意選択・既定無効の **Azure Speech Dragon HD Preview（S0 必須）** を公開します。
- 通常の Azure Speech と Dragon HD は、キー・リージョン・音声設定を分離しつつ、すべての認証情報で一貫した安全な保存・マスク・消去フローを共有します。
- Azure リージョンは自由に選択でき、変更時に即時自動保存されます。Dragon HD Flash の女性音声は Microsoft の公式対応リージョンだけに表示し、開発者固有の構成を固定しません。
- Dragon HD が失敗した場合は、通常の Azure Neural、次に Windows ローカル音声へ順番にフォールバックします。
- 音声プロバイダーに依存しないローカル 50 Hz リップシンクを維持し、固定ネットワーク遅延値で地域差を隠しません。
- 四言語 UI では各言語系統の女性音声だけを表示し、繁体字中国語と簡体字中国語では中国語女性音声を相互選択できます。
- 台湾から Central India S0 への実機試験で正常動作を確認しました。地域間遅延が明確なため、UI と文書に Preview 表示とリージョン遅延の注意を記載しています。

### 検証
- Python 3.15 完全回帰テスト：**70/70**
- Ruff、四言語文書の完全性、公開リリース安全監査：合格
- パッケージ化後セルフテスト、JIT 既定有効化検証、Qt イベントループ smoke test：合格
- リップシンク性能：平均 0.352 ms、p95 0.587 ms、p99 0.769 ms
- ローカル Inno Setup 7 EXE：成功
- ローカル WiX 7 MSI はコンパイル済みです。繁体字中国語 Windows では ICE 外部ロガーがシステムサービスのメッセージを解析できなかったため、PR の Windows Runner による完全な MSI 検証・インストール・セルフテスト・アンインストールをマージ前の必須条件とします
- キーや個人設定はコミット、パッケージ化、公開していません