### PR TITLE
v3.1.1：Azure 動態女聲與低延遲串流／v3.1.1：Azure 动态女声与低延迟流式传输／v3.1.1: Azure dynamic voices and low-latency streaming／v3.1.1：Azure 動的女性音声と低遅延ストリーミング

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### v3.1.1 — 2026-08-12
+
+- 一般 Azure 與 Dragon HD 依選定區域及各自的加密金鑰動態查詢實際女性聲線，排除男性、不相容模型及區域不支援的 HD Flash；固定清單只作查詢失敗時的安全備援。
+- Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 抵達便開始播放並送入既有 50 Hz 嘴型分析，不再等待完整 WAV。
+- 真實 East Asia F0 與 West US 2 S0 目錄查詢已通過；當時分別取得 21 筆可相容華語女性 Neural 與三筆簡體中文 Dragon HD 女性聲線。
+
 ### v3.1.0 — 2026-08-11
 
 - 新增預設關閉的 Azure Dragon HD／HD Omni 女性聲線 Preview，以獨立 S0 金鑰、區域與聲線設定運作，不改變既有語音供應器。
@@ -184,6 +190,12 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### v3.1.1 — 2026-08-12
+
+- 一般 Azure 与 Dragon HD 根据所选区域及各自的加密密钥动态查询实际女性声线，排除男性、不兼容模型及区域不支持的 HD Flash；固定列表仅作为查询失败时的安全备用。
+- Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 抵达后即开始播放并送入现有 50 Hz 嘴形分析，不再等待完整 WAV。
+- 真实 East Asia F0 与 West US 2 S0 目录查询已通过；当时分别取得 21 项可兼容华语女性 Neural 与三项简体中文 Dragon HD 女性声线。
+
 ### v3.1.0 — 2026-08-11
 
 - 新增默认关闭的 Azure Dragon HD／HD Omni 女性声线 Preview，以独立 S0 密钥、区域与声线设置运行，不改变现有语音供应器。
@@ -362,6 +374,12 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v3.1.1 — 2026-08-12
+
+- Standard Azure and Dragon HD dynamically query actual female voices using the selected region and their independent encrypted keys. Male voices, incompatible models, and region-ineligible HD Flash are excluded; the fixed catalog is now only a safe discovery fallback.
+- Azure synthesis now uses the Speech SDK `PushAudioOutputStream`, starting playback and the existing 50 Hz lip analysis with the first 24 kHz PCM16 chunk instead of waiting for a complete WAV.
+- Real East Asia F0 and West US 2 S0 discovery passed, returning 21 compatible Chinese female Neural voices and three Simplified Chinese Dragon HD female voices respectively at that time.
 
 ### v3.1.0 — 2026-08-11
 
@@ -581,6 +599,12 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v3.1.1 — 2026-08-12
+
+- 通常 Azure と Dragon HD は、選択したリージョンと各自の暗号化キーで実際の女性音声を動的に照会します。男性、非互換モデル、リージョン非対応の HD Flash を除外し、固定一覧は照会失敗時の安全な代替だけに使用します。
+- Azure 合成は Speech SDK `PushAudioOutputStream` を使用し、完全 WAV を待たず、最初の 24 kHz PCM16 断片から再生と既存の 50 Hz 口形解析を開始します。
+- 実際の East Asia F0 と West US 2 S0 の一覧照会に合格し、当時それぞれ互換性のある中国語女性 Neural 音声 21 件と簡体字中国語 Dragon HD 女性音声三件を取得しました。
 
 ### v3.1.0 — 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "3.1.0"
-date-released: "2026-08-11"
+version: "3.1.1"
+date-released: "2026-08-12"
 license: MIT
 abstract: >-
   A configurable Windows AI desktop companion and permission-gated

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -38,8 +38,8 @@ open-source
 
 ### 已準備的公開預發行版
 
-- 標籤：`v3.1.0`
-- 標題：`MoHan Desktop Assistant v3.1.0`
+- 標籤：`v3.1.1`
+- 標題：`MoHan Desktop Assistant v3.1.1`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
@@ -203,8 +203,8 @@ open-source
 
 ### 已准备的公开预发布版
 
-- 标签：`v3.1.0`
-- 标题：`MoHan Desktop Assistant v3.1.0`
+- 标签：`v3.1.1`
+- 标题：`MoHan Desktop Assistant v3.1.1`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
@@ -368,8 +368,8 @@ open-source
 
 ### Prepared public pre-release
 
-- Tag: `v3.1.0`
-- Title: `MoHan Desktop Assistant v3.1.0`
+- Tag: `v3.1.1`
+- Title: `MoHan Desktop Assistant v3.1.1`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
@@ -533,8 +533,8 @@ open-source
 
 ### 準備済みの公開プレリリース
 
-- タグ：`v3.1.0`
-- タイトル：`MoHan Desktop Assistant v3.1.0`
+- タグ：`v3.1.1`
+- タイトル：`MoHan Desktop Assistant v3.1.1`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-3.1.0.exe`。
+2. 執行 `MoHan-Desktop-Assistant-3.1.1.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -23,7 +23,7 @@ Microsoft、GitHub 與 Home Assistant 屬於尚未完成真實環境端到端驗
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.1.0` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
+`v3.1.1` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
 （內含 `.app`），以及 Linux x86_64 AppImage，只用於
 啟動、四語介面、平台路徑及安全停用驗證。請先核對 SHA256SUMS 與 Artifact
 Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角色、完整聊天／
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-3.1.0.exe`。
+2. 运行 `MoHan-Desktop-Assistant-3.1.1.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -52,7 +52,7 @@ Microsoft、GitHub 与 Home Assistant 仍属于尚未完成真实环境端到端
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.1.0` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
+`v3.1.1` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
 （内含 `.app`），以及 Linux x86_64 AppImage，只用于
 验证启动、四语界面、平台路径与安全停用。请核对 SHA256SUMS 与 Artifact
 Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色、完整聊天／工作
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-3.1.0.exe`.
+2. Run `MoHan-Desktop-Assistant-3.1.1.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -81,7 +81,7 @@ See [README.md](README.md) for complete setup, OAuth, safety, and privacy notes.
 
 ### Limited macOS/Linux Preview
 
-The `v3.1.0` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
+The `v3.1.1` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
 (each containing a `.app`) and Linux x86_64 AppImage
 validate startup, four-language UI, platform paths, and fail-closed boundaries
 only. Verify SHA256SUMS and the Artifact Attestation first. These packages have
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-3.1.0.exe` を実行します。
+2. `MoHan-Desktop-Assistant-3.1.1.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う
@@ -114,7 +114,7 @@ Microsoft、GitHub、Home Assistant は、実環境でのエンドツーエン�
 
 ### macOS／Linux 機能限定 Preview
 
-`v3.1.0` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
+`v3.1.1` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
 （各 `.app` 同梱）、および Linux x86_64 AppImage は、
 起動、四言語画面、OS ごとの保存先、安全な無効化だけを確認します。先に
 SHA256SUMS と Artifact Attestation を確認してください。API キー入力、音声、

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.0 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.1 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -222,7 +222,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證。此結果確認墨寒的整合路徑可用，但不保證每個帳號、區域或當期配額皆相同。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
-`v3.1.0` 新增獨立且預設關閉的 Azure Dragon HD／HD Omni 預覽供應器。它使用自己的 S0 金鑰、區域與女性聲線清單；HD Flash 只會在 Microsoft 官方支援的區域顯示。2026 年 8 月 11 日已使用 Central India S0 完成真實 Windows 合成與播放驗證，但臺灣連線的發話前等待明顯，實際延遲取決於網路路由與區域距離。Dragon HD 不提供 viseme 事件，因此墨寒仍以同一套 50 Hz 本機音訊分析驅動嘴型，網路等待不會被硬編碼成嘴型偏移。
+`v3.1.1` 會依目前選定的 Azure 區域與對應加密金鑰，動態查詢該資源中心實際回報的女性 Neural／Dragon HD 聲線；固定名單只在查詢失敗時作為安全備援，HD Flash 仍只會在 Microsoft 官方支援區域顯示。Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 音訊抵達後便開始播放，並以同一套 50 Hz 本機音訊分析同步驅動嘴型，不再等待完整 WAV。2026 年 8 月 12 日已真實查詢 East Asia F0 與 West US 2 S0；West US 2 當時回報三筆簡體中文 Dragon HD 女性聲線，實際清單、延遲、費率與區域能力仍以 Microsoft 當期服務為準。
 
 ### 整合驗證狀態
 
@@ -248,7 +248,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-v3.1.0 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.1.1 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
@@ -359,7 +359,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.0"
+.\build.ps1 -Version "3.1.1"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
@@ -405,7 +405,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.0 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.1 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -613,7 +613,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证。此结果确认墨寒的集成路径可用，但不保证每个账号、区域或当前配额都相同。Dragon HD／HD Omni 因方案、计费与区域支持不同，不混入免费默认列表。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
 
-`v3.1.0` 新增独立且默认关闭的 Azure Dragon HD／HD Omni 预览供应器。它使用自己的 S0 密钥、区域与女性声线列表；HD Flash 只会在 Microsoft 官方支持的区域显示。2026 年 8 月 11 日已使用 Central India S0 完成真实 Windows 合成与播放验证，但台湾连接的发话前等待明显，实际延迟取决于网络路由与区域距离。Dragon HD 不提供 viseme 事件，因此墨寒仍以同一套 50 Hz 本地音频分析驱动嘴型，网络等待不会被硬编码为嘴型偏移。
+`v3.1.1` 会根据当前选择的 Azure 区域与对应加密密钥，动态查询该资源中心实际返回的女性 Neural／Dragon HD 声线；固定列表仅在查询失败时作为安全备用，HD Flash 仍只会在 Microsoft 官方支持区域显示。Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 音频抵达后即开始播放，并以同一套 50 Hz 本地音频分析同步驱动嘴型，不再等待完整 WAV。2026 年 8 月 12 日已真实查询 East Asia F0 与 West US 2 S0；West US 2 当时返回三项简体中文 Dragon HD 女性声线，实际列表、延迟、费率与区域能力仍以 Microsoft 当前服务为准。
 
 ### 集成验证状态
 
@@ -639,7 +639,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-v3.1.0 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.1.1 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
@@ -750,7 +750,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.0"
+.\build.ps1 -Version "3.1.1"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
@@ -796,7 +796,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.0 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.1 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -1004,7 +1004,7 @@ The interface lists only Traditional Chinese, Simplified Chinese, English, and J
 
 On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. This confirms MoHan's integration path, but does not guarantee identical account, region, or quota behavior. Dragon HD and HD Omni stay out of the free default list because their tier, billing, and regional support differ. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
 
-`v3.1.0` adds a separate, disabled-by-default Azure Dragon HD/HD Omni Preview provider with its own S0 key, region, and female-voice catalog. HD Flash voices appear only in regions officially supported by Microsoft. A real Central India S0 resource completed Windows synthesis and playback validation on August 11, 2026, but Taiwan experienced a noticeable wait before speech; actual latency depends on network routing and region distance. Dragon HD provides no viseme events, so MoHan keeps the same local 50 Hz audio analysis as the lip-sync authority instead of hardcoding network delay as a mouth offset.
+`v3.1.1` dynamically queries the female Neural/Dragon HD voices actually returned by the currently selected Azure region and its encrypted key. A fixed catalog remains only as a safe fallback when discovery fails, and HD Flash still appears only in Microsoft-supported regions. Azure synthesis now uses the Speech SDK `PushAudioOutputStream`; playback begins with the first 24 kHz PCM16 chunk and drives the same local 50 Hz lip-analysis clock without waiting for a complete WAV. Real discovery against East Asia F0 and West US 2 S0 was completed on August 12, 2026; West US 2 returned three Simplified Chinese Dragon HD female voices at that time. The actual catalog, latency, pricing, and regional capabilities remain subject to Microsoft's current service.
 
 ### Integration verification status
 
@@ -1030,7 +1030,7 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-v3.1.0 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+v3.1.1 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
@@ -1141,7 +1141,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.0"
+.\build.ps1 -Version "3.1.1"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
@@ -1187,7 +1187,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.0 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.1 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
@@ -1395,7 +1395,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。これは墨寒の統合経路を確認する結果であり、すべてのアカウント、リージョン、割り当てで同じ動作を保証するものではありません。Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
 
-`v3.1.0` は、独立して初期状態では無効な Azure Dragon HD／HD Omni Preview 供給元を追加します。専用の S0 キー、リージョン、女性音声一覧を使用し、HD Flash は Microsoft が公式対応するリージョンだけに表示します。2026 年 8 月 11 日、Central India S0 の実リソースで Windows の合成と再生を検証しましたが、台湾からは発話開始前の待ち時間が明確にありました。実際の遅延はネットワーク経路とリージョン間距離に依存します。Dragon HD は viseme イベント非対応のため、墨寒はネットワーク待ち時間を口形オフセットへ固定せず、従来と同じ 50 Hz 本機音声解析を口形同期の正規情報源として維持します。
+`v3.1.1` は、現在選択中の Azure リージョンと対応する暗号化キーを使い、そのリソースセンターが実際に返す女性 Neural／Dragon HD 音声を動的に照会します。固定一覧は照会失敗時の安全な代替に限定し、HD Flash は引き続き Microsoft 公式対応リージョンだけに表示します。Azure 合成は Speech SDK の `PushAudioOutputStream` を使用し、最初の 24 kHz PCM16 断片が届いた時点で再生を開始して、完全な WAV を待たずに同じ本機 50 Hz 口形解析時計を駆動します。2026 年 8 月 12 日に East Asia F0 と West US 2 S0 で実照会を完了し、当時 West US 2 は簡体字中国語 Dragon HD 女性音声を三件返しました。実際の一覧、遅延、料金、リージョン機能は Microsoft の当期サービスに従います。
 
 ### 統合の検証状況
 
@@ -1421,7 +1421,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-v3.1.0 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.1.1 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 
@@ -1532,7 +1532,7 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.0"
+.\build.ps1 -Version "3.1.1"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,6 +11,7 @@ MoHan Desktop Assistant 採用 MIT License，但其原始碼及 Release 安裝�
 | 元件 | 目前固定版本 | 授權 |
 | --- | ---: | --- |
 | [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [Microsoft Azure Cognitive Services Speech SDK](https://pypi.org/project/azure-cognitiveservices-speech/) | 1.50.0 | Other/Proprietary License（Microsoft Speech SDK 條款） |
 | [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
 | [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
 | [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
@@ -49,6 +50,7 @@ MoHan Desktop Assistant 采用 MIT License，但其源代码及 Release 安装�
 | 组件 | 当前固定版本 | 许可 |
 | --- | ---: | --- |
 | [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [Microsoft Azure Cognitive Services Speech SDK](https://pypi.org/project/azure-cognitiveservices-speech/) | 1.50.0 | Other/Proprietary License（Microsoft Speech SDK 条款） |
 | [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
 | [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
 | [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
@@ -87,6 +89,7 @@ MoHan Desktop Assistant is MIT licensed, but its source and Release packages use
 | Component | Current pinned version | License |
 | --- | ---: | --- |
 | [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [Microsoft Azure Cognitive Services Speech SDK](https://pypi.org/project/azure-cognitiveservices-speech/) | 1.50.0 | Other/Proprietary License (Microsoft Speech SDK terms) |
 | [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
 | [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
 | [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |
@@ -125,6 +128,7 @@ MoHan Desktop Assistant は MIT License で提供されますが、そのソー�
 | コンポーネント | 現在の固定バージョン | ライセンス |
 | --- | ---: | --- |
 | [PySide6 / Qt for Python](https://doc.qt.io/qtforpython-6/) | 6.11.1 | LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only |
+| [Microsoft Azure Cognitive Services Speech SDK](https://pypi.org/project/azure-cognitiveservices-speech/) | 1.50.0 | Other/Proprietary License（Microsoft Speech SDK 条件） |
 | [PyInstaller](https://pyinstaller.org/) | 6.21.0 | GPL-2.0-or-later with the PyInstaller bootloader exception |
 | [python-sounddevice](https://python-sounddevice.readthedocs.io/) | 0.5.5 | MIT |
 | [websocket-client](https://github.com/websocket-client/websocket-client) | 1.9.0 | Apache-2.0 |

--- a/app.py
+++ b/app.py
@@ -111,6 +111,7 @@ lazy from background_agents import (
 )
 lazy from command_parser import is_start_work_command, is_stop_work_command
 lazy from contracts import (
+    AzureSpeechEnginePort,
     SecretStoreFactoryPort,
     SecretStorePort,
     SpeechListenerPort,
@@ -271,6 +272,8 @@ class DashboardDependencies:
     secret_store: SecretStorePort
     azure_secret_store: SecretStorePort | None = None
     azure_hd_secret_store: SecretStorePort | None = None
+    azure_speech: AzureSpeechEnginePort | None = None
+    azure_hd_speech: AzureSpeechEnginePort | None = None
     secret_store_factory: SecretStoreFactoryPort | None = None
     platform_services: PlatformServicePort | None = None
 
@@ -1923,6 +1926,8 @@ class Dashboard(QDialog):
         self.secret_store = dependencies.secret_store
         self.azure_secret_store = dependencies.azure_secret_store
         self.azure_hd_secret_store = dependencies.azure_hd_secret_store
+        self.azure_tts = dependencies.azure_speech
+        self.azure_hd_tts = dependencies.azure_hd_speech
         self.secret_store_factory = (
             dependencies.secret_store_factory
         )
@@ -2071,6 +2076,12 @@ class Dashboard(QDialog):
         self.listener.diagnostic_changed.connect(
             self._transcription_diagnostic
         )
+        for engine in (self.azure_tts, self.azure_hd_tts):
+            catalog_signal = getattr(engine, "voice_catalog_ready", None)
+            if catalog_signal is not None:
+                catalog_signal.connect(self._apply_azure_voice_catalog)
+        self._request_azure_voice_catalog(hd_only=False)
+        self._request_azure_voice_catalog(hd_only=True)
 
     def _start_dashboard_timer(self) -> None:
         self.timer = QTimer(self)
@@ -5666,10 +5677,9 @@ class Dashboard(QDialog):
         self.db.set_setting("azure_speech_voice", selected_voice)
 
     def _azure_region_changed(self, _index: int) -> None:
-        self.db.set_setting(
-            "azure_speech_region",
-            str(self.azure_region.currentData() or ""),
-        )
+        region = str(self.azure_region.currentData() or "")
+        self.db.set_setting("azure_speech_region", region)
+        self._request_azure_voice_catalog(hd_only=False)
 
     def _azure_hd_voice_changed(self, voice: str) -> None:
         selected_voice = voice.strip()
@@ -5684,6 +5694,52 @@ class Dashboard(QDialog):
             region,
         )
         self._refresh_azure_hd_voice_options(region)
+        self._request_azure_voice_catalog(hd_only=True)
+
+    def _request_azure_voice_catalog(self, *, hd_only: bool) -> None:
+        engine = self.azure_hd_tts if hd_only else self.azure_tts
+        secret_store = (
+            self.azure_hd_secret_store
+            if hd_only
+            else self.azure_secret_store
+        )
+        region_combo = self.azure_hd_region if hd_only else self.azure_region
+        if engine is None or secret_store is None:
+            return
+        refresh_catalog = getattr(engine, "refresh_voice_catalog", None)
+        if refresh_catalog is None:
+            return
+        region = str(region_combo.currentData() or "").strip().lower()
+        if not region:
+            return
+        refresh_catalog(
+            secret_store.load(),
+            region,
+            self.ui_language,
+            hd_only=hd_only,
+        )
+
+    def _apply_azure_voice_catalog(self, catalog: object) -> None:
+        hd_only = bool(getattr(catalog, "hd_only", False))
+        region_combo = self.azure_hd_region if hd_only else self.azure_region
+        expected_region = str(region_combo.currentData() or "").strip().lower()
+        if getattr(catalog, "region", "") != expected_region:
+            return
+        voices = tuple(getattr(catalog, "voices", ()))
+        if not voices:
+            return
+        combo = self.azure_hd_voice if hd_only else self.azure_voice
+        setting_key = (
+            "azure_hd_speech_voice" if hd_only else "azure_speech_voice"
+        )
+        current_voice = combo.currentText().strip()
+        selected_voice = current_voice if current_voice in voices else voices[0]
+        combo.blockSignals(True)
+        combo.clear()
+        combo.addItems(voices)
+        combo.setCurrentText(selected_voice)
+        combo.blockSignals(False)
+        self.db.set_setting(setting_key, selected_voice)
 
     def _refresh_azure_hd_voice_options(self, region: str) -> None:
         voices = azure_hd_female_voices(
@@ -5865,10 +5921,30 @@ class Dashboard(QDialog):
             )
 
     def _save_azure_key_immediately(self) -> None:
-        self._persist_azure_key(silent=False)
+        if self._persist_azure_key(silent=False):
+            invalidate = getattr(
+                self.azure_tts,
+                "invalidate_voice_catalog",
+                None,
+            )
+            if invalidate is not None:
+                invalidate(
+                    str(self.azure_region.currentData() or "")
+                )
+            self._request_azure_voice_catalog(hd_only=False)
 
     def _save_azure_hd_key_immediately(self) -> None:
-        self._persist_azure_hd_key(silent=False)
+        if self._persist_azure_hd_key(silent=False):
+            invalidate = getattr(
+                self.azure_hd_tts,
+                "invalidate_voice_catalog",
+                None,
+            )
+            if invalidate is not None:
+                invalidate(
+                    str(self.azure_hd_region.currentData() or "")
+                )
+            self._request_azure_voice_catalog(hd_only=True)
 
     def _persist_azure_key(self, *, silent: bool) -> None:
         self._persist_secret_input(
@@ -6404,6 +6480,8 @@ class CompanionWindow(QMainWindow):
                 secret_store=self.secret_store,
                 azure_secret_store=self.azure_secret_store,
                 azure_hd_secret_store=self.azure_hd_secret_store,
+                azure_speech=self.azure_tts,
+                azure_hd_speech=self.azure_hd_tts,
                 secret_store_factory=self.secret_store_factory,
                 platform_services=self.platform_services,
             ),

--- a/azure_speech.py
+++ b/azure_speech.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+lazy import queue
 lazy import re
 lazy import threading
 lazy import time
-lazy from urllib.error import HTTPError, URLError
-lazy from urllib.request import Request, urlopen
+lazy from dataclasses import dataclass, field
 lazy from xml.sax.saxutils import escape, quoteattr
 
+lazy from azure.cognitiveservices import speech as speechsdk
 lazy from PySide6.QtCore import QObject, Signal
 
+lazy from azure_regions import azure_region_supports_hd_flash
+lazy from azure_voice_catalog import AzureVoiceCatalog, AzureVoiceCatalogService
 lazy from immutable_config import deep_freeze
-lazy from speech import play_wave_with_visemes
+lazy from speech import play_pcm16_stream_with_visemes
 
 AZURE_FEMALE_VOICES: frozendict[str, tuple[str, ...]] = frozendict({
     "zh-TW": (
@@ -79,6 +82,10 @@ def _build_voice_locale_index() -> frozendict[str, str]:
 
 _VOICE_LOCALE = _build_voice_locale_index()
 _REGION_PATTERN = re.compile(r"^[a-z0-9-]{2,32}$")
+_VOICE_PATTERN = re.compile(
+    r"^(zh-(?:TW|CN)|en-US|ja-JP)-[A-Za-z0-9]+"
+    r"(?::DragonHD(?:Omni|Flash)?LatestNeural|Neural)$"
+)
 _MESSAGES = deep_freeze({
     "zh-TW": {
         "invalid_region": "Azure Speech 區域格式不正確。",
@@ -129,6 +136,58 @@ _MESSAGES = deep_freeze({
         "network": "Azure Speech に接続できません：{error}",
     },
 })
+
+
+class _PushAudioReader:
+    """Adapt Azure's push callback to the playback loop's bounded reads."""
+
+    def __init__(self) -> None:
+        self._chunks: queue.Queue[bytes | None] = queue.Queue()
+        self._pending = bytearray()
+
+    def write(self, audio_buffer: memoryview) -> int:
+        chunk = bytes(audio_buffer)
+        if chunk:
+            self._chunks.put(chunk)
+        return len(chunk)
+
+    def close(self) -> None:
+        self._chunks.put(None)
+
+    def read(self, audio_buffer: bytearray) -> int:
+        while not self._pending:
+            try:
+                chunk = self._chunks.get(timeout=60.0)
+            except queue.Empty as exc:
+                raise TimeoutError("Azure audio stream timed out") from exc
+            if chunk is None:
+                return 0
+            self._pending.extend(chunk)
+        bytes_read = min(len(audio_buffer), len(self._pending))
+        audio_buffer[:bytes_read] = self._pending[:bytes_read]
+        del self._pending[:bytes_read]
+        return bytes_read
+
+
+@dataclass(slots=True)
+class _SynthesisOutcome:
+    result: object | None = None
+    failure: Exception | None = None
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+def _await_synthesis(
+    synthesis: object,
+    audio_reader: _PushAudioReader,
+    outcome: _SynthesisOutcome,
+) -> None:
+    try:
+        outcome.result = synthesis.get()
+    except (OSError, RuntimeError, TimeoutError) as exc:
+        outcome.failure = exc
+    finally:
+        audio_reader.close()
+        outcome.done.set()
 
 
 def _message(locale: str, key: str, **values: object) -> str:
@@ -182,17 +241,18 @@ def azure_hd_voice_uses_flash(voice: str) -> bool:
 
 
 def is_azure_hd_voice(voice: str) -> bool:
-    return voice in {
-        *AZURE_HD_FEMALE_VOICES["zh-CN"],
-        *AZURE_HD_FEMALE_VOICES["en-US"],
-        *AZURE_HD_FEMALE_VOICES["ja-JP"],
-    }
+    return ":DragonHD" in str(voice)
 
 
-def build_azure_ssml(text: str, voice: str) -> bytes:
-    locale = _VOICE_LOCALE.get(voice)
-    if locale is None:
+def build_azure_ssml(
+    text: str,
+    voice: str,
+    verified_voices: tuple[str, ...] = (),
+) -> bytes:
+    is_verified = voice in _VOICE_LOCALE or voice in verified_voices
+    if not is_verified or not _VOICE_PATTERN.fullmatch(voice):
         raise ValueError("unsupported_voice")
+    locale = _VOICE_LOCALE.get(voice, voice[:5])
     parameters = (
         " parameters='temperature=0.8'"
         if is_azure_hd_voice(voice)
@@ -204,6 +264,10 @@ def build_azure_ssml(text: str, voice: str) -> bytes:
         f"name={quoteattr(voice)}{parameters}>{escape(text)}</voice></speak>"
     )
     return body.encode("utf-8")
+
+
+def _voice_locale(voice: str) -> str:
+    return _VOICE_LOCALE.get(voice, voice[:5] if len(voice) >= 5 else "zh-TW")
 
 
 def azure_speech_error_message(
@@ -226,12 +290,20 @@ class AzureSpeechTTS(QObject):
     finished = Signal()
     synthesis_latency_measured = Signal(float)
     viseme_cue = Signal(float, str)
+    voice_catalog_ready = Signal(object)
+    voice_catalog_failed = Signal(str, str, bool)
 
-    def __init__(self, parent: QObject | None = None):
+    def __init__(
+        self,
+        parent: QObject | None = None,
+        catalog_service: AzureVoiceCatalogService | None = None,
+    ):
         super().__init__(parent)
         self.volume_percent = 125
         self.muted = False
         self.last_synthesis_latency_ms: float | None = None
+        self._catalog_service = catalog_service or AzureVoiceCatalogService()
+        self._verified_dynamic_voices: set[str] = set()
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
@@ -247,13 +319,17 @@ class AzureSpeechTTS(QObject):
         if not text.strip():
             self.finished.emit()
             return
-        locale = _VOICE_LOCALE.get(voice, "zh-TW")
+        locale = _voice_locale(voice)
         if not api_key.strip() or not region.strip():
             self.failed.emit(_message(locale, "missing_settings"))
             return
         try:
             normalized_region = normalize_azure_region(region)
-            build_azure_ssml(text, voice)
+            build_azure_ssml(
+                text,
+                voice,
+                tuple(self._verified_dynamic_voices),
+            )
         except ValueError as exc:
             self.failed.emit(_message(locale, str(exc)))
             return
@@ -263,6 +339,78 @@ class AzureSpeechTTS(QObject):
             daemon=True,
         ).start()
 
+    def invalidate_voice_catalog(self, region: str | None = None) -> None:
+        self._catalog_service.invalidate(region)
+
+    def refresh_voice_catalog(
+        self,
+        api_key: str,
+        region: str,
+        language: str,
+        *,
+        hd_only: bool,
+    ) -> None:
+        try:
+            normalized_region = normalize_azure_region(region)
+        except ValueError:
+            self.voice_catalog_failed.emit(region, language, hd_only)
+            return
+        if not api_key.strip():
+            self._emit_fallback_catalog(
+                normalized_region,
+                language,
+                hd_only,
+            )
+            return
+        threading.Thread(
+            target=self._query_voice_catalog,
+            args=(api_key, normalized_region, language, hd_only),
+            daemon=True,
+        ).start()
+
+    def _query_voice_catalog(
+        self,
+        api_key: str,
+        region: str,
+        language: str,
+        hd_only: bool,
+    ) -> None:
+        try:
+            catalog = self._catalog_service.query(
+                api_key,
+                region,
+                language,
+                hd_only=hd_only,
+            )
+        except (OSError, RuntimeError, TimeoutError, ValueError):
+            self._emit_fallback_catalog(region, language, hd_only)
+            return
+        self._verified_dynamic_voices.update(catalog.voices)
+        self.voice_catalog_ready.emit(catalog)
+
+    def _emit_fallback_catalog(
+        self,
+        region: str,
+        language: str,
+        hd_only: bool,
+    ) -> None:
+        if hd_only:
+            voices = azure_hd_female_voices(
+                language,
+                include_flash=azure_region_supports_hd_flash(region),
+            )
+        else:
+            voices = azure_female_voices(language)
+        self.voice_catalog_ready.emit(
+            AzureVoiceCatalog(
+                region=region,
+                language=language,
+                hd_only=hd_only,
+                voices=voices,
+                source="fallback",
+            )
+        )
+
     def _run(
         self,
         text: str,
@@ -270,46 +418,84 @@ class AzureSpeechTTS(QObject):
         region: str,
         voice: str,
     ) -> None:
-        locale = _VOICE_LOCALE.get(voice, "zh-TW")
-        request = Request(
-            (
-                f"https://{region}.tts.speech.microsoft.com/"
-                "cognitiveservices/v1"
-            ),
-            data=build_azure_ssml(text, voice),
-            headers={
-                "Ocp-Apim-Subscription-Key": api_key,
-                "Content-Type": "application/ssml+xml",
-                "X-Microsoft-OutputFormat": "riff-24khz-16bit-mono-pcm",
-                "User-Agent": "MoHan-Desktop-Assistant",
-            },
-            method="POST",
-        )
+        locale = _voice_locale(voice)
         try:
             request_started = time.perf_counter()
-            with urlopen(request, timeout=60) as response:
-                audio = response.read()
-            self.last_synthesis_latency_ms = max(
-                0.0,
-                (time.perf_counter() - request_started) * 1_000.0,
+            speech_config = speechsdk.SpeechConfig(
+                subscription=api_key,
+                region=region,
             )
-            self.synthesis_latency_measured.emit(
-                self.last_synthesis_latency_ms
+            speech_config.set_speech_synthesis_output_format(
+                speechsdk.SpeechSynthesisOutputFormat.Raw24Khz16BitMonoPcm
             )
-            # Azure audio is fully buffered before playback. Regional network
-            # latency delays speech onset but must never offset the local
-            # 50 Hz viseme clock from the audio that it analyzes.
-            play_wave_with_visemes(
-                audio,
-                self.volume_percent,
-                self.muted,
-                self.viseme_cue.emit,
+            audio_reader = _PushAudioReader()
+
+            class StreamCallback(
+                speechsdk.audio.PushAudioOutputStreamCallback
+            ):
+                def __init__(self) -> None:
+                    super().__init__()
+
+                def write(self, audio_buffer: memoryview) -> int:
+                    return audio_reader.write(audio_buffer)
+
+                def close(self) -> None:
+                    audio_reader.close()
+
+            stream_callback = StreamCallback()
+            push_stream = speechsdk.audio.PushAudioOutputStream(
+                stream_callback
             )
+            audio_config = speechsdk.audio.AudioOutputConfig(
+                stream=push_stream,
+            )
+            synthesizer = speechsdk.SpeechSynthesizer(
+                speech_config=speech_config,
+                audio_config=audio_config,
+            )
+            synthesis = synthesizer.speak_ssml_async(
+                build_azure_ssml(
+                    text,
+                    voice,
+                    tuple(self._verified_dynamic_voices),
+                ).decode("utf-8")
+            )
+            outcome = _SynthesisOutcome()
+            result_thread = threading.Thread(
+                target=_await_synthesis,
+                args=(synthesis, audio_reader, outcome),
+                daemon=True,
+            )
+            result_thread.start()
+
+            def record_first_audio() -> None:
+                self.last_synthesis_latency_ms = max(
+                    0.0,
+                    (time.perf_counter() - request_started) * 1_000.0,
+                )
+                self.synthesis_latency_measured.emit(
+                    self.last_synthesis_latency_ms
+                )
+
+            play_pcm16_stream_with_visemes(
+                audio_reader.read,
+                volume_percent=self.volume_percent,
+                muted=self.muted,
+                emit_cue=self.viseme_cue.emit,
+                on_first_audio=record_first_audio,
+            )
+            if not outcome.done.wait(timeout=60.0):
+                raise TimeoutError("Azure synthesis did not finish")
+            if outcome.failure is not None:
+                raise outcome.failure
+            if outcome.result is None:
+                raise RuntimeError("Azure synthesis returned no result")
+            result = outcome.result
+            if result.reason == speechsdk.ResultReason.Canceled:
+                self.failed.emit(_message(locale, "service", status=503))
+                return
             self.finished.emit()
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")
+        except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
             self.failed.emit(
-                azure_speech_error_message(exc.code, detail, locale)
+                _message(locale, "network", error=type(exc).__name__)
             )
-        except (URLError, OSError, RuntimeError, TimeoutError) as exc:
-            self.failed.emit(_message(locale, "network", error=exc))

--- a/azure_voice_catalog.py
+++ b/azure_voice_catalog.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+lazy import threading
+lazy import time
+lazy from collections.abc import Callable
+lazy from dataclasses import dataclass
+lazy from typing import Any
+
+lazy from azure.cognitiveservices import speech as speechsdk
+
+lazy from azure_regions import azure_region_supports_hd_flash
+
+
+@dataclass(frozen=True, slots=True)
+class AzureVoiceCatalog:
+    """One verified, region-specific Azure female voice catalogue."""
+
+    region: str
+    language: str
+    hd_only: bool
+    voices: tuple[str, ...]
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedCatalog:
+    expires_at: float
+    catalog: AzureVoiceCatalog
+
+
+def _language_locales(language: str) -> tuple[str, ...]:
+    normalized = str(language or "").strip().lower()
+    if normalized == "zh-cn":
+        return ("zh-CN", "zh-TW")
+    if normalized in {"en", "en-us"}:
+        return ("en-US",)
+    if normalized in {"ja", "ja-jp"}:
+        return ("ja-JP",)
+    return ("zh-TW", "zh-CN")
+
+
+def _voice_value(voice: object, *names: str) -> str:
+    for name in names:
+        value = getattr(voice, name, "")
+        if value:
+            return str(value)
+    return ""
+
+
+def _is_female(voice: object) -> bool:
+    raw_gender = getattr(voice, "gender", "")
+    gender = str(getattr(raw_gender, "name", raw_gender))
+    return gender.rsplit(".", 1)[-1].strip().lower() == "female"
+
+
+def _voice_short_name(voice: object) -> str:
+    return _voice_value(voice, "short_name", "shortName")
+
+
+def _voice_locale(voice: object) -> str:
+    return _voice_value(voice, "locale")
+
+
+def _is_hd_voice(short_name: str) -> bool:
+    return ":DragonHD" in short_name
+
+
+def _filter_voices(
+    voices: tuple[object, ...],
+    language: str,
+    *,
+    hd_only: bool,
+    include_flash: bool,
+) -> tuple[str, ...]:
+    locales = _language_locales(language)
+    grouped: dict[str, list[str]] = {locale: [] for locale in locales}
+    for voice in voices:
+        if not _is_female(voice):
+            continue
+        locale = _voice_locale(voice)
+        short_name = _voice_short_name(voice)
+        if locale not in grouped or not short_name:
+            continue
+        is_hd = _is_hd_voice(short_name)
+        if is_hd != hd_only:
+            continue
+        incompatible_standard_voice = (
+            ":" in short_name or not short_name.endswith("Neural")
+        )
+        if not hd_only and incompatible_standard_voice:
+            continue
+        if not include_flash and ":DragonHDFlash" in short_name:
+            continue
+        grouped[locale].append(short_name)
+    return tuple(
+        dict.fromkeys(
+            voice
+            for locale in locales
+            for voice in sorted(grouped[locale], key=str.casefold)
+        )
+    )
+
+
+class AzureVoiceCatalogService:
+    """Query Azure for female voices and retain only a short-lived cache.
+
+    Subscription keys are passed directly to the SDK configuration and are
+    never stored in this service, cache keys, exceptions, or diagnostics.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_seconds: float = 3_600.0,
+        clock: Callable[[], float] = time.monotonic,
+        sdk_loader: Callable[[], Any] | None = None,
+    ) -> None:
+        self._cache_seconds = max(0.0, float(cache_seconds))
+        self._clock = clock
+        self._sdk_loader = sdk_loader or self._load_sdk
+        self._cache: dict[tuple[str, str, bool], _CachedCatalog] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _load_sdk() -> Any:
+        return speechsdk
+
+    def query(
+        self,
+        api_key: str,
+        region: str,
+        language: str,
+        *,
+        hd_only: bool,
+    ) -> AzureVoiceCatalog:
+        cache_key = (region, language, hd_only)
+        now = self._clock()
+        with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached is not None and cached.expires_at > now:
+                return cached.catalog
+
+        sdk = self._sdk_loader()
+        speech_config = sdk.SpeechConfig(subscription=api_key, region=region)
+        synthesizer = sdk.SpeechSynthesizer(
+            speech_config=speech_config,
+            audio_config=None,
+        )
+        result = synthesizer.get_voices_async().get()
+        voices = _filter_voices(
+            tuple(getattr(result, "voices", ())),
+            language,
+            hd_only=hd_only,
+            include_flash=(
+                not hd_only or azure_region_supports_hd_flash(region)
+            ),
+        )
+        if not voices:
+            raise RuntimeError("Azure returned no matching female voices")
+        catalog = AzureVoiceCatalog(
+            region=region,
+            language=language,
+            hd_only=hd_only,
+            voices=voices,
+            source="azure",
+        )
+        with self._lock:
+            self._cache[cache_key] = _CachedCatalog(
+                expires_at=now + self._cache_seconds,
+                catalog=catalog,
+            )
+        return catalog
+
+    def invalidate(self, region: str | None = None) -> None:
+        with self._lock:
+            if region is None:
+                self._cache.clear()
+                return
+            self._cache = {
+                key: value
+                for key, value in self._cache.items()
+                if key[0] != region
+            }

--- a/build.ps1
+++ b/build.ps1
@@ -55,6 +55,7 @@ try {
         --add-data "LICENSE;." `
         --add-data "THIRD_PARTY_NOTICES.md;." `
         --add-data "build-info.json;." `
+        --collect-all "azure.cognitiveservices.speech" `
         app.py
 }
 finally {

--- a/contracts.py
+++ b/contracts.py
@@ -72,6 +72,7 @@ class AzureSpeechEnginePort(Protocol):
     finished: SignalPort
     failed: SignalPort
     viseme_cue: SignalPort
+    voice_catalog_ready: SignalPort
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None: ...
 
@@ -82,6 +83,17 @@ class AzureSpeechEnginePort(Protocol):
         region: str,
         voice: str,
     ) -> None: ...
+
+    def refresh_voice_catalog(
+        self,
+        api_key: str,
+        region: str,
+        language: str,
+        *,
+        hd_only: bool,
+    ) -> None: ...
+
+    def invalidate_voice_catalog(self, region: str | None = None) -> None: ...
 
 
 class SpeechProviderRegistryPort(Protocol):

--- a/docs/releases/v3.1.1.md
+++ b/docs/releases/v3.1.1.md
@@ -1,0 +1,41 @@
+# 墨寒桌面助理 v3.1.1／墨寒桌面助手 v3.1.1／MoHan Desktop Assistant v3.1.1／墨寒デスクトップアシスタント v3.1.1
+
+## 繁體中文
+
+- 一般 Azure Speech 與 Dragon HD 改以目前選定的區域及其對應加密金鑰，動態查詢該資源中心實際提供的女性聲線；男性、不相容模型及區域不支援的 HD Flash 會被排除。
+- 繁中與簡中介面維持雙向華語女性聲線選擇，英文與日文則只列各自語系。有效的既有選項會保留，過期查詢也不能覆蓋後來切換的區域。
+- 固定女性聲線清單降為斷線或 Azure 查詢失敗時的安全備援，因此服務端日後新增或下架聲線時，不必再等墨寒改版才能反映。
+- Azure 合成由完整 WAV 下載改為 Speech SDK `PushAudioOutputStream`。第一段 24 kHz PCM16 音訊抵達後便開始播放，並直接送入既有 50 Hz 本機嘴型分析，縮短發話前等待而不改變其他語音供應器。
+- 金鑰仍只由 Windows DPAPI 加密保存，不進入 SQLite、聲線快取、錯誤訊息、log、Git 或安裝包；一般 Azure 與 Dragon HD 的區域、金鑰及失敗降級路徑仍彼此獨立。
+- 2026 年 8 月 12 日已使用真實 East Asia F0 與 West US 2 S0 完成動態目錄查詢。當時 East Asia 回傳 21 筆可相容的華語女性 Neural 聲線，West US 2 回傳三筆簡體中文 Dragon HD 女性聲線；實際清單以 Microsoft 當期服務為準。
+- Windows 仍是唯一完成真實功能、安裝及發布驗證的完整平台；macOS 與 Linux 套件仍為功能受限 Preview。
+
+## 简体中文
+
+- 一般 Azure Speech 与 Dragon HD 改为使用当前选择的区域及其对应加密密钥，动态查询该资源中心实际提供的女性声线；男性、不兼容模型及区域不支持的 HD Flash 会被排除。
+- 繁中与简中界面继续双向共享华语女性声线，英文与日文则只显示各自语言。有效的现有选项会被保留，过期查询也不能覆盖后来切换的区域。
+- 固定女性声线列表降为断线或 Azure 查询失败时的安全备用，因此服务端以后新增或下架声线时，无需等待墨寒更新版本即可反映。
+- Azure 合成由完整 WAV 下载改为 Speech SDK `PushAudioOutputStream`。第一段 24 kHz PCM16 音频抵达后即开始播放，并直接送入现有 50 Hz 本地嘴形分析，缩短发话前等待而不改变其他语音供应器。
+- 密钥仍只由 Windows DPAPI 加密保存，不会进入 SQLite、声线缓存、错误信息、日志、Git 或安装包；一般 Azure 与 Dragon HD 的区域、密钥及失败降级路径仍彼此独立。
+- 2026 年 8 月 12 日已使用真实 East Asia F0 与 West US 2 S0 完成动态目录查询。当时 East Asia 返回 21 项可兼容的华语女性 Neural 声线，West US 2 返回三项简体中文 Dragon HD 女性声线；实际列表以 Microsoft 当前服务为准。
+- Windows 仍是唯一完成真实功能、安装及发布验证的完整平台；macOS 与 Linux 软件包仍为功能受限 Preview。
+
+## English
+
+- Standard Azure Speech and Dragon HD now query the female voices actually provided by the selected region using its corresponding encrypted key. Male voices, incompatible model families, and region-ineligible HD Flash voices are excluded.
+- Traditional and Simplified Chinese interfaces retain two-way access to Chinese female voices, while English and Japanese list only their own locales. A valid prior selection is preserved, and a stale query cannot overwrite a newer region choice.
+- The fixed female catalog is now only a safe fallback for offline or failed Azure discovery. Future server-side voice additions and removals can therefore appear without waiting for a MoHan update.
+- Azure synthesis replaces complete-WAV downloading with the Speech SDK `PushAudioOutputStream`. Playback begins with the first 24 kHz PCM16 chunk, which feeds the existing local 50 Hz lip analysis directly, reducing speech-onset delay without changing other providers.
+- Keys remain encrypted only by Windows DPAPI and never enter SQLite, the voice cache, errors, logs, Git, or installers. Standard Azure and Dragon HD retain independent regions, keys, and failure fallback paths.
+- Real dynamic discovery completed against East Asia F0 and West US 2 S0 on August 12, 2026. East Asia returned 21 compatible Chinese female Neural voices, while West US 2 returned three Simplified Chinese Dragon HD female voices at that time. The actual catalog remains governed by Microsoft's current service.
+- Windows remains the only full platform validated for real features, installation, and publication; macOS and Linux packages remain a limited cross-platform Preview.
+
+## 日本語
+
+- 通常の Azure Speech と Dragon HD は、現在選択中のリージョンと対応する暗号化キーを使い、そのリソースセンターが実際に提供する女性音声を動的に照会します。男性音声、非互換モデル、リージョン非対応の HD Flash は除外します。
+- 繁体字・簡体字中国語画面は中国語女性音声を双方向で共有し、英語と日本語は各言語だけを表示します。有効な既存選択は保持され、古い照会結果が後から選んだリージョンを上書きすることもありません。
+- 固定女性音声一覧は、オフラインまたは Azure 照会失敗時の安全な代替に限定しました。今後サーバー側で音声が追加・削除された場合も、墨寒の更新を待たず反映できます。
+- Azure 合成は完全 WAV の取得から Speech SDK `PushAudioOutputStream` へ移行しました。最初の 24 kHz PCM16 断片が届いた時点で再生を開始し、既存の本機 50 Hz 口形解析へ直接渡すため、他の音声供給元を変更せず発話開始待ちを短縮します。
+- キーは引き続き Windows DPAPI だけで暗号化保存し、SQLite、音声一覧キャッシュ、エラー、ログ、Git、インストーラーには入りません。通常 Azure と Dragon HD のリージョン、キー、失敗時代替経路も独立したままです。
+- 2026 年 8 月 12 日、実際の East Asia F0 と West US 2 S0 で動的一覧照会を完了しました。当時 East Asia は互換性のある中国語女性 Neural 音声を 21 件、West US 2 は簡体字中国語 Dragon HD 女性音声を三件返しました。実際の一覧は Microsoft の当期サービスに従います。
+- 実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけで、macOS と Linux のパッケージは引き続き機能限定 Preview です。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "3.1.0"
+version = "3.1.1"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"
@@ -10,6 +10,7 @@ authors = [
   { name = "Flameblade Studio" },
 ]
 dependencies = [
+  "azure-cognitiveservices-speech==1.50.0",
   "PySide6==6.11.1",
   "sounddevice==0.5.5",
   "websocket-client==1.9.0",

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,4 +1,5 @@
 PySide6==6.11.1
+azure-cognitiveservices-speech==1.50.0
 sounddevice==0.5.5
 websocket-client==1.9.0
 opencc-python-reimplemented==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PySide6==6.11.1
+azure-cognitiveservices-speech==1.50.0
 PyInstaller==6.21.0
 sounddevice==0.5.5
 websocket-client==1.9.0

--- a/sbom/components.toml
+++ b/sbom/components.toml
@@ -15,6 +15,13 @@ scope = "runtime"
 profiles = ["windows"]
 
 [[component]]
+name = "azure-cognitiveservices-speech"
+version = "1.50.0"
+license = "LicenseRef-Microsoft-Speech-SDK"
+scope = "runtime"
+profiles = ["windows"]
+
+[[component]]
 name = "websocket-client"
 version = "1.9.0"
 license = "Apache-2.0"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "3.1.0"
+version = "3.1.1"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/speech.py
+++ b/speech.py
@@ -422,6 +422,56 @@ def play_wave_with_visemes(
         emit_cue(0.0, "CLOSED")
 
 
+def play_pcm16_stream_with_visemes(
+    read_chunk: Callable[[bytearray], int],
+    *,
+    volume_percent: int,
+    muted: bool,
+    emit_cue: Callable[[float, str], None],
+    on_first_audio: Callable[[], None] | None = None,
+) -> None:
+    """Play a pull-based PCM16 stream through the shared 50 Hz mouth clock."""
+
+    sample_rate = 24_000
+    frames_per_cue = max(1, sample_rate // VISEME_CUES_PER_SECOND)
+    bytes_per_cue = frames_per_cue * 2
+    read_buffer = bytearray(max(bytes_per_cue * 4, 4_096))
+    pending = bytearray()
+    gain = 0.0 if muted else max(0, min(160, volume_percent)) / 100.0
+    first_audio_pending = True
+
+    try:
+        with sd.RawOutputStream(
+            samplerate=sample_rate,
+            channels=1,
+            dtype="int16",
+            blocksize=frames_per_cue,
+        ) as output:
+            while True:
+                bytes_read = int(read_chunk(read_buffer))
+                if bytes_read <= 0:
+                    break
+                if first_audio_pending:
+                    first_audio_pending = False
+                    if on_first_audio is not None:
+                        on_first_audio()
+                pending.extend(read_buffer[:bytes_read])
+                while len(pending) >= bytes_per_cue:
+                    chunk = bytes(pending[:bytes_per_cue])
+                    del pending[:bytes_per_cue]
+                    emit_cue(*infer_vowel_pcm16(chunk, sample_rate))
+                    output.write(scale_pcm16(chunk, gain))
+            if pending:
+                if len(pending) % 2:
+                    pending.pop()
+                if pending:
+                    chunk = bytes(pending)
+                    emit_cue(*infer_vowel_pcm16(chunk, sample_rate))
+                    output.write(scale_pcm16(chunk, gain))
+    finally:
+        emit_cue(0.0, "CLOSED")
+
+
 @dataclass(frozen=True)
 class WindowsVoiceInfo:
     """One installed Windows speech voice with trustworthy metadata."""

--- a/tests/test_azure_audio_streaming.py
+++ b/tests/test_azure_audio_streaming.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+lazy from types import SimpleNamespace
+lazy from typing import ClassVar
+lazy from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from speech import play_pcm16_stream_with_visemes
+
+
+class FakeOutputStream:
+    writes: ClassVar[list[bytes]] = []
+
+    def __init__(self, **settings: object) -> None:
+        assert settings == {
+            "samplerate": 24_000,
+            "channels": 1,
+            "dtype": "int16",
+            "blocksize": 480,
+        }
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def write(self, chunk: bytes) -> None:
+        self.writes.append(bytes(chunk))
+
+
+def run() -> None:
+    FakeOutputStream.writes = []
+    source = bytearray(b"\x01\x00" * 1_200)
+    first_audio: list[bool] = []
+    cues: list[tuple[float, str]] = []
+
+    def read_chunk(buffer: bytearray) -> int:
+        if not source:
+            return 0
+        size = min(len(buffer), 730, len(source))
+        buffer[:size] = source[:size]
+        del source[:size]
+        return size
+
+    with patch(
+        "speech.sd",
+        SimpleNamespace(RawOutputStream=FakeOutputStream),
+    ):
+        play_pcm16_stream_with_visemes(
+            read_chunk,
+            volume_percent=100,
+            muted=False,
+            emit_cue=lambda level, vowel: cues.append((level, vowel)),
+            on_first_audio=lambda: first_audio.append(True),
+        )
+
+    assert first_audio == [True]
+    assert [len(chunk) for chunk in FakeOutputStream.writes] == [960, 960, 480]
+    assert cues[-1] == (0.0, "CLOSED")
+    assert len(cues) == 4
+    print("AZURE_AUDIO_STREAMING_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_azure_speech.py
+++ b/tests/test_azure_speech.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-lazy import io
 lazy import sys
 lazy from pathlib import Path
+lazy from types import SimpleNamespace
 lazy from unittest.mock import patch
-lazy from urllib.error import HTTPError
-lazy from urllib.request import Request
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -24,20 +22,6 @@ lazy from azure_speech import (
     normalize_azure_region,
 )
 lazy from ui_localization import ui_text
-
-
-class FakeResponse:
-    def __init__(self, payload: bytes):
-        self.payload = payload
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_args) -> None:
-        return None
-
-    def read(self) -> bytes:
-        return self.payload
 
 
 def _assert_region_normalization() -> None:
@@ -192,14 +176,12 @@ def _assert_missing_credentials_do_not_request(
     engine: AzureSpeechTTS,
     failures: list[str],
 ) -> None:
-    with patch("azure_speech.urlopen") as no_request:
-        engine.speak(
-            "主上，妾在。",
-            "",
-            "",
-            "zh-TW-HsiaoChenNeural",
-        )
-    no_request.assert_not_called()
+    engine.speak(
+        "主上，妾在。",
+        "",
+        "",
+        "zh-TW-HsiaoChenNeural",
+    )
     assert "尚未設定" in failures[-1]
 
 
@@ -217,24 +199,71 @@ def _assert_invalid_region_fails_locally(
     failures.clear()
 
 
-def _assert_successful_synthesis(
+def _assert_successful_streaming_synthesis(
     engine: AzureSpeechTTS,
     finished: list[bool],
     failures: list[str],
-) -> Request:
-    captured_requests: list[Request] = []
-    captured_timeouts: list[float] = []
+) -> None:
     measured_latencies: list[float] = []
     engine.synthesis_latency_measured.connect(measured_latencies.append)
+    callbacks: list[object] = []
+    push_stream = SimpleNamespace()
+    configured_formats: list[object] = []
+    spoken_ssml: list[str] = []
 
-    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
-        captured_requests.append(request)
-        captured_timeouts.append(timeout)
-        return FakeResponse(b"RIFF-test-wave")
+    class FakeSpeechConfig:
+        def __init__(self, subscription: str, region: str) -> None:
+            assert subscription == "not-a-real-key"
+            assert region == "eastasia"
+
+        def set_speech_synthesis_output_format(self, value: object) -> None:
+            configured_formats.append(value)
+
+    class FakeFuture:
+        def get(self) -> object:
+            return SimpleNamespace(reason="completed")
+
+    class FakeSynthesizer:
+        def __init__(self, **kwargs: object) -> None:
+            assert kwargs["audio_config"].stream is push_stream
+
+        def speak_ssml_async(self, ssml: str) -> FakeFuture:
+            spoken_ssml.append(ssml)
+            callbacks[0].write(memoryview(b"\x01\x00" * 480))
+            callbacks[0].close()
+            return FakeFuture()
+
+    def push_audio_output_stream(callback: object) -> object:
+        callbacks.append(callback)
+        return push_stream
+
+    fake_sdk = SimpleNamespace(
+        SpeechConfig=FakeSpeechConfig,
+        SpeechSynthesisOutputFormat=SimpleNamespace(
+            Raw24Khz16BitMonoPcm="raw-24khz-pcm16"
+        ),
+        SpeechSynthesizer=FakeSynthesizer,
+        ResultReason=SimpleNamespace(Canceled="canceled"),
+        audio=SimpleNamespace(
+            PushAudioOutputStream=push_audio_output_stream,
+            PushAudioOutputStreamCallback=object,
+            AudioOutputConfig=lambda stream: SimpleNamespace(stream=stream),
+        ),
+    )
+
+    def fake_playback(read_chunk, *_args, on_first_audio=None, **_kwargs):
+        assert on_first_audio is not None
+        buffer = bytearray(1_024)
+        assert read_chunk(buffer) == 960
+        assert read_chunk(buffer) == 0
+        on_first_audio()
 
     with (
-        patch("azure_speech.urlopen", fake_urlopen),
-        patch("azure_speech.play_wave_with_visemes") as playback,
+        patch("azure_speech.speechsdk", fake_sdk),
+        patch(
+            "azure_speech.play_pcm16_stream_with_visemes",
+            side_effect=fake_playback,
+        ) as playback,
     ):
         engine._run(
             "主上，妾在。",
@@ -243,48 +272,13 @@ def _assert_successful_synthesis(
             "zh-TW-HsiaoChenNeural",
         )
 
-    request = captured_requests[0]
-    assert request.full_url == (
-        "https://eastasia.tts.speech.microsoft.com/cognitiveservices/v1"
-    )
-    headers = dict(request.header_items())
-    assert headers["Ocp-apim-subscription-key"] == "not-a-real-key"
-    assert headers["X-microsoft-outputformat"] == (
-        "riff-24khz-16bit-mono-pcm"
-    )
-    assert captured_timeouts[0] == 60
     playback.assert_called_once()
+    assert configured_formats == ["raw-24khz-pcm16"]
+    assert "主上，妾在。" in spoken_ssml[0]
     assert finished == [True]
     assert not failures
     assert engine.last_synthesis_latency_ms is not None
     assert measured_latencies == [engine.last_synthesis_latency_ms]
-    return request
-
-
-def _assert_http_error_redacts_key(
-    engine: AzureSpeechTTS,
-    request: Request,
-    failures: list[str],
-) -> None:
-    http_error = HTTPError(
-        request.full_url,
-        401,
-        "Unauthorized",
-        {},
-        io.BytesIO(b"not-a-real-key"),
-    )
-    with patch(
-        "azure_speech.urlopen",
-        side_effect=http_error,
-    ):
-        engine._run(
-            "主上，妾在。",
-            "not-a-real-key",
-            "eastasia",
-            "zh-TW-HsiaoChenNeural",
-        )
-    assert "not-a-real-key" not in failures[-1]
-    assert "金鑰" in failures[-1]
 
 
 def run() -> None:
@@ -296,8 +290,7 @@ def run() -> None:
     engine, finished, failures = _create_engine()
     _assert_missing_credentials_do_not_request(engine, failures)
     _assert_invalid_region_fails_locally(engine, failures)
-    request = _assert_successful_synthesis(engine, finished, failures)
-    _assert_http_error_redacts_key(engine, request, failures)
+    _assert_successful_streaming_synthesis(engine, finished, failures)
     print("AZURE_SPEECH_OK")
 
 

--- a/tests/test_azure_voice_catalog.py
+++ b/tests/test_azure_voice_catalog.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+lazy from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from azure_voice_catalog import AzureVoiceCatalogService
+
+
+class FakeSynthesizer:
+    voices: tuple[object, ...] = ()
+    query_count = 0
+
+    def __init__(self, **_kwargs: object) -> None:
+        pass
+
+    def get_voices_async(self):
+        type(self).query_count += 1
+        return SimpleNamespace(
+            get=lambda: SimpleNamespace(voices=self.voices)
+        )
+
+
+def _voice(short_name: str, locale: str, gender: str) -> object:
+    return SimpleNamespace(
+        short_name=short_name,
+        locale=locale,
+        gender=SimpleNamespace(name=gender),
+    )
+
+
+def run() -> None:
+    FakeSynthesizer.voices = (
+        _voice("zh-CN-NewWomanNeural", "zh-CN", "Female"),
+        _voice("zh-TW-NewWomanNeural", "zh-TW", "Female"),
+        _voice("zh-CN-NewManNeural", "zh-CN", "Male"),
+        _voice("zh-CN-NewWoman:MAI-Voice-2", "zh-CN", "Female"),
+        _voice(
+            "zh-CN-NewWoman:DragonHDLatestNeural",
+            "zh-CN",
+            "Female",
+        ),
+        _voice(
+            "zh-CN-NewWoman:DragonHDFlashLatestNeural",
+            "zh-CN",
+            "Female",
+        ),
+    )
+    fake_sdk = SimpleNamespace(
+        SpeechConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+        SpeechSynthesizer=FakeSynthesizer,
+    )
+    now = [10.0]
+    service = AzureVoiceCatalogService(
+        cache_seconds=60.0,
+        clock=lambda: now[0],
+        sdk_loader=lambda: fake_sdk,
+    )
+    normal = service.query(
+        "secret-never-cached",
+        "westus2",
+        "zh-TW",
+        hd_only=False,
+    )
+    assert normal.voices == (
+        "zh-TW-NewWomanNeural",
+        "zh-CN-NewWomanNeural",
+    )
+    hd = service.query(
+        "secret-never-cached",
+        "westus2",
+        "zh-TW",
+        hd_only=True,
+    )
+    assert hd.voices == ("zh-CN-NewWoman:DragonHDLatestNeural",)
+    assert all("Man" not in voice for voice in (*normal.voices, *hd.voices))
+    service.query(
+        "a-different-secret",
+        "westus2",
+        "zh-TW",
+        hd_only=True,
+    )
+    assert FakeSynthesizer.query_count == 2
+    assert all(
+        "secret" not in repr(key)
+        for key in service._cache
+    )
+    print("AZURE_VOICE_CATALOG_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "3.1.0"
+FALLBACK_VERSION = "3.1.1"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文

### 摘要
- 一般 Azure Speech 與 Dragon HD 女聲改為依目前區域及各自密鑰動態查詢。
- 僅顯示相容女性聲線；繁中與簡中互相提供華語女聲，英文與日文維持各自語系。
- Azure 語音改用 PushAudioOutputStream 串流，接入既有 50 Hz 嘴型同步。
- 保留靜態安全清單與 Windows 本機語音退回路徑。
- 更新 v3.1.1 四語文件、依賴、授權聲明及 SBOM。

### 驗證
- Python 3.15、JIT 預設開啟。
- 本機完整回歸：72/72 通過。
- 公開發布稽核：445 檔、129.78 MiB。
- 變更檔 Gitleaks：通過。
- 真實 Azure 查詢與 Push 串流：通過。

## 简体中文

### 摘要
- 标准 Azure Speech 与 Dragon HD 女声改为根据当前区域及各自密钥动态查询。
- 仅显示兼容的女性声音；繁体中文与简体中文互相提供华语女声，英文与日文保持各自语言。
- Azure 语音改用 PushAudioOutputStream 流式输出，并接入现有 50 Hz 口型同步。
- 保留静态安全列表与 Windows 本地语音回退路径。
- 更新 v3.1.1 四语文档、依赖、许可声明及 SBOM。

### 验证
- Python 3.15，JIT 默认开启。
- 本地完整回归：72/72 通过。
- 公开发布审计：445 个文件、129.78 MiB。
- 变更文件 Gitleaks：通过。
- 真实 Azure 查询与 Push 流式输出：通过。

## English

### Summary
- Dynamically discover standard Azure Speech and Dragon HD female voices from each selected region and separately stored key.
- Show only compatible female voices; Traditional and Simplified Chinese share Mandarin options while English and Japanese remain locale-specific.
- Stream Azure audio through PushAudioOutputStream into the existing 50 Hz lip-sync pipeline.
- Preserve the static safe catalog and Windows local speech fallback.
- Update the four-language v3.1.1 documentation, dependencies, notices, and SBOM.

### Validation
- Python 3.15 with JIT enabled by default.
- Full local regression suite: 72/72 passed.
- Public-release audit: 445 files, 129.78 MiB.
- Gitleaks scan of changed files: passed.
- Live Azure discovery and Push streaming: passed.

## 日本語

### 概要
- 通常の Azure Speech と Dragon HD の女性音声を、選択中のリージョンと個別保存されたキーから動的に取得します。
- 互換性のある女性音声のみを表示します。繁体字中国語と簡体字中国語は中国語女性音声を相互利用し、英語と日本語は各言語に限定します。
- Azure 音声を PushAudioOutputStream でストリーミングし、既存の 50 Hz リップシンクへ接続します。
- 静的な安全カタログと Windows ローカル音声へのフォールバックを維持します。
- v3.1.1 の四言語文書、依存関係、ライセンス表記、SBOM を更新します。

### 検証
- Python 3.15、JIT は既定で有効。
- ローカル完全回帰テスト：72/72 合格。
- 公開リリース監査：445 ファイル、129.78 MiB。
- 変更ファイルの Gitleaks：合格。
- 実 Azure の動的取得と Push ストリーミング：合格。