### PR TITLE
準備墨寒 v3.1.2 Realtime Azure 語音、動作與安全修正／准备墨寒 v3.1.2 Realtime Azure 语音、动作与安全修复／Prepare MoHan v3.1.2 Realtime Azure speech, motion, and security fixes／墨寒 v3.1.2 の Realtime Azure 音声・動作・安全修正を準備

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,10 @@ jobs:
       - name: Install pinned runtime dependencies
         run: python tools/install_python315_dependencies.py
 
+      - name: Install pinned development quality tools
+        run: >-
+          python -m pip install --only-binary=:all: -r requirements-dev.txt
+
       - name: Install pinned Windows installer toolchains
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Compile and audit source
         run: |
           python -m compileall -q .
+          python -m ruff check .
           python tools/audit_public_release.py
 
       - name: Run full Windows regression suite
@@ -623,12 +624,6 @@ jobs:
             sha256sum --check --strict "$base-SHA256SUMS.txt"
           )
 
-      - name: Attest every published artifact
-        if: ${{ github.event_name == 'push' || inputs.publish }}
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: release-artifacts/*
-
       - name: Require the release tag to still identify the validated commit
         shell: bash
         env:
@@ -642,6 +637,12 @@ jobs:
             echo "Release tag changed after validation; refusing publication." >&2
             exit 4
           fi
+
+      - name: Attest every published artifact
+        if: ${{ github.event_name == 'push' || inputs.publish }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: release-artifacts/*
 
       - name: Verify existing release without modifying it
         if: ${{ github.event_name == 'workflow_dispatch' && !inputs.publish }}
@@ -658,12 +659,29 @@ jobs:
             exit 7
           }
           [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE")" == true ]]
-          mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
+          assets_json="$(mktemp)"
+          gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" > "$assets_json"
+          mapfile -t actual_assets < <(jq -r '.[].name' "$assets_json" | sort)
           mapfile -t expected_assets < <(find release-artifacts -maxdepth 1 -type f -printf '%f\n' | sort)
           [[ "$(printf '%s\n' "${actual_assets[@]}")" == "$(printf '%s\n' "${expected_assets[@]}")" ]] || {
             echo "Existing Release assets differ from the exact verified set." >&2
             exit 8
           }
+          while IFS= read -r expected; do
+            name="$(basename "$expected")"
+            expected_size="$(stat -c '%s' "$expected")"
+            asset="$(jq -c --arg name "$name" '.[] | select(.name == $name)' "$assets_json")"
+            [[ "$(jq -r '.size' <<< "$asset")" == "$expected_size" ]] || {
+              echo "Existing Release asset size differs: $name" >&2
+              exit 9
+            }
+            downloaded="$(mktemp)"
+            gh api -H 'Accept: application/octet-stream' "$(jq -r '.url' <<< "$asset")" > "$downloaded"
+            cmp --silent "$expected" "$downloaded" || {
+              echo "Existing Release asset content differs: $name" >&2
+              exit 10
+            }
+          done < <(find release-artifacts -maxdepth 1 -type f | sort)
           echo "Release $tag is unchanged and matches the verified artifact set."
 
       - name: Publish one GitHub release

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Compile source
         run: python -m compileall -q .
+      - name: Enforce Ruff static quality gate
+        run: python -m ruff check .
 
       - name: Audit public release contents
         run: python tools/audit_public_release.py

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Install dependencies
         run: python tools/install_python315_dependencies.py
 
+      - name: Install pinned development quality tools
+        run: >-
+          python -m pip install --only-binary=:all: -r requirements-dev.txt
+
       - name: Verify PYTHON_JIT forwarding and compare MoHan hot paths
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .venv/
 venv/
 env/
+_python315/
 
 build/
 dist/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@
 - Windows ZIP、EXE 與 MSI 仍是唯一完整產品封裝。
 - 分開提供的 macOS Apple Silicon（arm64）、Intel（x86_64）DMG，以及 Linux x86_64 AppImage，內含 `preview_app.py`，而非 Windows 的 `app.py` 外殼。其用途是驗證原生封裝、啟動、在地化、路徑與安全邊界。
 - Pull Request 可在封裝層級 smoke test 通過後上傳短期 artifact，但絕不建立 GitHub Release。
-- 只有既有的 `v2.3.0-rc.N` tag 可以發布多平台候選版本。唯讀中繼資料工作負責收集全部平台輸出並建立 SBOM、中繼資料與 checksum；另一個最小權限工作則重新檢查完全相同的 artifact 與 tag commit、產生證明，並發布單一 Release。
+- 只有符合 `vN.N.N` 或 `vN.N.N-rc.N` 規則且已存在的不可變 tag 可以發布多平台版本；正式 tag 建立 Stable Release，RC tag 建立 Pre-release。唯讀中繼資料工作負責收集全部平台輸出並建立 SBOM、中繼資料與 checksum；另一個最小權限工作則重新檢查完全相同的 artifact 與 tag commit、產生證明，並發布單一 Release。
 - 發布證據把可觀測性與供應鏈資料視為門檻，而非裝飾。Tachyon 證據必須完成淨化、JIT 驗證、取樣品質檢查，且可由單一二進位資料流重現；原始資料流僅能暫存。CycloneDX 1.7 清冊必須符合鎖定的執行期需求、包含完整根依賴邊、PURL 與宣告的 SPDX 授權，通過官方 schema 與隱私門檻，並分開追蹤僅建置使用的工具。
 - 每一個 Windows 與預覽二進位發行包，都必須在終端使用者可閱讀的位置攜帶 MIT 授權與第三方聲明。
 - 只有當 AppImage 建置工具的官方來源 commit、資產身分與 SHA-256 均符合已審查常數時，才可接受該工具。GitHub Actions 必須固定至完整 commit SHA。
@@ -108,7 +108,7 @@
 - Windows ZIP、EXE 与 MSI 仍是唯一完整产品封装。
 - 分别提供的 macOS Apple Silicon（arm64）、Intel（x86_64）DMG，以及 Linux x86_64 AppImage，内含 `preview_app.py`，而非 Windows 的 `app.py` 外壳。其用途是验证原生封装、启动、本地化、路径与安全边界。
 - Pull Request 可在封装层级 smoke test 通过后上传短期 artifact，但绝不创建 GitHub Release。
-- 只有现有的 `v2.3.0-rc.N` tag 可以发布多平台候选版本。只读元数据作业负责收集全部平台输出并创建 SBOM、元数据与 checksum；另一个最小权限作业则重新检查完全相同的 artifact 与 tag commit、生成证明，并发布单一 Release。
+- 只有符合 `vN.N.N` 或 `vN.N.N-rc.N` 规则且已存在的不可变 tag 可以发布多平台版本；正式 tag 创建 Stable Release，RC tag 创建 Pre-release。只读元数据作业负责收集全部平台输出并创建 SBOM、元数据与 checksum；另一个最小权限作业则重新检查完全相同的 artifact 与 tag commit、生成证明，并发布单一 Release。
 - 发布证据把可观测性与供应链数据视为门槛，而非装饰。Tachyon 证据必须完成净化、JIT 验证、采样质量检查，且可由单一二进制数据流重现；原始数据流只能暂存。CycloneDX 1.7 清单必须符合锁定的运行时需求、包含完整根依赖边、PURL 与声明的 SPDX 许可证，通过官方 schema 与隐私门槛，并分别追踪仅构建使用的工具。
 - 每一个 Windows 与预览二进制发行包，都必须在最终用户可阅读的位置携带 MIT 许可证与第三方声明。
 - 只有当 AppImage 构建工具的官方源 commit、资产身份与 SHA-256 均符合已审查常量时，才可接受该工具。GitHub Actions 必须固定至完整 commit SHA。
@@ -179,7 +179,7 @@ Circular local imports are prohibited and enforced by `tests/test_architecture_c
 - Windows ZIP, EXE, and MSI remain the only complete product packages.
 - Separate macOS Apple Silicon (arm64) and Intel (x86_64) DMGs plus the Linux x86_64 AppImage contain `preview_app.py`, not the Windows `app.py` shell. Their purpose is native packaging, startup, localization, path, and safety-boundary validation.
 - Pull requests may upload short-lived package artifacts after a package-level smoke test. They never create a GitHub Release.
-- Only an existing `v2.3.0-rc.N` tag may publish the multi-platform candidate. A read-only metadata job gathers all platform outputs and creates SBOMs, metadata, and checksums; a separate minimal privileged job rechecks the exact artifacts and tag commit, attests them, and publishes one Release.
+- Only an existing immutable tag matching `vN.N.N` or `vN.N.N-rc.N` may publish multi-platform packages; stable tags create Stable Releases and RC tags create Pre-releases. A read-only metadata job gathers all platform outputs and creates SBOMs, metadata, and checksums; a separate minimal privileged job rechecks the exact artifacts and tag commit, attests them, and publishes one Release.
 - Release evidence treats observability and supply-chain data as gates, not decoration. Tachyon evidence must be sanitized, JIT-verified, sample-quality checked, and reproducible from one binary stream; raw streams are temporary. CycloneDX 1.7 inventories must match pinned runtime requirements, include complete root dependency edges, PURLs and declared SPDX licenses, pass the official schema and privacy gates, and track build-only tools separately.
 - Every Windows and Preview binary distribution carries the MIT license and third-party notices in an end-user-readable location.
 - The AppImage build tool is accepted only when its official source commit, asset identity, and SHA-256 match the reviewed constants. GitHub Actions are pinned to complete commit SHAs.
@@ -250,7 +250,7 @@ Do not add a second setting, timer, or signal for behavior that already has a ca
 - Windows ZIP、EXE、MSI は、引き続き唯一の完全な製品パッケージです。
 - 個別に提供する macOS Apple Silicon（arm64）および Intel（x86_64）DMG と Linux x86_64 AppImage には、Windows の `app.py` シェルではなく `preview_app.py` を含めます。目的は、ネイティブパッケージング、起動、ローカライズ、パス、安全境界の検証です。
 - Pull Request では、パッケージレベルの smoke test 後に短期 artifact をアップロードできますが、GitHub Release は決して作成しません。
-- 既存の `v2.3.0-rc.N` tag だけがマルチプラットフォーム候補を公開できます。読み取り専用メタデータジョブが全プラットフォームの出力を収集して SBOM、メタデータ、checksum を作成し、別の最小権限ジョブが同一の artifact と tag commit を再検査して証明を生成し、単一の Release を公開します。
+- `vN.N.N` または `vN.N.N-rc.N` に一致する既存の不変 tag だけがマルチプラットフォームパッケージを公開できます。正式 tag は Stable Release、RC tag は Pre-release を作成します。読み取り専用メタデータジョブが全プラットフォームの出力を収集して SBOM、メタデータ、checksum を作成し、別の最小権限ジョブが同一の artifact と tag commit を再検査して証明を生成し、単一の Release を公開します。
 - リリース証拠では、可観測性とサプライチェーンデータを装飾ではなくゲートとして扱います。Tachyon 証拠はサニタイズ、JIT 検証、サンプル品質検査を完了し、単一のバイナリストリームから再現できなければなりません。生ストリームは一時保存に限ります。CycloneDX 1.7 インベントリは、固定された実行時要件と一致し、完全なルート依存エッジ、PURL、宣言済み SPDX ライセンスを含み、公式 schema とプライバシーゲートに合格し、ビルド専用ツールを分離して追跡しなければなりません。
 - すべての Windows および Preview バイナリ配布物には、エンドユーザーが読める場所に MIT ライセンスと第三者通知を収録します。
 - AppImage ビルドツールは、公式ソース commit、asset identity、SHA-256 が審査済み定数と一致する場合にだけ受け入れます。GitHub Actions は完全な commit SHA に固定します。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
-### v3.1.2 — 2026-08-12
+### v3.1.2 — 2026-08-13
 
 - 完整保留 OpenAI Realtime 原生聲音並維持為預設及最低額外延遲選項；偏好原有聲線的使用者不會被迫改用 Azure。
 - 新增可選的 Realtime 即時理解＋一般 Azure Speech 或 Dragon HD 串流發聲；安全短句完成後立即依序合成，首段音訊抵達即播放，以降低額外 TTS 等待，但不宣稱零延遲。
@@ -13,7 +13,7 @@
 - Azure 與 Windows 本機語音都支援真正停止目前播放；操作識別碼、受限佇列與過長回覆保護會隔離遲到回呼並限制記憶體壓力，敏感金鑰也不會出現在物件表示內容中。
 - 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
 - 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
-- 四語介面修正仍在進行最後驗證；v3.1.2 尚未發布，須待完整在地化、回歸、封裝、安全及發行檢查全部通過後才能建立正式版或候選版。
+- 本版四語介面修正以繁中、簡中、英文、日文相同功能邊界納入驗證；任何正式版或候選版產物都只有在完整在地化、回歸、封裝、安全及發行檢查全部通過後才會公開。
 
 ### v3.1.1 — 2026-08-12
 
@@ -201,7 +201,7 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
-### v3.1.2 — 2026-08-12
+### v3.1.2 — 2026-08-13
 
 - 完整保留 OpenAI Realtime 原生声音，并继续作为默认及最低额外延迟选项；偏好原有声线的用户不会被迫改用 Azure。
 - 新增可选的 Realtime 即时理解＋一般 Azure Speech 或 Dragon HD 流式发声；安全短句完成后立即依次合成，首段音频到达即播放，以降低新增的 TTS 等待，但不宣称零延迟。
@@ -210,7 +210,7 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 - Azure 与 Windows 本地语音都支持真正停止当前播放；操作标识、受限队列与过长回复保护会隔离迟到回调并限制内存压力，敏感密钥也不会出现在对象表示内容中。
 - 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
 - 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
-- 四语界面修复仍在进行最终验证；v3.1.2 尚未发布，必须在完整本地化、回归、打包、安全及发布检查全部通过后，才能创建正式版或候选版。
+- 本版本四语界面修复以繁中、简中、英文、日文相同功能边界纳入验证；任何正式版或候选版产物都只有在完整本地化、回归、打包、安全及发布检查全部通过后才会公开。
 
 ### v3.1.1 — 2026-08-12
 
@@ -397,7 +397,7 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 
 All notable public changes to MoHan Desktop Assistant are documented here.
 
-### v3.1.2 — 2026-08-12
+### v3.1.2 — 2026-08-13
 
 - Fully preserves native OpenAI Realtime voice as the default and lowest-added-latency option; users who prefer its original voices are never forced onto Azure.
 - Adds optional Realtime understanding with standard Azure Speech or Dragon HD streaming output. Safe short clauses synthesize in order as they complete, and playback starts with the first audio chunk to reduce the added TTS wait without claiming zero latency.
@@ -406,7 +406,7 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 - Azure and Windows local speech can both stop current playback. Operation IDs, bounded queues, and oversized-response guards isolate late callbacks and cap memory pressure, while secret keys stay out of object representations.
 - Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
 - Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
-- Four-language interface fixes remain under final validation. v3.1.2 is not published and cannot become a Stable Release or release candidate until complete localization, regression, packaging, security, and publication checks all pass.
+- This release validates its Traditional Chinese, Simplified Chinese, English, and Japanese interface fixes against the same functional boundaries; Stable Release and release-candidate artifacts are published only after complete localization, regression, packaging, security, and publication checks pass.
 
 ### v3.1.1 — 2026-08-12
 
@@ -633,7 +633,7 @@ speech, gaze, and physics stress test passed before this release candidate.
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
 
-### v3.1.2 — 2026-08-12
+### v3.1.2 — 2026-08-13
 
 - OpenAI Realtime のネイティブ音声を完全に維持し、既定かつ追加遅延が最も少ない選択肢とします。従来の音声を好む利用者へ Azure を強制しません。
 - Realtime による即時理解と、通常 Azure Speech または Dragon HD のストリーミング発話を組み合わせる任意モードを追加します。安全な短い句が完成するたび順番に合成し、最初の音声断片から再生して TTS の追加待ち時間を抑えますが、ゼロ遅延はうたいません。
@@ -642,7 +642,7 @@ speech, gaze, and physics stress test passed before this release candidate.
 - Azure と Windows 本機音声は、どちらも現在の再生を実際に停止できます。操作 ID、上限付きキュー、長すぎる応答の保護により遅延コールバックを隔離してメモリ負荷を制限し、秘密キーをオブジェクト表現へ出しません。
 - 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
 - 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
-- 四言語画面の修正は最終検証中です。v3.1.2 は未公開で、完全なローカライズ、回帰、パッケージ、セキュリティ、公開検査がすべて成功するまで、正式版にもリリース候補版にもできません。
+- 本版の繁体字中国語、簡体字中国語、英語、日本語の画面修正は、同じ機能境界で検証します。正式版とリリース候補版の成果物は、完全なローカライズ、回帰、パッケージ、セキュリティ、公開検査がすべて成功した場合にのみ公開されます。
 
 ### v3.1.1 — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - 三種輸出模式完全隔離且不混音，不改動其他語音供應器；Dragon HD 單句失敗時依序只退回一般 Azure 一次及 Windows 本機女性聲線一次，一般 Azure 單句失敗時只退回 Windows 本機女性聲線一次。回退僅發生於該句尚未播放音訊時；串流已開始後若失敗則立即停止，不整句重播，以免重複發聲與計費。
 - 只有狀態為 `completed` 的 Realtime 回覆才提交最終文字；取消、失敗、不完整、斷線及舊回覆的遲到事件不會發聲或污染後續回覆。
 - Azure 與 Windows 本機語音都支援真正停止目前播放；操作識別碼、受限佇列與過長回覆保護會隔離遲到回呼並限制記憶體壓力，敏感金鑰也不會出現在物件表示內容中。
+- 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
+- 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
+- 四語介面修正仍在進行最後驗證；v3.1.2 尚未發布，須待完整在地化、回歸、封裝、安全及發行檢查全部通過後才能建立正式版或候選版。
 
 ### v3.1.1 — 2026-08-12
 
@@ -205,6 +208,9 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 - 三种输出模式完全隔离且不混音，不改动其他语音供应器；Dragon HD 单句失败时依次只回退到一般 Azure 一次及 Windows 本地女性声线一次，一般 Azure 单句失败时只回退到 Windows 本地女性声线一次。回退仅发生于该句尚未播放音频时；流式播放开始后若失败则立即停止，不整句重播，以免重复发声及计费。
 - 只有状态为 `completed` 的 Realtime 回复才提交最终文字；取消、失败、不完整、断线及旧回复的迟到事件不会发声或污染后续回复。
 - Azure 与 Windows 本地语音都支持真正停止当前播放；操作标识、受限队列与过长回复保护会隔离迟到回调并限制内存压力，敏感密钥也不会出现在对象表示内容中。
+- 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
+- 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
+- 四语界面修复仍在进行最终验证；v3.1.2 尚未发布，必须在完整本地化、回归、打包、安全及发布检查全部通过后，才能创建正式版或候选版。
 
 ### v3.1.1 — 2026-08-12
 
@@ -398,6 +404,9 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 - Keeps all three output modes isolated and unmixed, without changing other speech providers. A failed Dragon HD clause falls back once to standard Azure and then once to a local Windows female voice; standard Azure falls back once to the local Windows female voice. Fallback occurs only before that clause has played any audio. A stream failure after playback begins stops the clause without replaying it in full, preventing duplicate speech and charges.
 - Commits final text only when a Realtime response has status `completed`; cancelled, failed, incomplete, disconnected, and late events from older responses cannot speak or contaminate the next response.
 - Azure and Windows local speech can both stop current playback. Operation IDs, bounded queues, and oversized-response guards isolate late callbacks and cap memory pressure, while secret keys stay out of object representations.
+- Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
+- Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
+- Four-language interface fixes remain under final validation. v3.1.2 is not published and cannot become a Stable Release or release candidate until complete localization, regression, packaging, security, and publication checks all pass.
 
 ### v3.1.1 — 2026-08-12
 
@@ -631,6 +640,9 @@ speech, gaze, and physics stress test passed before this release candidate.
 - 三つの出力モードを完全に分離して混音せず、他の音声供給元も変更しません。Dragon HD が一つの句で失敗した場合は通常 Azure へ一度、続いて Windows 本機女性音声へ一度だけ代替し、通常 Azure が失敗した場合は Windows 本機女性音声へ一度だけ代替します。代替するのは、その句の音声がまだ再生されていない場合だけです。再生開始後のストリーム障害では句を直ちに停止し、全体を再生し直さないことで重複発話と重複課金を防ぎます。
 - Realtime 応答の状態が `completed` の場合だけ最終テキストを確定します。取消、失敗、未完了、切断、過去の応答から遅れて届いたイベントは発話せず、次の応答も汚染しません。
 - Azure と Windows 本機音声は、どちらも現在の再生を実際に停止できます。操作 ID、上限付きキュー、長すぎる応答の保護により遅延コールバックを隔離してメモリ負荷を制限し、秘密キーをオブジェクト表現へ出しません。
+- 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
+- 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
+- 四言語画面の修正は最終検証中です。v3.1.2 は未公開で、完全なローカライズ、回帰、パッケージ、セキュリティ、公開検査がすべて成功するまで、正式版にもリリース候補版にもできません。
 
 ### v3.1.1 — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Azure 與 Windows 本機語音都支援真正停止目前播放；操作識別碼、受限佇列與過長回覆保護會隔離遲到回呼並限制記憶體壓力，敏感金鑰也不會出現在物件表示內容中。
 - 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
 - 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
+- 修正 WiX MSI 的 Windows 開始功能表捷徑，使其直接沿用目標 EXE 內嵌的墨寒半身圖示，不再引用 MSI 的獨立圖示資源。
 - 本版四語介面修正以繁中、簡中、英文、日文相同功能邊界納入驗證；任何正式版或候選版產物都只有在完整在地化、回歸、封裝、安全及發行檢查全部通過後才會公開。
 
 ### v3.1.1 — 2026-08-12
@@ -210,6 +211,7 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 - Azure 与 Windows 本地语音都支持真正停止当前播放；操作标识、受限队列与过长回复保护会隔离迟到回调并限制内存压力，敏感密钥也不会出现在对象表示内容中。
 - 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
 - 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
+- 修复 WiX MSI 的 Windows 开始菜单快捷方式，使其直接沿用目标 EXE 内嵌的墨寒半身图标，不再引用 MSI 的独立图标资源。
 - 本版本四语界面修复以繁中、简中、英文、日文相同功能边界纳入验证；任何正式版或候选版产物都只有在完整本地化、回归、打包、安全及发布检查全部通过后才会公开。
 
 ### v3.1.1 — 2026-08-12
@@ -406,6 +408,7 @@ All notable public changes to MoHan Desktop Assistant are documented here.
 - Azure and Windows local speech can both stop current playback. Operation IDs, bounded queues, and oversized-response guards isolate late callbacks and cap memory pressure, while secret keys stay out of object representations.
 - Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
 - Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
+- Fixes the WiX MSI Windows Start menu shortcut so it inherits MoHan's embedded half-body icon directly from the target EXE instead of referencing a separate MSI icon resource.
 - This release validates its Traditional Chinese, Simplified Chinese, English, and Japanese interface fixes against the same functional boundaries; Stable Release and release-candidate artifacts are published only after complete localization, regression, packaging, security, and publication checks pass.
 
 ### v3.1.1 — 2026-08-12
@@ -642,6 +645,7 @@ speech, gaze, and physics stress test passed before this release candidate.
 - Azure と Windows 本機音声は、どちらも現在の再生を実際に停止できます。操作 ID、上限付きキュー、長すぎる応答の保護により遅延コールバックを隔離してメモリ負荷を制限し、秘密キーをオブジェクト表現へ出しません。
 - 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
 - 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
+- WiX MSI の Windows スタートメニューショートカットを修正し、MSI 内の個別アイコンリソースではなく、対象 EXE に内蔵された墨寒の半身アイコンを直接継承するようにしました。
 - 本版の繁体字中国語、簡体字中国語、英語、日本語の画面修正は、同じ機能境界で検証します。正式版とリリース候補版の成果物は、完全なローカライズ、回帰、パッケージ、セキュリティ、公開検査がすべて成功した場合にのみ公開されます。
 
 ### v3.1.1 — 2026-08-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### v3.1.2 — 2026-08-12
+
+- 完整保留 OpenAI Realtime 原生聲音並維持為預設及最低額外延遲選項；偏好原有聲線的使用者不會被迫改用 Azure。
+- 新增可選的 Realtime 即時理解＋一般 Azure Speech 或 Dragon HD 串流發聲；安全短句完成後立即依序合成，首段音訊抵達即播放，以降低額外 TTS 等待，但不宣稱零延遲。
+- 三種輸出模式完全隔離且不混音，不改動其他語音供應器；Dragon HD 單句失敗時依序只退回一般 Azure 一次及 Windows 本機女性聲線一次，一般 Azure 單句失敗時只退回 Windows 本機女性聲線一次。回退僅發生於該句尚未播放音訊時；串流已開始後若失敗則立即停止，不整句重播，以免重複發聲與計費。
+- 只有狀態為 `completed` 的 Realtime 回覆才提交最終文字；取消、失敗、不完整、斷線及舊回覆的遲到事件不會發聲或污染後續回覆。
+- Azure 與 Windows 本機語音都支援真正停止目前播放；操作識別碼、受限佇列與過長回覆保護會隔離遲到回呼並限制記憶體壓力，敏感金鑰也不會出現在物件表示內容中。
+
 ### v3.1.1 — 2026-08-12
 
 - 一般 Azure 與 Dragon HD 依選定區域及各自的加密金鑰動態查詢實際女性聲線，排除男性、不相容模型及區域不支援的 HD Flash；固定清單只作查詢失敗時的安全備援。
@@ -190,6 +198,14 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### v3.1.2 — 2026-08-12
+
+- 完整保留 OpenAI Realtime 原生声音，并继续作为默认及最低额外延迟选项；偏好原有声线的用户不会被迫改用 Azure。
+- 新增可选的 Realtime 即时理解＋一般 Azure Speech 或 Dragon HD 流式发声；安全短句完成后立即依次合成，首段音频到达即播放，以降低新增的 TTS 等待，但不宣称零延迟。
+- 三种输出模式完全隔离且不混音，不改动其他语音供应器；Dragon HD 单句失败时依次只回退到一般 Azure 一次及 Windows 本地女性声线一次，一般 Azure 单句失败时只回退到 Windows 本地女性声线一次。回退仅发生于该句尚未播放音频时；流式播放开始后若失败则立即停止，不整句重播，以免重复发声及计费。
+- 只有状态为 `completed` 的 Realtime 回复才提交最终文字；取消、失败、不完整、断线及旧回复的迟到事件不会发声或污染后续回复。
+- Azure 与 Windows 本地语音都支持真正停止当前播放；操作标识、受限队列与过长回复保护会隔离迟到回调并限制内存压力，敏感密钥也不会出现在对象表示内容中。
+
 ### v3.1.1 — 2026-08-12
 
 - 一般 Azure 与 Dragon HD 根据所选区域及各自的加密密钥动态查询实际女性声线，排除男性、不兼容模型及区域不支持的 HD Flash；固定列表仅作为查询失败时的安全备用。
@@ -374,6 +390,14 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### v3.1.2 — 2026-08-12
+
+- Fully preserves native OpenAI Realtime voice as the default and lowest-added-latency option; users who prefer its original voices are never forced onto Azure.
+- Adds optional Realtime understanding with standard Azure Speech or Dragon HD streaming output. Safe short clauses synthesize in order as they complete, and playback starts with the first audio chunk to reduce the added TTS wait without claiming zero latency.
+- Keeps all three output modes isolated and unmixed, without changing other speech providers. A failed Dragon HD clause falls back once to standard Azure and then once to a local Windows female voice; standard Azure falls back once to the local Windows female voice. Fallback occurs only before that clause has played any audio. A stream failure after playback begins stops the clause without replaying it in full, preventing duplicate speech and charges.
+- Commits final text only when a Realtime response has status `completed`; cancelled, failed, incomplete, disconnected, and late events from older responses cannot speak or contaminate the next response.
+- Azure and Windows local speech can both stop current playback. Operation IDs, bounded queues, and oversized-response guards isolate late callbacks and cap memory pressure, while secret keys stay out of object representations.
 
 ### v3.1.1 — 2026-08-12
 
@@ -599,6 +623,14 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### v3.1.2 — 2026-08-12
+
+- OpenAI Realtime のネイティブ音声を完全に維持し、既定かつ追加遅延が最も少ない選択肢とします。従来の音声を好む利用者へ Azure を強制しません。
+- Realtime による即時理解と、通常 Azure Speech または Dragon HD のストリーミング発話を組み合わせる任意モードを追加します。安全な短い句が完成するたび順番に合成し、最初の音声断片から再生して TTS の追加待ち時間を抑えますが、ゼロ遅延はうたいません。
+- 三つの出力モードを完全に分離して混音せず、他の音声供給元も変更しません。Dragon HD が一つの句で失敗した場合は通常 Azure へ一度、続いて Windows 本機女性音声へ一度だけ代替し、通常 Azure が失敗した場合は Windows 本機女性音声へ一度だけ代替します。代替するのは、その句の音声がまだ再生されていない場合だけです。再生開始後のストリーム障害では句を直ちに停止し、全体を再生し直さないことで重複発話と重複課金を防ぎます。
+- Realtime 応答の状態が `completed` の場合だけ最終テキストを確定します。取消、失敗、未完了、切断、過去の応答から遅れて届いたイベントは発話せず、次の応答も汚染しません。
+- Azure と Windows 本機音声は、どちらも現在の再生を実際に停止できます。操作 ID、上限付きキュー、長すぎる応答の保護により遅延コールバックを隔離してメモリ負荷を制限し、秘密キーをオブジェクト表現へ出しません。
 
 ### v3.1.1 — 2026-08-12
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
 version: "3.1.2"
-date-released: "2026-08-12"
+date-released: "2026-08-13"
 license: MIT
 abstract: >-
   A configurable Windows AI desktop companion and permission-gated

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 authors:
   - family-names: "CHOU"
     given-names: "MING HUA"
-version: "3.1.1"
+version: "3.1.2"
 date-released: "2026-08-12"
 license: MIT
 abstract: >-

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -36,11 +36,13 @@ taiwan
 open-source
 ```
 
-### 已準備的公開預發行版
+### 已準備的公開版本
 
-- 標籤：`v3.1.1`
-- 標題：`MoHan Desktop Assistant v3.1.1`
+- 標籤：`v3.1.2`
+- 標題：`MoHan Desktop Assistant v3.1.2`
 - 發布條件：只有在所有必要 CI、套件 smoke、安全及發布政策檢查成功後才可發布。
+- 本版完整保留並預設使用 OpenAI Realtime 原生聲音，作為三種回覆聲音中額外延遲最低的路徑；另提供使用者明確選擇的 Realtime 即時理解＋一般 Azure Speech 或 Dragon HD 串流發聲。三種模式完全隔離且不混音，不得改動其他語音供應器；Dragon HD 單句失敗時依序只退回一般 Azure 一次及 Windows 本機女性聲線一次，一般 Azure 單句失敗時只退回 Windows 本機女性聲線一次。回退只能發生在該句尚未播放任何音訊時；播放開始後的串流失敗必須停止該句且不得整句重播，以防重複發聲與計費。
+- 混合模式增加 TTS 網路與合成階段；以安全短句依序合成及首段音訊即播降低等待，但發布說明不得宣稱零延遲或未經驗證的效能數字。
 - 內容包含 Windows x64 可攜式 ZIP、每位使用者安裝的 EXE 與 MSI、英文／簡體中文／日文 MSI 轉換檔、macOS Apple Silicon（arm64）與 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清單、可重現的 CycloneDX 1.7 SBOM 與驗證報告、已去識別化的 Tachyon 證據與效能摘要、更新資訊清單及產物證明。
 
 ### 後續發行系列
@@ -201,11 +203,13 @@ taiwan
 open-source
 ```
 
-### 已准备的公开预发布版
+### 已准备的公开版本
 
-- 标签：`v3.1.1`
-- 标题：`MoHan Desktop Assistant v3.1.1`
+- 标签：`v3.1.2`
+- 标题：`MoHan Desktop Assistant v3.1.2`
 - 发布条件：只有在所有必要 CI、软件包 smoke、安全及发布政策检查成功后才可发布。
+- 本版本完整保留并默认使用 OpenAI Realtime 原生声音，作为三种回复声音中额外延迟最低的路径；另提供用户明确选择的 Realtime 即时理解＋一般 Azure Speech 或 Dragon HD 流式发声。三种模式完全隔离且不混音，不得改动其他语音供应器；Dragon HD 单句失败时依次只回退到一般 Azure 一次及 Windows 本地女性声线一次，一般 Azure 单句失败时只回退到 Windows 本地女性声线一次。回退只能发生在该句尚未播放任何音频时；播放开始后的流式失败必须停止该句且不得整句重播，以防重复发声及计费。
+- 混合模式增加 TTS 网络与合成阶段；通过安全短句依次合成及首段音频即播降低等待，但发布说明不得宣称零延迟或未经验证的性能数字。
 - 内容包括 Windows x64 便携式 ZIP、按用户安装的 EXE 与 MSI、英文／简体中文／日文 MSI 转换文件、macOS Apple Silicon（arm64）与 Intel（x86_64）功能受限 Preview DMG、Linux x86_64 功能受限 Preview AppImage、SHA-256 清单、可重现的 CycloneDX 1.7 SBOM 与验证报告、已去除身份信息的 Tachyon 证据与性能摘要、更新清单及产物证明。
 
 ### 后续发布系列
@@ -366,11 +370,13 @@ taiwan
 open-source
 ```
 
-### Prepared public pre-release
+### Prepared public release
 
-- Tag: `v3.1.1`
-- Title: `MoHan Desktop Assistant v3.1.1`
+- Tag: `v3.1.2`
+- Title: `MoHan Desktop Assistant v3.1.2`
 - Publication condition: publish only after every required CI, package smoke, security, and release-policy check succeeds.
+- This release fully preserves native OpenAI Realtime voice and keeps it as the default, lowest-added-latency route among the three response-voice choices. Users may explicitly select Realtime understanding with standard Azure Speech or Dragon HD streaming output. The three modes remain isolated and unmixed and must not change other speech providers. A failed Dragon HD clause falls back once to standard Azure and then once to a local Windows female voice; standard Azure falls back once to the local Windows female voice. Fallback is permitted only before the clause has played any audio. A stream failure after playback begins must stop the clause without replaying it in full, preventing duplicate speech and charges.
+- Hybrid mode adds a TTS network and synthesis stage. Safe short-clause synthesis in order and first-chunk playback reduce the wait, but publication notes must not claim zero latency or unverified performance figures.
 - Includes the Windows x64 portable ZIP, per-user EXE and MSI installers, English/Simplified Chinese/Japanese MSI transforms, macOS Apple Silicon (arm64) and Intel (x86_64) limited Preview DMGs, Linux x86_64 limited Preview AppImage, SHA-256 catalog, reproducible CycloneDX 1.7 SBOMs and validation report, sanitized Tachyon evidence and performance summary, update manifest, and artifact attestations.
 
 ### Next release line
@@ -531,11 +537,13 @@ taiwan
 open-source
 ```
 
-### 準備済みの公開プレリリース
+### 準備済みの公開版
 
-- タグ：`v3.1.1`
-- タイトル：`MoHan Desktop Assistant v3.1.1`
+- タグ：`v3.1.2`
+- タイトル：`MoHan Desktop Assistant v3.1.2`
 - 公開条件：必須の CI、パッケージ smoke、セキュリティ、リリースポリシーの全検査が成功した場合に限り公開します。
+- 本版は OpenAI Realtime のネイティブ音声を完全に維持して既定値とし、三つの応答音声の中で追加遅延が最も少ない経路とします。利用者は Realtime の即時理解と通常 Azure Speech または Dragon HD のストリーミング発話を組み合わせるモードを明示的に選べます。三つのモードは完全に分離して混音せず、他の音声供給元を変更してはなりません。Dragon HD が一つの句で失敗した場合は通常 Azure へ一度、続いて Windows 本機女性音声へ一度だけ代替し、通常 Azure が失敗した場合は Windows 本機女性音声へ一度だけ代替します。代替できるのは、その句の音声がまだ再生されていない場合だけです。再生開始後のストリーム障害では句を停止し、全体を再生し直さず、重複発話と重複課金を防がなければなりません。
+- ハイブリッドモードでは TTS の通信と合成工程が増えます。安全な短い句を順番に合成し、最初の音声断片から再生して待ち時間を抑えますが、公開説明でゼロ遅延や未検証の性能値をうたってはなりません。
 - Windows x64 ポータブル ZIP、ユーザー単位の EXE および MSI インストーラー、英語／簡体字中国語／日本語の MSI 変換ファイル、macOS Apple Silicon（arm64）および Intel（x86_64）の機能限定 Preview DMG、Linux x86_64 の機能限定 Preview AppImage、SHA-256 カタログ、再現可能な CycloneDX 1.7 SBOM と検証レポート、匿名化済み Tachyon 証拠と性能要約、更新マニフェスト、成果物証明を含みます。
 
 ### 次のリリース系列

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## 繁體中文
 
 1. 將下載的 `Windows-x64.zip` 完整解壓縮。
-2. 執行 `MoHan-Desktop-Assistant-3.1.1.exe`。
+2. 執行 `MoHan-Desktop-Assistant-3.1.2.exe`。
 3. 在首次設定精靈選擇「繁體中文（臺灣）」，並確認助理名稱、稱呼、組織、
    工作類型與喚醒詞。
 4. 新使用者預設使用 Windows 本機語音；若要使用雲端 AI，請在設定頁輸入
@@ -23,7 +23,7 @@ Microsoft、GitHub 與 Home Assistant 屬於尚未完成真實環境端到端驗
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.1.1` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
+`v3.1.2` 的 macOS Apple Silicon（arm64）與 Intel（x86_64）DMG
 （內含 `.app`），以及 Linux x86_64 AppImage，只用於
 啟動、四語介面、平台路徑及安全停用驗證。請先核對 SHA256SUMS 與 Artifact
 Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角色、完整聊天／
@@ -32,7 +32,7 @@ Attestation。這些預覽包沒有 API 金鑰輸入、語音、完整桌面角�
 ## 简体中文
 
 1. 完整解压下载的 `Windows-x64.zip`。
-2. 运行 `MoHan-Desktop-Assistant-3.1.1.exe`。
+2. 运行 `MoHan-Desktop-Assistant-3.1.2.exe`。
 3. 在首次设置向导选择“简体中文（中国大陆）”，并确认助手名称、称呼、
    组织、工作类型与唤醒词。
 4. 新用户默认使用 Windows 本机语音；若要使用云端 AI，请在设置页输入
@@ -52,7 +52,7 @@ Microsoft、GitHub 与 Home Assistant 仍属于尚未完成真实环境端到端
 
 ### macOS／Linux 功能受限 Preview
 
-`v3.1.1` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
+`v3.1.2` 的 macOS Apple Silicon（arm64）与 Intel（x86_64）DMG
 （内含 `.app`），以及 Linux x86_64 AppImage，只用于
 验证启动、四语界面、平台路径与安全停用。请核对 SHA256SUMS 与 Artifact
 Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色、完整聊天／工作
@@ -61,7 +61,7 @@ Attestation。预览包不提供 API 密钥输入、语音、完整桌面角色�
 ## English
 
 1. Extract the complete `Windows-x64.zip`.
-2. Run `MoHan-Desktop-Assistant-3.1.1.exe`.
+2. Run `MoHan-Desktop-Assistant-3.1.2.exe`.
 3. Review the assistant name, user title, organization, work type, and wake word
    in the first-run wizard.
 4. Enter a user-owned OpenAI API key in Settings for cloud AI.
@@ -81,7 +81,7 @@ See [README.md](README.md) for complete setup, OAuth, safety, and privacy notes.
 
 ### Limited macOS/Linux Preview
 
-The `v3.1.1` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
+The `v3.1.2` macOS Apple Silicon (arm64) and Intel (x86_64) DMGs
 (each containing a `.app`) and Linux x86_64 AppImage
 validate startup, four-language UI, platform paths, and fail-closed boundaries
 only. Verify SHA256SUMS and the Artifact Attestation first. These packages have
@@ -92,7 +92,7 @@ maintainer's physical-device signoff.
 ## 日本語
 
 1. ダウンロードした `Windows-x64.zip` を完全に展開します。
-2. `MoHan-Desktop-Assistant-3.1.1.exe` を実行します。
+2. `MoHan-Desktop-Assistant-3.1.2.exe` を実行します。
 3. 初回設定で「日本語」を選び、アシスタント名、呼び名、組織、作業内容、
    ウェイクワードを確認します。
 4. 新規利用者は Windows 本機音声を既定で利用できます。クラウド AI を使う
@@ -114,7 +114,7 @@ Microsoft、GitHub、Home Assistant は、実環境でのエンドツーエン�
 
 ### macOS／Linux 機能限定 Preview
 
-`v3.1.1` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
+`v3.1.2` の macOS Apple Silicon（arm64）版と Intel（x86_64）版 DMG
 （各 `.app` 同梱）、および Linux x86_64 AppImage は、
 起動、四言語画面、OS ごとの保存先、安全な無効化だけを確認します。先に
 SHA256SUMS と Artifact Attestation を確認してください。API キー入力、音声、

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.1 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.2 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -226,7 +226,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 ### 整合驗證狀態
 
-> **公開預覽版注意事項：** Microsoft、GitHub 與 Home Assistant 的架構、權限邊界及內部測試已建立；截至 `v2.1.0-rc.1`，尚未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。它們是實驗性預覽功能，不是所有環境都可完整運作的保證。
+> **公開 Preview 注意事項：** Azure Speech 已完成下列真實資源驗證；Microsoft 帳號整合、GitHub 與 Home Assistant 雖已建立架構、權限邊界及內部測試，仍未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。尚未完成真實驗證的部分屬於實驗性 Preview，不保證可在所有環境完整運作。
 
 - Azure Speech 已完成本專案的真實 Free F0 資源、HTTPS 合成、RIFF 音訊與 Windows 播放驗證；每位使用者仍須自行建立 Speech 資源並承擔其帳號、配額與費用。
 - Microsoft 帳號的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
@@ -248,7 +248,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-v3.1.1 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
@@ -268,6 +268,14 @@ v3.1.1 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各
 | Realtime 即時語音 | `gpt-realtime-2.1-mini` |
 | 語音轉文字 | `gpt-4o-mini-transcribe` |
 | OpenAI 文字轉語音 | `gpt-4o-mini-tts` |
+
+#### Realtime 回覆聲音
+
+`v3.1.2` 完整保留 OpenAI Realtime 原生聲音，並維持為預設選項。原生模式由 Realtime 透過同一路徑理解並直接輸出音訊，適合偏好原有聲線，或希望在這些選項中取得最低額外延遲的使用者。
+
+使用者也可明確改選「Realtime 即時理解＋一般 Azure Speech 串流發聲」或「Realtime 即時理解＋Azure Dragon HD 串流發聲」。混合模式只把 Realtime 產生的文字交給所選 Azure 引擎；安全短句一完成便排入順序播放，首段音訊抵達即開始發聲，避免等待完整回答與完整音檔。不過，多出的 TTS 網路與合成階段仍會增加發話等待，因此本專案不宣稱零延遲。
+
+三種模式彼此隔離，同一時間只有一條輸出路徑掌管播放，不會混音，也不會改動一般 Windows 本機語音、OpenAI TTS、一般 Azure 朗讀或其他語音模型。Dragon HD 單句失敗時，依序只退回一般 Azure 一次及 Windows 本機女性聲線一次；一般 Azure 單句失敗時只退回 Windows 本機女性聲線一次。上述回退僅適用於該句尚未播放任何音訊時；若串流已開始後才失敗，系統會立即停止該句而不整句重播，以避免重複發聲與重複計費。Azure 選項不會取代原生 Realtime。
 
 從 `v2.1.0-rc.1` 起，文字對話預設改為 `gpt-5.6-luna`，設定清單不再提供 `gpt-5.4-mini`；既有 mini 設定會遷移至 Luna，使用者主動選擇的 Terra、Sol 或其他自訂模型不會被覆蓋。實際可用性取決於帳號、Project、地區與當時供應狀態。
 
@@ -359,12 +367,12 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.1"
+.\build.ps1 -Version "3.1.2"
 ```
 
 歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
 
-每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立預發行版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
+每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立對應的 Stable Release 或 Pre-release。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
 
 互動式 EXE 安裝程式提供臺灣繁中、簡中、英文、日文；MSI 維持臺灣繁中基底，並提供經測試的 en-US、zh-CN、ja-JP 語言轉換，詳見 [安裝程式在地化](installer/LOCALIZATION.md)。
 
@@ -405,7 +413,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.1 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.2 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -617,7 +625,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 ### 集成验证状态
 
-> **公开预览版注意事项：** Microsoft、GitHub 与 Home Assistant 的架构、权限边界及内部测试已建立；截至 `v2.1.0-rc.1`，尚未以全部真实账号、仓库、主机与实体设备完成端到端验证。它们是实验性预览功能，不是所有环境都可完整运行的保证。
+> **公开 Preview 注意事项：** Azure Speech 已完成下列真实资源验证；Microsoft 账号集成、GitHub 与 Home Assistant 虽已建立架构、权限边界及内部测试，仍未以全部真实账号、仓库、主机与实体设备完成端到端验证。尚未完成真实验证的部分属于实验性 Preview，不保证可在所有环境完整运行。
 
 - Azure Speech 已完成本项目的真实 Free F0 资源、HTTPS 合成、RIFF 音频与 Windows 播放验证；每位用户仍须自行建立 Speech 资源并承担其账号、配额与费用。
 - Microsoft 账号的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
@@ -639,7 +647,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-v3.1.1 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
@@ -659,6 +667,14 @@ v3.1.1 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各
 | Realtime 即时语音 | `gpt-realtime-2.1-mini` |
 | 语音转文字 | `gpt-4o-mini-transcribe` |
 | OpenAI 文字转语音 | `gpt-4o-mini-tts` |
+
+#### Realtime 回复声音
+
+`v3.1.2` 完整保留 OpenAI Realtime 原生声音，并继续作为默认选项。原生模式由 Realtime 通过同一路径理解并直接输出音频，适合偏好原有声线，或希望在这些选项中获得最低额外延迟的用户。
+
+用户也可明确改选“Realtime 即时理解＋一般 Azure Speech 流式发声”或“Realtime 即时理解＋Azure Dragon HD 流式发声”。混合模式只把 Realtime 生成的文字交给所选 Azure 引擎；安全短句完成后立即按顺序排队，首段音频到达即开始发声，避免等待完整回答与完整音频文件。但是，新增的 TTS 网络与合成阶段仍会增加发话等待，因此本项目不宣称零延迟。
+
+三种模式彼此隔离，同一时间只有一条输出路径负责播放，不会混音，也不会改动一般 Windows 本地语音、OpenAI TTS、一般 Azure 朗读或其他语音模型。Dragon HD 单句失败时，依次只回退到一般 Azure 一次及 Windows 本地女性声线一次；一般 Azure 单句失败时只回退到 Windows 本地女性声线一次。上述回退仅适用于该句尚未播放任何音频时；若流式播放开始后才失败，系统会立即停止该句而不整句重播，以避免重复发声及重复计费。Azure 选项不会取代原生 Realtime。
 
 从 `v2.1.0-rc.1` 起，文字对话默认改为 `gpt-5.6-luna`，设置列表不再提供 `gpt-5.4-mini`；现有 mini 设置会迁移至 Luna，用户主动选择的 Terra、Sol 或其他自定义模型不会被覆盖。实际可用性取决于账号、Project、地区与当时供应状态。
 
@@ -750,12 +766,12 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.1"
+.\build.ps1 -Version "3.1.2"
 ```
 
 历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
 
-每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建预发布版。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
+每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建对应的 Stable Release 或 Pre-release。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
 
 交互式 EXE 安装程序提供台湾繁中、简中、英文、日文；MSI 保持台湾繁中基础，并提供经过测试的 en-US、zh-CN、ja-JP 语言转换，详情请见 [安装程序本地化](installer/LOCALIZATION.md)。
 
@@ -796,7 +812,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.1 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.2 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -1008,7 +1024,7 @@ On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed 
 
 ### Integration verification status
 
-> **Public preview notice:** Microsoft, GitHub, and Home Assistant architecture, permission boundaries, and internal tests are implemented. As of `v2.1.0-rc.1`, end-to-end validation across all real accounts, repositories, servers, and physical devices is incomplete. These are experimental Preview features, not a guarantee of complete operation in every environment.
+> **Public Preview notice:** Azure Speech has completed the live-resource validation described below. Microsoft account integration, GitHub, and Home Assistant have architecture, permission boundaries, and internal tests, but have not completed end-to-end validation across every real account, repository, server, and physical device. The portions without live validation remain experimental Preview features and are not guaranteed to operate completely in every environment.
 
 - Azure Speech completed this project's live Free F0 resource, HTTPS synthesis, RIFF audio, and Windows playback validation; every user must still create a Speech resource and remains responsible for account, quota, and cost.
 - Microsoft account real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
@@ -1030,7 +1046,7 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-v3.1.1 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+v3.1.2 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
@@ -1050,6 +1066,14 @@ Current default models:
 | Realtime voice | `gpt-realtime-2.1-mini` |
 | Speech-to-text | `gpt-4o-mini-transcribe` |
 | OpenAI text-to-speech | `gpt-4o-mini-tts` |
+
+#### Realtime response voice
+
+`v3.1.2` fully preserves native OpenAI Realtime voice and keeps it as the default. Native mode lets Realtime understand and emit audio through the same path, serving people who prefer the original voices or want the lowest added latency among these options.
+
+Users may instead explicitly select “Realtime understanding + standard Azure Speech streaming” or “Realtime understanding + Azure Dragon HD streaming.” Hybrid mode sends only Realtime-generated text to the selected Azure engine. Safe, short clauses enter the ordered queue as soon as they complete, and speech starts with the first audio chunk instead of waiting for the full response or complete audio file. The added TTS network and synthesis stage still increases the wait before speech, so this project does not claim zero latency.
+
+The three modes are isolated: only one output route owns playback at a time, with no mixing and no changes to standard Windows local speech, OpenAI TTS, regular Azure reading, or other voice models. If Dragon HD fails for a clause, it falls back once to standard Azure and then once to a local Windows female voice; standard Azure falls back once to the local Windows female voice. Those fallbacks apply only before any audio from that clause has played. If a stream fails after playback begins, MoHan stops that clause instead of replaying it in full, preventing duplicate speech and duplicate charges. Azure choices do not replace native Realtime.
 
 Starting with `v2.1.0-rc.1`, text chat defaults to `gpt-5.6-luna`, and `gpt-5.4-mini` is no longer listed in Settings. Existing mini settings migrate to Luna without overwriting user-selected Terra, Sol, or other custom models. Actual availability depends on the account, Project, region, and current service state.
 
@@ -1141,12 +1165,12 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.1"
+.\build.ps1 -Version "3.1.2"
 ```
 
 Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
 
-Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before a pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
+Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before its corresponding Stable Release or Pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
 
 The interactive EXE installer provides Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese. The MSI retains a Taiwan Traditional Chinese base with tested en-US, zh-CN, and ja-JP transforms; see [installer localization](installer/LOCALIZATION.md).
 
@@ -1187,7 +1211,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.1 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.2 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
@@ -1399,7 +1423,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 ### 統合の検証状況
 
-> **公開 Preview の注意：** Microsoft、GitHub、Home Assistant の構造、権限境界、内部テストは実装済みです。`v2.1.0-rc.1` 時点で、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。これらは実験的 Preview であり、あらゆる環境で完全動作する保証ではありません。
+> **公開 Preview の注意：** Azure Speech は、以下に記載する実リソース検証を完了しています。Microsoft アカウント連携、GitHub、Home Assistant は構造、権限境界、内部テストを実装済みですが、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。実検証が完了していない部分は実験的 Preview であり、あらゆる環境で完全動作する保証はありません。
 
 - Azure Speech は本プロジェクトの実 Free F0 リソース、HTTPS 合成、RIFF 音声、Windows 再生検証を完了しました。各利用者は自身の Speech リソースを作成し、アカウント、割り当て、費用に責任を負う必要があります。
 - Microsoft アカウントの実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
@@ -1421,7 +1445,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-v3.1.1 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.1.2 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 
@@ -1441,6 +1465,14 @@ v3.1.1 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`
 | Realtime 即時音声 | `gpt-realtime-2.1-mini` |
 | 音声から文字 | `gpt-4o-mini-transcribe` |
 | OpenAI 文字から音声 | `gpt-4o-mini-tts` |
+
+#### Realtime 応答音声
+
+`v3.1.2` は OpenAI Realtime のネイティブ音声を完全に維持し、引き続き既定値とします。ネイティブモードでは Realtime が同じ経路で理解と音声出力を行うため、従来の音声を好む利用者や、これらの選択肢の中で追加遅延を最小にしたい利用者に適しています。
+
+利用者は「Realtime 即時理解＋通常 Azure Speech ストリーミング発話」または「Realtime 即時理解＋Azure Dragon HD ストリーミング発話」を明示的に選ぶこともできます。ハイブリッドモードは Realtime が生成した文字だけを選択中の Azure エンジンへ渡します。安全な短い句が完成するたび順番待ちへ追加し、完全な応答や音声ファイルを待たず、最初の音声断片から発話を始めます。ただし TTS の通信と合成工程が増えるため、発話前の待ち時間は長くなり得ます。本プロジェクトはゼロ遅延をうたいません。
+
+三つのモードは完全に分離し、同時に再生を管理する出力経路は一つだけです。音声を混合せず、通常の Windows 本機音声、OpenAI TTS、通常 Azure 読み上げ、その他の音声モデルも変更しません。Dragon HD が一つの句で失敗した場合は通常 Azure へ一度、続いて Windows 本機女性音声へ一度だけ代替し、通常 Azure が失敗した場合は Windows 本機女性音声へ一度だけ代替します。この代替は、その句の音声がまだ一切再生されていない場合に限ります。ストリーミング再生の開始後に失敗した場合は、重複発話と重複課金を避けるため、句全体を再生し直さず直ちに停止します。Azure の選択肢がネイティブ Realtime を置き換えることはありません。
 
 `v2.1.0-rc.1` から文字会話の既定値は `gpt-5.6-luna` で、設定一覧から `gpt-5.4-mini` を外しました。既存 mini 設定は Luna へ移行しますが、利用者が選んだ Terra、Sol、その他の独自モデルを上書きしません。実際の利用可否はアカウント、Project、地域、提供状況に依存します。
 
@@ -1532,12 +1564,12 @@ python app.py
 ```powershell
 python tools\audit_public_release.py
 python tests\run_all.py
-.\build.ps1 -Version "3.1.1"
+.\build.ps1 -Version "3.1.2"
 ```
 
 過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。
 
-受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければプレリリースを作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
+受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければ、対応する Stable Release または Pre-release を作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
 
 対話型 EXE インストーラーは台湾繁体字中国語、簡体字中国語、英語、日本語を提供します。MSI は台湾繁体字中国語を基底とし、検証済み en-US、zh-CN、ja-JP 変換を提供します。詳しくは[インストーラーのローカライズ](installer/LOCALIZATION.md)をご覧ください。
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台進度：** Windows 仍是唯一完成實機、完整回歸、安裝與發布驗證的平台。v3.1.2 的 macOS／Linux 版本具備安全的平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI，並提供可啟動、可切換四語但功能受限的 DMG／AppImage Preview；CI 不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+> **跨平台進度：** Windows 仍是唯一完成既有公開版本實機、完整回歸、安裝與發布驗證的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已納入安全平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI；實際產物仍須通過本版最終發布門檻，CI 也不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -248,7 +248,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-v3.1.2 另提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 預定提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`；這些產物必須先通過本版最終發布門檻。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
@@ -413,7 +413,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **跨平台进度：** Windows 仍是唯一完成真机、完整回归、安装与发布验证的平台。v3.1.2 的 macOS／Linux 版本具备安全的平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI，并提供可启动、可切换四语但功能受限的 DMG／AppImage Preview；CI 不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+> **跨平台进度：** Windows 仍是唯一完成现有公开版本真机、完整回归、安装与发布验证的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已纳入安全平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI；实际产物仍须通过本版本最终发布关卡，CI 也不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -647,7 +647,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-v3.1.2 另提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 计划提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`；这些产物必须先通过本版本最终发布关卡。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
@@ -812,7 +812,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Cross-platform status:** Windows remains the only platform validated through real-device use, the full regression suite, installation, and publication. The v3.1.2 macOS/Linux builds have safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen, and provide launchable, four-language, deliberately limited DMG/AppImage Previews. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+> **Cross-platform status:** Windows remains the only platform whose existing public releases have completed real-device use, the full regression suite, installation, and publication validation. The limited v3.1.2 macOS/Linux DMG/AppImage Previews include safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen; the actual artifacts must still pass this release's final publication gates. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -1046,7 +1046,7 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-v3.1.2 also provides separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`. These are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+v3.1.2 is planned to provide separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`; these artifacts must first pass this release's final publication gates. They are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
@@ -1211,7 +1211,7 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **クロスプラットフォーム状況：** 実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.2 の macOS／Linux 版には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI があり、起動と四言語切替が可能な機能限定 DMG／AppImage Preview も提供します。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+> **クロスプラットフォーム状況：** 既存の公開版について、実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.2 の macOS／Linux 機能限定 DMG／AppImage Preview には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI を導入していますが、実際の成果物は本版の最終公開ゲートに合格する必要があります。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 
@@ -1445,7 +1445,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-v3.1.2 は、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` も提供します。これらは機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.1.2 では、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` の提供を予定しており、これらの成果物は本版の最終公開ゲートに合格しなければなりません。いずれも機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需�
 
 尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
 
-v3.1.2 預定提供 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`；這些產物必須先通過本版最終發布門檻。它們是功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 的跨平台發行範圍包含 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`；每一項實際產物只有在通過本版完整發布門檻後才會公開。這些產物定位為功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
 
 #### 自動化發布邊界
 
@@ -647,7 +647,7 @@ Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要�
 
 尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
 
-v3.1.2 计划提供 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`；这些产物必须先通过本版本最终发布关卡。它们是功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
+v3.1.2 的跨平台发布范围包含 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`；每一项实际产物只有在通过本版本完整发布关卡后才会公开。这些产物定位为功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
 
 #### 自动化发布边界
 
@@ -1046,7 +1046,7 @@ General users do not need to install Python:
 
 Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
 
-v3.1.2 is planned to provide separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`; these artifacts must first pass this release's final publication gates. They are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
+The v3.1.2 cross-platform release scope covers separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`; each actual artifact is published only after it passes this release's complete publication gates. These artifacts are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
 
 #### Automated release boundary
 
@@ -1445,7 +1445,7 @@ Azure Speech は初期状態で無効な Preview 供給元で、利用者が明�
 
 署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
 
-v3.1.2 では、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` の提供を予定しており、これらの成果物は本版の最終公開ゲートに合格しなければなりません。いずれも機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
+v3.1.2 のクロスプラットフォーム公開範囲には、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` が含まれ、各成果物は本版の完全な公開ゲートに合格した場合にのみ公開されます。いずれも機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
 
 #### 自動リリースの境界
 

--- a/ai_client.py
+++ b/ai_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 lazy import json
 lazy import os
-lazy from dataclasses import dataclass
+lazy from dataclasses import dataclass, field
 lazy from urllib.error import HTTPError, URLError
 lazy from urllib.request import Request, urlopen
 
@@ -425,7 +425,7 @@ class AIWorkerRequest:
     user_text: str
     mode: str
     history: tuple[dict[str, str], ...] = ()
-    api_key: str = ""
+    api_key: str = field(default="", repr=False)
     memories: str = ""
     model: str = DEFAULT_TEXT_MODEL
     persona: str = PERSONA

--- a/ai_client.py
+++ b/ai_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 lazy import json
 lazy import os
 lazy from dataclasses import dataclass, field
+lazy from typing import NotRequired, TypedDict, Unpack
 lazy from urllib.error import HTTPError, URLError
 lazy from urllib.request import Request, urlopen
 
@@ -16,6 +17,8 @@ lazy from language_support import (
     is_simplified_chinese,
     response_language_instruction,
 )
+lazy from safe_error import sanitize_error
+lazy from service_status_localization import ServiceStatus, service_status
 
 DEFAULT_TEXT_MODEL = "gpt-5.6-luna"
 TEXT_MODELS = (
@@ -262,6 +265,13 @@ class ActionPlannerSignals(QObject):
     failed = Signal(str)
 
 
+class _ActionPlannerOptions(TypedDict):
+    api_key: str
+    model: str
+    available_targets: str
+    source: NotRequired[str]
+
+
 class ActionPlannerWorker(QRunnable):
     """Ask the model for a plan only; the model never executes local tools."""
 
@@ -269,23 +279,34 @@ class ActionPlannerWorker(QRunnable):
         self,
         instruction: str,
         *,
-        api_key: str,
-        model: str,
-        available_targets: str,
-        source: str = "local",
+        language: str = "zh-TW",
+        **options: Unpack[_ActionPlannerOptions],
     ):
         super().__init__()
         self.instruction = instruction
-        self.api_key = api_key
-        self.model = model or DEFAULT_TEXT_MODEL
-        self.available_targets = available_targets
-        self.source = source
+        self.api_key = options["api_key"]
+        self.model = options["model"] or DEFAULT_TEXT_MODEL
+        self.available_targets = options["available_targets"]
+        self.source = options.get("source", "local")
+        self.language = language
         self.signals = ActionPlannerSignals()
+
+    @property
+    def waiting_status(self) -> str:
+        return service_status(
+            self.language,
+            ServiceStatus.AI_PLANNING,
+        )
 
     def run(self) -> None:
         key = (self.api_key or os.getenv("OPENAI_API_KEY", "")).strip()
         if not key:
-            self.signals.failed.emit("尚未設定 OpenAI API 金鑰，無法理解自由語句工具任務")
+            self.signals.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.AI_PLANNER_KEY_MISSING,
+                )
+            )
             return
         schema = {
             "type": "object",
@@ -398,26 +419,44 @@ class ActionPlannerWorker(QRunnable):
                 and item.get("name") == "propose_action_plan"
             ]
             if len(calls) != 1:
-                raise ValueError("API 未傳回唯一的安全任務計畫")
+                raise ValueError(
+                    service_status(
+                        self.language,
+                        ServiceStatus.AI_PLAN_RESPONSE_MISSING,
+                    )
+                )
             arguments = calls[0].get("arguments", "")
             plan = json.loads(arguments)
             if not isinstance(plan, dict):
-                raise TypeError("任務計畫格式錯誤")
+                raise TypeError(
+                    service_status(
+                        self.language,
+                        ServiceStatus.AI_PLAN_FORMAT_INVALID,
+                    )
+                )
             for step in plan.get("steps", []):
                 if not isinstance(step, dict):
-                    raise TypeError("任務步驟格式錯誤")
+                    raise TypeError(
+                        service_status(
+                            self.language,
+                            ServiceStatus.AI_PLAN_STEP_INVALID,
+                        )
+                    )
                 raw_arguments = step.pop("arguments_json", "{}")
                 parsed_arguments = json.loads(raw_arguments)
                 if not isinstance(parsed_arguments, dict):
-                    raise TypeError("工具參數必須是 JSON 物件")
+                    raise TypeError(
+                        service_status(
+                            self.language,
+                            ServiceStatus.AI_PLAN_ARGUMENTS_INVALID,
+                        )
+                    )
                 step["arguments"] = parsed_arguments
             self.signals.done.emit(plan)
         except Exception as exc:  # noqa: BLE001 -- UI worker must always report failure
             # This worker is a UI task boundary. Socket timeouts and unexpected
             # response-shape errors must always release the "規劃中" state.
-            self.signals.failed.emit(
-                f"{type(exc).__name__}: {exc}"
-            )
+            self.signals.failed.emit(str(sanitize_error(exc)))
 
 
 @dataclass(frozen=True, slots=True)
@@ -518,7 +557,12 @@ class AIWorker(QRunnable):
                 ]
                 text = "".join(chunks).strip()
             if not text:
-                raise ValueError("API 沒有傳回文字")
+                raise ValueError(
+                    service_status(
+                        request_data.response_language,
+                        ServiceStatus.AI_RESPONSE_EMPTY,
+                    )
+                )
             self.signals.done.emit(text)
         except (URLError, HTTPError, ValueError) as exc:
-            self.signals.failed.emit(str(exc))
+            self.signals.failed.emit(str(sanitize_error(exc)))

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ lazy from collections.abc import Iterable
 lazy from contextlib import suppress
 lazy from ctypes import wintypes
 lazy from dataclasses import dataclass
+lazy from dataclasses import field as dataclass_field
 lazy from datetime import datetime
 lazy from datetime import time as clock_time
 lazy from pathlib import Path
@@ -153,6 +154,14 @@ lazy from lip_sync import (
 lazy from platform_contracts import PlatformCapabilities, PlatformServicePort
 lazy from platform_services import current_platform_services, resolved_data_dir
 lazy from profile_transfer_ui import PortableProfilePanel
+lazy from realtime_speech_output import (
+    REALTIME_OUTPUT_AZURE,
+    REALTIME_OUTPUT_AZURE_HD,
+    REALTIME_OUTPUT_OPENAI,
+    AzureRealtimeVoice,
+    LocalRealtimeVoice,
+    RealtimeSpeechOutputConfig,
+)
 lazy from realtime_voice import (
     RealtimeSessionConfig,
     RealtimeVoiceClient,
@@ -223,10 +232,10 @@ class QueuedSpeech:
 
 @dataclass(frozen=True, slots=True)
 class SpeechCredentials:
-    openai_api_key: str
-    azure_api_key: str
+    openai_api_key: str = dataclass_field(repr=False)
+    azure_api_key: str = dataclass_field(repr=False)
     azure_region: str
-    azure_hd_api_key: str
+    azure_hd_api_key: str = dataclass_field(repr=False)
     azure_hd_region: str
 
 
@@ -1884,6 +1893,8 @@ class Dashboard(QDialog):
     voice_preview_requested = Signal()
     realtime_toggle_requested = Signal(bool)
     realtime_voice_changed = Signal(str)
+    realtime_output_mode_changed = Signal(str)
+    realtime_output_settings_changed = Signal()
     state_requested = Signal(str)
     ai_wait_expression_requested = Signal(int, str, float)
     ai_wait_expression_finished = Signal(int)
@@ -3350,6 +3361,14 @@ class Dashboard(QDialog):
         self.azure_clear_key.setEnabled(secure_storage)
 
     def _initialize_realtime_controls(self) -> None:
+        self.realtime_output_mode = self._realtime_output_mode_combo()
+        self.realtime_output_mode_note = self._voice_note("")
+        self._apply_realtime_output_mode_state(
+            str(
+                self.realtime_output_mode.currentData()
+                or REALTIME_OUTPUT_OPENAI
+            )
+        )
         self.realtime_model = self._editable_combo(
             ("gpt-realtime-2.1-mini", "gpt-realtime-2.1"),
             str(
@@ -3378,6 +3397,65 @@ class Dashboard(QDialog):
         self.realtime_hybrid_transcription = (
             self._realtime_hybrid_transcription_checkbox()
         )
+
+    def _realtime_output_mode_combo(self) -> QComboBox:
+        combo = QComboBox()
+        combo.addItem(
+            self._t(
+                "realtime_output_openai",
+                "OpenAI Realtime 原生語音（最低延遲，既有預設）",
+            ),
+            REALTIME_OUTPUT_OPENAI,
+        )
+        combo.addItem(
+            self._t(
+                "realtime_output_azure",
+                "Azure Speech 女性聲線（柔和串流）",
+            ),
+            REALTIME_OUTPUT_AZURE,
+        )
+        combo.addItem(
+            self._t(
+                "realtime_output_azure_hd",
+                "Azure Dragon HD 女性聲線（需 S0）",
+            ),
+            REALTIME_OUTPUT_AZURE_HD,
+        )
+        self._select_combo_data(
+            combo,
+            str(
+                self.db.setting(
+                    "realtime_output_mode",
+                    REALTIME_OUTPUT_OPENAI,
+                )
+            ),
+        )
+        return combo
+
+    def _apply_realtime_output_mode_state(self, mode: str) -> None:
+        native_output = mode == REALTIME_OUTPUT_OPENAI
+        self.realtime_voice.setEnabled(native_output)
+        if mode == REALTIME_OUTPUT_AZURE:
+            note = self._t(
+                "realtime_output_note_azure",
+                "沿用上方「Azure Speech 女性聲線」、區域與金鑰。"
+                "OpenAI Realtime 負責即時理解，Azure 以串流方式發聲。",
+            )
+        elif mode == REALTIME_OUTPUT_AZURE_HD:
+            note = self._t(
+                "realtime_output_note_azure_hd",
+                "沿用上方「Dragon HD 女性聲線」、S0 區域與獨立金鑰。"
+                "OpenAI Realtime 負責即時理解，Dragon HD 以串流方式發聲。",
+            )
+        else:
+            note = self._t(
+                "realtime_output_note_openai",
+                "使用下方「OpenAI Realtime 原生聲線」；延遲最低，"
+                "完整保留 OpenAI Realtime 的原生即時語音輸出。",
+            )
+        self.realtime_output_mode_note.setText(note)
+        self.realtime_output_mode.setToolTip(note)
+        self.realtime_voice.setToolTip(note)
 
     def _realtime_noise_reduction_combo(self) -> QComboBox:
         combo = QComboBox()
@@ -3492,6 +3570,7 @@ class Dashboard(QDialog):
         self.voice_rate_up.setFixedWidth(48)
         self.voice_rate_down.clicked.connect(self.voice_rate.stepDown)
         self.voice_rate_up.clicked.connect(self.voice_rate.stepUp)
+        self.voice_rate.valueChanged.connect(self._voice_rate_changed)
         layout.addWidget(self.voice_rate_down)
         layout.addWidget(self.voice_rate, 1)
         layout.addWidget(self.voice_rate_up)
@@ -3752,7 +3831,15 @@ class Dashboard(QDialog):
 
     def _add_realtime_rows(self, form: QFormLayout) -> None:
         form.addRow(
-            self._t("realtime_voice", "Realtime 對話聲音"),
+            self._t(
+                "realtime_output_source",
+                "Realtime 回覆聲音來源",
+            ),
+            self.realtime_output_mode,
+        )
+        form.addRow("", self.realtime_output_mode_note)
+        form.addRow(
+            self._t("realtime_voice", "OpenAI Realtime 原生聲線"),
             self.realtime_voice,
         )
         form.addRow(
@@ -3854,6 +3941,9 @@ class Dashboard(QDialog):
         )
         self.realtime_voice.currentTextChanged.connect(
             self._realtime_voice_changed
+        )
+        self.realtime_output_mode.currentIndexChanged.connect(
+            self._realtime_output_mode_index_changed
         )
         return tab
 
@@ -5662,6 +5752,11 @@ class Dashboard(QDialog):
         self.db.set_setting(
             "windows_voice", str(self.windows_voice.currentData() or "")
         )
+        self.realtime_output_settings_changed.emit()
+
+    def _voice_rate_changed(self, rate: int) -> None:
+        self.db.set_setting("voice_rate", rate)
+        self.realtime_output_settings_changed.emit()
 
     def _openai_voice_changed(self, voice: str) -> None:
         selected_voice = voice.strip()
@@ -5675,10 +5770,12 @@ class Dashboard(QDialog):
         if not selected_voice:
             return
         self.db.set_setting("azure_speech_voice", selected_voice)
+        self.realtime_output_settings_changed.emit()
 
     def _azure_region_changed(self, _index: int) -> None:
         region = str(self.azure_region.currentData() or "")
         self.db.set_setting("azure_speech_region", region)
+        self.realtime_output_settings_changed.emit()
         self._request_azure_voice_catalog(hd_only=False)
 
     def _azure_hd_voice_changed(self, voice: str) -> None:
@@ -5686,6 +5783,7 @@ class Dashboard(QDialog):
         if not selected_voice:
             return
         self.db.set_setting("azure_hd_speech_voice", selected_voice)
+        self.realtime_output_settings_changed.emit()
 
     def _azure_hd_region_changed(self, _index: int) -> None:
         region = str(self.azure_hd_region.currentData() or "")
@@ -5740,6 +5838,8 @@ class Dashboard(QDialog):
         combo.setCurrentText(selected_voice)
         combo.blockSignals(False)
         self.db.set_setting(setting_key, selected_voice)
+        if selected_voice != current_voice:
+            self.realtime_output_settings_changed.emit()
 
     def _refresh_azure_hd_voice_options(self, region: str) -> None:
         voices = azure_hd_female_voices(
@@ -5754,6 +5854,7 @@ class Dashboard(QDialog):
         self.azure_hd_voice.setCurrentText(selected_voice)
         self.azure_hd_voice.blockSignals(False)
         self.db.set_setting("azure_hd_speech_voice", selected_voice)
+        self.realtime_output_settings_changed.emit()
 
     def _realtime_voice_changed(self, voice: str) -> None:
         selected_voice = voice.strip()
@@ -5761,6 +5862,15 @@ class Dashboard(QDialog):
             return
         self.db.set_setting("realtime_voice", selected_voice)
         self.realtime_voice_changed.emit(selected_voice)
+
+    def _realtime_output_mode_index_changed(self, _index: int) -> None:
+        mode = str(
+            self.realtime_output_mode.currentData()
+            or REALTIME_OUTPUT_OPENAI
+        )
+        self.db.set_setting("realtime_output_mode", mode)
+        self._apply_realtime_output_mode_state(mode)
+        self.realtime_output_mode_changed.emit(mode)
 
     def clear_azure_speech_key(self) -> None:
         if self.azure_secret_store is None:
@@ -5783,6 +5893,7 @@ class Dashboard(QDialog):
                     "貼上 Azure Speech 資源金鑰",
                 )
             )
+            self.realtime_output_settings_changed.emit()
 
     def clear_azure_hd_speech_key(self) -> None:
         if self.azure_hd_secret_store is None:
@@ -5806,6 +5917,7 @@ class Dashboard(QDialog):
                     "貼上獨立的 Dragon HD S0 資源金鑰",
                 )
             )
+            self.realtime_output_settings_changed.emit()
 
     def _update_voice_volume_label(self) -> None:
         self.voice_volume_label.setText(f"{self.voice_volume.value()}%")
@@ -5868,6 +5980,13 @@ class Dashboard(QDialog):
         self.db.set_setting("cloud_voice", self.tts_voice.currentText())
         self.db.set_setting("realtime_voice", self.realtime_voice.currentText())
         self.db.set_setting(
+            "realtime_output_mode",
+            str(
+                self.realtime_output_mode.currentData()
+                or REALTIME_OUTPUT_OPENAI
+            ),
+        )
+        self.db.set_setting(
             "azure_speech_voice",
             self.azure_voice.currentText(),
         )
@@ -5922,6 +6041,7 @@ class Dashboard(QDialog):
 
     def _save_azure_key_immediately(self) -> None:
         if self._persist_azure_key(silent=False):
+            self.realtime_output_settings_changed.emit()
             invalidate = getattr(
                 self.azure_tts,
                 "invalidate_voice_catalog",
@@ -5935,6 +6055,7 @@ class Dashboard(QDialog):
 
     def _save_azure_hd_key_immediately(self) -> None:
         if self._persist_azure_hd_key(silent=False):
+            self.realtime_output_settings_changed.emit()
             invalidate = getattr(
                 self.azure_hd_tts,
                 "invalidate_voice_catalog",
@@ -5946,16 +6067,16 @@ class Dashboard(QDialog):
                 )
             self._request_azure_voice_catalog(hd_only=True)
 
-    def _persist_azure_key(self, *, silent: bool) -> None:
-        self._persist_secret_input(
+    def _persist_azure_key(self, *, silent: bool) -> bool:
+        return self._persist_secret_input(
             self.azure_key_input,
             self.azure_secret_store,
             AZURE_SECRET_POLICY,
             silent=silent,
         )
 
-    def _persist_azure_hd_key(self, *, silent: bool) -> None:
-        self._persist_secret_input(
+    def _persist_azure_hd_key(self, *, silent: bool) -> bool:
+        return self._persist_secret_input(
             self.azure_hd_key_input,
             self.azure_hd_secret_store,
             AZURE_HD_SECRET_POLICY,
@@ -5994,7 +6115,13 @@ class Dashboard(QDialog):
         return True
 
     def set_realtime_status(self, status: str, active: bool | None = None) -> None:
-        self.realtime_status.setText(f"Realtime：{status}")
+        self.realtime_status.setText(
+            self._t(
+                "realtime_status_format",
+                "Realtime：{status}",
+                status=status,
+            )
+        )
         if active is not None:
             self.realtime_btn.blockSignals(True)
             self.realtime_btn.setChecked(active)
@@ -6453,6 +6580,7 @@ class CompanionWindow(QMainWindow):
             )
         )
         self.realtime = services.realtime
+        self.realtime_speech_output = services.realtime_speech_output
         self.listener = services.listener
 
     def _run_first_run_wizard_if_needed(
@@ -6495,6 +6623,12 @@ class CompanionWindow(QMainWindow):
         )
         self.dashboard.realtime_voice_changed.connect(
             self._apply_realtime_voice_change
+        )
+        self.dashboard.realtime_output_mode_changed.connect(
+            self._apply_realtime_voice_change
+        )
+        self.dashboard.realtime_output_settings_changed.connect(
+            self._refresh_realtime_output_settings
         )
         self.dashboard.volume_changed.connect(self._apply_voice_volume)
         self.dashboard.visibility_changed.connect(
@@ -6553,6 +6687,34 @@ class CompanionWindow(QMainWindow):
         )
         self.realtime.viseme_cue.connect(self._audio_viseme_cue)
         self.realtime.failed.connect(self._realtime_failed)
+        if self.realtime_speech_output is not None:
+            self.realtime.output_text_started.connect(
+                self.realtime_speech_output.begin_response
+            )
+            self.realtime.output_text_delta.connect(
+                self.realtime_speech_output.add_text
+            )
+            self.realtime.output_text_done.connect(
+                self.realtime_speech_output.finish_response
+            )
+            self.realtime.output_interrupted.connect(
+                self.realtime_speech_output.cancel
+            )
+            self.realtime_speech_output.speaking_changed.connect(
+                self._realtime_speaking
+            )
+            self.realtime_speech_output.playback_guard_changed.connect(
+                self.realtime.set_external_playback_active
+            )
+            self.realtime_speech_output.viseme_cue.connect(
+                self._audio_viseme_cue
+            )
+            self.realtime_speech_output.status_changed.connect(
+                self._realtime_status
+            )
+            self.realtime_speech_output.failed.connect(
+                self._realtime_failed
+            )
 
     def _initialize_companion_state(self, startup_speech: bool) -> None:
         self.state = "idle"
@@ -9899,7 +10061,8 @@ class CompanionWindow(QMainWindow):
                     credentials.azure_hd_region
                     if provider_id == VOICE_ENGINE_AZURE_HD
                     else credentials.azure_region
-                )
+                ),
+                "locale": str(self.db.setting("ui_language", "zh-TW")),
             },
         )
         self.speech_providers.provider(provider_id).speak(request)
@@ -10002,6 +10165,8 @@ class CompanionWindow(QMainWindow):
             engines.append(self.azure_tts)
         if self.azure_hd_tts is not None:
             engines.append(self.azure_hd_tts)
+        if self.realtime_speech_output is not None:
+            engines.append(self.realtime_speech_output)
         for engine in engines:
             engine.set_volume(volume_percent, muted)
 
@@ -10042,10 +10207,55 @@ class CompanionWindow(QMainWindow):
             lines.append(f"{labels[role]}：{normalized}")
         return "\n".join(lines)[-5000:]
 
+    def _configure_realtime_speech_output(self, mode: str) -> None:
+        output = self.realtime_speech_output
+        if output is None:
+            if mode == REALTIME_OUTPUT_OPENAI:
+                return
+            raise RuntimeError(
+                ui_text(
+                    profile_setting(self.db, "ui_language"),
+                    "realtime_output_unavailable",
+                    "Realtime Azure 語音輸出服務尚未建立，未啟動即時對話。",
+                )
+            )
+        credentials = self._speech_credentials()
+        output.configure(
+            RealtimeSpeechOutputConfig(
+                mode=mode,
+                locale=profile_setting(self.db, "ui_language"),
+                azure=AzureRealtimeVoice(
+                    credentials.azure_api_key,
+                    credentials.azure_region,
+                    str(self.db.setting("azure_speech_voice", "")),
+                ),
+                azure_hd=AzureRealtimeVoice(
+                    credentials.azure_hd_api_key,
+                    credentials.azure_hd_region,
+                    str(self.db.setting("azure_hd_speech_voice", "")),
+                ),
+                local=LocalRealtimeVoice(
+                    available=bool(
+                        self.platform_services.capabilities.system_local_speech
+                        and self.db.setting("windows_voice", "")
+                    ),
+                    voice=str(self.db.setting("windows_voice", "")),
+                    rate=int(self.db.setting("voice_rate", -1)),
+                ),
+            )
+        )
+
     def toggle_realtime(self, enabled: bool) -> None:
         if not enabled:
-            self.realtime.stop()
-            self.dashboard.set_realtime_status("未連線", False)
+            self._stop_realtime_output()
+            self.dashboard.set_realtime_status(
+                ui_text(
+                    profile_setting(self.db, "ui_language"),
+                    "realtime_disconnected_status",
+                    "未連線",
+                ),
+                False,
+            )
             return
         self.dashboard.cancel_ai_wait_expression()
         self.dashboard.save_voice_settings(silent=True)
@@ -10061,6 +10271,35 @@ class CompanionWindow(QMainWindow):
                 SpeechListener.TRANSCRIPTION_PROMPT,
             )
         )
+        output_mode = str(
+            self.db.setting(
+                "realtime_output_mode",
+                REALTIME_OUTPUT_OPENAI,
+            )
+        )
+        try:
+            self._configure_realtime_speech_output(output_mode)
+        except (RuntimeError, ValueError) as exc:
+            language = profile_setting(self.db, "ui_language")
+            self.dashboard.set_realtime_status(
+                ui_text(
+                    language,
+                    "realtime_error_status",
+                    "錯誤：{error}",
+                    error=exc,
+                ),
+                False,
+            )
+            QMessageBox.warning(
+                self.dashboard,
+                ui_text(
+                    language,
+                    "realtime_voice_title",
+                    "Realtime 語音",
+                ),
+                str(exc),
+            )
+            return
         self.realtime.start(
             RealtimeVoiceRequest(
                 api_key=self.secret_store.load(),
@@ -10128,6 +10367,10 @@ class CompanionWindow(QMainWindow):
                             True,
                         )
                     ),
+                    output_mode=str(
+                        output_mode
+                    ),
+                    locale=profile_setting(self.db, "ui_language"),
                 ),
             ),
         )
@@ -10138,9 +10381,17 @@ class CompanionWindow(QMainWindow):
         self.toggle_realtime(False)
         self.toggle_realtime(True)
 
+    def _refresh_realtime_output_settings(self) -> None:
+        if not self.realtime.running:
+            return
+        mode = str(
+            self.db.setting("realtime_output_mode", REALTIME_OUTPUT_OPENAI)
+        )
+        if mode != REALTIME_OUTPUT_OPENAI:
+            self._configure_realtime_speech_output(mode)
+
     def _realtime_status(self, status: str) -> None:
-        active = self.realtime.running and status != "未連線"
-        self.dashboard.set_realtime_status(status, active)
+        self.dashboard.set_realtime_status(status, self.realtime.running)
 
     def _realtime_user_text(self, text: str) -> None:
         text = normalize_for_language(
@@ -10326,9 +10577,31 @@ class CompanionWindow(QMainWindow):
             )
 
     def _realtime_failed(self, message: str) -> None:
-        self.dashboard.set_realtime_status(f"錯誤：{message[:90]}", False)
-        self.realtime.stop()
-        QMessageBox.warning(self.dashboard, "Realtime 語音", message)
+        language = profile_setting(self.db, "ui_language")
+        self._stop_realtime_output()
+        self.dashboard.set_realtime_status(
+            ui_text(
+                language,
+                "realtime_error_status",
+                "錯誤：{error}",
+                error=message[:90],
+            ),
+            False,
+        )
+        QMessageBox.warning(
+            self.dashboard,
+            ui_text(
+                language,
+                "realtime_voice_title",
+                "Realtime 語音",
+            ),
+            message,
+        )
+
+    def _stop_realtime_output(self) -> None:
+        barrier = self.realtime.stop()
+        if self.realtime_speech_output is not None:
+            self.realtime_speech_output.cancel(barrier)
 
     def _cloud_voice_failed(self, message: str) -> None:
         self._online_voice_failed(
@@ -10420,7 +10693,10 @@ class CompanionWindow(QMainWindow):
                             credentials.azure_region
                             if fallback_provider_id == VOICE_ENGINE_AZURE
                             else ""
-                        )
+                        ),
+                        "locale": str(
+                            self.db.setting("ui_language", "zh-TW")
+                        ),
                     },
                 )
             )
@@ -10799,7 +11075,7 @@ class CompanionWindow(QMainWindow):
             animation = getattr(self, animation_name, None)
             if animation is not None:
                 animation.stop()
-        self.realtime.stop()
+        self._stop_realtime_output()
         for timer_name in (
             "idle_timer",
             "pose_timer",

--- a/app.py
+++ b/app.py
@@ -96,6 +96,7 @@ lazy from ai_client import (
     AIWorker,
     AIWorkerRequest,
 )
+lazy from safe_error_localization import safe_error_message
 lazy from azure_regions import (
     azure_region_identifiers,
     azure_region_options,
@@ -168,6 +169,13 @@ lazy from realtime_voice import (
     RealtimeVoiceRequest,
 )
 lazy from service_container import CompanionServices, create_default_services
+lazy from settings_ui_localization import (
+    PHYSICS_TEXT_KEYS,
+    PROACTIVE_MODE_KEYS,
+    TOPMOST_MODE_KEYS,
+    SettingsText,
+    settings_text,
+)
 lazy from speech import (
     SpeechListener,
     female_windows_voices_for_language,
@@ -188,15 +196,21 @@ lazy from speech_providers import (
 lazy from text_normalizer import to_taiwan_traditional
 lazy from time_utils import local_wall_time
 lazy from ui_localization import (
+    MEMORY_CATEGORY_LABELS,
     MODE_LABELS,
+    PLATFORM_STATUS_LABELS,
+    SIMPLIFIED_MEMORY_CATEGORY_LABELS,
     SIMPLIFIED_MODE_LABELS,
+    SIMPLIFIED_PLATFORM_STATUS_LABELS,
     SIMPLIFIED_WORK_TYPE_LABELS,
     WORK_TYPE_LABELS,
     display_label,
     ui_text,
 )
 lazy from ui_localization_ja import (
+    JAPANESE_MEMORY_CATEGORY_LABELS,
     JAPANESE_MODE_LABELS,
+    JAPANESE_PLATFORM_STATUS_LABELS,
     JAPANESE_WORK_TYPE_LABELS,
 )
 lazy from updater_ui import UpdatePanel
@@ -372,6 +386,16 @@ MEMORY_CATEGORIES = (
     "工作流程",
     "重要日期",
     "其他",
+)
+
+TODO_CATEGORIES = (
+    ("漫畫", "todo_category_comic"),
+    ("文章", "todo_category_article"),
+    ("音樂", "todo_category_music"),
+    ("貼圖", "todo_category_stickers"),
+    ("出版", "todo_category_publishing"),
+    ("行政", "todo_category_administration"),
+    ("其他", "todo_category_other"),
 )
 
 EMERGENCY_COMMANDS = frozenset(
@@ -711,6 +735,8 @@ MOUTH_CLOSE_DEADLINE_MS = max(
     110,
     math.ceil(VISEME_CLOSE_TRANSITION_SECONDS * 1000) + 32,
 )
+MOTION_FRAME_INTERVAL_MS = 16
+SPEECH_MOTION_RELEASE_LIMIT = 12
 PLATFORM_STATUSES = (
     "尚未開始",
     "準備資料",
@@ -768,6 +794,26 @@ def combo_data_or_custom_text(combo: QComboBox, fallback: str = "") -> str:
     if index >= 0 and text == combo.itemText(index).strip():
         return str(combo.itemData(index) or text or fallback)
     return text or fallback
+
+
+def platform_status_label(language: str, value: str) -> str:
+    return display_label(
+        language,
+        value,
+        PLATFORM_STATUS_LABELS,
+        SIMPLIFIED_PLATFORM_STATUS_LABELS,
+        JAPANESE_PLATFORM_STATUS_LABELS,
+    )
+
+
+def memory_category_label(language: str, value: str) -> str:
+    return display_label(
+        language,
+        value,
+        MEMORY_CATEGORY_LABELS,
+        SIMPLIFIED_MEMORY_CATEGORY_LABELS,
+        JAPANESE_MEMORY_CATEGORY_LABELS,
+    )
 
 VOICE_GENERATION_PROMPT = (
     "請使用台灣繁體中文，以自然的台灣中文口音說話。"
@@ -1182,7 +1228,7 @@ class ZoomTextBrowser(QTextBrowser):
 class TodoRow(QFrame):
     changed = Signal()
 
-    def __init__(self, db: StudioDB, todo):
+    def __init__(self, db: StudioDB, todo, language: str = "zh-TW"):
         super().__init__()
         self.setObjectName("todoCard")
         # A task card should keep its content height.  Letting QVBoxLayout
@@ -1191,21 +1237,36 @@ class TodoRow(QFrame):
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.db = db
         self.todo_id = int(todo["id"])
+        self.language = language
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 9, 10, 9)
         layout.setSpacing(10)
         done = QCheckBox()
-        done.setToolTip("標記為已完成")
+        done.setToolTip(
+            ui_text(language, "todo_complete_tooltip", "標記為已完成")
+        )
         done.setChecked(todo["status"] == "完成")
         text_column = QVBoxLayout()
         text_column.setSpacing(2)
-        title = QLabel(to_taiwan_traditional(str(todo["title"])))
+        title = QLabel(str(todo["title"]))
         title.setObjectName("todoTitle")
         title.setWordWrap(True)
-        category = QLabel(f"{todo['category']} · 今日待辦")
+        category_value = str(todo["category"])
+        category_key = dict(TODO_CATEGORIES).get(category_value)
+        category_label = (
+            ui_text(language, category_key, category_value)
+            if category_key is not None
+            else category_value
+        )
+        category = QLabel(
+            f"{category_label} · "
+            f"{ui_text(language, 'todo_category_suffix', '今日待辦')}"
+        )
         category.setObjectName("todoCategory")
-        delete = QPushButton("刪除")
-        delete.setToolTip("刪除這筆待辦")
+        delete = QPushButton(ui_text(language, "delete", "刪除"))
+        delete.setToolTip(
+            ui_text(language, "delete_todo_tooltip", "刪除這筆待辦")
+        )
         delete.setFixedWidth(64)
         done.toggled.connect(self._toggle)
         delete.clicked.connect(self._delete)
@@ -1225,25 +1286,51 @@ class TodoRow(QFrame):
 
 
 class IdeaEditorDialog(QDialog):
-    def __init__(self, title: str, content: str, parent=None):
+    def __init__(
+        self,
+        title: str,
+        content: str,
+        parent=None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
-        self.setWindowTitle("編輯創作靈感")
+        self.language = language
+        self.setWindowTitle(
+            ui_text(language, "idea_editor_title", "編輯創作靈感")
+        )
         self.setMinimumSize(560, 420)
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("<b>靈感標題</b>"))
-        self.title_input = QLineEdit(to_taiwan_traditional(title))
-        self.title_input.setPlaceholderText("替這則靈感取一個清楚的標題")
+        layout.addWidget(
+            QLabel(ui_text(language, "idea_title", "<b>靈感標題</b>"))
+        )
+        self.title_input = QLineEdit(str(title))
+        self.title_input.setPlaceholderText(
+            ui_text(
+                language,
+                "idea_title_placeholder",
+                "替這則靈感取一個清楚的標題",
+            )
+        )
         layout.addWidget(self.title_input)
-        layout.addWidget(QLabel("<b>靈感內文</b>"))
+        layout.addWidget(
+            QLabel(ui_text(language, "idea_content", "<b>靈感內文</b>"))
+        )
         self.content_input = QTextEdit()
-        self.content_input.setPlainText(to_taiwan_traditional(content))
+        self.content_input.setPlainText(
+            str(content)
+        )
         self.content_input.setPlaceholderText(
-            "記下情節、畫面、台詞、音樂方向或後續可執行的想法……"
+            ui_text(
+                language,
+                "idea_content_placeholder",
+                "記下情節、畫面、台詞、音樂方向或後續可執行的想法……",
+            )
         )
         layout.addWidget(self.content_input, 1)
         buttons = QHBoxLayout()
-        cancel = QPushButton("取消")
-        save = QPushButton("保存靈感")
+        cancel = QPushButton(ui_text(language, "cancel", "取消"))
+        save = QPushButton(ui_text(language, "save_idea", "保存靈感"))
         buttons.addStretch()
         buttons.addWidget(cancel)
         buttons.addWidget(save)
@@ -1253,44 +1340,154 @@ class IdeaEditorDialog(QDialog):
 
     def _save(self) -> None:
         if not self.title_input.text().strip():
-            QMessageBox.information(self, "尚無標題", "請先填寫靈感標題。")
+            QMessageBox.information(
+                self,
+                ui_text(
+                    self.language,
+                    "idea_title_required_title",
+                    "尚無標題",
+                ),
+                ui_text(
+                    self.language,
+                    "idea_title_required",
+                    "請先填寫靈感標題。",
+                ),
+            )
             self.title_input.setFocus()
             return
         self.accept()
 
     def values(self) -> tuple[str, str]:
         return (
-            to_taiwan_traditional(self.title_input.text().strip()),
-            to_taiwan_traditional(self.content_input.toPlainText().strip()),
+            self.title_input.text().strip(),
+            self.content_input.toPlainText().strip(),
         )
 
 
 class MemoryEditorDialog(QDialog):
-    def __init__(self, memory, parent=None):
+    def __init__(
+        self,
+        memory,
+        parent=None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
-        self.setWindowTitle("編輯長期記憶")
+        self.language = language
+        self.setWindowTitle(
+            ui_text(language, "memory_editor_title", "編輯長期記憶")
+        )
         self.setMinimumSize(620, 500)
         self.setStyleSheet(STYLE)
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("<b>記憶標題</b>"))
-        self.title_input = QLineEdit(
-            to_taiwan_traditional(str(memory["title"] or ""))
+        layout.addWidget(
+            QLabel(
+                ui_text(language, "memory_title_label", "<b>記憶標題</b>")
+            )
         )
-        self.title_input.setPlaceholderText("用一句短標題辨識這則記憶")
+        self.title_input = QLineEdit(
+            str(memory["title"] or "")
+        )
+        self.title_input.setPlaceholderText(
+            ui_text(
+                language,
+                "memory_title_placeholder",
+                "用一句短標題辨識這則記憶",
+            )
+        )
         layout.addWidget(self.title_input)
+        layout.addLayout(self._details_row(memory))
 
+        layout.addWidget(
+            QLabel(
+                ui_text(language, "memory_content_label", "<b>記憶內容</b>")
+            )
+        )
+        self.content_input = QTextEdit()
+        self.content_input.setPlainText(
+            str(memory["content"] or "")
+        )
+        self.content_input.setPlaceholderText(
+            ui_text(
+                language,
+                "memory_content_placeholder",
+                "完整記錄人物背景、偏好、目標、工作流程或重要日期……",
+            )
+        )
+        layout.addWidget(self.content_input, 1)
+        source_labels = {
+            "manual": ui_text(
+                language, "memory_source_manual", "手動建立"
+            ),
+            "conversation": ui_text(
+                language,
+                "memory_source_conversation",
+                "由對話明確記住",
+            ),
+        }
+        source = source_labels.get(
+            str(memory["source"]), str(memory["source"])
+        )
+        meta = QLabel(
+            ui_text(
+                language,
+                "memory_metadata",
+                "來源：{source}　建立：{created}　更新：{updated}",
+                source=source,
+                created=str(memory["created_at"])[:16],
+                updated=str(memory["updated_at"])[:16],
+            )
+        )
+        meta.setStyleSheet("color:#4c6b82;")
+        layout.addWidget(meta)
+        buttons = QHBoxLayout()
+        cancel = QPushButton(ui_text(language, "cancel", "取消"))
+        save = QPushButton(ui_text(language, "save_memory", "保存記憶"))
+        buttons.addStretch()
+        buttons.addWidget(cancel)
+        buttons.addWidget(save)
+        layout.addLayout(buttons)
+        cancel.clicked.connect(self.reject)
+        save.clicked.connect(self._save)
+
+    def _details_row(self, memory) -> QHBoxLayout:
         details = QHBoxLayout()
         category_box = QVBoxLayout()
-        category_box.addWidget(QLabel("<b>類別</b>"))
+        category_box.addWidget(
+            QLabel(
+                ui_text(
+                    self.language,
+                    "memory_category_label",
+                    "<b>類別</b>",
+                )
+            )
+        )
         self.category_input = QComboBox()
-        self.category_input.addItems(MEMORY_CATEGORIES)
+        for category in MEMORY_CATEGORIES:
+            self.category_input.addItem(
+                memory_category_label(self.language, category), category
+            )
         current_category = to_taiwan_traditional(str(memory["category"]))
-        if self.category_input.findText(current_category) < 0:
-            self.category_input.addItem(current_category)
-        self.category_input.setCurrentText(current_category)
+        current_index = self.category_input.findData(current_category)
+        if current_index < 0:
+            self.category_input.addItem(
+                current_category,
+                current_category,
+            )
+            current_index = self.category_input.count() - 1
+        self.category_input.setCurrentIndex(current_index)
         category_box.addWidget(self.category_input)
+
         importance_box = QVBoxLayout()
-        importance_box.addWidget(QLabel("<b>重要度</b>"))
+        importance_box.addWidget(
+            QLabel(
+                ui_text(
+                    self.language,
+                    "memory_importance_label",
+                    "<b>重要度</b>",
+                )
+            )
+        )
         self.importance_input = QSpinBox()
         self.importance_input.setRange(1, 5)
         self.importance_input.setValue(int(memory["importance"]))
@@ -1298,72 +1495,81 @@ class MemoryEditorDialog(QDialog):
         importance_box.addWidget(self.importance_input)
         details.addLayout(category_box, 1)
         details.addLayout(importance_box, 1)
-        layout.addLayout(details)
-
-        layout.addWidget(QLabel("<b>記憶內容</b>"))
-        self.content_input = QTextEdit()
-        self.content_input.setPlainText(
-            to_taiwan_traditional(str(memory["content"] or ""))
-        )
-        self.content_input.setPlaceholderText(
-            "完整記錄人物背景、偏好、目標、工作流程或重要日期……"
-        )
-        layout.addWidget(self.content_input, 1)
-        source_labels = {
-            "manual": "手動建立",
-            "conversation": "由對話明確記住",
-        }
-        source = source_labels.get(
-            str(memory["source"]), str(memory["source"])
-        )
-        meta = QLabel(
-            f"來源：{source}　建立：{str(memory['created_at'])[:16]}　"
-            f"更新：{str(memory['updated_at'])[:16]}"
-        )
-        meta.setStyleSheet("color:#4c6b82;")
-        layout.addWidget(meta)
-        buttons = QHBoxLayout()
-        cancel = QPushButton("取消")
-        save = QPushButton("保存記憶")
-        buttons.addStretch()
-        buttons.addWidget(cancel)
-        buttons.addWidget(save)
-        layout.addLayout(buttons)
-        cancel.clicked.connect(self.reject)
-        save.clicked.connect(self._save)
+        return details
 
     def _save(self) -> None:
         if not self.title_input.text().strip():
-            QMessageBox.information(self, "尚無標題", "請先填寫記憶標題。")
+            QMessageBox.information(
+                self,
+                ui_text(
+                    self.language,
+                    "memory_title_required_title",
+                    "尚無標題",
+                ),
+                ui_text(
+                    self.language,
+                    "memory_title_required",
+                    "請先填寫記憶標題。",
+                ),
+            )
             self.title_input.setFocus()
             return
         if not self.content_input.toPlainText().strip():
-            QMessageBox.information(self, "尚無內容", "請先填寫記憶內容。")
+            QMessageBox.information(
+                self,
+                ui_text(
+                    self.language,
+                    "memory_content_required_title",
+                    "尚無內容",
+                ),
+                ui_text(
+                    self.language,
+                    "memory_content_required",
+                    "請先填寫記憶內容。",
+                ),
+            )
             self.content_input.setFocus()
             return
         self.accept()
 
     def values(self) -> tuple[str, str, str, int]:
         return (
-            to_taiwan_traditional(self.title_input.text().strip()),
-            to_taiwan_traditional(self.content_input.toPlainText().strip()),
-            self.category_input.currentText(),
+            self.title_input.text().strip(),
+            self.content_input.toPlainText().strip(),
+            str(self.category_input.currentData() or "其他"),
             self.importance_input.value(),
         )
 
 
 class ArchivedMemoryDialog(QDialog):
-    def __init__(self, db: StudioDB, parent=None):
+    def __init__(
+        self,
+        db: StudioDB,
+        parent=None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
         self.db = db
+        self.language = language
         self.changed = False
-        self.setWindowTitle("已封存的長期記憶")
+        self.setWindowTitle(
+            ui_text(
+                language,
+                "archived_memory_title",
+                "已封存的長期記憶",
+            )
+        )
         self.setMinimumSize(720, 520)
         self.setStyleSheet(STYLE)
         layout = QVBoxLayout(self)
         intro = QLabel(
-            "自動整理只會封存較舊、低重要度的對話記憶，不會直接銷毀。"
-            "您可以在這裡隨時勾選還原。"
+            ui_text(
+                language,
+                "archived_memory_intro",
+                "自動整理只會封存較舊、低重要度的對話記憶，不會直接銷毀。"
+                "您可以在這裡隨時勾選還原。",
+            )
         )
         intro.setWordWrap(True)
         layout.addWidget(intro)
@@ -1372,8 +1578,14 @@ class ArchivedMemoryDialog(QDialog):
         self.archive_status = QLabel()
         layout.addWidget(self.archive_status)
         buttons = QHBoxLayout()
-        restore = QPushButton("還原勾選記憶")
-        close = QPushButton("關閉")
+        restore = QPushButton(
+            ui_text(
+                language,
+                "restore_checked_memories",
+                "還原勾選記憶",
+            )
+        )
+        close = QPushButton(ui_text(language, "close", "關閉"))
         buttons.addWidget(restore)
         buttons.addStretch()
         buttons.addWidget(close)
@@ -1387,16 +1599,33 @@ class ArchivedMemoryDialog(QDialog):
         rows = self.db.list_archived_memories(1000)
         for row in rows:
             item = QListWidgetItem(
-                f"【{to_taiwan_traditional(str(row['category']))}】"
-                f"{to_taiwan_traditional(str(row['title']))}\n"
-                f"{to_taiwan_traditional(str(row['content']))}\n"
-                f"封存原因：{row['reason']}　時間：{str(row['archived_at'])[:16]}"
+                ui_text(
+                    self.language,
+                    "archived_memory_item",
+                    "【{category}】{title}\n{content}\n"
+                    "封存原因：{reason}　時間：{archived}",
+                    category=memory_category_label(
+                        self.language,
+                        to_taiwan_traditional(str(row["category"])),
+                    ),
+                    title=str(row["title"]),
+                    content=str(row["content"]),
+                    reason=str(row["reason"]),
+                    archived=str(row["archived_at"])[:16],
+                )
             )
             item.setData(Qt.UserRole, int(row["id"]))
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Unchecked)
             self.archive_list.addItem(item)
-        self.archive_status.setText(f"目前共有 {len(rows)} 則可還原記憶")
+        self.archive_status.setText(
+            ui_text(
+                self.language,
+                "archived_memory_count",
+                "目前共有 {count} 則可還原記憶",
+                count=len(rows),
+            )
+        )
 
     def restore_checked(self) -> None:
         selected = [
@@ -1405,7 +1634,19 @@ class ArchivedMemoryDialog(QDialog):
             if self.archive_list.item(index).checkState() == Qt.Checked
         ]
         if not selected:
-            QMessageBox.information(self, "尚未選取", "請先勾選要還原的記憶。")
+            QMessageBox.information(
+                self,
+                ui_text(
+                    self.language,
+                    "archived_memory_select_title",
+                    "尚未選取",
+                ),
+                ui_text(
+                    self.language,
+                    "archived_memory_select",
+                    "請先勾選要還原的記憶。",
+                ),
+            )
             return
         restored = sum(
             1 for archive_id in selected
@@ -1413,20 +1654,40 @@ class ArchivedMemoryDialog(QDialog):
         )
         self.changed = self.changed or restored > 0
         self.refresh_archives()
-        self.archive_status.setText(f"已還原 {restored} 則記憶。")
+        self.archive_status.setText(
+            ui_text(
+                self.language,
+                "archived_memory_restored",
+                "已還原 {count} 則記憶。",
+                count=restored,
+            )
+        )
 
 
 class ChatHistoryDialog(QDialog):
-    def __init__(self, db: StudioDB, parent=None):
+    def __init__(
+        self,
+        db: StudioDB,
+        parent=None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
         self.db = db
+        self.language = language
         self.changed = False
-        self.setWindowTitle("管理／清除對話")
+        self.setWindowTitle(
+            ui_text(language, "chat_history_title", "管理／清除對話")
+        )
         self.setMinimumSize(720, 520)
         layout = QVBoxLayout(self)
         intro = QLabel(
-            "對話平時保存在本機，不會自動刪除。"
-            "請只勾選確定要永久刪除的紀錄。"
+            ui_text(
+                language,
+                "chat_history_intro",
+                "對話平時保存在本機，不會自動刪除。"
+                "請只勾選確定要永久刪除的紀錄。",
+            )
         )
         intro.setWordWrap(True)
         layout.addWidget(intro)
@@ -1436,8 +1697,10 @@ class ChatHistoryDialog(QDialog):
         self.history_status.setStyleSheet("color: #356d88;")
         layout.addWidget(self.history_status)
         buttons = QHBoxLayout()
-        delete = QPushButton("刪除勾選對話")
-        close = QPushButton("關閉")
+        delete = QPushButton(
+            ui_text(language, "delete_checked_chats", "刪除勾選對話")
+        )
+        close = QPushButton(ui_text(language, "close", "關閉"))
         buttons.addWidget(delete)
         buttons.addStretch()
         buttons.addWidget(close)
@@ -1456,21 +1719,44 @@ class ChatHistoryDialog(QDialog):
                 else profile_setting(self.db, "assistant_name")
             )
             content = " ".join(
-                to_taiwan_traditional(row["content"]).split()
+                str(row["content"]).split()
             )
             if len(content) > 110:
                 content = content[:110] + "…"
             item = QListWidgetItem(
-                f"{row['created_at'][5:16]}｜{speaker}\n{content}"
+                ui_text(
+                    self.language,
+                    "chat_history_item",
+                    "{created}｜{speaker}\n{content}",
+                    created=row["created_at"][5:16],
+                    speaker=speaker,
+                    content=content,
+                )
             )
             item.setData(Qt.UserRole, int(row["id"]))
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Unchecked)
-            item.setToolTip(to_taiwan_traditional(row["content"]))
+            item.setToolTip(str(row["content"]))
             self.history_list.addItem(item)
         total = self.db.chat_count()
-        suffix = "（管理視窗最多顯示最近 500 則）" if total > 500 else ""
-        self.history_status.setText(f"本機共保存 {total} 則對話。{suffix}")
+        suffix = (
+            ui_text(
+                self.language,
+                "chat_history_truncated_suffix",
+                "（管理視窗最多顯示最近 500 則）",
+            )
+            if total > 500
+            else ""
+        )
+        self.history_status.setText(
+            ui_text(
+                self.language,
+                "chat_history_status",
+                "本機共保存 {count} 則對話。{suffix}",
+                count=total,
+                suffix=suffix,
+            )
+        )
 
     def checked_chat_ids(self) -> list[int]:
         checked: list[int] = []
@@ -1484,13 +1770,32 @@ class ChatHistoryDialog(QDialog):
         chat_ids = self.checked_chat_ids()
         if not chat_ids:
             QMessageBox.information(
-                self, "尚未勾選", "請先勾選要刪除的對話。"
+                self,
+                ui_text(
+                    self.language,
+                    "chat_select_delete_title",
+                    "尚未勾選",
+                ),
+                ui_text(
+                    self.language,
+                    "chat_select_delete",
+                    "請先勾選要刪除的對話。",
+                ),
             )
             return
         answer = QMessageBox.question(
             self,
-            "永久刪除對話",
-            f"確定永久刪除勾選的 {len(chat_ids)} 則對話嗎？",
+            ui_text(
+                self.language,
+                "chat_delete_title",
+                "永久刪除對話",
+            ),
+            ui_text(
+                self.language,
+                "chat_delete_confirm",
+                "確定永久刪除勾選的 {count} 則對話嗎？",
+                count=len(chat_ids),
+            ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
@@ -1758,6 +2063,7 @@ class FirstRunWizard(QDialog):
 
     def _update_wizard_headings(self) -> None:
         self.setWindowTitle(self._t("first_run_title", "首次啟動設定"))
+        self.hero_brand.setText(self._t("first_run_brand", "墨寒  MoHan"))
         self.hero_tagline.setText(
             self._t(
                 "first_run_hero_tagline",
@@ -2110,6 +2416,13 @@ class Dashboard(QDialog):
     def _t(self, key: str, chinese: str, **values: object) -> str:
         return ui_text(self.ui_language, key, chinese, **values)
 
+    def _settings_text(
+        self,
+        key: SettingsText,
+        **values: object,
+    ) -> str:
+        return settings_text(self.ui_language, key, **values)
+
     def _tab_changed(self, index: int) -> None:
         if getattr(self, "_today_split_initialized", False):
             return
@@ -2209,19 +2522,39 @@ class Dashboard(QDialog):
         self.load_older_chat_btn = QPushButton(
             self._t("load_older_chat", "載入較早對話")
         )
-        self.load_older_chat_btn.setToolTip("每次向前載入 50 則本機對話")
+        self.load_older_chat_btn.setToolTip(
+            self._t(
+                "load_older_chat_tooltip",
+                "每次向前載入 50 則本機對話",
+            )
+        )
         self.manage_chat_btn = QPushButton(
             self._t("manage_chat", "管理／清除對話")
         )
-        self.manage_chat_btn.setToolTip("勾選並刪除指定對話，其他內容不受影響")
+        self.manage_chat_btn.setToolTip(
+            self._t(
+                "manage_chat_tooltip",
+                "勾選並刪除指定對話，其他內容不受影響",
+            )
+        )
         self.chat_zoom_down = QPushButton("A－")
-        self.chat_zoom_down.setToolTip("縮小對話文字（Ctrl＋滑鼠滾輪向下）")
+        self.chat_zoom_down.setToolTip(
+            self._t(
+                "chat_zoom_out_tooltip",
+                "縮小對話文字（Ctrl＋滑鼠滾輪向下）",
+            )
+        )
         self.chat_zoom_down.setFixedWidth(48)
         self.chat_zoom_label = QLabel()
         self.chat_zoom_label.setMinimumWidth(48)
         self.chat_zoom_label.setAlignment(Qt.AlignCenter)
         self.chat_zoom_up = QPushButton("A＋")
-        self.chat_zoom_up.setToolTip("放大對話文字（Ctrl＋滑鼠滾輪向上）")
+        self.chat_zoom_up.setToolTip(
+            self._t(
+                "chat_zoom_in_tooltip",
+                "放大對話文字（Ctrl＋滑鼠滾輪向上）",
+            )
+        )
         self.chat_zoom_up.setFixedWidth(48)
         history_row.addWidget(self.chat_retention)
         history_row.addStretch()
@@ -2289,11 +2622,19 @@ class Dashboard(QDialog):
     ) -> tuple[QHBoxLayout, QPushButton, QPushButton]:
         entry = QHBoxLayout()
         self.todo_input = QLineEdit()
-        self.todo_input.setPlaceholderText("輸入待辦標題，例如：完成漫畫第 3 話分鏡")
+        self.todo_input.setPlaceholderText(
+            self._t(
+                "today_input_placeholder",
+                "輸入待辦標題，例如：完成漫畫第 3 話分鏡",
+            )
+        )
         self.todo_category = QComboBox()
-        self.todo_category.addItems(["漫畫", "文章", "音樂", "貼圖", "出版", "行政", "其他"])
-        add = QPushButton("＋ 加入待辦")
-        idea = QPushButton("✦ 收入靈感")
+        for category, key in TODO_CATEGORIES:
+            self.todo_category.addItem(self._t(key, category), category)
+        add = QPushButton(self._t("add_todo", "＋ 加入待辦"))
+        idea = QPushButton(self._t("save_as_idea", "✦ 收入靈感"))
+        self.today_add_button = add
+        self.today_save_idea_button = idea
         entry.addWidget(self.todo_input, 1)
         entry.addWidget(self.todo_category)
         entry.addWidget(add)
@@ -2304,7 +2645,10 @@ class Dashboard(QDialog):
         self.todo_feedback = QLabel("")
         self.todo_feedback.setObjectName("entryFeedback")
         todo_header = QHBoxLayout()
-        todo_header.addWidget(QLabel("<b>今天要做</b>"))
+        self.today_tasks_heading = QLabel(
+            self._t("today_tasks_heading", "<b>今天要做</b>")
+        )
+        todo_header.addWidget(self.today_tasks_heading)
         self.todo_count = QLabel()
         self.todo_count.setObjectName("sectionCount")
         todo_header.addWidget(self.todo_count)
@@ -2335,16 +2679,35 @@ class Dashboard(QDialog):
         self,
     ) -> tuple[QWidget, QPushButton, QPushButton]:
         idea_header = QHBoxLayout()
-        idea_header.addWidget(QLabel("<b>創作靈感</b>"))
+        self.creative_ideas_heading = QLabel(
+            self._t("creative_ideas_heading", "<b>創作靈感</b>")
+        )
+        idea_header.addWidget(self.creative_ideas_heading)
         self.idea_count = QLabel()
         self.idea_count.setObjectName("sectionCount")
         idea_header.addWidget(self.idea_count)
         idea_header.addStretch()
-        edit_idea = QPushButton("編輯選取靈感")
-        edit_idea.setToolTip("也可以直接雙擊下方任一靈感")
+        edit_idea = QPushButton(
+            self._t("edit_selected_idea", "編輯選取靈感")
+        )
+        edit_idea.setToolTip(
+            self._t(
+                "edit_selected_idea_tooltip",
+                "也可以直接雙擊下方任一靈感",
+            )
+        )
         idea_header.addWidget(edit_idea)
-        delete_ideas = QPushButton("刪除勾選靈感")
-        delete_ideas.setToolTip("只刪除已勾選的靈感，執行前會再次確認")
+        delete_ideas = QPushButton(
+            self._t("delete_checked_ideas", "刪除勾選靈感")
+        )
+        delete_ideas.setToolTip(
+            self._t(
+                "delete_checked_ideas_tooltip",
+                "只刪除已勾選的靈感，執行前會再次確認",
+            )
+        )
+        self.today_edit_idea_button = edit_idea
+        self.today_delete_ideas_button = delete_ideas
         idea_header.addWidget(delete_ideas)
         self.idea_list = QListWidget()
         self.idea_list.setObjectName("ideaList")
@@ -2393,13 +2756,21 @@ class Dashboard(QDialog):
         add_row = QHBoxLayout()
         self.new_platform_name = QLineEdit()
         self.new_platform_name.setPlaceholderText(
-            "平台、系統或工具名稱，例如：公司 ERP、Notion、客戶後台"
+            self._t(
+                "platform_name_placeholder",
+                "平台、系統或工具名稱，例如：公司 ERP、Notion、客戶後台",
+            )
         )
         self.new_platform_url = QLineEdit()
         self.new_platform_url.setPlaceholderText(
-            "網址（可留空，例如：https://example.com）"
+            self._t(
+                "platform_url_placeholder",
+                "網址（可留空，例如：https://example.com）",
+            )
         )
-        add_platform = QPushButton("新增工作平台")
+        add_platform = QPushButton(
+            self._t("add_platform", "新增工作平台")
+        )
         add_row.addWidget(self.new_platform_name, 2)
         add_row.addWidget(self.new_platform_url, 2)
         add_row.addWidget(add_platform)
@@ -2412,18 +2783,19 @@ class Dashboard(QDialog):
         self.platform_summary = QLabel()
         self.platform_summary.setObjectName("sectionCount")
         self.platform_filter = QComboBox()
-        self.platform_filter.addItems(
-            [
-                "全部平台",
-                "進行中",
-                "待補資料／阻礙",
-                "已完成／已上架",
-                "尚未開始",
-            ]
+        for key, chinese, value in (
+            ("platform_filter_all", "全部平台", "all"),
+            ("platform_filter_active", "進行中", "active"),
+            ("platform_filter_blocked", "待補資料／阻礙", "blocked"),
+            ("platform_filter_finished", "已完成／已上架", "finished"),
+            ("platform_filter_not_started", "尚未開始", "not_started"),
+        ):
+            self.platform_filter.addItem(self._t(key, chinese), value)
+        save_all = QPushButton(
+            self._t("save_all_platforms", "立即保存全部")
         )
-        save_all = QPushButton("立即保存全部")
         header.addWidget(self.platform_summary, 1)
-        header.addWidget(QLabel("顯示"))
+        header.addWidget(QLabel(self._t("show", "顯示")))
         header.addWidget(self.platform_filter)
         header.addWidget(save_all)
         return header, save_all
@@ -2441,8 +2813,11 @@ class Dashboard(QDialog):
         self.platform_controls: dict[str, PlatformCardControls] = {}
         self._platform_loading = False
         self.platform_empty = QLabel(
-            "尚未建立工作平台。\n"
-            "請在上方輸入公司系統、協作工具、客戶後台或任何工作平台。"
+            self._t(
+                "platform_empty",
+                "尚未建立工作平台。\n"
+                "請在上方輸入公司系統、協作工具、客戶後台或任何工作平台。",
+            )
         )
         self.platform_empty.setObjectName("emptyState")
         self.platform_empty.setAlignment(Qt.AlignCenter)
@@ -2456,8 +2831,11 @@ class Dashboard(QDialog):
         tab = QWidget()
         layout = QVBoxLayout(tab)
         intro = QLabel(
-            "集中管理工作中使用的平台、系統、客戶入口或協作工具。"
-            "每位使用者都可以建立自己的工作平台，不預設綁定任何產業。"
+            self._t(
+                "platform_intro",
+                "集中管理工作中使用的平台、系統、客戶入口或協作工具。"
+                "每位使用者都可以建立自己的工作平台，不預設綁定任何產業。",
+            )
         )
         intro.setWordWrap(True)
         intro.setStyleSheet("color:#486d83;")
@@ -2466,7 +2844,10 @@ class Dashboard(QDialog):
         layout.addLayout(add_row)
         header, save_all = self._platform_filter_controls()
         self.platform_feedback = QLabel(
-            "修改後會自動保存；也可以使用每張卡片的保存按鈕。"
+            self._t(
+                "platform_auto_save_note",
+                "修改後會自動保存；也可以使用每張卡片的保存按鈕。",
+            )
         )
         self.platform_feedback.setStyleSheet("color:#4c6b82;")
         self.platform_feedback.setWordWrap(True)
@@ -2509,22 +2890,38 @@ class Dashboard(QDialog):
         grid.setHorizontalSpacing(10)
         grid.setVerticalSpacing(8)
         status = QComboBox()
-        status.addItems(PLATFORM_STATUSES)
+        for value in PLATFORM_STATUSES:
+            status.addItem(platform_status_label(self.ui_language, value), value)
         controls = PlatformCardControls(
             card=card,
             status=status,
             item_name=self._platform_editor(
-                "目前負責的工作項目、專案或案件"
+                self._t(
+                    "platform_item_placeholder",
+                    "目前負責的工作項目、專案或案件",
+                )
             ),
             missing=self._platform_editor(
-                "待補資料、等待他人回覆或其他阻礙；沒有可留空"
+                self._t(
+                    "platform_missing_placeholder",
+                    "待補資料、等待他人回覆或其他阻礙；沒有可留空",
+                )
             ),
-            next_action=self._platform_editor("下一個具體動作與期限"),
-            notes=self._platform_editor("備註、規則、聯絡窗口或其他補充"),
-            url=self._platform_editor("https://…（可留空）"),
+            next_action=self._platform_editor(
+                self._t("platform_next_placeholder", "下一個具體動作與期限")
+            ),
+            notes=self._platform_editor(
+                self._t(
+                    "platform_notes_placeholder",
+                    "備註、規則、聯絡窗口或其他補充",
+                )
+            ),
+            url=self._platform_editor(
+                self._t("platform_url_card_placeholder", "https://…（可留空）")
+            ),
             validation=QLabel(),
-            updated=QLabel("尚未保存"),
-            save_button=QPushButton("保存此平台"),
+            updated=QLabel(self._t("platform_not_saved", "尚未保存")),
+            save_button=QPushButton(self._t("save_platform", "保存此平台")),
             timer=QTimer(self),
         )
         controls.validation.setWordWrap(True)
@@ -2556,11 +2953,11 @@ class Dashboard(QDialog):
             3,
         )
         fields = (
-            ("工作項目／專案", controls.item_name),
-            ("待補資料／阻礙", controls.missing),
-            ("下一步", controls.next_action),
-            ("備註", controls.notes),
-            ("網址", controls.url),
+            (self._t("platform_field_item", "工作項目／專案"), controls.item_name),
+            (self._t("platform_field_missing", "待補資料／阻礙"), controls.missing),
+            (self._t("platform_field_next", "下一步"), controls.next_action),
+            (self._t("platform_field_notes", "備註"), controls.notes),
+            (self._t("platform_field_url", "網址"), controls.url),
         )
         for row, (label, editor) in enumerate(fields, start=1):
             grid.addWidget(QLabel(label), row, 0)
@@ -2572,8 +2969,12 @@ class Dashboard(QDialog):
         platform: str,
         save_button: QPushButton,
     ) -> QHBoxLayout:
-        open_button = QPushButton("開啟網站／工具")
-        delete_button = QPushButton("刪除平台")
+        open_button = QPushButton(
+            self._t("open_platform", "開啟網站／工具")
+        )
+        delete_button = QPushButton(
+            self._t("delete_platform", "刪除平台")
+        )
         delete_button.setObjectName("dangerButton")
         open_button.clicked.connect(
             lambda _checked=False, name=platform: self.open_platform(name)
@@ -2612,15 +3013,21 @@ class Dashboard(QDialog):
         controls = self.platform_controls.get(platform)
         if controls is None:
             return
-        status = to_taiwan_traditional(row["status"])
-        if controls.status.findText(status) < 0:
-            controls.status.addItem(status)
-        controls.status.setCurrentText(status)
+        status = str(row["status"])
+        if controls.status.findData(status) < 0:
+            controls.status.addItem(
+                platform_status_label(self.ui_language, status), status
+            )
+        controls.status.setCurrentIndex(
+            max(0, controls.status.findData(status))
+        )
         for field in ("item_name", "missing", "next_action", "notes", "url"):
             editor = getattr(controls, field)
-            editor.setText(to_taiwan_traditional(row[field] or ""))
+            editor.setText(str(row[field] or ""))
         controls.dirty = False
-        controls.save_button.setText("保存此平台")
+        controls.save_button.setText(
+            self._t("save_platform", "保存此平台")
+        )
         controls.updated.setText(
             self._format_platform_updated(row["updated_at"])
         )
@@ -2652,15 +3059,24 @@ class Dashboard(QDialog):
         return value
 
     def add_custom_platform(self) -> None:
-        platform = to_taiwan_traditional(self.new_platform_name.text().strip())
+        platform = self.new_platform_name.text().strip()
         url = self._normalize_platform_url(self.new_platform_url.text())
         if not platform:
-            self.platform_feedback.setText("請先輸入平台、系統或工具名稱。")
+            self.platform_feedback.setText(
+                self._t(
+                    "platform_name_required",
+                    "請先輸入平台、系統或工具名稱。",
+                )
+            )
             self.new_platform_name.setFocus()
             return
         if not self.db.add_platform(platform, url):
             self.platform_feedback.setText(
-                f"「{platform}」已存在，請使用不同名稱。"
+                self._t(
+                    "platform_duplicate",
+                    "「{platform}」已存在，請使用不同名稱。",
+                    platform=platform,
+                )
             )
             return
         row = next(
@@ -2676,15 +3092,25 @@ class Dashboard(QDialog):
         self.new_platform_name.clear()
         self.new_platform_url.clear()
         self.platform_empty.hide()
-        self.platform_feedback.setText(f"已新增工作平台：{platform}")
+        self.platform_feedback.setText(
+            self._t(
+                "platform_added",
+                "已新增工作平台：{platform}",
+                platform=platform,
+            )
+        )
         self._refresh_platform_summary()
         self._filter_platform_cards()
 
     def delete_custom_platform(self, platform: str) -> None:
         answer = QMessageBox.question(
             self,
-            "刪除工作平台",
-            f"確定刪除「{platform}」及其工作進度嗎？此動作無法復原。",
+            self._t("platform_delete_title", "刪除工作平台"),
+            self._t(
+                "platform_delete_confirm",
+                "確定刪除「{platform}」及其工作進度嗎？此動作無法復原。",
+                platform=platform,
+            ),
         )
         if answer != QMessageBox.Yes:
             return
@@ -2692,13 +3118,25 @@ class Dashboard(QDialog):
         if controls is not None:
             controls.timer.stop()
         if not self.db.delete_platform(platform):
-            self.platform_feedback.setText(f"找不到工作平台：{platform}")
+            self.platform_feedback.setText(
+                self._t(
+                    "platform_not_found",
+                    "找不到工作平台：{platform}",
+                    platform=platform,
+                )
+            )
             return
         if controls is not None:
             controls.card.deleteLater()
             del self.platform_controls[platform]
         self.platform_empty.setVisible(not self.platform_controls)
-        self.platform_feedback.setText(f"已刪除工作平台：{platform}")
+        self.platform_feedback.setText(
+            self._t(
+                "platform_deleted",
+                "已刪除工作平台：{platform}",
+                platform=platform,
+            )
+        )
         self._refresh_platform_summary()
         self._filter_platform_cards()
 
@@ -2732,11 +3170,13 @@ class Dashboard(QDialog):
         )
         return tab
 
-    @staticmethod
-    def _memory_intro() -> QLabel:
+    def _memory_intro(self) -> QLabel:
         intro = QLabel(
-            "墨寒只保存主上允許留下的人物、偏好、目標、工作流程與"
-            "重要日期。記憶存於本機，可分類瀏覽、逐項編輯或刪除。"
+            self._t(
+                "memory_intro",
+                "墨寒只保存主上允許留下的人物、偏好、目標、工作流程與"
+                "重要日期。記憶存於本機，可分類瀏覽、逐項編輯或刪除。",
+            )
         )
         intro.setWordWrap(True)
         return intro
@@ -2744,11 +3184,21 @@ class Dashboard(QDialog):
     def _memory_entry_row(self) -> tuple[QHBoxLayout, QPushButton]:
         entry = QHBoxLayout()
         self.memory_input = QLineEdit()
-        self.memory_input.setPlaceholderText("例如：主上偏好先完成漫畫，再處理行政工作")
+        self.memory_input.setPlaceholderText(
+            self._t(
+                "memory_input_placeholder",
+                "例如：主上偏好先完成漫畫，再處理行政工作",
+            )
+        )
         self.memory_category = QComboBox()
-        self.memory_category.addItems(MEMORY_CATEGORIES)
-        self.memory_category.setCurrentText("偏好")
-        add_button = QPushButton("讓寒記住")
+        for category in MEMORY_CATEGORIES:
+            self.memory_category.addItem(
+                memory_category_label(self.ui_language, category), category
+            )
+        self.memory_category.setCurrentIndex(
+            self.memory_category.findData("偏好")
+        )
+        add_button = QPushButton(self._t("remember", "讓寒記住"))
         entry.addWidget(self.memory_input, 1)
         entry.addWidget(self.memory_category)
         entry.addWidget(add_button)
@@ -2758,20 +3208,35 @@ class Dashboard(QDialog):
         self,
     ) -> tuple[QHBoxLayout, QPushButton, QPushButton]:
         filter_row = QHBoxLayout()
-        filter_row.addWidget(QLabel("分類瀏覽"))
+        filter_row.addWidget(
+            QLabel(self._t("memory_filter_label", "分類瀏覽"))
+        )
         self.memory_filter = QComboBox()
-        self.memory_filter.addItem("全部記憶", "")
+        self.memory_filter.addItem(self._t("all_memories", "全部記憶"), "")
         for category in MEMORY_CATEGORIES:
-            self.memory_filter.addItem(category, category)
+            self.memory_filter.addItem(
+                memory_category_label(self.ui_language, category), category
+            )
         self.memory_count = QLabel()
         self.memory_count.setObjectName("sectionCount")
         filter_row.addWidget(self.memory_filter)
         filter_row.addWidget(self.memory_count)
         filter_row.addStretch()
-        edit_button = QPushButton("編輯選取記憶")
-        edit_button.setToolTip("也可以直接雙擊下方任一記憶")
-        delete_button = QPushButton("刪除勾選記憶")
-        delete_button.setToolTip("只刪除已勾選的記憶，執行前會再次確認")
+        edit_button = QPushButton(
+            self._t("edit_selected_memory", "編輯選取記憶")
+        )
+        edit_button.setToolTip(
+            self._t("edit_memory_tooltip", "也可以直接雙擊下方任一記憶")
+        )
+        delete_button = QPushButton(
+            self._t("delete_checked_memories", "刪除勾選記憶")
+        )
+        delete_button.setToolTip(
+            self._t(
+                "delete_checked_memories_tooltip",
+                "只刪除已勾選的記憶，執行前會再次確認",
+            )
+        )
         filter_row.addWidget(edit_button)
         filter_row.addWidget(delete_button)
         return filter_row, edit_button, delete_button
@@ -2783,16 +3248,25 @@ class Dashboard(QDialog):
         memory_list.setSpacing(3)
         return memory_list
 
-    @staticmethod
     def _memory_action_row(
+        self,
     ) -> tuple[QHBoxLayout, QPushButton, QPushButton, QPushButton]:
         actions = QHBoxLayout()
-        clear_button = QPushButton("清除全部記憶")
-        optimize_button = QPushButton("安全整理記憶")
-        optimize_button.setToolTip(
-            "合併低重要度重複內容，超量舊記憶只會先封存"
+        clear_button = QPushButton(
+            self._t("clear_all_memories", "清除全部記憶")
         )
-        archives_button = QPushButton("查看已封存記憶")
+        optimize_button = QPushButton(
+            self._t("optimize_memories", "安全整理記憶")
+        )
+        optimize_button.setToolTip(
+            self._t(
+                "optimize_memories_tooltip",
+                "合併低重要度重複內容，超量舊記憶只會先封存",
+            )
+        )
+        archives_button = QPushButton(
+            self._t("view_archived_memories", "查看已封存記憶")
+        )
         actions.addWidget(clear_button)
         actions.addWidget(optimize_button)
         actions.addWidget(archives_button)
@@ -2806,7 +3280,10 @@ class Dashboard(QDialog):
 
     def _memory_auto_checkbox(self) -> QCheckBox:
         checkbox = QCheckBox(
-            "從「請記住／我喜歡／我習慣」等明確說法自動建立記憶"
+            self._t(
+                "auto_memory",
+                "從「請記住／我喜歡／我習慣」等明確說法自動建立記憶",
+            )
         )
         checkbox.setChecked(bool(self.db.setting("auto_memory", True)))
         return checkbox
@@ -3520,8 +3997,11 @@ class Dashboard(QDialog):
             bool(self.db.setting("realtime_echo_guard", True))
         )
         checkbox.setToolTip(
-            "墨寒說話時暫停上傳麥克風，播放結束後再恢復；"
-            "啟用時無法在她說話途中插話。"
+            self._t(
+                "echo_guard_tooltip",
+                "墨寒說話時暫停上傳麥克風，播放結束後再恢復；"
+                "啟用時無法在她說話途中插話。",
+            )
         )
         return checkbox
 
@@ -3541,8 +4021,11 @@ class Dashboard(QDialog):
             )
         )
         checkbox.setToolTip(
-            "Realtime 保留原生音訊理解；每句說完後，畫面文字改用"
-            "完整錄音的 OpenAI 高精度轉錄。成功後才允許墨寒回答。"
+            self._t(
+                "hybrid_transcript_tooltip",
+                "Realtime 保留原生音訊理解；每句說完後，畫面文字改用"
+                "完整錄音的 OpenAI 高精度轉錄。成功後才允許墨寒回答。",
+            )
         )
         return checkbox
 
@@ -4027,6 +4510,7 @@ class Dashboard(QDialog):
             self,
             platform_services=self.platform_services,
             secret_store_factory=self.secret_store_factory,
+            language=self.ui_language,
         )
         self.flagship_center.setMinimumHeight(720)
         self.flagship_center.speak_requested.connect(
@@ -4035,7 +4519,9 @@ class Dashboard(QDialog):
         self.flagship_center.remote_command_received.connect(
             self._receive_remote_command
         )
-        flagship_heading = QLabel("<b>旗艦控制中心</b>")
+        flagship_heading = QLabel(
+            self._t("flagship_heading", "<b>旗艦控制中心</b>")
+        )
         flagship_heading.setStyleSheet(
             "color:#2f6987;font-size:16px;margin-top:12px;"
         )
@@ -4058,8 +4544,8 @@ class Dashboard(QDialog):
         down = QPushButton("▼")
         up.setObjectName(f"{object_prefix}Up")
         down.setObjectName(f"{object_prefix}Down")
-        up.setToolTip("增加")
-        down.setToolTip("減少")
+        up.setToolTip(self._t("increase", "增加"))
+        down.setToolTip(self._t("decrease", "減少"))
         for button in (up, down):
             button.setFixedWidth(46)
             button.setAutoRepeat(True)
@@ -4094,7 +4580,10 @@ class Dashboard(QDialog):
             profile_setting(self.db, "window_title")
         )
         self.profile_window_title.setPlaceholderText(
-            "留空時自動顯示「助理名稱．組織名稱」"
+            self._t(
+                "window_title_placeholder",
+                "留空時自動顯示「助理名稱．組織名稱」",
+            )
         )
         self.profile_work_type = self._profile_work_type_combo()
         self.profile_ui_language = self._profile_language_combo()
@@ -4121,6 +4610,7 @@ class Dashboard(QDialog):
             self.db,
             parent,
             before_export=lambda: self.save_settings(silent=True),
+            language=self.ui_language,
         )
         form.addRow(self.portable_profile_panel)
 
@@ -4267,7 +4757,7 @@ class Dashboard(QDialog):
             self._t("overwork_message", "久坐／過勞提醒訊息"),
             self.overwork_message,
         )
-        form.addRow("語音", self.tts_enabled)
+        form.addRow(self._t("voice_section", "語音"), self.tts_enabled)
 
     def _add_desktop_settings(
         self,
@@ -4276,46 +4766,70 @@ class Dashboard(QDialog):
     ) -> None:
         self.autostart = self._autostart_checkbox(capabilities)
         self.topmost_mode = QComboBox()
-        self.topmost_mode.addItems(
-            ["智慧置頂（推薦）", "永遠置頂", "不置頂"]
+        topmost_values = (
+            "智慧置頂（推薦）",
+            "永遠置頂",
+            "不置頂",
         )
-        self.topmost_mode.setCurrentText(
-            str(
-                self.db.setting(
-                    "topmost_mode",
-                    "智慧置頂（推薦）",
-                )
-            )
+        for key, value in zip(
+            TOPMOST_MODE_KEYS,
+            topmost_values,
+            strict=True,
+        ):
+            self.topmost_mode.addItem(self._settings_text(key), value)
+        self._select_combo_data(
+            self.topmost_mode,
+            str(self.db.setting("topmost_mode", topmost_values[0])),
         )
-        self.topmost_mode.currentTextChanged.connect(
+        self.topmost_mode.currentIndexChanged.connect(
             self._topmost_mode_changed
         )
         character_scale = self._character_scale_control()
-        self.proactive_mode = self._editable_combo(
-            ("安靜（只提醒必要事項）", "平衡（推薦）", "積極（主動建議）"),
-            str(self.db.setting("proactive_mode", "平衡（推薦）")),
+        self.proactive_mode = QComboBox()
+        proactive_values = (
+            "安靜（只提醒必要事項）",
+            "平衡（推薦）",
+            "積極（主動建議）",
         )
-        self.proactive_mode.setEditable(False)
-        autostart_label = (
-            "自動啟動"
-            if capabilities.desktop_autostart
-            else self._t("autostart", "自動啟動")
+        for key, value in zip(
+            PROACTIVE_MODE_KEYS,
+            proactive_values,
+            strict=True,
+        ):
+            self.proactive_mode.addItem(self._settings_text(key), value)
+        self._select_combo_data(
+            self.proactive_mode,
+            str(self.db.setting("proactive_mode", proactive_values[1])),
         )
-        form.addRow(autostart_label, self.autostart)
-        form.addRow("桌面置頂方式", self.topmost_mode)
-        form.addRow("桌面墨寒顯示大小", character_scale)
-        form.addRow("主動協助程度", self.proactive_mode)
+        form.addRow(
+            self._settings_text(SettingsText.AUTOSTART_LABEL),
+            self.autostart,
+        )
+        form.addRow(
+            self._settings_text(SettingsText.TOPMOST_LABEL),
+            self.topmost_mode,
+        )
+        form.addRow(
+            self._settings_text(
+                SettingsText.CHARACTER_SCALE_LABEL,
+                assistant=self.assistant_name,
+            ),
+            character_scale,
+        )
+        form.addRow(
+            self._settings_text(SettingsText.PROACTIVE_LABEL),
+            self.proactive_mode,
+        )
 
     def _autostart_checkbox(
         self,
         capabilities: PlatformCapabilities,
     ) -> QCheckBox:
         checkbox = QCheckBox(
-            "Windows 登入後自動啟動"
+            self._settings_text(SettingsText.AUTOSTART_WINDOWS)
             if capabilities.desktop_autostart
-            else self._t(
-                "platform_autostart_unavailable",
-                f"{capabilities.display_name} 自動啟動尚未完成實機驗證",
+            else self._settings_text(
+                SettingsText.AUTOSTART_UNAVAILABLE,
                 platform=capabilities.display_name,
             )
         )
@@ -4352,8 +4866,15 @@ class Dashboard(QDialog):
         self.character_scale_label = QLabel(f"{scale}%")
         self.character_scale_label.setMinimumWidth(48)
         self.character_scale_label.setAlignment(Qt.AlignCenter)
-        reset_button = QPushButton("恢復 100%")
-        reset_button.setToolTip("將桌面墨寒恢復為原始顯示大小")
+        reset_button = QPushButton(
+            self._settings_text(SettingsText.CHARACTER_SCALE_RESET)
+        )
+        reset_button.setToolTip(
+            self._settings_text(
+                SettingsText.CHARACTER_SCALE_RESET_TOOLTIP,
+                assistant=self.assistant_name,
+            )
+        )
         reset_button.clicked.connect(
             lambda: self.character_scale_slider.setValue(
                 CHARACTER_SCALE_DEFAULT
@@ -4372,7 +4893,7 @@ class Dashboard(QDialog):
 
     def _add_background_settings(self, form: QFormLayout) -> None:
         self.background_assistant_enabled = QCheckBox(
-            "啟用背景多工助理（預設關閉）"
+            self._settings_text(SettingsText.BACKGROUND_ASSISTANT_ENABLED)
         )
         self.background_assistant_enabled.setChecked(
             bool(self.db.setting("background_assistant_enabled", False))
@@ -4386,59 +4907,68 @@ class Dashboard(QDialog):
             )
         )
         self.background_watch_apps.setPlaceholderText(
-            "以逗號分隔，例如：Visual Studio Code,GitHub Desktop"
+            self._settings_text(
+                SettingsText.BACKGROUND_WATCH_APPS_PLACEHOLDER
+            )
         )
         self.background_diagnostic_report = QLineEdit(
             str(self.db.setting("background_diagnostic_report", ""))
         )
         self.background_diagnostic_report.setPlaceholderText(
-            "選填：IDE 匯出的 .txt 或 .log 診斷報告完整路徑"
+            self._settings_text(
+                SettingsText.BACKGROUND_DIAGNOSTIC_PLACEHOLDER
+            )
         )
-        note = QLabel(
-            "背景助理只讀取可見程式名稱與您明確指定的診斷報告；"
-            "不會截取編輯器內容、不會自動修改檔案，也會遵守勿擾模式與冷卻時間。"
-        )
+        note = QLabel(self._settings_text(SettingsText.BACKGROUND_SAFETY_NOTE))
         note.setWordWrap(True)
         note.setStyleSheet("color:#356f8d;")
-        form.addRow("背景多工助理", self.background_assistant_enabled)
-        form.addRow("監測程式名稱", self.background_watch_apps)
-        form.addRow("IDE 診斷報告", self.background_diagnostic_report)
+        form.addRow(
+            self._settings_text(SettingsText.BACKGROUND_ASSISTANT_LABEL),
+            self.background_assistant_enabled,
+        )
+        form.addRow(
+            self._settings_text(SettingsText.BACKGROUND_WATCH_APPS_LABEL),
+            self.background_watch_apps,
+        )
+        form.addRow(
+            self._settings_text(SettingsText.BACKGROUND_DIAGNOSTIC_LABEL),
+            self.background_diagnostic_report,
+        )
         form.addRow("", note)
 
     def _add_physics_settings(self, form: QFormLayout) -> None:
-        labels = frozendict(
-            {
-                "physics_sleeves": "袖擺呼吸與慣性",
-                "physics_hair": "長髮柔性擺動",
-                "physics_ornament": "髮飾與流蘇慣性",
-                "physics_eye_tracking": "眼球追蹤滑鼠",
-                "physics_face_parallax": "臉部柔和視差",
-            }
-        )
         box = QWidget()
         layout = QVBoxLayout(box)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
         self.physics_controls: dict[str, QCheckBox] = {}
-        for key, label in labels.items():
-            control = QCheckBox(label)
+        for key, (name_key, description_key) in PHYSICS_TEXT_KEYS.items():
+            control = QCheckBox(self._settings_text(name_key))
+            control.setToolTip(self._settings_text(description_key))
             control.setChecked(bool(self.db.setting(key, True)))
             layout.addWidget(control)
             self.physics_controls[key] = control
-        note = QLabel("旗艦物理預設全部開啟；可依效能需要個別關閉。")
+        note = QLabel(self._settings_text(SettingsText.PHYSICS_NOTE))
         note.setWordWrap(True)
         note.setStyleSheet("color:#356f8d;")
         layout.addWidget(note)
-        form.addRow("電影級物理", box)
+        form.addRow(self._settings_text(SettingsText.PHYSICS_LABEL), box)
 
     def _add_work_folder_settings(self, form: QFormLayout) -> None:
         self.work_folder = QLineEdit(
             str(self.db.setting("work_folder", ""))
         )
-        self.work_folder.setPlaceholderText("常用工作資料夾路徑")
-        open_button = QPushButton("開啟工作資料夾")
+        self.work_folder.setPlaceholderText(
+            self._settings_text(SettingsText.WORK_FOLDER_PLACEHOLDER)
+        )
+        open_button = QPushButton(
+            self._settings_text(SettingsText.WORK_FOLDER_OPEN)
+        )
         open_button.clicked.connect(self.open_work_folder)
-        form.addRow("工作資料夾", self.work_folder)
+        form.addRow(
+            self._settings_text(SettingsText.WORK_FOLDER_LABEL),
+            self.work_folder,
+        )
         form.addRow("", open_button)
 
     def _add_ai_settings(
@@ -4479,12 +5009,15 @@ class Dashboard(QDialog):
             self.ai_model,
         )
         form.addRow(
-            self._t("persona_prompt", "AI 人格提示詞"),
+            self._settings_text(SettingsText.PERSONA_LABEL),
             self.persona_prompt,
         )
         form.addRow(self._settings_language_note())
         form.addRow("", clear_button)
-        form.addRow("智能核心", self.api_status)
+        form.addRow(
+            self._settings_text(SettingsText.AI_CORE_LABEL),
+            self.api_status,
+        )
 
     def _api_key_input(
         self,
@@ -4562,7 +5095,7 @@ class Dashboard(QDialog):
         )
         prompt.setMinimumHeight(160)
         prompt.setPlaceholderText(
-            "設定助理的角色背景、語氣、工作方式與界線。"
+            self._settings_text(SettingsText.PERSONA_PLACEHOLDER)
         )
         return prompt
 
@@ -4586,6 +5119,7 @@ class Dashboard(QDialog):
             self.db,
             data_dir(self.platform_services),
             parent,
+            language=self.ui_language,
         )
         save_button = QPushButton(
             self._t("save_settings", "保存設定")
@@ -4616,11 +5150,8 @@ class Dashboard(QDialog):
             if speaker == self.assistant_name
             else "#8a4f82"
         )
-        normalized = normalize_for_language(
-            personalize_text(self.db, text),
-            self.ui_language,
-        )
-        safe_text = html.escape(normalized).replace("\n", "<br>")
+        display_text = personalize_text(self.db, text)
+        safe_text = html.escape(display_text).replace("\n", "<br>")
         self.chat.append(
             f'<p><b style="color:{color}">{speaker}</b><br>{safe_text}</p>'
         )
@@ -4697,7 +5228,12 @@ class Dashboard(QDialog):
             )
         shown = min(total, self.chat_loaded_limit)
         self.chat_retention.setText(
-            f"本機保存 {total} 則對話，目前顯示最近 {shown} 則"
+            self._t(
+                "chat_retention_status",
+                "本機保存 {total} 則對話，目前顯示最近 {shown} 則",
+                total=total,
+                shown=shown,
+            )
         )
         self.load_older_chat_btn.setEnabled(shown < total)
 
@@ -4706,7 +5242,11 @@ class Dashboard(QDialog):
         self.refresh_chat()
 
     def manage_chat_history(self) -> None:
-        manager = ChatHistoryDialog(self.db, self)
+        manager = ChatHistoryDialog(
+            self.db,
+            self,
+            language=self.ui_language,
+        )
         manager.exec()
         if manager.changed:
             self.refresh_chat()
@@ -4746,43 +5286,74 @@ class Dashboard(QDialog):
             category = to_taiwan_traditional(str(row["category"]))
             counts[category] = counts.get(category, 0) + 1
         if hasattr(self, "memory_filter"):
-            self.memory_filter.setItemText(0, f"全部記憶（{len(all_rows)}）")
+            self.memory_filter.setItemText(
+                0,
+                f"{self._t('all_memories', '全部記憶')}（{len(all_rows)}）",
+            )
             for index in range(1, self.memory_filter.count()):
                 category = str(self.memory_filter.itemData(index))
                 self.memory_filter.setItemText(
-                    index, f"{category}（{counts.get(category, 0)}）"
+                    index,
+                    f"{memory_category_label(self.ui_language, category)}"
+                    f"（{counts.get(category, 0)}）",
                 )
-        self.memory_count.setText(f"{len(rows)} 則")
+        self.memory_count.setText(
+            self._t("memory_count", "{count} 則", count=len(rows))
+        )
         if not rows:
-            empty = QListWidgetItem("這個分類目前沒有記憶。")
+            empty = QListWidgetItem(
+                self._t(
+                    "memory_empty",
+                    "這個分類目前沒有記憶。",
+                )
+            )
             empty.setFlags(Qt.NoItemFlags)
             self.memory_list.addItem(empty)
             return
         source_labels = {
-            "manual": "手動",
-            "conversation": "對話",
+            "manual": self._t(
+                "memory_source_manual_short",
+                "手動",
+            ),
+            "conversation": self._t(
+                "memory_source_conversation_short",
+                "對話",
+            ),
         }
         for row in rows:
             content = " ".join(
-                to_taiwan_traditional(str(row["content"])).split()
+                str(row["content"]).split()
             )
             if len(content) > 90:
                 content = content[:90].rstrip() + "…"
-            title = to_taiwan_traditional(
-                str(row["title"] or content or "未命名記憶")
+            title = str(
+                row["title"]
+                or content
+                or self._t("memory_untitled", "未命名記憶")
             )
             source = source_labels.get(
                 str(row["source"]), str(row["source"])
             )
             item = QListWidgetItem(
-                f"【{to_taiwan_traditional(str(row['category']))}】"
-                f"{title}　重要度 {int(row['importance'])}／5\n"
-                f"{content}\n來源：{source}　更新：{str(row['updated_at'])[5:16]}"
+                self._t(
+                    "memory_item",
+                    "【{category}】{title}　重要度 {importance}／5\n"
+                    "{content}\n來源：{source}　更新：{updated}",
+                    category=memory_category_label(
+                        self.ui_language,
+                        to_taiwan_traditional(str(row["category"])),
+                    ),
+                    title=title,
+                    importance=int(row["importance"]),
+                    content=content,
+                    source=source,
+                    updated=str(row["updated_at"])[5:16],
+                )
             )
             item.setData(Qt.UserRole, int(row["id"]))
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Unchecked)
-            item.setToolTip(to_taiwan_traditional(str(row["content"])))
+            item.setToolTip(str(row["content"]))
             self.memory_list.addItem(item)
 
     def refresh_todos(self) -> None:
@@ -4791,28 +5362,42 @@ class Dashboard(QDialog):
             if item.widget():
                 item.widget().deleteLater()
         rows = self.db.list_todos()
-        self.todo_count.setText(f"{len(rows)} 件未完成")
+        self.todo_count.setText(
+            self._t("todo_count", "{count} 件未完成", count=len(rows))
+        )
         if not rows:
-            empty = QLabel("今日卷冊尚空。\n主上先寫下一件真正重要的事。")
+            empty = QLabel(
+                self._t(
+                    "todo_empty",
+                    "今日卷冊尚空。\n主上先寫下一件真正重要的事。",
+                )
+            )
             empty.setObjectName("emptyState")
             empty.setAlignment(Qt.AlignCenter)
             self.todo_list.addWidget(empty)
         for row in rows:
-            widget = TodoRow(self.db, row)
+            widget = TodoRow(self.db, row, self.ui_language)
             widget.changed.connect(self.refresh_todos)
             self.todo_list.addWidget(widget)
 
     def refresh_ideas(self) -> None:
         self.idea_list.clear()
         rows = self.db.list_ideas()
-        self.idea_count.setText(f"{len(rows)} 則")
+        self.idea_count.setText(
+            self._t("idea_count", "{count} 則", count=len(rows))
+        )
         if not rows:
-            empty = QListWidgetItem("尚無靈感紀錄；輸入上方文字後按「收入靈感」。")
+            empty = QListWidgetItem(
+                self._t(
+                    "idea_empty",
+                    "尚無靈感紀錄；輸入上方文字後按「收入靈感」。",
+                )
+            )
             empty.setFlags(Qt.NoItemFlags)
             self.idea_list.addItem(empty)
         for row in rows:
-            title = to_taiwan_traditional(row["title"] or row["text"])
-            content = to_taiwan_traditional(row["content"] or "")
+            title = str(row["title"] or row["text"])
+            content = str(row["content"] or "")
             preview = " ".join(content.split())
             if len(preview) > 58:
                 preview = preview[:58] + "…"
@@ -4824,7 +5409,12 @@ class Dashboard(QDialog):
             item.setData(Qt.UserRole, int(row["id"]))
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Unchecked)
-            item.setToolTip("雙擊開啟並編輯標題與內文")
+            item.setToolTip(
+                self._t(
+                    "idea_edit_tooltip",
+                    "雙擊開啟並編輯標題與內文",
+                )
+            )
             self.idea_list.addItem(item)
 
     def refresh_work_time(self) -> None:
@@ -4835,40 +5425,78 @@ class Dashboard(QDialog):
             minutes, seconds_part = divmod(remainder, 60)
             total = f"{hours:02d}:{minutes:02d}:{seconds_part:02d}"
         else:
-            total = format_duration(seconds)
-        state = "計時中" if active else "未計時"
-        self.work_label.setText(f"今日 {total}｜{state}")
+            total = format_duration(seconds, self.ui_language)
+        state = self._t(
+            "timing_active" if active else "timing_inactive",
+            "計時中" if active else "未計時",
+        )
+        self.work_label.setText(
+            self._t(
+                "today_time",
+                "今日 {total}｜{state}",
+                total=total,
+                state=state,
+            )
+        )
 
     def add_todo(self) -> None:
-        text = to_taiwan_traditional(self.todo_input.text().strip())
+        text = self.todo_input.text().strip()
         if not text:
-            self.todo_feedback.setText("請先輸入待辦標題。")
+            self.todo_feedback.setText(
+                self._t("todo_title_required", "請先輸入待辦標題。")
+            )
             self.todo_input.setFocus()
             return
-        self.db.add_todo(text, self.todo_category.currentText())
+        category = str(
+            self.todo_category.currentData()
+            or self.todo_category.currentText()
+        )
+        self.db.add_todo(text, category)
         self.todo_input.clear()
         self.refresh_todos()
-        self.todo_feedback.setText(f"✓ 已加入待辦：{text}")
+        self.todo_feedback.setText(
+            self._t("todo_added", "✓ 已加入待辦：{text}", text=text)
+        )
         self.todo_input.setFocus()
-        self.speak_requested.emit("已收入今日卷冊。", "happy")
+        self.speak_requested.emit(
+            self._t("todo_added_speech", "已收入今日卷冊。"), "happy"
+        )
 
     def add_idea(self) -> None:
-        text = to_taiwan_traditional(self.todo_input.text().strip())
+        text = self.todo_input.text().strip()
         if not text:
-            self.todo_feedback.setText("請先輸入要收藏的靈感。")
+            self.todo_feedback.setText(
+                self._t(
+                    "idea_capture_required",
+                    "請先輸入要收藏的靈感。",
+                )
+            )
             self.todo_input.setFocus()
             return
         self.db.add_idea(text)
         self.todo_input.clear()
         self.refresh_ideas()
-        self.todo_feedback.setText(f"✓ 已收入靈感：{text}")
+        self.todo_feedback.setText(
+            self._t("idea_added", "✓ 已收入靈感：{text}", text=text)
+        )
         self.todo_input.setFocus()
-        self.speak_requested.emit("靈光稍縱即逝，妾已替主上收好。", "happy")
+        self.speak_requested.emit(
+            self._t(
+                "idea_added_speech",
+                "靈光稍縱即逝，妾已替主上收好。",
+            ),
+            "happy",
+        )
 
     def edit_selected_idea(self) -> None:
         item = self.idea_list.currentItem()
         if item is None or item.data(Qt.UserRole) is None:
-            self.todo_feedback.setText("請先選取一則要編輯的靈感。")
+            self.todo_feedback.setText(
+                self._t(
+                    "idea_select_edit",
+                    "請先選取一則要編輯的靈感。",
+                )
+            )
             return
         self.edit_idea_item(item)
 
@@ -4878,19 +5506,31 @@ class Dashboard(QDialog):
             return
         row = self.db.idea(int(idea_id))
         if row is None:
-            self.todo_feedback.setText("找不到這則靈感，請重新整理後再試。")
+            self.todo_feedback.setText(
+                self._t(
+                    "idea_not_found",
+                    "找不到這則靈感，請重新整理後再試。",
+                )
+            )
             return
         editor = IdeaEditorDialog(
             str(row["title"] or row["text"]),
             str(row["content"] or ""),
             self,
+            language=self.ui_language,
         )
         if editor.exec() != QDialog.Accepted:
             return
         title, content = editor.values()
         self.db.update_idea(int(idea_id), title, content)
         self.refresh_ideas()
-        self.todo_feedback.setText(f"✓ 已更新靈感：{title}")
+        self.todo_feedback.setText(
+            self._t(
+                "idea_updated",
+                "✓ 已更新靈感：{title}",
+                title=title,
+            )
+        )
 
     def checked_idea_ids(self) -> list[int]:
         checked: list[int] = []
@@ -4904,12 +5544,21 @@ class Dashboard(QDialog):
     def delete_checked_ideas(self) -> None:
         idea_ids = self.checked_idea_ids()
         if not idea_ids:
-            self.todo_feedback.setText("請先勾選要刪除的靈感。")
+            self.todo_feedback.setText(
+                self._t(
+                    "idea_select_delete",
+                    "請先勾選要刪除的靈感。",
+                )
+            )
             return
         answer = QMessageBox.question(
             self,
-            "刪除創作靈感",
-            f"確定永久刪除勾選的 {len(idea_ids)} 則靈感嗎？",
+            self._t("idea_delete_title", "刪除創作靈感"),
+            self._t(
+                "idea_delete_confirm",
+                "確定永久刪除勾選的 {count} 則靈感嗎？",
+                count=len(idea_ids),
+            ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
@@ -4917,7 +5566,13 @@ class Dashboard(QDialog):
             return
         deleted = self.db.delete_ideas(idea_ids)
         self.refresh_ideas()
-        self.todo_feedback.setText(f"✓ 已刪除 {deleted} 則靈感。")
+        self.todo_feedback.setText(
+            self._t(
+                "idea_deleted",
+                "✓ 已刪除 {count} 則靈感。",
+                count=deleted,
+            )
+        )
 
     def start_work(self) -> None:
         if self.db.start_work():
@@ -5027,16 +5682,19 @@ class Dashboard(QDialog):
         self.speak_requested.emit(line, "speaking")
 
     def send_chat(self) -> None:
-        text = normalize_for_language(
-            self.chat_input.text().strip(),
-            self.ui_language,
-        )
+        text = self.chat_input.text().strip()
         if not text:
             QMessageBox.information(
                 self,
-                "尚未輸入內容",
-                "請先在左側輸入文字，再按「送出文字」；"
-                "也可以按麥克風直接說話。",
+                self._t(
+                    "send_chat_required_title",
+                    "尚未輸入內容",
+                ),
+                self._t(
+                    "send_chat_required",
+                    "請先在左側輸入文字，再按「送出文字」；"
+                    "也可以按麥克風直接說話。",
+                ),
             )
             self.chat_input.setFocus()
             return
@@ -5049,14 +5707,17 @@ class Dashboard(QDialog):
         if self._handle_command(text, source=source):
             return
         self.ai_queue.append((text, self.mode))
-        self.set_voice_phase(f"{self.assistant_name}思考中…")
+        self.set_voice_phase(
+            self._t(
+                "thinking_status",
+                "{assistant}思考中…",
+                assistant=self.assistant_name,
+            )
+        )
         self._start_next_ai_request()
 
     def _receive_remote_command(self, text: str) -> None:
-        normalized = normalize_for_language(
-            text.strip(),
-            self.ui_language,
-        )
+        normalized = text.strip()
         if not normalized:
             return
         # The remote server has already authenticated and audited the device.
@@ -5073,7 +5734,13 @@ class Dashboard(QDialog):
             return
         text, mode = self.ai_queue.popleft()
         self.ai_busy = True
-        self.set_voice_phase(f"{self.assistant_name}思考中…")
+        self.set_voice_phase(
+            self._t(
+                "thinking_status",
+                "{assistant}思考中…",
+                assistant=self.assistant_name,
+            )
+        )
         history = [{"role": row["role"], "content": row["content"]} for row in self.db.recent_chat()]
         worker = AIWorker(
             AIWorkerRequest(
@@ -5196,7 +5863,10 @@ class Dashboard(QDialog):
         elif "今天" in text and any(
             marker in text for marker in TODAY_WORK_DURATION_MARKERS
         ):
-            duration = format_duration(self.db.today_work_seconds())
+            duration = format_duration(
+                self.db.today_work_seconds(),
+                self.ui_language,
+            )
             self._reply(f"主上今日已工作 {duration}。", "speaking")
         else:
             return False
@@ -5247,13 +5917,10 @@ class Dashboard(QDialog):
         intensity: float = 0.5,
         source: str = "conversation",
     ) -> None:
-        text = normalize_for_language(
-            personalize_text(self.db, text),
-            self.ui_language,
-        )
+        text = personalize_text(self.db, text)
         self.db.log_chat("assistant", text)
         self.append_chat(self.assistant_name, text)
-        self.set_voice_phase("回答中…")
+        self.set_voice_phase(self._t("answering_status", "回答中…"))
         self.next_expression_metadata = (
             state,
             max(0.0, min(1.0, float(intensity))),
@@ -5419,13 +6086,25 @@ class Dashboard(QDialog):
         else:
             message = "雲端傳音暫時中斷。妾仍在，只是此刻無法借用外部智識。"
         self._reply(message, "worried")
-        self.api_status.setText(f"OpenAI API：連線失敗（{error[:70]}）")
+        self.api_status.setText(
+            self._t(
+                "api_connection_failed",
+                "OpenAI API：連線失敗（{error}）",
+                error=error[:70],
+            )
+        )
         self.ai_busy = False
         self._start_next_ai_request()
 
     def _voice_text(self, text: str) -> None:
-        text = normalize_for_language(text, self.ui_language)
-        self.set_voice_phase("墨寒思考中…")
+        text = text.strip()
+        self.set_voice_phase(
+            self._t(
+                "thinking_status",
+                "{assistant}思考中…",
+                assistant=self.assistant_name,
+            )
+        )
         wake_word = profile_setting(self.db, "wake_word")
         self.chat_input.setText(
             text.replace(wake_word, "", 1).strip() or text
@@ -5434,27 +6113,39 @@ class Dashboard(QDialog):
         self.send_chat()
 
     def _voice_error(self, message: str) -> None:
-        self.set_voice_phase("準備就緒")
+        self.set_voice_phase(
+            self._t("voice_ready_short", "準備就緒")
+        )
         self.append_chat("寒", message)
         self.speak_requested.emit(message, "worried")
 
     def _listening_changed(self, listening: bool) -> None:
         if not listening:
-            self.mic_btn.setText("🎙 麥克風")
+            self.mic_btn.setText(
+                self._t("microphone_idle", "🎙 麥克風")
+            )
             self.mic_btn.setEnabled(True)
         elif self.listener.is_recording:
-            self.mic_btn.setText("⏹ 立即送出")
+            self.mic_btn.setText(
+                self._t("microphone_send_now", "⏹ 立即送出")
+            )
             self.mic_btn.setEnabled(True)
         else:
-            self.mic_btn.setText("辨識中…")
+            self.mic_btn.setText(
+                self._t("microphone_recognizing", "辨識中…")
+            )
             self.mic_btn.setEnabled(False)
 
     def _recording_changed(self, recording: bool) -> None:
         if recording:
-            self.mic_btn.setText("⏹ 立即送出")
+            self.mic_btn.setText(
+                self._t("microphone_send_now", "⏹ 立即送出")
+            )
             self.mic_btn.setEnabled(True)
         else:
-            self.mic_btn.setText("辨識中…")
+            self.mic_btn.setText(
+                self._t("microphone_recognizing", "辨識中…")
+            )
             self.mic_btn.setEnabled(False)
 
     def _transcription_diagnostic(self, message: str) -> None:
@@ -5463,21 +6154,36 @@ class Dashboard(QDialog):
             self.transcription_diagnostic.setText(message)
 
     def set_voice_phase(self, phase: str) -> None:
-        self.voice_phase.setText(f"語音狀態：{phase}")
+        self.voice_phase.setText(
+            self._t(
+                "voice_status_format",
+                "語音狀態：{phase}",
+                phase=phase,
+            )
+        )
 
-    @staticmethod
-    def _format_platform_updated(value: str) -> str:
+    def _format_platform_updated(self, value: str) -> str:
         try:
             updated = datetime.fromisoformat(value)
-            return f"更新：{updated:%m/%d %H:%M}"
+            return self._t(
+                "platform_updated",
+                "更新：{updated}",
+                updated=f"{updated:%m/%d %H:%M}",
+            )
         except (TypeError, ValueError):
-            return "更新時間不明"
+            return self._t(
+                "platform_updated_unknown",
+                "更新時間不明",
+            )
 
     def _platform_update(self, platform: str) -> PlatformProgressUpdate:
         controls = self.platform_controls[platform]
         return PlatformProgressUpdate(
             platform=platform,
-            status=controls.status.currentText(),
+            status=str(
+                controls.status.currentData()
+                or controls.status.currentText()
+            ),
             item_name=controls.item_name.text(),
             missing=controls.missing.text(),
             next_action=controls.next_action.text(),
@@ -5490,11 +6196,19 @@ class Dashboard(QDialog):
             return
         controls = self.platform_controls[platform]
         controls.dirty = True
-        controls.save_button.setText("保存變更")
-        controls.updated.setText("尚未保存")
+        controls.save_button.setText(
+            self._t("save_changes", "保存變更")
+        )
+        controls.updated.setText(
+            self._t("platform_not_saved", "尚未保存")
+        )
         controls.timer.start()
         self.platform_feedback.setText(
-            f"{platform} 有變更，正在等待自動保存……"
+            self._t(
+                "platform_waiting_auto_save",
+                "{platform} 有變更，正在等待自動保存……",
+                platform=platform,
+            )
         )
         self._validate_platform(platform)
         self._refresh_platform_summary()
@@ -5502,7 +6216,10 @@ class Dashboard(QDialog):
 
     def _validate_platform(self, platform: str) -> None:
         controls = self.platform_controls[platform]
-        status = controls.status.currentText()
+        status = str(
+            controls.status.currentData()
+            or controls.status.currentText()
+        )
         missing = controls.missing.text().strip()
         next_action = controls.next_action.text().strip()
         item_name = controls.item_name.text().strip()
@@ -5510,13 +6227,22 @@ class Dashboard(QDialog):
         message = ""
         color = "#efc27f"
         if status in {"已完成", "已上架"} and missing:
-            message = "注意：工作已完成，但仍列有待補資料或阻礙。"
+            message = self._t(
+                "platform_validation_finished_blocked",
+                "注意：工作已完成，但仍列有待補資料或阻礙。",
+            )
         elif status == "需修正" and not (missing or next_action or notes):
-            message = "請在待補資料／阻礙、下一步或備註中寫明需修正的內容。"
+            message = self._t(
+                "platform_validation_revision_details",
+                "請在待補資料／阻礙、下一步或備註中寫明需修正的內容。",
+            )
         elif status == "尚未開始" and any(
             (item_name, missing, next_action, notes)
         ):
-            message = "已有工作資料，請確認狀態是否應改為「準備資料」。"
+            message = self._t(
+                "platform_validation_not_started_data",
+                "已有工作資料，請確認狀態是否應改為「準備資料」。",
+            )
         elif status in {
             "待送出",
             "等待回覆",
@@ -5525,7 +6251,10 @@ class Dashboard(QDialog):
             "已完成",
             "已上架",
         } and not item_name:
-            message = "建議填寫工作項目、專案或案件名稱，日後較容易辨認。"
+            message = self._t(
+                "platform_validation_item_name",
+                "建議填寫工作項目、專案或案件名稱，日後較容易辨認。",
+            )
             color = "#356f8d"
         controls.validation.setText(message)
         controls.validation.setStyleSheet(f"color:{color};")
@@ -5534,7 +6263,7 @@ class Dashboard(QDialog):
         if not hasattr(self, "platform_controls"):
             return
         statuses = [
-            controls.status.currentText()
+            str(controls.status.currentData() or controls.status.currentText())
             for controls in self.platform_controls.values()
         ]
         missing_count = sum(
@@ -5550,29 +6279,51 @@ class Dashboard(QDialog):
         )
         not_started = statuses.count("尚未開始")
         in_progress = len(statuses) - finished - not_started
-        dirty_text = f"｜未保存 {dirty_count}" if dirty_count else ""
+        dirty_text = (
+            self._t(
+                "platform_summary_unsaved",
+                "｜未保存 {count}",
+                count=dirty_count,
+            )
+            if dirty_count
+            else ""
+        )
         self.platform_summary.setText(
-            f"{len(statuses)} 個平台｜已完成 {finished}｜"
-            f"進行中 {in_progress}｜尚未開始 {not_started}｜"
-            f"待補／阻礙 {missing_count}{dirty_text}"
+            self._t(
+                "platform_summary",
+                "{total} 個平台｜已完成 {finished}｜進行中 {active}｜"
+                "尚未開始 {not_started}｜待補／阻礙 {blocked}{unsaved}",
+                total=len(statuses),
+                finished=finished,
+                active=in_progress,
+                not_started=not_started,
+                blocked=missing_count,
+                unsaved=dirty_text,
+            )
         )
 
     def _filter_platform_cards(self, _value: str = "") -> None:
         if not hasattr(self, "platform_filter"):
             return
-        selected = self.platform_filter.currentText()
+        selected = str(
+            self.platform_filter.currentData()
+            or self.platform_filter.currentText()
+        )
         for controls in self.platform_controls.values():
-            status = controls.status.currentText()
+            status = str(
+                controls.status.currentData()
+                or controls.status.currentText()
+            )
             has_missing = bool(controls.missing.text().strip())
             visible = (
-                selected == "全部平台"
-                or selected == "進行中"
+                selected == "all"
+                or selected == "active"
                 and status not in {"尚未開始", "已完成", "已上架"}
-                or selected == "待補資料／阻礙"
+                or selected == "blocked"
                 and has_missing
-                or selected == "已完成／已上架"
+                or selected == "finished"
                 and status in {"已完成", "已上架"}
-                or selected == "尚未開始"
+                or selected == "not_started"
                 and status == "尚未開始"
             )
             controls.card.setVisible(visible)
@@ -5582,7 +6333,9 @@ class Dashboard(QDialog):
         controls.timer.stop()
         self.db.update_platforms([self._platform_update(platform)])
         controls.dirty = False
-        controls.save_button.setText("保存此平台")
+        controls.save_button.setText(
+            self._t("save_platform", "保存此平台")
+        )
         controls.updated.setText(
             self._format_platform_updated(
                 local_wall_time().isoformat(timespec="seconds")
@@ -5591,7 +6344,11 @@ class Dashboard(QDialog):
         self._validate_platform(platform)
         self._refresh_platform_summary()
         self.platform_feedback.setText(
-            f"{platform} 已{'自動' if silent else ''}保存。"
+            self._t(
+                "platform_saved_automatic" if silent else "platform_saved",
+                "{platform} 已自動保存。" if silent else "{platform} 已保存。",
+                platform=platform,
+            )
         )
 
     def save_platforms(self, silent: bool = False) -> None:
@@ -5603,7 +6360,9 @@ class Dashboard(QDialog):
         now = local_wall_time().isoformat(timespec="seconds")
         for platform, controls in self.platform_controls.items():
             controls.dirty = False
-            controls.save_button.setText("保存此平台")
+            controls.save_button.setText(
+                self._t("save_platform", "保存此平台")
+            )
             controls.updated.setText(
                 self._format_platform_updated(now)
             )
@@ -5614,11 +6373,19 @@ class Dashboard(QDialog):
             for controls in self.platform_controls.values()
         )
         self.platform_feedback.setText(
-            f"全部工作平台已保存；{missing_count} 個平台仍列有待補資料或阻礙。"
+            self._t(
+                "all_platforms_saved",
+                "全部工作平台已保存；{count} 個平台仍列有待補資料或阻礙。",
+                count=missing_count,
+            )
         )
         if not silent:
             self.speak_requested.emit(
-                f"工作平台已保存。仍有 {missing_count} 個平台標有待補資料或阻礙。",
+                self._t(
+                    "all_platforms_saved_speech",
+                    "工作平台已保存。仍有 {count} 個平台標有待補資料或阻礙。",
+                    count=missing_count,
+                ),
                 "happy",
             )
 
@@ -5629,14 +6396,17 @@ class Dashboard(QDialog):
             return
         self.db.add_memory(
             text,
-            self.memory_category.currentText(),
+            str(self.memory_category.currentData() or "其他"),
             "manual",
             4,
         )
         self.memory_input.clear()
         self.refresh_memories()
         self.speak_requested.emit(
-            "妾已記下。主上日後若要更改，也可逐項整理。",
+            self._t(
+                "memory_added_speech",
+                "妾已記下。主上日後若要更改，也可逐項整理。",
+            ),
             "happy",
         )
 
@@ -5644,7 +6414,12 @@ class Dashboard(QDialog):
         item = self.memory_list.currentItem()
         if item is None or item.data(Qt.UserRole) is None:
             QMessageBox.information(
-                self, "尚未選取", "請先選取一則要編輯的記憶。"
+                self,
+                self._t("memory_select_edit_title", "尚未選取"),
+                self._t(
+                    "memory_select_edit",
+                    "請先選取一則要編輯的記憶。",
+                ),
             )
             return
         self.edit_memory_item(item)
@@ -5656,11 +6431,20 @@ class Dashboard(QDialog):
         row = self.db.memory(int(memory_id))
         if row is None:
             QMessageBox.information(
-                self, "找不到記憶", "這則記憶已不存在，清單將重新整理。"
+                self,
+                self._t("memory_not_found_title", "找不到記憶"),
+                self._t(
+                    "memory_not_found",
+                    "這則記憶已不存在，清單將重新整理。",
+                ),
             )
             self.refresh_memories()
             return
-        editor = MemoryEditorDialog(row, self)
+        editor = MemoryEditorDialog(
+            row,
+            self,
+            language=self.ui_language,
+        )
         if editor.exec() != QDialog.Accepted:
             return
         title, content, category, importance = editor.values()
@@ -5669,8 +6453,14 @@ class Dashboard(QDialog):
         ):
             QMessageBox.warning(
                 self,
-                "無法保存記憶",
-                "可能已有內容完全相同的記憶。原有資料未被變更。",
+                self._t(
+                    "memory_save_failed_title",
+                    "無法保存記憶",
+                ),
+                self._t(
+                    "memory_save_failed",
+                    "可能已有內容完全相同的記憶。原有資料未被變更。",
+                ),
             )
             return
         self.refresh_memories()
@@ -5688,13 +6478,25 @@ class Dashboard(QDialog):
         memory_ids = self.checked_memory_ids()
         if not memory_ids:
             QMessageBox.information(
-                self, "尚未勾選", "請先勾選要刪除的記憶。"
+                self,
+                self._t(
+                    "memory_select_delete_title",
+                    "尚未勾選",
+                ),
+                self._t(
+                    "memory_select_delete",
+                    "請先勾選要刪除的記憶。",
+                ),
             )
             return
         answer = QMessageBox.question(
             self,
-            "刪除長期記憶",
-            f"確定永久刪除勾選的 {len(memory_ids)} 則記憶嗎？",
+            self._t("memory_delete_title", "刪除長期記憶"),
+            self._t(
+                "memory_delete_confirm",
+                "確定永久刪除勾選的 {count} 則記憶嗎？",
+                count=len(memory_ids),
+            ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
@@ -5713,8 +6515,11 @@ class Dashboard(QDialog):
     def clear_memories(self) -> None:
         answer = QMessageBox.question(
             self,
-            "清除長期記憶",
-            "確定要刪除墨寒保存的全部長期記憶嗎？此動作無法復原。",
+            self._t("memory_clear_title", "清除長期記憶"),
+            self._t(
+                "memory_clear_confirm",
+                "確定要刪除墨寒保存的全部長期記憶嗎？此動作無法復原。",
+            ),
         )
         if answer == QMessageBox.Yes:
             self.db.clear_memories()
@@ -5725,15 +6530,23 @@ class Dashboard(QDialog):
         self.refresh_memories()
         QMessageBox.information(
             self,
-            "記憶整理完成",
-            f"合併 {result['deduplicated']} 則近似記憶，"
-            f"封存 {result['pruned']} 則較舊低重要度記憶。\n"
-            f"目前使用中 {result['active']} 則；"
-            f"可還原封存 {result['archived']} 則。",
+            self._t("memory_optimize_title", "記憶整理完成"),
+            self._t(
+                "memory_optimize_result",
+                "合併 {deduplicated} 則近似記憶，"
+                "封存 {pruned} 則較舊低重要度記憶。\n"
+                "目前使用中 {active} 則；"
+                "可還原封存 {archived} 則。",
+                **result,
+            ),
         )
 
     def show_archived_memories(self) -> None:
-        dialog = ArchivedMemoryDialog(self.db, self)
+        dialog = ArchivedMemoryDialog(
+            self.db,
+            self,
+            language=self.ui_language,
+        )
         dialog.exec()
         if dialog.changed:
             self.refresh_memories()
@@ -5930,7 +6743,10 @@ class Dashboard(QDialog):
         self.db.set_setting("voice_muted", muted)
         self.volume_changed.emit(volume, muted)
 
-    def _topmost_mode_changed(self, mode: str) -> None:
+    def _topmost_mode_changed(self, _index: int) -> None:
+        mode = str(
+            self.topmost_mode.currentData() or "智慧置頂（推薦）"
+        )
         self.db.set_setting("topmost_mode", mode)
         self.topmost_mode_changed.emit(mode)
 
@@ -6204,18 +7020,36 @@ class Dashboard(QDialog):
         if not url:
             QMessageBox.information(
                 self,
-                "尚未設定網址",
-                f"請先在「{platform}」卡片填入網站或工具網址。",
+                self._t(
+                    "platform_url_missing_title",
+                    "尚未設定網址",
+                ),
+                self._t(
+                    "platform_url_missing",
+                    "請先在「{platform}」卡片填入網站或工具網址。",
+                    platform=platform,
+                ),
             )
             return
         if not url.lower().startswith(("https://", "http://")):
             QMessageBox.warning(
                 self,
-                "網址格式不支援",
-                "只允許開啟 http:// 或 https:// 網址。",
+                self._t(
+                    "platform_url_unsupported_title",
+                    "網址格式不支援",
+                ),
+                self._t(
+                    "platform_url_unsupported",
+                    "只允許開啟 http:// 或 https:// 網址。",
+                ),
             )
             return
-        if self._permission_allowed("open_web", f"開啟 {platform} 網站"):
+        action = self._t(
+            "permission_open_platform",
+            "開啟 {platform} 網站",
+            platform=platform,
+        )
+        if self._permission_allowed("open_web", action):
             webbrowser.open(url)
 
     def _current_profile_localization(self) -> ProfileLocalizationContext:
@@ -6235,8 +7069,8 @@ class Dashboard(QDialog):
         if not assistant_name or not user_title:
             QMessageBox.information(
                 self,
-                "尚缺必要資料",
-                "助理名稱與助理對你的稱呼不可留空。",
+                self._settings_text(SettingsText.PROFILE_REQUIRED_TITLE),
+                self._settings_text(SettingsText.PROFILE_REQUIRED_MESSAGE),
             )
             return None
         return ProfileSettingsValues(
@@ -6401,12 +7235,18 @@ class Dashboard(QDialog):
                 "persona_prompt",
                 persona or default_persona_for_language(ui_language),
             ),
-            ("topmost_mode", self.topmost_mode.currentText()),
+            (
+                "topmost_mode",
+                str(self.topmost_mode.currentData() or "智慧置頂（推薦）"),
+            ),
             (
                 "character_scale_percent",
                 self.character_scale_slider.value(),
             ),
-            ("proactive_mode", self.proactive_mode.currentText()),
+            (
+                "proactive_mode",
+                str(self.proactive_mode.currentData() or "平衡（推薦）"),
+            ),
             (
                 "background_assistant_enabled",
                 self.background_assistant_enabled.isChecked(),
@@ -6450,8 +7290,11 @@ class Dashboard(QDialog):
         except OSError as exc:
             QMessageBox.warning(
                 self,
-                "自動啟動",
-                f"無法更新自動啟動：{exc}",
+                self._settings_text(SettingsText.AUTOSTART_ERROR_TITLE),
+                self._settings_text(
+                    SettingsText.AUTOSTART_ERROR,
+                    reason=exc,
+                ),
             )
             return
         self.db.set_setting("autostart", enabled)
@@ -6514,11 +7357,16 @@ class Dashboard(QDialog):
     def open_work_folder(self) -> None:
         value = self.work_folder.text().strip()
         if value and Path(value).is_dir():
-            if self._permission_allowed("open_folder", "開啟工作室資料夾"):
+            if self._permission_allowed(
+                "open_folder",
+                self._settings_text(SettingsText.WORK_FOLDER_OPEN),
+            ):
                 self.platform_services.open_path(Path(value))
         else:
             QMessageBox.information(
-                self, "工作資料夾", "請先填入有效的資料夾路徑。"
+                self,
+                self._settings_text(SettingsText.WORK_FOLDER_INVALID_TITLE),
+                self._settings_text(SettingsText.WORK_FOLDER_INVALID_MESSAGE),
             )
 
 
@@ -7037,14 +7885,15 @@ class CompanionWindow(QMainWindow):
             self.move(proposed)
 
     def _show_bubble(self, text: str) -> None:
-        normalized = normalize_for_language(
-            text.strip(),
-            profile_setting(self.db, "ui_language"),
-        )
+        normalized = text.strip()
         if len(normalized) > 230:
             display = (
                 normalized[:227].rstrip()
-                + "…\n（完整內容請見對話頁）"
+                + ui_text(
+                    profile_setting(self.db, "ui_language"),
+                    "bubble_full_content",
+                    "…\n（完整內容請見對話頁）",
+                )
             )
         else:
             display = normalized
@@ -7119,6 +7968,8 @@ class CompanionWindow(QMainWindow):
         self.viseme_dynamics = VisemeDynamics()
         self.mouth_aperture_target = 0.0
         self.head_motion_y = 0.0
+        self.speech_motion_release_attempts = 0
+        self.realtime_motion_release_attempts = 0
         self.after_speech_state = "idle"
         self.speech_closed_expression = "idle"
         self.speech_mid_expression = "mouth_mid"
@@ -7167,7 +8018,7 @@ class CompanionWindow(QMainWindow):
         self.gaze_target_x = 0.0
         self.gaze_target_y = 0.0
         self.motion_timer = QTimer(self)
-        self.motion_timer.setInterval(16)
+        self.motion_timer.setInterval(MOTION_FRAME_INTERVAL_MS)
         self.motion_timer.timeout.connect(self._motion_tick)
         self.motion_timer.start()
         self.attention_pose = ""
@@ -7201,8 +8052,19 @@ class CompanionWindow(QMainWindow):
         self.tray.setToolTip(profile_window_title(self.db))
         menu = QMenu()
         self.tray_menu = menu
-        open_action = QAction("開啟今日卷冊", self)
-        quit_action = QAction("讓寒歸劍", self)
+        language = profile_setting(self.db, "ui_language")
+        open_action = QAction(
+            ui_text(
+                language,
+                "tray_open_today",
+                "開啟今日卷冊",
+            ),
+            self,
+        )
+        quit_action = QAction(
+            ui_text(language, "tray_quit", "讓寒歸劍"),
+            self,
+        )
         open_action.triggered.connect(self.open_dashboard)
         quit_action.triggered.connect(QApplication.instance().quit)
         menu.addAction(open_action)
@@ -7759,6 +8621,41 @@ class CompanionWindow(QMainWindow):
             value = getattr(self, attribute)
             if abs(value) < 0.015:
                 setattr(self, attribute, 0.0)
+        self._compose_character_position()
+
+    def _begin_speech_motion_release(self) -> None:
+        """Release the final spoken head lift while the mouth closes."""
+        if self.audio_driven_mouth:
+            self.mouth_closing = True
+        self.head_motion_y = 0.0
+        self.speech_motion_target_y = 0.0
+
+    def _wait_for_speech_motion_release(
+        self,
+        timer: QTimer,
+        attempts_attribute: str,
+    ) -> bool:
+        """Delay state hand-off until speech motion is visually centred."""
+        scale = getattr(self, "character_scale", 1.0)
+        if round(self.speech_motion_y * scale) == 0:
+            setattr(self, attempts_attribute, 0)
+            self._finish_speech_motion_release()
+            return False
+        attempts = int(getattr(self, attempts_attribute, 0)) + 1
+        if attempts >= SPEECH_MOTION_RELEASE_LIMIT:
+            setattr(self, attempts_attribute, 0)
+            self._finish_speech_motion_release()
+            return False
+        setattr(self, attempts_attribute, attempts)
+        timer.start(MOTION_FRAME_INTERVAL_MS)
+        return True
+
+    def _finish_speech_motion_release(self) -> None:
+        """Transfer visual ownership without changing the composed pixel."""
+        if not self.speech_motion_y:
+            return
+        self.ambient_motion_y += self.speech_motion_y
+        self.speech_motion_y = 0.0
         self._compose_character_position()
 
     def _compose_character_position(self) -> None:
@@ -9388,6 +10285,7 @@ class CompanionWindow(QMainWindow):
         # pose above the new closed-mouth frame for one or two audio cues.
         self._cancel_expression_transition()
         self._cancel_pose_transition()
+        self._stop_gesture_animation()
         self.expression_overlay.hide()
         self.mouth_timer.stop()
         self.mouth_visual_timer.stop()
@@ -9402,6 +10300,8 @@ class CompanionWindow(QMainWindow):
         self.mouth_aperture_target = 0.0
         self.head_motion_y = 0.0
         self.speech_motion_target_y = 0.0
+        self.speech_motion_release_attempts = 0
+        self.realtime_motion_release_attempts = 0
         self.mouth_frame_index = 0
         self.mouth_open = False
         self.speech_current_expression = self.speech_closed_expression
@@ -9716,6 +10616,7 @@ class CompanionWindow(QMainWindow):
         source: str = "conversation",
         intensity: float = 0.5,
         force: bool = False,
+        animate_gesture: bool = True,
     ) -> bool:
         decision = self.expression_arbiter.request(
             state,
@@ -9725,12 +10626,7 @@ class CompanionWindow(QMainWindow):
         )
         if not decision.accepted:
             return False
-        previous_animation = getattr(self, "state_animation", None)
-        if previous_animation is not None and previous_animation.state():
-            previous_animation.stop()
-        self.gesture_motion_x = 0.0
-        self.gesture_motion_y = 0.0
-        self._compose_character_position()
+        self._stop_gesture_animation()
         self.expression_generation += 1
         self.state = state
         if state == "idle":
@@ -9756,7 +10652,7 @@ class CompanionWindow(QMainWindow):
             "proud_front",
             *NEW_EXPRESSION_ASSETS,
         }
-        if state in expressive_states:
+        if state in expressive_states and animate_gesture:
             animation = QVariantAnimation(self)
             animation.setDuration(
                 720
@@ -9819,6 +10715,14 @@ class CompanionWindow(QMainWindow):
             animation.start()
             self.state_animation = animation
         return True
+
+    def _stop_gesture_animation(self) -> None:
+        animation = getattr(self, "state_animation", None)
+        if animation is not None and animation.state():
+            animation.stop()
+        self.gesture_motion_x = 0.0
+        self.gesture_motion_y = 0.0
+        self._compose_character_position()
 
     def _start_ai_wait_expression(
         self,
@@ -10200,11 +11104,7 @@ class CompanionWindow(QMainWindow):
                 )
             ):
                 continue
-            normalized = normalize_for_language(
-                content,
-                profile_setting(self.db, "ui_language"),
-            )
-            lines.append(f"{labels[role]}：{normalized}")
+            lines.append(f"{labels[role]}：{content}")
         return "\n".join(lines)[-5000:]
 
     def _configure_realtime_speech_output(self, mode: str) -> None:
@@ -10281,12 +11181,13 @@ class CompanionWindow(QMainWindow):
             self._configure_realtime_speech_output(output_mode)
         except (RuntimeError, ValueError) as exc:
             language = profile_setting(self.db, "ui_language")
+            safe_message = safe_error_message(language, exc)
             self.dashboard.set_realtime_status(
                 ui_text(
                     language,
                     "realtime_error_status",
                     "錯誤：{error}",
-                    error=exc,
+                    error=safe_message,
                 ),
                 False,
             )
@@ -10297,7 +11198,7 @@ class CompanionWindow(QMainWindow):
                     "realtime_voice_title",
                     "Realtime 語音",
                 ),
-                str(exc),
+                safe_message,
             )
             return
         self.realtime.start(
@@ -10394,10 +11295,7 @@ class CompanionWindow(QMainWindow):
         self.dashboard.set_realtime_status(status, self.realtime.running)
 
     def _realtime_user_text(self, text: str) -> None:
-        text = normalize_for_language(
-            text,
-            profile_setting(self.db, "ui_language"),
-        )
+        text = text.strip()
         wake_word = profile_setting(self.db, "wake_word")
         clean = text.replace(wake_word, "", 1).strip() or text
         self.db.log_chat("user", clean)
@@ -10435,10 +11333,7 @@ class CompanionWindow(QMainWindow):
 
     def _realtime_assistant_text(self, text: str) -> None:
         tagged = parse_internal_emotion(text)
-        text = normalize_for_language(
-            tagged.text,
-            profile_setting(self.db, "ui_language"),
-        )
+        text = tagged.text.strip()
         if not text:
             return
         self.db.log_chat("assistant", text)
@@ -10503,6 +11398,7 @@ class CompanionWindow(QMainWindow):
             self.realtime_mouth_active = False
             if not is_realtime_mouth:
                 return
+            self._begin_speech_motion_release()
             if self.realtime_finish_timer.isActive():
                 return
             if (
@@ -10527,16 +11423,24 @@ class CompanionWindow(QMainWindow):
 
     def _complete_realtime_speaking_stop(self) -> None:
         self.realtime_finish_timer.stop()
-        self.realtime_mouth_active = False
         was_realtime_speaking = (
             self.state == "speaking"
             and self.audio_driven_mouth
             and not self.speech_playing
         )
+        if not was_realtime_speaking:
+            self.realtime_mouth_active = False
+            if self.audio_driven_mouth or self.mouth_visual_timer.isActive():
+                self._stop_mouth_animation()
+            return
+        if self._wait_for_speech_motion_release(
+            self.realtime_finish_timer,
+            "realtime_motion_release_attempts",
+        ):
+            return
+        self.realtime_mouth_active = False
         if self.audio_driven_mouth or self.mouth_visual_timer.isActive():
             self._stop_mouth_animation()
-        if not was_realtime_speaking:
-            return
         final_state = self.realtime_after_speech_state
         self.realtime_after_speech_state = "idle"
         if (
@@ -10566,6 +11470,7 @@ class CompanionWindow(QMainWindow):
             source="ai_tag",
             intensity=final_intensity,
             force=True,
+            animate_gesture=False,
         )
         if final_state != "idle":
             self._schedule_return_to_idle(
@@ -10578,13 +11483,14 @@ class CompanionWindow(QMainWindow):
 
     def _realtime_failed(self, message: str) -> None:
         language = profile_setting(self.db, "ui_language")
+        safe_message = safe_error_message(language, message)
         self._stop_realtime_output()
         self.dashboard.set_realtime_status(
             ui_text(
                 language,
                 "realtime_error_status",
                 "錯誤：{error}",
-                error=message[:90],
+                error=safe_message,
             ),
             False,
         )
@@ -10595,7 +11501,7 @@ class CompanionWindow(QMainWindow):
                 "realtime_voice_title",
                 "Realtime 語音",
             ),
-            message,
+            safe_message,
         )
 
     def _stop_realtime_output(self) -> None:
@@ -10630,6 +11536,8 @@ class CompanionWindow(QMainWindow):
         provider_label: str,
         message: str,
     ) -> None:
+        language = profile_setting(self.db, "ui_language")
+        safe_message = safe_error_message(language, message)
         credentials = self._speech_credentials()
         configured = set(self._configured_speech_providers(credentials))
         candidates = (
@@ -10654,12 +11562,12 @@ class CompanionWindow(QMainWindow):
             )
             self.dashboard.set_api_status(
                 f"{provider_label}失敗，已切換 {fallback_label}："
-                f"{message[:50]}"
+                f"{safe_message}"
             )
         else:
             self.dashboard.set_api_status(
                 f"{provider_label}失敗；此平台沒有已驗證的本機語音備援："
-                f"{message[:50]}"
+                f"{safe_message}"
             )
         if (
             self.speech_playing
@@ -10705,13 +11613,16 @@ class CompanionWindow(QMainWindow):
 
     def _windows_voice_failed(self, message: str) -> None:
         platform_name = self.platform_services.capabilities.display_name
+        language = profile_setting(self.db, "ui_language")
         self.dashboard.set_api_status(
-            f"{platform_name} 本機語音失敗：{message[:70]}"
+            f"{platform_name} 本機語音失敗："
+            f"{safe_error_message(language, message)}"
         )
 
     def _speech_audio_finished(self) -> None:
         if not self.speech_playing:
             return
+        self._begin_speech_motion_release()
         if self.speech_finish_timer.isActive():
             return
         if (
@@ -10737,6 +11648,12 @@ class CompanionWindow(QMainWindow):
     def _complete_speech_audio_finished(self) -> None:
         if not self.speech_playing:
             return
+        self.speech_finish_timer.stop()
+        if self._wait_for_speech_motion_release(
+            self.speech_finish_timer,
+            "speech_motion_release_attempts",
+        ):
+            return
         self._stop_mouth_animation()
         final_state = self.after_speech_state
         final_intensity = getattr(self, "after_speech_intensity", 0.5)
@@ -10745,6 +11662,7 @@ class CompanionWindow(QMainWindow):
             source="conversation",
             intensity=final_intensity,
             force=True,
+            animate_gesture=False,
         )
         self.speech_playing = False
         self.active_speech_text = ""
@@ -10754,7 +11672,14 @@ class CompanionWindow(QMainWindow):
         if self.speech_queue:
             QTimer.singleShot(120, self._start_next_speech)
         else:
-            self.dashboard.set_voice_phase("準備就緒")
+            language = profile_setting(self.db, "ui_language")
+            self.dashboard.set_voice_phase(
+                ui_text(
+                    language,
+                    "voice_ready_short",
+                    "準備就緒",
+                )
+            )
             if final_state != "idle":
                 self._schedule_return_to_idle(
                     self.expression_arbiter.hold_duration(

--- a/app.py
+++ b/app.py
@@ -96,7 +96,6 @@ lazy from ai_client import (
     AIWorker,
     AIWorkerRequest,
 )
-lazy from safe_error_localization import safe_error_message
 lazy from azure_regions import (
     azure_region_identifiers,
     azure_region_options,
@@ -168,6 +167,7 @@ lazy from realtime_voice import (
     RealtimeVoiceClient,
     RealtimeVoiceRequest,
 )
+lazy from safe_error_localization import safe_error_message
 lazy from service_container import CompanionServices, create_default_services
 lazy from settings_ui_localization import (
     PHYSICS_TEXT_KEYS,
@@ -6699,6 +6699,7 @@ class Dashboard(QDialog):
         )
         if answer == QMessageBox.Yes:
             self.azure_secret_store.clear()
+            self._invalidate_azure_voice_catalog(hd_only=False)
             self.azure_key_input.clear()
             self.azure_key_input.setPlaceholderText(
                 self._t(
@@ -6723,6 +6724,7 @@ class Dashboard(QDialog):
         )
         if answer == QMessageBox.Yes:
             self.azure_hd_secret_store.clear()
+            self._invalidate_azure_voice_catalog(hd_only=True)
             self.azure_hd_key_input.clear()
             self.azure_hd_key_input.setPlaceholderText(
                 self._t(
@@ -6858,46 +6860,40 @@ class Dashboard(QDialog):
     def _save_azure_key_immediately(self) -> None:
         if self._persist_azure_key(silent=False):
             self.realtime_output_settings_changed.emit()
-            invalidate = getattr(
-                self.azure_tts,
-                "invalidate_voice_catalog",
-                None,
-            )
-            if invalidate is not None:
-                invalidate(
-                    str(self.azure_region.currentData() or "")
-                )
             self._request_azure_voice_catalog(hd_only=False)
 
     def _save_azure_hd_key_immediately(self) -> None:
         if self._persist_azure_hd_key(silent=False):
             self.realtime_output_settings_changed.emit()
-            invalidate = getattr(
-                self.azure_hd_tts,
-                "invalidate_voice_catalog",
-                None,
-            )
-            if invalidate is not None:
-                invalidate(
-                    str(self.azure_hd_region.currentData() or "")
-                )
             self._request_azure_voice_catalog(hd_only=True)
 
     def _persist_azure_key(self, *, silent: bool) -> bool:
-        return self._persist_secret_input(
+        saved = self._persist_secret_input(
             self.azure_key_input,
             self.azure_secret_store,
             AZURE_SECRET_POLICY,
             silent=silent,
         )
+        if saved:
+            self._invalidate_azure_voice_catalog(hd_only=False)
+        return saved
 
     def _persist_azure_hd_key(self, *, silent: bool) -> bool:
-        return self._persist_secret_input(
+        saved = self._persist_secret_input(
             self.azure_hd_key_input,
             self.azure_hd_secret_store,
             AZURE_HD_SECRET_POLICY,
             silent=silent,
         )
+        if saved:
+            self._invalidate_azure_voice_catalog(hd_only=True)
+        return saved
+
+    def _invalidate_azure_voice_catalog(self, *, hd_only: bool) -> None:
+        engine = self.azure_hd_tts if hd_only else self.azure_tts
+        invalidate = getattr(engine, "invalidate_voice_catalog", None)
+        if invalidate is not None:
+            invalidate()
 
     def _persist_secret_input(
         self,
@@ -6920,7 +6916,7 @@ class Dashboard(QDialog):
                     self._t(
                         policy.error_key,
                         policy.error_fallback,
-                        error=exc,
+                        error=safe_error_message(self.ui_language, exc),
                     ),
                 )
             return False
@@ -7293,7 +7289,7 @@ class Dashboard(QDialog):
                 self._settings_text(SettingsText.AUTOSTART_ERROR_TITLE),
                 self._settings_text(
                     SettingsText.AUTOSTART_ERROR,
-                    reason=exc,
+                    reason=safe_error_message(self.ui_language, exc),
                 ),
             )
             return

--- a/auxiliary_ui_localization.py
+++ b/auxiliary_ui_localization.py
@@ -4,6 +4,8 @@ lazy from collections.abc import Mapping
 lazy from enum import StrEnum
 
 lazy from language_support import canonical_ui_language
+lazy from safe_error import SafeError
+lazy from safe_error_localization import safe_error_message
 
 
 class AuxiliaryText(StrEnum):
@@ -611,13 +613,15 @@ def _profile_error_key(message: str) -> AuxiliaryText:
 
 def localized_operation_error(
     language: str,
-    message: str,
+    message: str | SafeError,
     *,
     operation: AuxiliaryOperation,
 ) -> str:
     """Localize backend failures without leaking source-language UI text."""
 
     normalized_language = canonical_ui_language(language)
+    if isinstance(message, SafeError):
+        return safe_error_message(normalized_language, message)
     if normalized_language == "zh-TW":
         return str(message).strip() or auxiliary_text(
             language,

--- a/auxiliary_ui_localization.py
+++ b/auxiliary_ui_localization.py
@@ -1,0 +1,633 @@
+from __future__ import annotations
+
+lazy from collections.abc import Mapping
+lazy from enum import StrEnum
+
+lazy from language_support import canonical_ui_language
+
+
+class AuxiliaryText(StrEnum):
+    """Complete, typed text contract for auxiliary desktop panels."""
+
+    UPDATE_TITLE = "update_title"
+    CURRENT_VERSION = "current_version"
+    CHANNEL_STABLE = "channel_stable"
+    CHANNEL_PREVIEW = "channel_preview"
+    AUTO_CHECK = "auto_check"
+    CHECK_NOW = "check_now"
+    DOWNLOAD_INSTALL = "download_install"
+    CHANNEL_LABEL = "channel_label"
+    NOT_CHECKED = "not_checked"
+    NOTES_PLACEHOLDER = "notes_placeholder"
+    CHECKING = "checking"
+    UP_TO_DATE = "up_to_date"
+    NEW_VERSION = "new_version"
+    NO_RELEASE_NOTES = "no_release_notes"
+    NEW_VERSION_TITLE = "new_version_title"
+    NEW_VERSION_AVAILABLE = "new_version_available"
+    DOWNLOAD_TITLE = "download_title"
+    DOWNLOAD_PROMPT = "download_prompt"
+    DOWNLOADING = "downloading"
+    VERIFIED_TITLE = "verified_title"
+    VERIFIED_PROMPT = "verified_prompt"
+    SAFE_DOWNLOADED = "safe_downloaded"
+    INSTALLER_LAUNCH_FAILED = "installer_launch_failed"
+    UPDATE_DIALOG_TITLE = "update_dialog_title"
+    UPDATE_ERROR_NO_RELEASE = "update_error_no_release"
+    UPDATE_ERROR_CONNECTION = "update_error_connection"
+    UPDATE_ERROR_SECURITY = "update_error_security"
+    UPDATE_ERROR_DATA = "update_error_data"
+    UPDATE_ERROR_VERSION = "update_error_version"
+    UPDATE_ERROR_DOWNLOAD = "update_error_download"
+    UPDATE_ERROR_GENERIC = "update_error_generic"
+    PROFILE_HEADING = "profile_heading"
+    PROFILE_NOTE = "profile_note"
+    EXPORT_BUTTON = "export_button"
+    IMPORT_BUTTON = "import_button"
+    DEFAULT_ASSISTANT_NAME = "default_assistant_name"
+    EXPORT_FILENAME = "export_filename"
+    EXPORT_DIALOG_TITLE = "export_dialog_title"
+    PROFILE_FILTER = "profile_filter"
+    EXPORT_FAILED_TITLE = "export_failed_title"
+    EXPORT_FAILED = "export_failed"
+    EXPORT_COMPLETE_TITLE = "export_complete_title"
+    EXPORT_COMPLETE = "export_complete"
+    IMPORT_DIALOG_TITLE = "import_dialog_title"
+    IMPORT_READ_FAILED_TITLE = "import_read_failed_title"
+    IMPORT_READ_FAILED = "import_read_failed"
+    LEGACY_SOURCE = "legacy_source"
+    UNKNOWN = "unknown"
+    UNNAMED = "unnamed"
+    OLDER_WARNING = "older_warning"
+    IMPORT_CONFIRM_TITLE = "import_confirm_title"
+    IMPORT_CONFIRM = "import_confirm"
+    IMPORT_FAILED_TITLE = "import_failed_title"
+    IMPORT_FAILED = "import_failed"
+    IMPORT_COMPLETE_TITLE = "import_complete_title"
+    IMPORT_COMPLETE = "import_complete"
+    PROFILE_ERROR_NOT_FOUND = "profile_error_not_found"
+    PROFILE_ERROR_FORMAT = "profile_error_format"
+    PROFILE_ERROR_SECURITY = "profile_error_security"
+    PROFILE_ERROR_DUPLICATE = "profile_error_duplicate"
+    PROFILE_ERROR_DATABASE = "profile_error_database"
+    PROFILE_ERROR_GENERIC = "profile_error_generic"
+
+
+class AuxiliaryOperation(StrEnum):
+    """Backend operation families that need user-facing error localization."""
+
+    PROFILE = "profile"
+    UPDATE = "update"
+
+
+_ZH_TW: Mapping[AuxiliaryText, str] = frozendict({
+    AuxiliaryText.UPDATE_TITLE: "<b>軟體更新</b>",
+    AuxiliaryText.CURRENT_VERSION: "目前版本：{version}",
+    AuxiliaryText.CHANNEL_STABLE: "穩定版（建議）",
+    AuxiliaryText.CHANNEL_PREVIEW: "預覽版／RC",
+    AuxiliaryText.AUTO_CHECK: "啟動後自動檢查更新",
+    AuxiliaryText.CHECK_NOW: "立即檢查更新",
+    AuxiliaryText.DOWNLOAD_INSTALL: "下載並安裝",
+    AuxiliaryText.CHANNEL_LABEL: "更新頻道",
+    AuxiliaryText.NOT_CHECKED: "尚未檢查",
+    AuxiliaryText.NOTES_PLACEHOLDER: "有新版本時會在此顯示版本說明。",
+    AuxiliaryText.CHECKING: "正在安全地檢查 GitHub Release……",
+    AuxiliaryText.UP_TO_DATE: "目前已是此更新頻道的最新版本。",
+    AuxiliaryText.NEW_VERSION: "發現新版本 {version}；安裝前會驗證 SHA256。",
+    AuxiliaryText.NO_RELEASE_NOTES: "此版本未提供說明。",
+    AuxiliaryText.NEW_VERSION_TITLE: "發現墨寒新版本",
+    AuxiliaryText.NEW_VERSION_AVAILABLE: "新版本 {version} 已可下載。",
+    AuxiliaryText.DOWNLOAD_TITLE: "下載官方更新",
+    AuxiliaryText.DOWNLOAD_PROMPT: (
+        "將從官方 GitHub Release 下載安裝程式，完成 SHA256 驗證後再啟動。\n\n"
+        "版本：{version}\n檔案：{filename}\n\n是否繼續？"
+    ),
+    AuxiliaryText.DOWNLOADING: "正在下載並核對安裝程式……",
+    AuxiliaryText.VERIFIED_TITLE: "驗證完成",
+    AuxiliaryText.VERIFIED_PROMPT: (
+        "SHA256 驗證通過。現在將關閉墨寒並開啟安裝程式。\n"
+        "您的對話、記憶、待辦與設定仍保留在本機資料目錄。\n\n"
+        "是否立即升級？"
+    ),
+    AuxiliaryText.SAFE_DOWNLOADED: "已安全下載：{path}",
+    AuxiliaryText.INSTALLER_LAUNCH_FAILED: "無法啟動安裝程式。",
+    AuxiliaryText.UPDATE_DIALOG_TITLE: "墨寒更新",
+    AuxiliaryText.UPDATE_ERROR_NO_RELEASE: "目前沒有此頻道可用的相容更新。",
+    AuxiliaryText.UPDATE_ERROR_CONNECTION: (
+        "無法連線至 GitHub 更新服務，請檢查網路後再試。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_SECURITY: (
+        "更新因來源、清單、大小或 SHA256 驗證未通過而被安全阻擋。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_DATA: "GitHub Release 的更新資料無法安全讀取。",
+    AuxiliaryText.UPDATE_ERROR_VERSION: "更新版本或頻道資料無效。",
+    AuxiliaryText.UPDATE_ERROR_DOWNLOAD: "安裝程式未能完整且安全地下載。",
+    AuxiliaryText.UPDATE_ERROR_GENERIC: "更新作業未能安全完成，請稍後再試。",
+    AuxiliaryText.PROFILE_HEADING: "<b>攜帶、換機與進度接續</b>",
+    AuxiliaryText.PROFILE_NOTE: (
+        "匯出後只需攜帶一個檔案，即可在另一台電腦接續對話、記憶、待辦、"
+        "靈感與工作進度。API 金鑰、OAuth、電腦權限、資料夾路徑與裝置設定"
+        "不會被帶走。"
+    ),
+    AuxiliaryText.EXPORT_BUTTON: "匯出墨寒攜帶檔",
+    AuxiliaryText.IMPORT_BUTTON: "匯入並接續進度",
+    AuxiliaryText.DEFAULT_ASSISTANT_NAME: "墨寒",
+    AuxiliaryText.EXPORT_FILENAME: "{assistant}-攜帶進度-{timestamp}{extension}",
+    AuxiliaryText.EXPORT_DIALOG_TITLE: "匯出墨寒攜帶檔",
+    AuxiliaryText.PROFILE_FILTER: "墨寒攜帶檔 (*{extension})",
+    AuxiliaryText.EXPORT_FAILED_TITLE: "匯出墨寒攜帶檔",
+    AuxiliaryText.EXPORT_FAILED: "匯出失敗：{reason}",
+    AuxiliaryText.EXPORT_COMPLETE_TITLE: "匯出完成",
+    AuxiliaryText.EXPORT_COMPLETE: (
+        "墨寒攜帶檔已建立。\n\n位置：{path}\n收錄資料與設定共 {count} 筆。\n\n"
+        "此檔案不含 API 金鑰、OAuth 權杖或本機電腦權限。"
+    ),
+    AuxiliaryText.IMPORT_DIALOG_TITLE: "匯入墨寒攜帶檔",
+    AuxiliaryText.IMPORT_READ_FAILED_TITLE: "匯入墨寒攜帶檔",
+    AuxiliaryText.IMPORT_READ_FAILED: "無法讀取攜帶檔：{reason}",
+    AuxiliaryText.LEGACY_SOURCE: "舊版攜帶檔",
+    AuxiliaryText.UNKNOWN: "未知",
+    AuxiliaryText.UNNAMED: "未命名",
+    AuxiliaryText.OLDER_WARNING: (
+        "\n\n⚠ 此檔建立時間早於上次匯入的進度。"
+        "若繼續，較新的共同進度可能被取代。"
+    ),
+    AuxiliaryText.IMPORT_CONFIRM_TITLE: "確認接續進度",
+    AuxiliaryText.IMPORT_CONFIRM: (
+        "即將以攜帶檔內的共同進度取代這台電腦目前的對話、記憶、待辦與工作資料。"
+        "\n\n建立時間：{created_at}\n來源裝置識別：{source}\n助理名稱：{assistant}"
+        "\n資料與設定：約 {count} 筆\n\n匯入前會自動備份目前資料；這台電腦的 "
+        "API 金鑰、OAuth、權限、路徑與裝置設定將維持不變。{older_warning}"
+        "\n\n確定匯入嗎？"
+    ),
+    AuxiliaryText.IMPORT_FAILED_TITLE: "匯入墨寒攜帶檔",
+    AuxiliaryText.IMPORT_FAILED: "匯入失敗，原資料未變更：{reason}",
+    AuxiliaryText.IMPORT_COMPLETE_TITLE: "進度接續完成",
+    AuxiliaryText.IMPORT_COMPLETE: (
+        "墨寒的共同進度已匯入完成。\n\n原資料備份：{path}\n\n"
+        "程式現在會安全關閉；請重新開啟墨寒，即可從匯入後的進度繼續使用。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_NOT_FOUND: "找不到指定的墨寒攜帶檔。",
+    AuxiliaryText.PROFILE_ERROR_FORMAT: "攜帶檔格式、版本或資料內容無法安全讀取。",
+    AuxiliaryText.PROFILE_ERROR_SECURITY: "攜帶檔未通過安全或完整性驗證。",
+    AuxiliaryText.PROFILE_ERROR_DUPLICATE: (
+        "這份攜帶檔已匯入過；為避免覆蓋較新的進度，本次未重複匯入。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_DATABASE: "資料庫匯入失敗；原資料未變更。",
+    AuxiliaryText.PROFILE_ERROR_GENERIC: "攜帶檔作業未能安全完成。",
+})
+
+_ZH_CN: Mapping[AuxiliaryText, str] = frozendict({
+    AuxiliaryText.UPDATE_TITLE: "<b>软件更新</b>",
+    AuxiliaryText.CURRENT_VERSION: "当前版本：{version}",
+    AuxiliaryText.CHANNEL_STABLE: "稳定版（推荐）",
+    AuxiliaryText.CHANNEL_PREVIEW: "预览版／RC",
+    AuxiliaryText.AUTO_CHECK: "启动后自动检查更新",
+    AuxiliaryText.CHECK_NOW: "立即检查更新",
+    AuxiliaryText.DOWNLOAD_INSTALL: "下载并安装",
+    AuxiliaryText.CHANNEL_LABEL: "更新频道",
+    AuxiliaryText.NOT_CHECKED: "尚未检查",
+    AuxiliaryText.NOTES_PLACEHOLDER: "有新版本时会在此显示版本说明。",
+    AuxiliaryText.CHECKING: "正在安全地检查 GitHub Release……",
+    AuxiliaryText.UP_TO_DATE: "当前已是此更新频道的最新版本。",
+    AuxiliaryText.NEW_VERSION: "发现新版本 {version}；安装前会验证 SHA256。",
+    AuxiliaryText.NO_RELEASE_NOTES: "此版本未提供说明。",
+    AuxiliaryText.NEW_VERSION_TITLE: "发现墨寒新版本",
+    AuxiliaryText.NEW_VERSION_AVAILABLE: "新版本 {version} 已可下载。",
+    AuxiliaryText.DOWNLOAD_TITLE: "下载官方更新",
+    AuxiliaryText.DOWNLOAD_PROMPT: (
+        "将从官方 GitHub Release 下载安装程序，完成 SHA256 验证后再启动。\n\n"
+        "版本：{version}\n文件：{filename}\n\n是否继续？"
+    ),
+    AuxiliaryText.DOWNLOADING: "正在下载并核对安装程序……",
+    AuxiliaryText.VERIFIED_TITLE: "验证完成",
+    AuxiliaryText.VERIFIED_PROMPT: (
+        "SHA256 验证通过。现在将关闭墨寒并启动安装程序。\n"
+        "您的对话、记忆、待办与设置仍保留在本地数据目录。\n\n"
+        "是否立即升级？"
+    ),
+    AuxiliaryText.SAFE_DOWNLOADED: "已安全下载：{path}",
+    AuxiliaryText.INSTALLER_LAUNCH_FAILED: "无法启动安装程序。",
+    AuxiliaryText.UPDATE_DIALOG_TITLE: "墨寒更新",
+    AuxiliaryText.UPDATE_ERROR_NO_RELEASE: "当前没有此频道可用的兼容更新。",
+    AuxiliaryText.UPDATE_ERROR_CONNECTION: (
+        "无法连接 GitHub 更新服务，请检查网络后重试。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_SECURITY: (
+        "更新因来源、清单、大小或 SHA256 验证未通过而被安全阻止。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_DATA: "无法安全读取 GitHub Release 更新数据。",
+    AuxiliaryText.UPDATE_ERROR_VERSION: "更新版本或频道数据无效。",
+    AuxiliaryText.UPDATE_ERROR_DOWNLOAD: "安装程序未能完整且安全地下载。",
+    AuxiliaryText.UPDATE_ERROR_GENERIC: "更新操作未能安全完成，请稍后重试。",
+    AuxiliaryText.PROFILE_HEADING: "<b>携带、换机与进度接续</b>",
+    AuxiliaryText.PROFILE_NOTE: (
+        "导出后只需携带一个文件，即可在另一台电脑接续对话、记忆、待办、"
+        "灵感与工作进度。API 密钥、OAuth、电脑权限、文件夹路径与设备设置"
+        "不会被带走。"
+    ),
+    AuxiliaryText.EXPORT_BUTTON: "导出墨寒携带文件",
+    AuxiliaryText.IMPORT_BUTTON: "导入并接续进度",
+    AuxiliaryText.DEFAULT_ASSISTANT_NAME: "墨寒",
+    AuxiliaryText.EXPORT_FILENAME: "{assistant}-携带进度-{timestamp}{extension}",
+    AuxiliaryText.EXPORT_DIALOG_TITLE: "导出墨寒携带文件",
+    AuxiliaryText.PROFILE_FILTER: "墨寒携带文件 (*{extension})",
+    AuxiliaryText.EXPORT_FAILED_TITLE: "导出墨寒携带文件",
+    AuxiliaryText.EXPORT_FAILED: "导出失败：{reason}",
+    AuxiliaryText.EXPORT_COMPLETE_TITLE: "导出完成",
+    AuxiliaryText.EXPORT_COMPLETE: (
+        "墨寒携带文件已建立。\n\n位置：{path}\n共收录 {count} 项数据与设置。\n\n"
+        "此文件不含 API 密钥、OAuth 令牌或本地电脑权限。"
+    ),
+    AuxiliaryText.IMPORT_DIALOG_TITLE: "导入墨寒携带文件",
+    AuxiliaryText.IMPORT_READ_FAILED_TITLE: "导入墨寒携带文件",
+    AuxiliaryText.IMPORT_READ_FAILED: "无法读取携带文件：{reason}",
+    AuxiliaryText.LEGACY_SOURCE: "旧版携带文件",
+    AuxiliaryText.UNKNOWN: "未知",
+    AuxiliaryText.UNNAMED: "未命名",
+    AuxiliaryText.OLDER_WARNING: (
+        "\n\n⚠ 此文件的建立时间早于上次导入的进度。"
+        "若继续，较新的共同进度可能被替换。"
+    ),
+    AuxiliaryText.IMPORT_CONFIRM_TITLE: "确认接续进度",
+    AuxiliaryText.IMPORT_CONFIRM: (
+        "即将使用携带文件中的共同进度替换这台电脑当前的对话、记忆、待办与工作数据。"
+        "\n\n建立时间：{created_at}\n来源设备标识：{source}\n助手名称：{assistant}"
+        "\n数据与设置：约 {count} 项\n\n导入前会自动备份当前数据；这台电脑的 "
+        "API 密钥、OAuth、权限、路径与设备设置将保持不变。{older_warning}"
+        "\n\n确定导入吗？"
+    ),
+    AuxiliaryText.IMPORT_FAILED_TITLE: "导入墨寒携带文件",
+    AuxiliaryText.IMPORT_FAILED: "导入失败，原数据未更改：{reason}",
+    AuxiliaryText.IMPORT_COMPLETE_TITLE: "进度接续完成",
+    AuxiliaryText.IMPORT_COMPLETE: (
+        "墨寒的共同进度已导入完成。\n\n原数据备份：{path}\n\n"
+        "程序现在会安全关闭；请重新打开墨寒，即可从导入后的进度继续使用。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_NOT_FOUND: "找不到指定的墨寒携带文件。",
+    AuxiliaryText.PROFILE_ERROR_FORMAT: "无法安全读取携带文件的格式、版本或数据内容。",
+    AuxiliaryText.PROFILE_ERROR_SECURITY: "携带文件未通过安全或完整性验证。",
+    AuxiliaryText.PROFILE_ERROR_DUPLICATE: (
+        "这份携带文件已经导入；为避免覆盖较新的进度，本次未重复导入。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_DATABASE: "数据库导入失败；原数据未更改。",
+    AuxiliaryText.PROFILE_ERROR_GENERIC: "携带文件操作未能安全完成。",
+})
+
+_EN: Mapping[AuxiliaryText, str] = frozendict({
+    AuxiliaryText.UPDATE_TITLE: "<b>Software updates</b>",
+    AuxiliaryText.CURRENT_VERSION: "Current version: {version}",
+    AuxiliaryText.CHANNEL_STABLE: "Stable (recommended)",
+    AuxiliaryText.CHANNEL_PREVIEW: "Preview / RC",
+    AuxiliaryText.AUTO_CHECK: "Check for updates after startup",
+    AuxiliaryText.CHECK_NOW: "Check now",
+    AuxiliaryText.DOWNLOAD_INSTALL: "Download and install",
+    AuxiliaryText.CHANNEL_LABEL: "Update channel",
+    AuxiliaryText.NOT_CHECKED: "Not checked yet",
+    AuxiliaryText.NOTES_PLACEHOLDER: "Release notes appear here when an update is available.",
+    AuxiliaryText.CHECKING: "Safely checking GitHub Releases…",
+    AuxiliaryText.UP_TO_DATE: "You already have the latest version in this channel.",
+    AuxiliaryText.NEW_VERSION: (
+        "Version {version} is available. Its SHA256 will be verified before installation."
+    ),
+    AuxiliaryText.NO_RELEASE_NOTES: "No release notes were provided for this version.",
+    AuxiliaryText.NEW_VERSION_TITLE: "A new MoHan version is available",
+    AuxiliaryText.NEW_VERSION_AVAILABLE: "Version {version} is ready to download.",
+    AuxiliaryText.DOWNLOAD_TITLE: "Download the official update",
+    AuxiliaryText.DOWNLOAD_PROMPT: (
+        "The installer will be downloaded from the official GitHub Release and started only "
+        "after SHA256 verification.\n\nVersion: {version}\nFile: {filename}\n\nContinue?"
+    ),
+    AuxiliaryText.DOWNLOADING: "Downloading and verifying the installer…",
+    AuxiliaryText.VERIFIED_TITLE: "Verification complete",
+    AuxiliaryText.VERIFIED_PROMPT: (
+        "SHA256 verification passed. MoHan will now close and start the installer.\n"
+        "Your chats, memories, tasks, and settings remain in the local data folder.\n\n"
+        "Upgrade now?"
+    ),
+    AuxiliaryText.SAFE_DOWNLOADED: "Safely downloaded: {path}",
+    AuxiliaryText.INSTALLER_LAUNCH_FAILED: "The installer could not be started.",
+    AuxiliaryText.UPDATE_DIALOG_TITLE: "MoHan update",
+    AuxiliaryText.UPDATE_ERROR_NO_RELEASE: (
+        "No compatible published update is currently available in this channel."
+    ),
+    AuxiliaryText.UPDATE_ERROR_CONNECTION: (
+        "GitHub's update service could not be reached. Check your connection and try again."
+    ),
+    AuxiliaryText.UPDATE_ERROR_SECURITY: (
+        "The update was safely blocked because its source, manifest, size, or SHA256 "
+        "verification did not pass."
+    ),
+    AuxiliaryText.UPDATE_ERROR_DATA: "The GitHub Release data could not be read safely.",
+    AuxiliaryText.UPDATE_ERROR_VERSION: "The update version or channel data is invalid.",
+    AuxiliaryText.UPDATE_ERROR_DOWNLOAD: (
+        "The installer could not be downloaded completely and safely."
+    ),
+    AuxiliaryText.UPDATE_ERROR_GENERIC: (
+        "The update operation could not be completed safely. Please try again later."
+    ),
+    AuxiliaryText.PROFILE_HEADING: "<b>Move devices and continue your progress</b>",
+    AuxiliaryText.PROFILE_NOTE: (
+        "Export one portable file to continue your chats, memories, tasks, ideas, and work "
+        "progress on another computer. API keys, OAuth credentials, computer permissions, "
+        "folder paths, and device settings are never included."
+    ),
+    AuxiliaryText.EXPORT_BUTTON: "Export portable MoHan profile",
+    AuxiliaryText.IMPORT_BUTTON: "Import and continue",
+    AuxiliaryText.DEFAULT_ASSISTANT_NAME: "MoHan",
+    AuxiliaryText.EXPORT_FILENAME: "{assistant}-portable-progress-{timestamp}{extension}",
+    AuxiliaryText.EXPORT_DIALOG_TITLE: "Export portable MoHan profile",
+    AuxiliaryText.PROFILE_FILTER: "MoHan portable profile (*{extension})",
+    AuxiliaryText.EXPORT_FAILED_TITLE: "Portable profile export",
+    AuxiliaryText.EXPORT_FAILED: "Export failed: {reason}",
+    AuxiliaryText.EXPORT_COMPLETE_TITLE: "Export complete",
+    AuxiliaryText.EXPORT_COMPLETE: (
+        "The portable MoHan profile was created.\n\nLocation: {path}\n"
+        "Included data and settings: {count}.\n\nThis file contains no API keys, "
+        "OAuth tokens, or local computer permissions."
+    ),
+    AuxiliaryText.IMPORT_DIALOG_TITLE: "Import portable MoHan profile",
+    AuxiliaryText.IMPORT_READ_FAILED_TITLE: "Portable profile import",
+    AuxiliaryText.IMPORT_READ_FAILED: "The portable profile could not be read: {reason}",
+    AuxiliaryText.LEGACY_SOURCE: "Legacy portable profile",
+    AuxiliaryText.UNKNOWN: "Unknown",
+    AuxiliaryText.UNNAMED: "Unnamed",
+    AuxiliaryText.OLDER_WARNING: (
+        "\n\n⚠ This file was created before the last imported progress. Continuing may "
+        "replace newer shared progress."
+    ),
+    AuxiliaryText.IMPORT_CONFIRM_TITLE: "Confirm progress import",
+    AuxiliaryText.IMPORT_CONFIRM: (
+        "The shared progress in this portable profile will replace this computer's current "
+        "chats, memories, tasks, and work data.\n\nCreated: {created_at}\n"
+        "Source device ID: {source}\nAssistant name: {assistant}\n"
+        "Data and settings: about {count}\n\nCurrent data will be backed up first. "
+        "This computer's API keys, OAuth credentials, permissions, paths, and device settings "
+        "will remain unchanged.{older_warning}\n\nImport this profile?"
+    ),
+    AuxiliaryText.IMPORT_FAILED_TITLE: "Portable profile import",
+    AuxiliaryText.IMPORT_FAILED: "Import failed; existing data was not changed: {reason}",
+    AuxiliaryText.IMPORT_COMPLETE_TITLE: "Progress import complete",
+    AuxiliaryText.IMPORT_COMPLETE: (
+        "MoHan's shared progress was imported.\n\nExisting data backup: {path}\n\n"
+        "The application will now close safely. Reopen MoHan to continue from the imported "
+        "progress."
+    ),
+    AuxiliaryText.PROFILE_ERROR_NOT_FOUND: "The selected portable MoHan profile was not found.",
+    AuxiliaryText.PROFILE_ERROR_FORMAT: (
+        "The portable profile's format, version, or data could not be read safely."
+    ),
+    AuxiliaryText.PROFILE_ERROR_SECURITY: (
+        "The portable profile did not pass its security or integrity checks."
+    ),
+    AuxiliaryText.PROFILE_ERROR_DUPLICATE: (
+        "This portable profile was already imported. It was not imported again, protecting "
+        "newer progress from being overwritten."
+    ),
+    AuxiliaryText.PROFILE_ERROR_DATABASE: (
+        "The database import failed; existing data was not changed."
+    ),
+    AuxiliaryText.PROFILE_ERROR_GENERIC: (
+        "The portable profile operation could not be completed safely."
+    ),
+})
+
+_JA: Mapping[AuxiliaryText, str] = frozendict({
+    AuxiliaryText.UPDATE_TITLE: "<b>ソフトウェア更新</b>",
+    AuxiliaryText.CURRENT_VERSION: "現在のバージョン：{version}",
+    AuxiliaryText.CHANNEL_STABLE: "安定版（推奨）",
+    AuxiliaryText.CHANNEL_PREVIEW: "プレビュー版／RC",
+    AuxiliaryText.AUTO_CHECK: "起動後に更新を自動確認",
+    AuxiliaryText.CHECK_NOW: "今すぐ確認",
+    AuxiliaryText.DOWNLOAD_INSTALL: "ダウンロードしてインストール",
+    AuxiliaryText.CHANNEL_LABEL: "更新チャンネル",
+    AuxiliaryText.NOT_CHECKED: "まだ確認していません",
+    AuxiliaryText.NOTES_PLACEHOLDER: "更新がある場合、ここにリリースノートを表示します。",
+    AuxiliaryText.CHECKING: "GitHub Release を安全に確認しています……",
+    AuxiliaryText.UP_TO_DATE: "この更新チャンネルでは最新バージョンです。",
+    AuxiliaryText.NEW_VERSION: (
+        "新しいバージョン {version} があります。インストール前に SHA256 を検証します。"
+    ),
+    AuxiliaryText.NO_RELEASE_NOTES: "このバージョンには説明がありません。",
+    AuxiliaryText.NEW_VERSION_TITLE: "墨寒の新しいバージョンがあります",
+    AuxiliaryText.NEW_VERSION_AVAILABLE: "バージョン {version} をダウンロードできます。",
+    AuxiliaryText.DOWNLOAD_TITLE: "公式アップデートをダウンロード",
+    AuxiliaryText.DOWNLOAD_PROMPT: (
+        "公式 GitHub Release からインストーラーをダウンロードし、SHA256 検証後に"
+        "起動します。\n\nバージョン：{version}\nファイル：{filename}\n\n続行しますか？"
+    ),
+    AuxiliaryText.DOWNLOADING: "インストーラーをダウンロードして検証しています……",
+    AuxiliaryText.VERIFIED_TITLE: "検証完了",
+    AuxiliaryText.VERIFIED_PROMPT: (
+        "SHA256 検証に合格しました。墨寒を終了してインストーラーを起動します。\n"
+        "会話、記憶、予定、設定はローカルデータフォルダーに保持されます。\n\n"
+        "今すぐアップグレードしますか？"
+    ),
+    AuxiliaryText.SAFE_DOWNLOADED: "安全にダウンロードしました：{path}",
+    AuxiliaryText.INSTALLER_LAUNCH_FAILED: "インストーラーを起動できませんでした。",
+    AuxiliaryText.UPDATE_DIALOG_TITLE: "墨寒の更新",
+    AuxiliaryText.UPDATE_ERROR_NO_RELEASE: "このチャンネルで利用できる互換更新はありません。",
+    AuxiliaryText.UPDATE_ERROR_CONNECTION: (
+        "GitHub の更新サービスに接続できません。ネットワークを確認して再試行してください。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_SECURITY: (
+        "配布元、マニフェスト、サイズ、または SHA256 の検証に合格しなかったため、"
+        "更新を安全に停止しました。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_DATA: "GitHub Release の更新データを安全に読み取れません。",
+    AuxiliaryText.UPDATE_ERROR_VERSION: "更新バージョンまたはチャンネルのデータが無効です。",
+    AuxiliaryText.UPDATE_ERROR_DOWNLOAD: (
+        "インストーラーを完全かつ安全にダウンロードできませんでした。"
+    ),
+    AuxiliaryText.UPDATE_ERROR_GENERIC: (
+        "更新処理を安全に完了できませんでした。後でもう一度お試しください。"
+    ),
+    AuxiliaryText.PROFILE_HEADING: "<b>持ち運び、端末移行、進捗の継続</b>",
+    AuxiliaryText.PROFILE_NOTE: (
+        "一つのポータブルファイルを書き出すだけで、別のパソコンでも会話、記憶、予定、"
+        "アイデア、作業進捗を継続できます。API キー、OAuth 認証情報、パソコンの権限、"
+        "フォルダーパス、端末設定は含まれません。"
+    ),
+    AuxiliaryText.EXPORT_BUTTON: "墨寒ポータブルプロファイルを書き出す",
+    AuxiliaryText.IMPORT_BUTTON: "読み込んで進捗を継続",
+    AuxiliaryText.DEFAULT_ASSISTANT_NAME: "墨寒",
+    AuxiliaryText.EXPORT_FILENAME: "{assistant}-ポータブル進捗-{timestamp}{extension}",
+    AuxiliaryText.EXPORT_DIALOG_TITLE: "墨寒ポータブルプロファイルを書き出す",
+    AuxiliaryText.PROFILE_FILTER: "墨寒ポータブルプロファイル (*{extension})",
+    AuxiliaryText.EXPORT_FAILED_TITLE: "ポータブルプロファイルの書き出し",
+    AuxiliaryText.EXPORT_FAILED: "書き出しに失敗しました：{reason}",
+    AuxiliaryText.EXPORT_COMPLETE_TITLE: "書き出し完了",
+    AuxiliaryText.EXPORT_COMPLETE: (
+        "墨寒ポータブルプロファイルを作成しました。\n\n保存先：{path}\n"
+        "収録したデータと設定：{count} 件。\n\nこのファイルには API キー、OAuth トークン、"
+        "ローカルパソコンの権限は含まれません。"
+    ),
+    AuxiliaryText.IMPORT_DIALOG_TITLE: "墨寒ポータブルプロファイルを読み込む",
+    AuxiliaryText.IMPORT_READ_FAILED_TITLE: "ポータブルプロファイルの読み込み",
+    AuxiliaryText.IMPORT_READ_FAILED: "ポータブルプロファイルを読み取れません：{reason}",
+    AuxiliaryText.LEGACY_SOURCE: "旧形式のポータブルプロファイル",
+    AuxiliaryText.UNKNOWN: "不明",
+    AuxiliaryText.UNNAMED: "名称なし",
+    AuxiliaryText.OLDER_WARNING: (
+        "\n\n⚠ このファイルは前回読み込んだ進捗より前に作成されています。続行すると、"
+        "新しい共有進捗が置き換わる可能性があります。"
+    ),
+    AuxiliaryText.IMPORT_CONFIRM_TITLE: "進捗の読み込みを確認",
+    AuxiliaryText.IMPORT_CONFIRM: (
+        "ポータブルプロファイル内の共有進捗で、このパソコンにある現在の会話、記憶、"
+        "予定、作業データを置き換えます。\n\n作成日時：{created_at}\n"
+        "移行元端末 ID：{source}\nアシスタント名：{assistant}\n"
+        "データと設定：約 {count} 件\n\n読み込み前に現在のデータを自動バックアップします。"
+        "このパソコンの API キー、OAuth 認証情報、権限、パス、端末設定は変更されません。"
+        "{older_warning}\n\nこのプロファイルを読み込みますか？"
+    ),
+    AuxiliaryText.IMPORT_FAILED_TITLE: "ポータブルプロファイルの読み込み",
+    AuxiliaryText.IMPORT_FAILED: "読み込みに失敗しました。元のデータは変更されていません：{reason}",
+    AuxiliaryText.IMPORT_COMPLETE_TITLE: "進捗の読み込み完了",
+    AuxiliaryText.IMPORT_COMPLETE: (
+        "墨寒の共有進捗を読み込みました。\n\n元データのバックアップ：{path}\n\n"
+        "アプリを安全に終了します。墨寒を再度開くと、読み込んだ進捗から利用を続けられます。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_NOT_FOUND: "選択した墨寒ポータブルプロファイルが見つかりません。",
+    AuxiliaryText.PROFILE_ERROR_FORMAT: (
+        "ポータブルプロファイルの形式、バージョン、またはデータを安全に読み取れません。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_SECURITY: (
+        "ポータブルプロファイルは安全性または整合性の検証に合格しませんでした。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_DUPLICATE: (
+        "このポータブルプロファイルは読み込み済みです。新しい進捗を上書きしないよう、"
+        "再読み込みは行いませんでした。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_DATABASE: (
+        "データベースの読み込みに失敗しました。元のデータは変更されていません。"
+    ),
+    AuxiliaryText.PROFILE_ERROR_GENERIC: (
+        "ポータブルプロファイルの処理を安全に完了できませんでした。"
+    ),
+})
+
+
+TRANSLATIONS: Mapping[str, Mapping[AuxiliaryText, str]] = frozendict({
+    "zh-TW": _ZH_TW,
+    "zh-CN": _ZH_CN,
+    "en": _EN,
+    "ja-JP": _JA,
+})
+
+_EXPECTED_KEYS = frozenset(AuxiliaryText)
+for _language, _translations in TRANSLATIONS.items():
+    if frozenset(_translations) != _EXPECTED_KEYS:
+        missing = sorted(key.value for key in _EXPECTED_KEYS - frozenset(_translations))
+        extra = sorted(key.value for key in frozenset(_translations) - _EXPECTED_KEYS)
+        raise RuntimeError(
+            f"Incomplete auxiliary UI translations for {_language}: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
+def auxiliary_text(
+    language: str,
+    key: AuxiliaryText,
+    **values: object,
+) -> str:
+    """Return one localized auxiliary-UI string from the complete key set."""
+
+    template = TRANSLATIONS[canonical_ui_language(language)][key]
+    return template.format(**values) if values else template
+
+
+def _update_error_key(message: str) -> AuxiliaryText:
+    rules = (
+        (
+            ("目前沒有符合更新頻道", "沒有可用的 Windows 安裝程式"),
+            AuxiliaryText.UPDATE_ERROR_NO_RELEASE,
+        ),
+        (
+            ("無法連線", "更新服務回應錯誤"),
+            AuxiliaryText.UPDATE_ERROR_CONNECTION,
+        ),
+        (
+            (
+                "受信任",
+                "登入憑證",
+                "SHA256",
+                "不屬於官方",
+                "檔名不安全",
+                "安全大小限制",
+            ),
+            AuxiliaryText.UPDATE_ERROR_SECURITY,
+        ),
+        (("下載",), AuxiliaryText.UPDATE_ERROR_DOWNLOAD),
+        (
+            ("語意版本", "更新頻道必須"),
+            AuxiliaryText.UPDATE_ERROR_VERSION,
+        ),
+        (
+            ("格式", "清單", "Release 回應"),
+            AuxiliaryText.UPDATE_ERROR_DATA,
+        ),
+    )
+    return next(
+        (
+            key
+            for markers, key in rules
+            if any(marker in message for marker in markers)
+        ),
+        AuxiliaryText.UPDATE_ERROR_GENERIC,
+    )
+
+
+def _profile_error_key(message: str) -> AuxiliaryText:
+    if "找不到指定" in message:
+        return AuxiliaryText.PROFILE_ERROR_NOT_FOUND
+    if "已匯入過" in message:
+        return AuxiliaryText.PROFILE_ERROR_DUPLICATE
+    if any(
+        marker in message
+        for marker in ("密鑰", "機器權限", "不安全", "雜湊", "完整性")
+    ):
+        return AuxiliaryText.PROFILE_ERROR_SECURITY
+    if "資料庫" in message or "匯入資料" in message:
+        return AuxiliaryText.PROFILE_ERROR_DATABASE
+    if any(
+        marker in message
+        for marker in (
+            "版本",
+            "資料筆數",
+            "內容不完整",
+            "超過安全",
+            "描述格式",
+            "格式識別",
+            "不是有效",
+            "必要資料表",
+            "必要欄位",
+            "可安全匯入的欄位",
+        )
+    ):
+        return AuxiliaryText.PROFILE_ERROR_FORMAT
+    return AuxiliaryText.PROFILE_ERROR_GENERIC
+
+
+def localized_operation_error(
+    language: str,
+    message: str,
+    *,
+    operation: AuxiliaryOperation,
+) -> str:
+    """Localize backend failures without leaking source-language UI text."""
+
+    normalized_language = canonical_ui_language(language)
+    if normalized_language == "zh-TW":
+        return str(message).strip() or auxiliary_text(
+            language,
+            AuxiliaryText.PROFILE_ERROR_GENERIC
+            if operation is AuxiliaryOperation.PROFILE
+            else AuxiliaryText.UPDATE_ERROR_GENERIC,
+        )
+    key = (
+        _profile_error_key(str(message))
+        if operation is AuxiliaryOperation.PROFILE
+        else _update_error_key(str(message))
+    )
+    return auxiliary_text(normalized_language, key)

--- a/azure_speech.py
+++ b/azure_speech.py
@@ -4,6 +4,7 @@ lazy import queue
 lazy import re
 lazy import threading
 lazy import time
+lazy from contextlib import suppress
 lazy from dataclasses import dataclass, field
 lazy from xml.sax.saxutils import escape, quoteattr
 
@@ -13,6 +14,7 @@ lazy from PySide6.QtCore import QObject, Signal
 lazy from azure_regions import azure_region_supports_hd_flash
 lazy from azure_voice_catalog import AzureVoiceCatalog, AzureVoiceCatalogService
 lazy from immutable_config import deep_freeze
+lazy from language_support import canonical_ui_language
 lazy from speech import play_pcm16_stream_with_visemes
 
 AZURE_FEMALE_VOICES: frozendict[str, tuple[str, ...]] = frozendict({
@@ -86,6 +88,10 @@ _VOICE_PATTERN = re.compile(
     r"^(zh-(?:TW|CN)|en-US|ja-JP)-[A-Za-z0-9]+"
     r"(?::DragonHD(?:Omni|Flash)?LatestNeural|Neural)$"
 )
+_AUDIO_CHUNK_MAX_BYTES = 65_536
+_AUDIO_QUEUE_MAX_CHUNKS = 64
+_AUDIO_QUEUE_POLL_SECONDS = 0.05
+_AUDIO_STREAM_TIMEOUT_SECONDS = 60.0
 _MESSAGES = deep_freeze({
     "zh-TW": {
         "invalid_region": "Azure Speech 區域格式不正確。",
@@ -109,9 +115,7 @@ _MESSAGES = deep_freeze({
     },
     "en-US": {
         "invalid_region": "The Azure Speech region is invalid.",
-        "unsupported_voice": (
-            "Azure Speech accepts only verified female voices."
-        ),
+        "unsupported_voice": ("Azure Speech accepts only verified female voices."),
         "missing_settings": (
             "The Azure Speech key and region have not been configured."
         ),
@@ -119,9 +123,7 @@ _MESSAGES = deep_freeze({
             "The Azure Speech key, region, or resource permission is invalid."
         ),
         "quota": "The Azure Speech quota or rate limit has been reached.",
-        "service": (
-            "Azure Speech is temporarily unavailable (HTTP {status})."
-        ),
+        "service": ("Azure Speech is temporarily unavailable (HTTP {status})."),
         "request": "Azure Speech failed (HTTP {status}).",
         "network": "Could not connect to Azure Speech: {error}",
     },
@@ -142,31 +144,69 @@ class _PushAudioReader:
     """Adapt Azure's push callback to the playback loop's bounded reads."""
 
     def __init__(self) -> None:
-        self._chunks: queue.Queue[bytes | None] = queue.Queue()
+        self._chunks: queue.Queue[bytes] = queue.Queue(maxsize=_AUDIO_QUEUE_MAX_CHUNKS)
         self._pending = bytearray()
+        self._pending_lock = threading.Lock()
+        self._cancelled = threading.Event()
+        self._closed = threading.Event()
 
     def write(self, audio_buffer: memoryview) -> int:
         chunk = bytes(audio_buffer)
-        if chunk:
-            self._chunks.put(chunk)
+        for offset in range(0, len(chunk), _AUDIO_CHUNK_MAX_BYTES):
+            bounded_chunk = chunk[offset : offset + _AUDIO_CHUNK_MAX_BYTES]
+            while not self._cancelled.is_set() and not self._closed.is_set():
+                try:
+                    self._chunks.put(
+                        bounded_chunk,
+                        timeout=_AUDIO_QUEUE_POLL_SECONDS,
+                    )
+                    break
+                except queue.Full:
+                    continue
         return len(chunk)
 
     def close(self) -> None:
-        self._chunks.put(None)
+        self._closed.set()
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+        self._closed.set()
+        with self._pending_lock:
+            self._pending.clear()
+        while True:
+            try:
+                self._chunks.get_nowait()
+            except queue.Empty:
+                break
 
     def read(self, audio_buffer: bytearray) -> int:
-        while not self._pending:
-            try:
-                chunk = self._chunks.get(timeout=60.0)
-            except queue.Empty as exc:
-                raise TimeoutError("Azure audio stream timed out") from exc
-            if chunk is None:
+        if self._cancelled.is_set():
+            return 0
+        deadline = time.monotonic() + _AUDIO_STREAM_TIMEOUT_SECONDS
+        while True:
+            with self._pending_lock:
+                if self._pending:
+                    bytes_read = min(len(audio_buffer), len(self._pending))
+                    audio_buffer[:bytes_read] = self._pending[:bytes_read]
+                    del self._pending[:bytes_read]
+                    return bytes_read
+            if self._cancelled.is_set():
                 return 0
-            self._pending.extend(chunk)
-        bytes_read = min(len(audio_buffer), len(self._pending))
-        audio_buffer[:bytes_read] = self._pending[:bytes_read]
-        del self._pending[:bytes_read]
-        return bytes_read
+            if self._closed.is_set() and self._chunks.empty():
+                return 0
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                raise TimeoutError("Azure audio stream timed out")
+            try:
+                chunk = self._chunks.get(
+                    timeout=min(_AUDIO_QUEUE_POLL_SECONDS, remaining)
+                )
+            except queue.Empty as exc:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("Azure audio stream timed out") from exc
+                continue
+            with self._pending_lock:
+                self._pending.extend(chunk)
 
 
 @dataclass(slots=True)
@@ -174,6 +214,15 @@ class _SynthesisOutcome:
     result: object | None = None
     failure: Exception | None = None
     done: threading.Event = field(default_factory=threading.Event)
+
+
+@dataclass(frozen=True, slots=True)
+class _SynthesisRequest:
+    text: str
+    api_key: str = field(repr=False)
+    region: str
+    voice: str
+    locale: str
 
 
 def _await_synthesis(
@@ -190,9 +239,59 @@ def _await_synthesis(
         outcome.done.set()
 
 
+def _streaming_synthesizer(
+    api_key: str,
+    region: str,
+) -> tuple[_PushAudioReader, object]:
+    speech_config = speechsdk.SpeechConfig(
+        subscription=api_key,
+        region=region,
+    )
+    speech_config.set_speech_synthesis_output_format(
+        speechsdk.SpeechSynthesisOutputFormat.Raw24Khz16BitMonoPcm
+    )
+    audio_reader = _PushAudioReader()
+
+    class StreamCallback(speechsdk.audio.PushAudioOutputStreamCallback):
+        def __init__(self) -> None:
+            super().__init__()
+
+        def write(self, audio_buffer: memoryview) -> int:
+            return audio_reader.write(audio_buffer)
+
+        def close(self) -> None:
+            audio_reader.close()
+
+    push_stream = speechsdk.audio.PushAudioOutputStream(StreamCallback())
+    audio_config = speechsdk.audio.AudioOutputConfig(stream=push_stream)
+    synthesizer = speechsdk.SpeechSynthesizer(
+        speech_config=speech_config,
+        audio_config=audio_config,
+    )
+    return audio_reader, synthesizer
+
+
+def _completed_synthesis_result(outcome: _SynthesisOutcome) -> object:
+    if not outcome.done.wait(timeout=60.0):
+        raise TimeoutError("Azure synthesis did not finish")
+    if outcome.failure is not None:
+        raise outcome.failure
+    if outcome.result is None:
+        raise RuntimeError("Azure synthesis returned no result")
+    return outcome.result
+
+
 def _message(locale: str, key: str, **values: object) -> str:
-    catalog = _MESSAGES.get(locale, _MESSAGES["zh-TW"])
+    normalized = canonical_ui_language(locale)
+    catalog_key = "en-US" if normalized == "en" else normalized
+    catalog = _MESSAGES[catalog_key]
     return catalog[key].format(**values)
+
+
+def _error_locale(locale: str, voice: str) -> str:
+    """Use the explicit UI locale, retaining compatibility for old callers."""
+
+    return canonical_ui_language(locale) if locale.strip() else _voice_locale(voice)
 
 
 def normalize_azure_region(region: str) -> str:
@@ -244,26 +343,24 @@ def is_azure_hd_voice(voice: str) -> bool:
     return ":DragonHD" in str(voice)
 
 
-def build_azure_ssml(
-    text: str,
-    voice: str,
-    verified_voices: tuple[str, ...] = (),
-) -> bytes:
-    is_verified = voice in _VOICE_LOCALE or voice in verified_voices
-    if not is_verified or not _VOICE_PATTERN.fullmatch(voice):
+def _render_azure_ssml(text: str, voice: str) -> bytes:
+    if not _VOICE_PATTERN.fullmatch(voice):
         raise ValueError("unsupported_voice")
     locale = _VOICE_LOCALE.get(voice, voice[:5])
-    parameters = (
-        " parameters='temperature=0.8'"
-        if is_azure_hd_voice(voice)
-        else ""
-    )
+    parameters = " parameters='temperature=0.8'" if is_azure_hd_voice(voice) else ""
     body = (
         f"<speak version='1.0' xml:lang={quoteattr(locale)}>"
         f"<voice xml:lang={quoteattr(locale)} xml:gender='Female' "
         f"name={quoteattr(voice)}{parameters}>{escape(text)}</voice></speak>"
     )
     return body.encode("utf-8")
+
+
+def build_azure_ssml(text: str, voice: str) -> bytes:
+    """Build SSML only for the bundled, statically verified female voices."""
+    if voice not in _VOICE_LOCALE:
+        raise ValueError("unsupported_voice")
+    return _render_azure_ssml(text, voice)
 
 
 def _voice_locale(voice: str) -> str:
@@ -290,6 +387,11 @@ class AzureSpeechTTS(QObject):
     finished = Signal()
     synthesis_latency_measured = Signal(float)
     viseme_cue = Signal(float, str)
+    operation_started = Signal(int)
+    operation_failed = Signal(int, str)
+    operation_finished = Signal(int)
+    operation_synthesis_latency_measured = Signal(int, float)
+    operation_viseme_cue = Signal(int, float, str)
     voice_catalog_ready = Signal(object)
     voice_catalog_failed = Signal(str, str, bool)
 
@@ -303,7 +405,10 @@ class AzureSpeechTTS(QObject):
         self.muted = False
         self.last_synthesis_latency_ms: float | None = None
         self._catalog_service = catalog_service or AzureVoiceCatalogService()
-        self._verified_dynamic_voices: set[str] = set()
+        self._playback_lock = threading.RLock()
+        self._playback_generation = 0
+        self._active_reader: _PushAudioReader | None = None
+        self._active_synthesizer: object | None = None
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
@@ -315,29 +420,63 @@ class AzureSpeechTTS(QObject):
         api_key: str,
         region: str,
         voice: str,
+        locale: str = "",
     ) -> None:
+        operation_id = self._begin_operation()
+        self._emit_started(operation_id)
         if not text.strip():
-            self.finished.emit()
+            self._emit_finished(operation_id)
             return
-        locale = _voice_locale(voice)
+        locale = _error_locale(locale, voice)
         if not api_key.strip() or not region.strip():
-            self.failed.emit(_message(locale, "missing_settings"))
+            self._emit_failed(
+                operation_id,
+                _message(locale, "missing_settings"),
+            )
             return
         try:
             normalized_region = normalize_azure_region(region)
-            build_azure_ssml(
-                text,
-                voice,
-                tuple(self._verified_dynamic_voices),
-            )
+            if not _VOICE_PATTERN.fullmatch(voice):
+                raise ValueError("unsupported_voice")
         except ValueError as exc:
-            self.failed.emit(_message(locale, str(exc)))
+            self._emit_failed(operation_id, _message(locale, str(exc)))
             return
         threading.Thread(
             target=self._run,
-            args=(text, api_key, normalized_region, voice),
+            args=(
+                _SynthesisRequest(
+                    text=text,
+                    api_key=api_key,
+                    region=normalized_region,
+                    voice=voice,
+                    locale=locale,
+                ),
+                operation_id,
+            ),
             daemon=True,
         ).start()
+
+    def stop(self) -> None:
+        """Cancel only this engine instance's current synthesis and playback."""
+        with self._playback_lock:
+            self._playback_generation += 1
+            reader = self._active_reader
+            synthesizer = self._active_synthesizer
+            self._active_reader = None
+            self._active_synthesizer = None
+        self._cancel_playback(reader, synthesizer)
+
+    @staticmethod
+    def _cancel_playback(
+        reader: _PushAudioReader | None,
+        synthesizer: object | None,
+    ) -> None:
+        if reader is not None:
+            reader.cancel()
+        stop_speaking = getattr(synthesizer, "stop_speaking_async", None)
+        if stop_speaking is not None:
+            with suppress(RuntimeError, OSError):
+                stop_speaking()
 
     def invalidate_voice_catalog(self, region: str | None = None) -> None:
         self._catalog_service.invalidate(region)
@@ -382,10 +521,9 @@ class AzureSpeechTTS(QObject):
                 language,
                 hd_only=hd_only,
             )
-        except (OSError, RuntimeError, TimeoutError, ValueError):
+        except OSError, RuntimeError, TimeoutError, ValueError:
             self._emit_fallback_catalog(region, language, hd_only)
             return
-        self._verified_dynamic_voices.update(catalog.voices)
         self.voice_catalog_ready.emit(catalog)
 
     def _emit_fallback_catalog(
@@ -413,52 +551,41 @@ class AzureSpeechTTS(QObject):
 
     def _run(
         self,
-        text: str,
-        api_key: str,
-        region: str,
-        voice: str,
+        request: _SynthesisRequest,
+        operation_id: int,
     ) -> None:
-        locale = _voice_locale(voice)
+        if not self._is_current_playback(operation_id):
+            return
+        try:
+            ssml = self._verified_ssml_for_request(
+                request.text,
+                request.api_key,
+                request.region,
+                request.voice,
+            )
+        except OSError, RuntimeError, TimeoutError, ValueError:
+            self._emit_failed(
+                operation_id,
+                _message(request.locale, "unsupported_voice"),
+            )
+            return
+        if not self._is_current_playback(operation_id):
+            return
         try:
             request_started = time.perf_counter()
-            speech_config = speechsdk.SpeechConfig(
-                subscription=api_key,
-                region=region,
+            audio_reader, synthesizer = _streaming_synthesizer(
+                request.api_key,
+                request.region,
             )
-            speech_config.set_speech_synthesis_output_format(
-                speechsdk.SpeechSynthesisOutputFormat.Raw24Khz16BitMonoPcm
-            )
-            audio_reader = _PushAudioReader()
-
-            class StreamCallback(
-                speechsdk.audio.PushAudioOutputStreamCallback
+            if not self._activate_playback(
+                operation_id,
+                audio_reader,
+                synthesizer,
             ):
-                def __init__(self) -> None:
-                    super().__init__()
-
-                def write(self, audio_buffer: memoryview) -> int:
-                    return audio_reader.write(audio_buffer)
-
-                def close(self) -> None:
-                    audio_reader.close()
-
-            stream_callback = StreamCallback()
-            push_stream = speechsdk.audio.PushAudioOutputStream(
-                stream_callback
-            )
-            audio_config = speechsdk.audio.AudioOutputConfig(
-                stream=push_stream,
-            )
-            synthesizer = speechsdk.SpeechSynthesizer(
-                speech_config=speech_config,
-                audio_config=audio_config,
-            )
+                audio_reader.close()
+                return
             synthesis = synthesizer.speak_ssml_async(
-                build_azure_ssml(
-                    text,
-                    voice,
-                    tuple(self._verified_dynamic_voices),
-                ).decode("utf-8")
+                ssml.decode("utf-8")
             )
             outcome = _SynthesisOutcome()
             result_thread = threading.Thread(
@@ -469,33 +596,157 @@ class AzureSpeechTTS(QObject):
             result_thread.start()
 
             def record_first_audio() -> None:
-                self.last_synthesis_latency_ms = max(
-                    0.0,
-                    (time.perf_counter() - request_started) * 1_000.0,
+                self._record_synthesis_latency(
+                    operation_id,
+                    request_started,
                 )
-                self.synthesis_latency_measured.emit(
-                    self.last_synthesis_latency_ms
-                )
+
+            def emit_viseme(level: float, vowel: str) -> None:
+                self._emit_viseme(operation_id, level, vowel)
 
             play_pcm16_stream_with_visemes(
                 audio_reader.read,
                 volume_percent=self.volume_percent,
                 muted=self.muted,
-                emit_cue=self.viseme_cue.emit,
+                emit_cue=emit_viseme,
                 on_first_audio=record_first_audio,
             )
-            if not outcome.done.wait(timeout=60.0):
-                raise TimeoutError("Azure synthesis did not finish")
-            if outcome.failure is not None:
-                raise outcome.failure
-            if outcome.result is None:
-                raise RuntimeError("Azure synthesis returned no result")
-            result = outcome.result
-            if result.reason == speechsdk.ResultReason.Canceled:
-                self.failed.emit(_message(locale, "service", status=503))
+            if not self._is_current_playback(operation_id):
                 return
-            self.finished.emit()
+            result = _completed_synthesis_result(outcome)
+            if result.reason == speechsdk.ResultReason.Canceled:
+                self._emit_failed(
+                    operation_id,
+                    _message(request.locale, "service", status=503),
+                )
+                return
+            self._emit_finished(operation_id)
         except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
-            self.failed.emit(
-                _message(locale, "network", error=type(exc).__name__)
+            self._emit_failed(
+                operation_id,
+                _message(
+                    request.locale,
+                    "network",
+                    error=type(exc).__name__,
+                ),
             )
+        finally:
+            self._release_playback(operation_id)
+
+    def _verified_ssml_for_request(
+        self,
+        text: str,
+        api_key: str,
+        region: str,
+        voice: str,
+    ) -> bytes:
+        if voice in _VOICE_LOCALE:
+            return build_azure_ssml(text, voice)
+        if not _VOICE_PATTERN.fullmatch(voice):
+            raise ValueError("unsupported_voice")
+        locale = _voice_locale(voice)
+        hd_only = is_azure_hd_voice(voice)
+        catalog = self._catalog_service.query(
+            api_key,
+            region,
+            locale,
+            hd_only=hd_only,
+        )
+        expected_catalog = (
+            catalog.source == "azure"
+            and catalog.region == region
+            and catalog.language == locale
+            and catalog.hd_only == hd_only
+            and voice in catalog.voices
+        )
+        if not expected_catalog:
+            raise ValueError("unsupported_voice")
+        return _render_azure_ssml(text, voice)
+
+    def _begin_operation(self) -> int:
+        with self._playback_lock:
+            self._playback_generation += 1
+            operation_id = self._playback_generation
+            reader = self._active_reader
+            synthesizer = self._active_synthesizer
+            self._active_reader = None
+            self._active_synthesizer = None
+        self._cancel_playback(reader, synthesizer)
+        return operation_id
+
+    def _activate_playback(
+        self,
+        operation_id: int,
+        audio_reader: _PushAudioReader,
+        synthesizer: object,
+    ) -> bool:
+        with self._playback_lock:
+            if operation_id != self._playback_generation:
+                return False
+            self._active_reader = audio_reader
+            self._active_synthesizer = synthesizer
+            return True
+
+    def _is_current_playback(self, operation_id: int) -> bool:
+        with self._playback_lock:
+            return operation_id == self._playback_generation
+
+    def _record_synthesis_latency(
+        self,
+        operation_id: int,
+        request_started: float,
+    ) -> None:
+        latency_ms = max(
+            0.0,
+            (time.perf_counter() - request_started) * 1_000.0,
+        )
+        with self._playback_lock:
+            if operation_id != self._playback_generation:
+                return
+            self.last_synthesis_latency_ms = latency_ms
+            self.operation_synthesis_latency_measured.emit(
+                operation_id,
+                latency_ms,
+            )
+            if operation_id == self._playback_generation:
+                self.synthesis_latency_measured.emit(latency_ms)
+
+    def _emit_started(self, operation_id: int) -> None:
+        with self._playback_lock:
+            if operation_id == self._playback_generation:
+                self.operation_started.emit(operation_id)
+
+    def _emit_viseme(
+        self,
+        operation_id: int,
+        level: float,
+        vowel: str,
+    ) -> None:
+        with self._playback_lock:
+            if operation_id != self._playback_generation:
+                return
+            self.operation_viseme_cue.emit(operation_id, level, vowel)
+            if operation_id == self._playback_generation:
+                self.viseme_cue.emit(level, vowel)
+
+    def _emit_finished(self, operation_id: int) -> None:
+        with self._playback_lock:
+            if operation_id != self._playback_generation:
+                return
+            self.operation_finished.emit(operation_id)
+            if operation_id == self._playback_generation:
+                self.finished.emit()
+
+    def _emit_failed(self, operation_id: int, message: str) -> None:
+        with self._playback_lock:
+            if operation_id != self._playback_generation:
+                return
+            self.operation_failed.emit(operation_id, message)
+            if operation_id == self._playback_generation:
+                self.failed.emit(message)
+
+    def _release_playback(self, operation_id: int) -> None:
+        with self._playback_lock:
+            if operation_id == self._playback_generation:
+                self._active_reader = None
+                self._active_synthesizer = None

--- a/azure_speech.py
+++ b/azure_speech.py
@@ -394,6 +394,8 @@ class AzureSpeechTTS(QObject):
     operation_viseme_cue = Signal(int, float, str)
     voice_catalog_ready = Signal(object)
     voice_catalog_failed = Signal(str, str, bool)
+    _voice_catalog_result_pending = Signal(int, object)
+    _voice_catalog_fallback_pending = Signal(int, str, str, bool)
 
     def __init__(
         self,
@@ -405,10 +407,18 @@ class AzureSpeechTTS(QObject):
         self.muted = False
         self.last_synthesis_latency_ms: float | None = None
         self._catalog_service = catalog_service or AzureVoiceCatalogService()
+        self._catalog_lock = threading.Lock()
+        self._catalog_generation = 0
         self._playback_lock = threading.RLock()
         self._playback_generation = 0
         self._active_reader: _PushAudioReader | None = None
         self._active_synthesizer: object | None = None
+        self._voice_catalog_result_pending.connect(
+            self._publish_voice_catalog_result
+        )
+        self._voice_catalog_fallback_pending.connect(
+            self._publish_fallback_catalog
+        )
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
@@ -479,7 +489,18 @@ class AzureSpeechTTS(QObject):
                 stop_speaking()
 
     def invalidate_voice_catalog(self, region: str | None = None) -> None:
+        with self._catalog_lock:
+            self._catalog_generation += 1
         self._catalog_service.invalidate(region)
+
+    def _begin_catalog_request(self) -> int:
+        with self._catalog_lock:
+            self._catalog_generation += 1
+            return self._catalog_generation
+
+    def _is_current_catalog_request(self, generation: int) -> bool:
+        with self._catalog_lock:
+            return generation == self._catalog_generation
 
     def refresh_voice_catalog(
         self,
@@ -489,21 +510,30 @@ class AzureSpeechTTS(QObject):
         *,
         hd_only: bool,
     ) -> None:
+        generation = self._begin_catalog_request()
         try:
             normalized_region = normalize_azure_region(region)
         except ValueError:
-            self.voice_catalog_failed.emit(region, language, hd_only)
+            if self._is_current_catalog_request(generation):
+                self.voice_catalog_failed.emit(region, language, hd_only)
             return
         if not api_key.strip():
-            self._emit_fallback_catalog(
+            self._queue_fallback_catalog(
                 normalized_region,
                 language,
                 hd_only,
+                generation,
             )
             return
         threading.Thread(
             target=self._query_voice_catalog,
-            args=(api_key, normalized_region, language, hd_only),
+            args=(
+                api_key,
+                normalized_region,
+                language,
+                hd_only,
+                generation,
+            ),
             daemon=True,
         ).start()
 
@@ -513,6 +543,7 @@ class AzureSpeechTTS(QObject):
         region: str,
         language: str,
         hd_only: bool,
+        generation: int,
     ) -> None:
         try:
             catalog = self._catalog_service.query(
@@ -522,16 +553,47 @@ class AzureSpeechTTS(QObject):
                 hd_only=hd_only,
             )
         except OSError, RuntimeError, TimeoutError, ValueError:
-            self._emit_fallback_catalog(region, language, hd_only)
+            self._queue_fallback_catalog(
+                region,
+                language,
+                hd_only,
+                generation,
+            )
             return
-        self.voice_catalog_ready.emit(catalog)
+        self._voice_catalog_result_pending.emit(generation, catalog)
 
-    def _emit_fallback_catalog(
+    def _queue_fallback_catalog(
         self,
         region: str,
         language: str,
         hd_only: bool,
+        generation: int,
     ) -> None:
+        self._voice_catalog_fallback_pending.emit(
+            generation,
+            region,
+            language,
+            hd_only,
+        )
+
+    def _publish_voice_catalog_result(
+        self,
+        generation: int,
+        catalog: AzureVoiceCatalog,
+    ) -> None:
+        if not self._is_current_catalog_request(generation):
+            return
+        self.voice_catalog_ready.emit(catalog)
+
+    def _publish_fallback_catalog(
+        self,
+        generation: int,
+        region: str,
+        language: str,
+        hd_only: bool,
+    ) -> None:
+        if not self._is_current_catalog_request(generation):
+            return
         if hd_only:
             voices = azure_hd_female_voices(
                 language,

--- a/azure_voice_catalog.py
+++ b/azure_voice_catalog.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+lazy import hmac
+lazy import secrets
 lazy import threading
 lazy import time
 lazy from collections.abc import Callable
-lazy from dataclasses import dataclass
+lazy from dataclasses import dataclass, field
 lazy from typing import Any
 
 lazy from azure.cognitiveservices import speech as speechsdk
 
 lazy from azure_regions import azure_region_supports_hd_flash
+
+_CREDENTIAL_FINGERPRINT_SECRET = secrets.token_bytes(32)
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,6 +30,24 @@ class AzureVoiceCatalog:
 class _CachedCatalog:
     expires_at: float
     catalog: AzureVoiceCatalog
+
+
+@dataclass(frozen=True, slots=True)
+class _CatalogCacheKey:
+    region: str
+    language: str
+    hd_only: bool
+    credential_fingerprint: bytes = field(repr=False)
+
+
+def _credential_fingerprint(api_key: str) -> bytes:
+    """Return a process-local, irreversible credential identity."""
+
+    return hmac.digest(
+        _CREDENTIAL_FINGERPRINT_SECRET,
+        api_key.encode("utf-8"),
+        "sha256",
+    )
 
 
 def _language_locales(language: str) -> tuple[str, ...]:
@@ -106,6 +128,8 @@ class AzureVoiceCatalogService:
 
     Subscription keys are passed directly to the SDK configuration and are
     never stored in this service, cache keys, exceptions, or diagnostics.
+    A process-local, non-reversible fingerprint isolates cached catalogues
+    belonging to different Azure credentials without exposing either key.
     """
 
     def __init__(
@@ -118,7 +142,7 @@ class AzureVoiceCatalogService:
         self._cache_seconds = max(0.0, float(cache_seconds))
         self._clock = clock
         self._sdk_loader = sdk_loader or self._load_sdk
-        self._cache: dict[tuple[str, str, bool], _CachedCatalog] = {}
+        self._cache: dict[_CatalogCacheKey, _CachedCatalog] = {}
         self._lock = threading.Lock()
 
     @staticmethod
@@ -133,7 +157,12 @@ class AzureVoiceCatalogService:
         *,
         hd_only: bool,
     ) -> AzureVoiceCatalog:
-        cache_key = (region, language, hd_only)
+        cache_key = _CatalogCacheKey(
+            region=region,
+            language=language,
+            hd_only=hd_only,
+            credential_fingerprint=_credential_fingerprint(api_key),
+        )
         now = self._clock()
         with self._lock:
             cached = self._cache.get(cache_key)
@@ -179,5 +208,5 @@ class AzureVoiceCatalogService:
             self._cache = {
                 key: value
                 for key, value in self._cache.items()
-                if key[0] != region
+                if key.region != region
             }

--- a/azure_voice_catalog.py
+++ b/azure_voice_catalog.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-lazy import hmac
-lazy import secrets
 lazy import threading
 lazy import time
 lazy from collections.abc import Callable
-lazy from dataclasses import dataclass, field
+lazy from dataclasses import dataclass
 lazy from typing import Any
 
 lazy from azure.cognitiveservices import speech as speechsdk
 
 lazy from azure_regions import azure_region_supports_hd_flash
-
-_CREDENTIAL_FINGERPRINT_SECRET = secrets.token_bytes(32)
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,17 +33,6 @@ class _CatalogCacheKey:
     region: str
     language: str
     hd_only: bool
-    credential_fingerprint: bytes = field(repr=False)
-
-
-def _credential_fingerprint(api_key: str) -> bytes:
-    """Return a process-local, irreversible credential identity."""
-
-    return hmac.digest(
-        _CREDENTIAL_FINGERPRINT_SECRET,
-        api_key.encode("utf-8"),
-        "sha256",
-    )
 
 
 def _language_locales(language: str) -> tuple[str, ...]:
@@ -127,9 +112,10 @@ class AzureVoiceCatalogService:
     """Query Azure for female voices and retain only a short-lived cache.
 
     Subscription keys are passed directly to the SDK configuration and are
-    never stored in this service, cache keys, exceptions, or diagnostics.
-    A process-local, non-reversible fingerprint isolates cached catalogues
-    belonging to different Azure credentials without exposing either key.
+    never stored, transformed, fingerprinted, logged, or placed in cache keys.
+    Each service instance is one credential domain. Call ``invalidate`` when
+    that domain's credential or resource changes; MoHan's standard and Dragon
+    HD engines intentionally own separate service instances.
     """
 
     def __init__(
@@ -144,6 +130,7 @@ class AzureVoiceCatalogService:
         self._sdk_loader = sdk_loader or self._load_sdk
         self._cache: dict[_CatalogCacheKey, _CachedCatalog] = {}
         self._lock = threading.Lock()
+        self._generation = 0
 
     @staticmethod
     def _load_sdk() -> Any:
@@ -161,13 +148,13 @@ class AzureVoiceCatalogService:
             region=region,
             language=language,
             hd_only=hd_only,
-            credential_fingerprint=_credential_fingerprint(api_key),
         )
         now = self._clock()
         with self._lock:
             cached = self._cache.get(cache_key)
             if cached is not None and cached.expires_at > now:
                 return cached.catalog
+            query_generation = self._generation
 
         sdk = self._sdk_loader()
         speech_config = sdk.SpeechConfig(subscription=api_key, region=region)
@@ -194,14 +181,16 @@ class AzureVoiceCatalogService:
             source="azure",
         )
         with self._lock:
-            self._cache[cache_key] = _CachedCatalog(
-                expires_at=now + self._cache_seconds,
-                catalog=catalog,
-            )
+            if query_generation == self._generation:
+                self._cache[cache_key] = _CachedCatalog(
+                    expires_at=now + self._cache_seconds,
+                    catalog=catalog,
+                )
         return catalog
 
     def invalidate(self, region: str | None = None) -> None:
         with self._lock:
+            self._generation += 1
             if region is None:
                 self._cache.clear()
                 return

--- a/camera_presence.py
+++ b/camera_presence.py
@@ -4,6 +4,8 @@ lazy import time
 
 lazy from PySide6.QtCore import QObject, Signal
 
+lazy from service_status_localization import ServiceStatus, service_status
+
 try:
     from PySide6.QtMultimedia import (
         QCamera,
@@ -22,8 +24,9 @@ class CameraPresenceController(QObject):
     presence_changed = Signal(bool)
     status_changed = Signal(str)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, *, language: str = "zh-TW"):
         super().__init__(parent)
+        self.language = language
         self.camera = None
         self.session = None
         self.sink = None
@@ -38,10 +41,20 @@ class CameraPresenceController(QObject):
 
     def start(self, device_index: int = 0) -> None:
         if QCamera is None:
-            raise RuntimeError("此封裝未包含 QtMultimedia 攝影機元件")
+            raise RuntimeError(
+                service_status(
+                    self.language,
+                    ServiceStatus.CAMERA_COMPONENT_UNAVAILABLE,
+                )
+            )
         devices = QMediaDevices.videoInputs()
         if not devices:
-            raise RuntimeError("找不到可用攝影機")
+            raise RuntimeError(
+                service_status(
+                    self.language,
+                    ServiceStatus.CAMERA_NOT_FOUND,
+                )
+            )
         if self.camera is not None:
             return
         index = max(0, min(int(device_index), len(devices) - 1))
@@ -53,12 +66,26 @@ class CameraPresenceController(QObject):
         self.sink.videoFrameChanged.connect(self._frame)
         self.camera.errorOccurred.connect(
             lambda _error, message: self.status_changed.emit(
-                f"攝影機錯誤：{message}"
+                service_status(
+                    self.language,
+                    ServiceStatus.CAMERA_ERROR,
+                    detail=message,
+                )
+            )
+        )
+        self.status_changed.emit(
+            service_status(
+                self.language,
+                ServiceStatus.CAMERA_STARTING,
             )
         )
         self.camera.start()
         self.status_changed.emit(
-            f"攝影機使用中：{devices[index].description()}（僅本機在場偵測）"
+            service_status(
+                self.language,
+                ServiceStatus.CAMERA_ACTIVE,
+                device=devices[index].description(),
+            )
         )
 
     def stop(self) -> None:
@@ -72,7 +99,12 @@ class CameraPresenceController(QObject):
         if self._present:
             self._present = False
             self.presence_changed.emit(False)
-        self.status_changed.emit("攝影機已關閉")
+        self.status_changed.emit(
+            service_status(
+                self.language,
+                ServiceStatus.CAMERA_CLOSED,
+            )
+        )
 
     def _frame(self, frame: QVideoFrame) -> None:
         now = time.monotonic()

--- a/cloud_connectors.py
+++ b/cloud_connectors.py
@@ -11,11 +11,12 @@ lazy import webbrowser
 lazy from dataclasses import dataclass
 lazy from http.server import BaseHTTPRequestHandler, HTTPServer
 lazy from typing import Any
-lazy from urllib.error import HTTPError
+lazy from urllib.error import HTTPError, URLError
 lazy from urllib.parse import parse_qs, quote, urlencode, urlparse
 lazy from urllib.request import Request, urlopen
 
 lazy from flagship_core import sanitize_external_content
+lazy from safe_error import sanitize_error
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,6 +138,16 @@ class OAuthError(RuntimeError):
     pass
 
 
+def _sanitized_external_error(
+    error: BaseException | str,
+    *,
+    http_status: int | None = None,
+) -> str:
+    """Discard provider detail before an error crosses the cloud boundary."""
+    safe_input = UnicodeError() if isinstance(error, json.JSONDecodeError) else error
+    return str(sanitize_error(safe_input, http_status=http_status))
+
+
 def _callback_handler(
     received: dict[str, str],
     ready: threading.Event,
@@ -182,9 +193,8 @@ def _authorization_code(received: dict[str, str], expected_state: str) -> str:
     if received.get("state") != expected_state:
         raise OAuthError("OAuth state 驗證失敗")
     if received.get("error"):
-        raise OAuthError(
-            received.get("error_description") or received["error"]
-        )
+        detail = received.get("error_description") or received["error"]
+        raise OAuthError(_sanitized_external_error(detail))
     code = received.get("code")
     if not code:
         raise OAuthError("授權服務未傳回授權碼")
@@ -279,21 +289,30 @@ class OAuthPKCEFlow:
         }
         if self.client_secret:
             payload["client_secret"] = self.client_secret
-        request = Request(
-            self.provider.token_endpoint,
-            data=urlencode(payload).encode("ascii"),
-            headers={
-                "Accept": "application/json",
-                "Content-Type": "application/x-www-form-urlencoded",
-            },
-            method="POST",
-        )
+        exchange_failure: str | None = None
         try:
+            request = Request(
+                self.provider.token_endpoint,
+                data=urlencode(payload).encode("ascii"),
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                method="POST",
+            )
             with urlopen(request, timeout=30) as response:
                 token = json.load(response)
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:500]
-            raise OAuthError(f"權杖交換失敗：HTTP {exc.code} {detail}") from exc
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            exchange_failure = _sanitized_external_error(exc)
+        if exchange_failure is not None:
+            raise OAuthError(exchange_failure)
+
         if not isinstance(token, dict) or not token.get("access_token"):
             raise OAuthError("授權服務未傳回存取權杖")
         token["obtained_at"] = int(time.time())
@@ -318,21 +337,24 @@ def refresh_oauth_token(
     client_secret = str(token.get("client_secret", ""))
     if client_secret:
         payload["client_secret"] = client_secret
-    request = Request(
-        provider.token_endpoint,
-        data=urlencode(payload).encode("ascii"),
-        headers={
-            "Accept": "application/json",
-            "Content-Type": "application/x-www-form-urlencoded",
-        },
-        method="POST",
-    )
+    refresh_failure: str | None = None
     try:
+        request = Request(
+            provider.token_endpoint,
+            data=urlencode(payload).encode("ascii"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            method="POST",
+        )
         with urlopen(request, timeout=30) as response:
             updated = json.load(response)
-    except HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")[:500]
-        raise OAuthError(f"更新權杖失敗：HTTP {exc.code} {detail}") from exc
+    except (HTTPError, URLError, OSError, UnicodeError, json.JSONDecodeError) as exc:
+        refresh_failure = _sanitized_external_error(exc)
+    if refresh_failure is not None:
+        raise OAuthError(refresh_failure)
+
     if not isinstance(updated, dict) or not updated.get("access_token"):
         raise OAuthError("服務商未傳回新的存取權杖")
     merged = dict(token)
@@ -362,24 +384,31 @@ class JsonApiClient:
             if payload is not None
             else None
         )
-        request = Request(
-            url,
-            data=data,
-            method=method,
-            headers={
-                "Authorization": f"Bearer {self.token}",
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-                "User-Agent": "MoHan-Desktop-Assistant/2.0",
-            },
-        )
+        request_failure: str | None = None
         try:
+            request = Request(
+                url,
+                data=data,
+                method=method,
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "MoHan-Desktop-Assistant/2.0",
+                },
+            )
             with urlopen(request, timeout=30) as response:
                 raw = response.read()
                 return json.loads(raw.decode("utf-8")) if raw else None
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:1000]
-            raise OAuthError(f"雲端服務 HTTP {exc.code}: {detail}") from exc
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            request_failure = _sanitized_external_error(exc)
+        raise OAuthError(request_failure)
 
     def request_bytes(
         self,
@@ -388,24 +417,31 @@ class JsonApiClient:
         content: bytes,
         content_type: str,
     ) -> Any:
-        request = Request(
-            self.base_url + path,
-            data=content,
-            method=method,
-            headers={
-                "Authorization": f"Bearer {self.token}",
-                "Accept": "application/json",
-                "Content-Type": content_type,
-                "User-Agent": "MoHan-Desktop-Assistant/2.0",
-            },
-        )
+        request_failure: str | None = None
         try:
+            request = Request(
+                self.base_url + path,
+                data=content,
+                method=method,
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/json",
+                    "Content-Type": content_type,
+                    "User-Agent": "MoHan-Desktop-Assistant/2.0",
+                },
+            )
             with urlopen(request, timeout=45) as response:
                 raw = response.read()
                 return json.loads(raw.decode("utf-8")) if raw else None
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:1000]
-            raise OAuthError(f"雲端服務 HTTP {exc.code}: {detail}") from exc
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            request_failure = _sanitized_external_error(exc)
+        raise OAuthError(request_failure)
 
 
 class GmailConnector(JsonApiClient):
@@ -536,22 +572,31 @@ class GoogleDriveConnector(JsonApiClient):
             + content
             + f"\r\n--{boundary}--\r\n".encode()
         )
-        request = Request(
-            "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
-            data=body,
-            method="POST",
-            headers={
-                "Authorization": f"Bearer {self.token}",
-                "Accept": "application/json",
-                "Content-Type": f"multipart/related; boundary={boundary}",
-            },
-        )
+        upload_failure: str | None = None
         try:
+            request = Request(
+                "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+                data=body,
+                method="POST",
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/json",
+                    "Content-Type": f"multipart/related; boundary={boundary}",
+                },
+            )
             with urlopen(request, timeout=45) as response:
                 result = json.load(response)
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:1000]
-            raise OAuthError(f"Google Drive HTTP {exc.code}: {detail}") from exc
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            upload_failure = _sanitized_external_error(exc)
+        if upload_failure is not None:
+            raise OAuthError(upload_failure)
+
         if not isinstance(result, dict):
             raise OAuthError("Google Drive 上傳回應格式錯誤")
         return result

--- a/contracts.py
+++ b/contracts.py
@@ -51,6 +51,8 @@ class LocalSpeechEnginePort(Protocol):
         rate: int = -1,
     ) -> None: ...
 
+    def stop(self) -> None: ...
+
 
 class CloudSpeechEnginePort(Protocol):
     finished: SignalPort
@@ -82,7 +84,10 @@ class AzureSpeechEnginePort(Protocol):
         api_key: str,
         region: str,
         voice: str,
+        locale: str = "",
     ) -> None: ...
+
+    def stop(self) -> None: ...
 
     def refresh_voice_catalog(
         self,
@@ -123,13 +128,19 @@ class RealtimeVoicePort(Protocol):
     speaking_changed: SignalPort
     viseme_cue: SignalPort
     failed: SignalPort
+    output_text_started: SignalPort
+    output_text_delta: SignalPort
+    output_text_done: SignalPort
+    output_interrupted: SignalPort
     running: bool
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None: ...
 
+    def set_external_playback_active(self, active: bool) -> None: ...
+
     def start(self, *args: Any, **kwargs: Any) -> None: ...
 
-    def stop(self) -> None: ...
+    def stop(self) -> int: ...
 
 
 class SpeechListenerPort(Protocol):

--- a/db.py
+++ b/db.py
@@ -11,6 +11,7 @@ lazy from pathlib import Path
 lazy from language_support import (
     LEGACY_AUTHOR_ORGANIZATION,
     LEGACY_TRANSCRIPTION_PROMPT,
+    canonical_ui_language,
     localized_transcription_prompt,
 )
 lazy from memory_index import (
@@ -107,6 +108,32 @@ TRANSCRIPTION_PROFILE_KEYS = (
 
 
 @dataclass(frozen=True, slots=True)
+class DurationFormat:
+    with_hours: str
+    minutes_only: str
+
+
+DURATION_FORMATS: Mapping[str, DurationFormat] = frozendict({
+    "zh-TW": DurationFormat(
+        with_hours="{hours} 小時 {minutes} 分",
+        minutes_only="{minutes} 分鐘",
+    ),
+    "zh-CN": DurationFormat(
+        with_hours="{hours} 小时 {minutes} 分",
+        minutes_only="{minutes} 分钟",
+    ),
+    "en": DurationFormat(
+        with_hours="{hours} h {minutes} min",
+        minutes_only="{minutes} min",
+    ),
+    "ja-JP": DurationFormat(
+        with_hours="{hours}時間{minutes}分",
+        minutes_only="{minutes}分",
+    ),
+})
+
+
+@dataclass(frozen=True, slots=True)
 class PlatformProgressUpdate:
     platform: str
     status: str
@@ -118,12 +145,12 @@ class PlatformProgressUpdate:
 
     def database_row(self, updated_at: str) -> tuple[str, ...]:
         return (
-            self.platform,
-            to_taiwan_traditional(self.status.strip()) or "尚未開始",
-            to_taiwan_traditional(self.missing.strip()),
-            to_taiwan_traditional(self.item_name.strip()),
-            to_taiwan_traditional(self.next_action.strip()),
-            to_taiwan_traditional(self.notes.strip()),
+            self.platform.strip(),
+            self.status.strip() or "尚未開始",
+            self.missing.strip(),
+            self.item_name.strip(),
+            self.next_action.strip(),
+            self.notes.strip(),
             self.url.strip(),
             updated_at,
         )
@@ -350,26 +377,11 @@ class StudioDB:
             )
 
     def _migrate_chat_history(self) -> None:
+        # Older single-language releases rewrote every chat row to Traditional
+        # Chinese. A four-language profile must preserve user and model text
+        # verbatim, so the legacy marker remains only for upgrade compatibility.
         self.conn.execute(
-            "UPDATE chat_log SET content=REPLACE(content,'劍主','主上') "
-            "WHERE content LIKE '%劍主%'"
-        )
-        marker = self.conn.execute(
-            "SELECT value FROM settings "
-            "WHERE key='traditional_chat_v1215_migrated'"
-        ).fetchone()
-        if marker is not None:
-            return
-        rows = self.conn.execute("SELECT id,content FROM chat_log").fetchall()
-        for row in rows:
-            normalized = to_taiwan_traditional(row["content"])
-            if normalized != row["content"]:
-                self.conn.execute(
-                    "UPDATE chat_log SET content=? WHERE id=?",
-                    (normalized, row["id"]),
-                )
-        self.conn.execute(
-            "INSERT INTO settings(key,value) "
+            "INSERT OR IGNORE INTO settings(key,value) "
             "VALUES('traditional_chat_v1215_migrated','true')"
         )
 
@@ -472,11 +484,11 @@ class StudioDB:
             return default
 
     def add_todo(self, title: str, category: str = "其他") -> int:
-        normalized_title = to_taiwan_traditional(title.strip())
+        title = title.strip()
         cur = self.conn.execute(
             "INSERT INTO todos(title,category,created_at) VALUES(?,?,?)",
             (
-                normalized_title,
+                title,
                 category,
                 local_wall_time().isoformat(timespec="seconds"),
             ),
@@ -508,16 +520,16 @@ class StudioDB:
         self.conn.commit()
 
     def add_idea(self, text: str, content: str = "") -> int:
-        normalized_text = to_taiwan_traditional(text.strip())
-        normalized_content = to_taiwan_traditional(content.strip())
+        text = text.strip()
+        content = content.strip()
         now = local_wall_time().isoformat(timespec="seconds")
         cur = self.conn.execute(
             "INSERT INTO ideas(text,title,content,created_at,updated_at) "
             "VALUES(?,?,?,?,?)",
             (
-                normalized_text,
-                normalized_text,
-                normalized_content,
+                text,
+                text,
+                content,
                 now,
                 now,
             ),
@@ -536,14 +548,14 @@ class StudioDB:
         ).fetchone()
 
     def update_idea(self, idea_id: int, title: str, content: str) -> None:
-        normalized_title = to_taiwan_traditional(title.strip())
-        normalized_content = to_taiwan_traditional(content.strip())
+        title = title.strip()
+        content = content.strip()
         self.conn.execute(
             "UPDATE ideas SET text=?,title=?,content=?,updated_at=? WHERE id=?",
             (
-                normalized_title,
-                normalized_title,
-                normalized_content,
+                title,
+                title,
+                content,
                 local_wall_time().isoformat(timespec="seconds"),
                 idea_id,
             ),
@@ -660,7 +672,7 @@ class StudioDB:
         )
 
     def add_platform(self, platform: str, url: str = "") -> bool:
-        name = to_taiwan_traditional(platform.strip())
+        name = platform.strip()
         if not name:
             return False
         row = self.conn.execute(
@@ -730,7 +742,7 @@ class StudioDB:
             "INSERT INTO chat_log(role,content,created_at) VALUES(?,?,?)",
             (
                 role,
-                to_taiwan_traditional(content),
+                content,
                 local_wall_time().isoformat(timespec="seconds"),
             ),
         )
@@ -775,15 +787,15 @@ class StudioDB:
         importance: int = 3,
         title: str = "",
     ) -> int:
-        text = to_taiwan_traditional(content.strip())
+        text = content.strip()
         if not text:
             return 0
         title_was_supplied = bool(title.strip())
-        normalized_title = to_taiwan_traditional(title.strip())
-        if not normalized_title:
-            normalized_title = " ".join(text.split())
-            if len(normalized_title) > 36:
-                normalized_title = normalized_title[:36].rstrip() + "…"
+        memory_title = title.strip()
+        if not memory_title:
+            memory_title = " ".join(text.split())
+            if len(memory_title) > 36:
+                memory_title = memory_title[:36].rstrip() + "…"
         now = local_wall_time().isoformat(timespec="seconds")
         conflict_title = (
             "title=excluded.title,"
@@ -803,7 +815,7 @@ class StudioDB:
             statement,
             (
                 to_taiwan_traditional(category.strip()) or "其他",
-                normalized_title or "未命名記憶",
+                memory_title or "未命名記憶",
                 text,
                 source,
                 max(1, min(5, importance)),
@@ -857,20 +869,20 @@ class StudioDB:
         category: str,
         importance: int,
     ) -> bool:
-        normalized_title = to_taiwan_traditional(title.strip())
-        normalized_content = to_taiwan_traditional(content.strip())
+        title = title.strip()
+        content = content.strip()
         normalized_category = (
             to_taiwan_traditional(category.strip()) or "其他"
         )
-        if not normalized_title or not normalized_content:
+        if not title or not content:
             return False
         try:
             cursor = self.conn.execute(
                 "UPDATE memories SET title=?,content=?,category=?,"
                 "importance=?,updated_at=? WHERE id=?",
                 (
-                    normalized_title,
-                    normalized_content,
+                    title,
+                    content,
                     normalized_category,
                     max(1, min(5, int(importance))),
                     local_wall_time().isoformat(timespec="seconds"),
@@ -1227,8 +1239,8 @@ class StudioDB:
         enabled: bool = True,
         workflow_id: int | None = None,
     ) -> int:
-        normalized = to_taiwan_traditional(name.strip())
-        if not normalized:
+        name = name.strip()
+        if not name:
             raise ValueError("工作流程名稱不可留空")
         json.loads(definition)
         now = local_wall_time().isoformat(timespec="seconds")
@@ -1238,13 +1250,13 @@ class StudioDB:
                     "INSERT INTO workflows("
                     "name,definition,enabled,created_at,updated_at"
                     ") VALUES(?,?,?,?,?)",
-                    (normalized, definition, int(enabled), now, now),
+                    (name, definition, int(enabled), now, now),
                 )
                 return int(cursor.lastrowid)
             self.conn.execute(
                 "UPDATE workflows SET name=?,definition=?,enabled=?,"
                 "updated_at=? WHERE id=?",
-                (normalized, definition, int(enabled), now, int(workflow_id)),
+                (name, definition, int(enabled), now, int(workflow_id)),
             )
         return int(workflow_id)
 
@@ -1306,7 +1318,7 @@ class StudioDB:
                 """,
                 (
                     connector_id,
-                    to_taiwan_traditional(display_name.strip()),
+                    display_name.strip(),
                     int(enabled),
                     json.dumps(configuration, ensure_ascii=False),
                     last_health,
@@ -1350,7 +1362,7 @@ class StudioDB:
                 """,
                 (
                     target_type.strip(),
-                    to_taiwan_traditional(display_name.strip()),
+                    display_name.strip(),
                     target_value.strip(),
                     access_mode,
                 ),
@@ -1401,7 +1413,7 @@ class StudioDB:
             "device_name,token_hash,permissions,created_at"
             ") VALUES(?,?,?,?)",
             (
-                to_taiwan_traditional(device_name.strip()),
+                device_name.strip(),
                 token_hash,
                 json.dumps(sorted(set(permissions)), ensure_ascii=False),
                 now,
@@ -1446,9 +1458,13 @@ class StudioDB:
         return cursor.rowcount > 0
 
 
-def format_duration(seconds: int) -> str:
+def format_duration(seconds: int, language: str = "zh-TW") -> str:
     hours, rest = divmod(max(0, seconds), 3600)
     minutes = rest // 60
-    if hours:
-        return f"{hours} 小時 {minutes} 分"
-    return f"{minutes} 分鐘"
+    duration_format = DURATION_FORMATS[canonical_ui_language(language)]
+    template = (
+        duration_format.with_hours
+        if hours
+        else duration_format.minutes_only
+    )
+    return template.format(hours=hours, minutes=minutes)

--- a/docs/CROSS-PLATFORM.md
+++ b/docs/CROSS-PLATFORM.md
@@ -26,7 +26,7 @@
   金鑰、OAuth 與 Home Assistant 權杖輸入，且不顯示 Windows 專用語音選項。
 - GitHub Actions 的三系統測試只證明原始碼可匯入、核心邏輯與無畫面 Qt
   守門通過，不等同真實麥克風、喇叭或完整桌面環境驗證。
-- `v2.3.0-rc.N` 另在原生 runner 產生兩種 macOS 架構的 DMG 與 Linux
+- 符合 `vN.N.N` 或 `vN.N.N-rc.N` 的發布系列，另在原生 runner 產生兩種 macOS 架構的 DMG 與 Linux
   AppImage，並從完成的安裝包執行
   啟動與四語畫面 smoke test。預覽殼層不提供秘密輸入、語音、完整桌面角色、
   雲端連接器與系統工具；這是刻意的 fail-closed 邊界，不是功能遺失。
@@ -57,7 +57,7 @@ Windows 正式版本的完整功能。Windows 仍是目前唯一经过真机使�
 - 设置页与旗舰控制中心共用同一个可注入密钥边界；未验证平台会停用密钥、
   OAuth 与 Home Assistant 权杖输入，也不会显示 Windows 专用语音选项。
 - 三系统 CI 不等同真实麦克风、扬声器或完整桌面环境验证。
-- `v2.3.0-rc.N` 会在原生 runner 生成两种 macOS 架构的 DMG 与 Linux
+- 符合 `vN.N.N` 或 `vN.N.N-rc.N` 的发布系列会在原生 runner 生成两种 macOS 架构的 DMG 与 Linux
   AppImage，并从完成的安装包执行
   启动与四语界面 smoke test。预览外壳不提供秘密输入、语音、完整桌面角色、
   云端连接器或系统工具，这是刻意的 fail-closed 边界。
@@ -94,7 +94,7 @@ suite, installer testing, and published packages.
   inputs and do not advertise Windows-only speech controls.
 - A green matrix proves imports, pure-core behavior, and headless Qt only. It is
   not evidence of real microphones, speakers, or a complete desktop session.
-- The `v2.3.0-rc.N` line also builds both macOS architecture DMGs and the Linux
+- Release lines matching `vN.N.N` or `vN.N.N-rc.N` also build both macOS architecture DMGs and the Linux
   AppImage on native runners
   and smoke-tests startup and all four UI languages from the finished package.
   The Preview shell exposes no secret entry, voice, complete character UI,
@@ -131,7 +131,7 @@ macOS／Linux が Windows 版と同等に完成したという意味ではあり
   Windows 専用音声も表示しません。
 - 三 OS の CI 合格は、実機のマイク、スピーカー、デスクトップ環境、
   完全なデスクトップ利用の検証を意味しません。
-- `v2.3.0-rc.N` 系列では、ネイティブ runner で macOS 両アーキテクチャの
+- `vN.N.N` または `vN.N.N-rc.N` に一致するリリース系列では、ネイティブ runner で macOS 両アーキテクチャの
   DMG と Linux AppImage を作成し、
   完成した配布物から起動と四言語画面の smoke test を実行します。Preview
   シェルには秘密情報入力、音声、完全なキャラクター画面、クラウド連携、

--- a/docs/PREVIEW-PACKAGES.md
+++ b/docs/PREVIEW-PACKAGES.md
@@ -4,11 +4,11 @@
 
 ### 這些安裝檔是什麼
 
-`v2.3.0-rc.N` 發行線會分別在 GitHub 原生 Apple Silicon（arm64）與 Intel
+`vN.N.N` 與 `vN.N.N-rc.N` 發行線會分別在 GitHub 原生 Apple Silicon（arm64）與 Intel
 （x86_64）macOS runner 製作 `.dmg`，其中包含相符架構的 `.app`；Linux
 x86_64 runner 則製作 `.AppImage`。三個流程都會先建立封裝，
 再從成品執行無畫面啟動測試，確認四語畫面與安全邊界能載入。Pull Request
-只保存短期測試產物；只有已存在且符合 `v2.3.0-rc.N` 的標籤才會發布到
+只保存短期測試產物；只有已存在且符合上述正式版或 RC 格式的標籤才會發布到
 GitHub Releases。
 
 ### 目前可以驗證的範圍
@@ -46,11 +46,11 @@ CI 不是作者持有真實 Mac 或 Linux 桌面電腦的證明。此 Preview �
 
 ### 这些安装文件是什么
 
-`v2.3.0-rc.N` 发布线会分别在 GitHub 原生 Apple Silicon（arm64）与 Intel
+`vN.N.N` 与 `vN.N.N-rc.N` 发布线会分别在 GitHub 原生 Apple Silicon（arm64）与 Intel
 （x86_64）macOS runner 生成 `.dmg`（内含对应架构的 `.app`），并在 Linux
 x86_64 runner 生成 `.AppImage`。三个流程都会从完成的
 安装包执行无画面启动测试，检查四语界面与安全边界。Pull Request 仅保存短期
-测试产物；只有已经存在并符合 `v2.3.0-rc.N` 的标签才能发布到 Releases。
+测试产物；只有已经存在并符合上述正式版或 RC 格式的标签才能发布到 Releases。
 
 ### 当前验证范围
 
@@ -85,12 +85,12 @@ CI 并不表示作者已经拥有并实测真实 Mac 或 Linux 桌面电脑。�
 
 ### What these packages are
 
-The `v2.3.0-rc.N` line builds separate `.dmg` files on native GitHub Apple
+The `vN.N.N` and `vN.N.N-rc.N` lines build separate `.dmg` files on native GitHub Apple
 Silicon (arm64) and Intel (x86_64) macOS runners, each containing a matching
 `.app`, plus an `.AppImage` on a Linux x86_64 runner. Each job executes a
 headless smoke test from the finished package and checks all four UI languages
 and fail-closed boundaries. Pull requests retain short-lived test artifacts;
-only an existing tag matching `v2.3.0-rc.N` may publish a GitHub Release.
+only an existing tag matching either stable or RC format may publish a GitHub Release.
 
 ### What is verified now
 
@@ -132,12 +132,12 @@ Gatekeeper globally.
 
 ### この配布物について
 
-`v2.3.0-rc.N` 系列では、GitHub の Apple Silicon（arm64）版と Intel
+`vN.N.N` および `vN.N.N-rc.N` 系列では、GitHub の Apple Silicon（arm64）版と Intel
 （x86_64）版 macOS ネイティブ runner で、個別の `.dmg`（対応する `.app`
 を同梱）を作成し、Linux x86_64 runner で `.AppImage` を作成します。完成した
 配布物から headless 起動検査を実行し、四言語画面と安全な停止境界を確認します。
 Pull Request の成果物は短期間の検査用です。Releases へ公開できるのは、既に
-存在し `v2.3.0-rc.N` に一致するタグだけです。
+存在し、上記の正式版または RC 形式に一致するタグだけです。
 
 ### 現在確認する範囲
 

--- a/docs/releases/v3.1.2.md
+++ b/docs/releases/v3.1.2.md
@@ -8,7 +8,10 @@
 - 三種 Realtime 回覆聲音完全隔離且不混音；只有伺服器確認回應完整完成後才會提交最後文字。取消、失敗、不完整、連線中斷及其他舊回應的晚到事件都不會繼續發聲或驅動嘴型。
 - Dragon HD 單句失敗時只依序退回一般 Azure 一次，再退回 Windows 本機女性聲線一次；一般 Azure 則只退回本機聲線一次。回退僅適用於該句尚未播放任何音訊時；串流已開始後若失敗，系統會停止該句而不整句重播，避免循環、重複播放與重複計費。
 - Azure 與 Windows 本機合成都可真正取消；過期操作識別碼、音訊壓力、有界緩衝與過長回應均有安全防護。API 金鑰仍不會進入 SQLite、錯誤訊息、log、Git、安裝包或物件文字表示。
-- Windows 仍是唯一完成真實功能、安裝及發布驗證的完整平台；macOS 與 Linux 套件仍為功能受限 Preview。
+- 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
+- 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
+- 四語介面修正仍在進行最後驗證；本文件是預備發行說明，不代表 CI 已全綠或 v3.1.2 已發布。只有完整在地化、回歸、封裝、安全與發布政策檢查全部成功後，才可依最終標籤建立正式版或候選版。
+- Windows 仍是唯一完成既有公開版本真實功能、安裝及發布驗證的完整平台；本版 macOS 與 Linux 產物仍須通過最終發布門檻，且維持功能受限 Preview。
 
 ## 简体中文
 
@@ -18,7 +21,10 @@
 - 三种 Realtime 回复声音完全隔离且不会混音；只有服务器确认回复完整完成后才会提交最终文字。取消、失败、不完整、连接中断及其他旧回复的迟到事件均不会继续发声或驱动嘴形。
 - Dragon HD 单句失败时只依次回退到一般 Azure 一次，再回退到 Windows 本地女性声线一次；一般 Azure 则只回退到本地声线一次。回退仅适用于该句尚未播放任何音频时；流式播放开始后若失败，系统会停止该句而不整句重播，避免循环、重复播放及重复计费。
 - Azure 与 Windows 本地合成都可以真正取消；过期操作标识、音频压力、有界缓冲及过长回复均有安全保护。API 密钥仍不会进入 SQLite、错误信息、日志、Git、安装包或对象文字表示。
-- Windows 仍是唯一完成真实功能、安装及发布验证的完整平台；macOS 与 Linux 软件包仍为功能受限 Preview。
+- 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
+- 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
+- 四语界面修复仍在进行最终验证；本文档是预备发布说明，并不代表 CI 已全部通过或 v3.1.2 已发布。只有完整本地化、回归、打包、安全与发布策略检查全部成功后，才可根据最终标签创建正式版或候选版。
+- Windows 仍是唯一完成现有公开版本真实功能、安装及发布验证的完整平台；本版本 macOS 与 Linux 产物仍须通过最终发布关卡，并继续作为功能受限 Preview。
 
 ## English
 
@@ -28,7 +34,10 @@
 - The three Realtime response-voice modes remain isolated and never mix. Final text is committed only after the server confirms a fully completed response. Late events from cancelled, failed, incomplete, disconnected, or older responses cannot continue speech or drive lip motion.
 - A failed Dragon HD clause falls back once to standard Azure and then once to a local Windows female voice. Standard Azure falls back to the local voice only once. Fallback applies only before that clause has played any audio; if the stream fails after playback begins, MoHan stops the clause without replaying it in full, preventing loops, duplicate playback, and duplicate charges.
 - Azure and local Windows synthesis can now be cancelled effectively. Stale operation IDs, audio pressure, bounded buffers, and oversized responses are guarded safely. API keys still never enter SQLite, errors, logs, Git, installers, or object representations.
-- Windows remains the only full platform validated for real features, installation, and publication; macOS and Linux packages remain a limited cross-platform Preview.
+- Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
+- Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
+- Four-language interface fixes remain under final validation. This is a prepared Release description; it does not mean CI is all green or v3.1.2 has been published. A Stable Release or release candidate may be created from the final tag only after complete localization, regression, packaging, security, and publication-policy checks all succeed.
+- Windows remains the only full platform whose existing public releases have completed real-feature, installation, and publication validation. This release's macOS and Linux artifacts must still pass the final publication gates and remain limited cross-platform Previews.
 
 ## 日本語
 
@@ -38,4 +47,7 @@
 - 三つの Realtime 応答音声モードは完全に分離し、混音しません。サーバーが応答の完全な完了を確認した場合だけ最終テキストを確定します。取消、失敗、未完了、切断、または古い応答から遅れて届いたイベントが発話や口形を続けることはありません。
 - Dragon HD の一つの句が失敗した場合は通常 Azure へ一度、その後 Windows 本機女性音声へ一度だけ代替します。通常 Azure は本機音声へ一度だけ代替します。この代替は、その句の音声がまだ一切再生されていない場合に限ります。再生開始後にストリームが失敗した場合は句全体を再生し直さず停止し、循環、重複再生、重複課金を防ぎます。
 - Azure と Windows 本機の合成を実際に取り消せるようにしました。古い操作 ID、音声負荷、有界バッファー、長すぎる応答を安全に防護します。API キーは引き続き SQLite、エラー、ログ、Git、インストーラー、オブジェクトの文字列表現へ入りません。
-- 実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけで、macOS と Linux のパッケージは引き続き機能限定 Preview です。
+- 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
+- 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
+- 四言語画面の修正は最終検証中です。本書は公開準備用の説明であり、CI の全成功や v3.1.2 の公開完了を示しません。完全なローカライズ、回帰、パッケージ、セキュリティ、公開ポリシーの検査がすべて成功した後に限り、最終タグに従って正式版またはリリース候補版を作成できます。
+- 既存の公開版で実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけです。本版の macOS と Linux の成果物は最終公開ゲートに合格する必要があり、引き続き機能限定 Preview とします。

--- a/docs/releases/v3.1.2.md
+++ b/docs/releases/v3.1.2.md
@@ -1,0 +1,41 @@
+# 墨寒桌面助理 v3.1.2／墨寒桌面助手 v3.1.2／MoHan Desktop Assistant v3.1.2／墨寒デスクトップアシスタント v3.1.2
+
+## 繁體中文
+
+- 完整保留 OpenAI Realtime 原生聲音，並維持為預設及額外延遲最低的回覆聲音；偏好既有 Realtime 聲線的使用者不會被迫改用 Azure。
+- 新增兩種明確選用的混合模式：OpenAI Realtime 負責即時理解，再由一般 Azure Speech 或 Dragon HD 以目前各自獨立的區域、加密金鑰與女性聲線串流發聲；切換回覆聲音來源後會立即保存。
+- 混合模式將完成的安全短句依序加入有界佇列，第一段 24 kHz PCM16 音訊抵達便開始播放並送入既有 50 Hz 本機嘴型分析，以降低額外 TTS 等待，但不宣稱零延遲。
+- 三種 Realtime 回覆聲音完全隔離且不混音；只有伺服器確認回應完整完成後才會提交最後文字。取消、失敗、不完整、連線中斷及其他舊回應的晚到事件都不會繼續發聲或驅動嘴型。
+- Dragon HD 單句失敗時只依序退回一般 Azure 一次，再退回 Windows 本機女性聲線一次；一般 Azure 則只退回本機聲線一次。回退僅適用於該句尚未播放任何音訊時；串流已開始後若失敗，系統會停止該句而不整句重播，避免循環、重複播放與重複計費。
+- Azure 與 Windows 本機合成都可真正取消；過期操作識別碼、音訊壓力、有界緩衝與過長回應均有安全防護。API 金鑰仍不會進入 SQLite、錯誤訊息、log、Git、安裝包或物件文字表示。
+- Windows 仍是唯一完成真實功能、安裝及發布驗證的完整平台；macOS 與 Linux 套件仍為功能受限 Preview。
+
+## 简体中文
+
+- 完整保留 OpenAI Realtime 原生声音，并继续作为默认及额外延迟最低的回复声音；偏好现有 Realtime 声线的用户不会被迫改用 Azure。
+- 新增两种明确选用的混合模式：OpenAI Realtime 负责即时理解，再由一般 Azure Speech 或 Dragon HD 使用当前各自独立的区域、加密密钥及女性声线进行流式发声；切换回复声音来源后会立即保存。
+- 混合模式将完成的安全短句依次加入有界队列，第一段 24 kHz PCM16 音频到达即开始播放并送入现有 50 Hz 本地嘴形分析，以降低额外 TTS 等待，但不宣称零延迟。
+- 三种 Realtime 回复声音完全隔离且不会混音；只有服务器确认回复完整完成后才会提交最终文字。取消、失败、不完整、连接中断及其他旧回复的迟到事件均不会继续发声或驱动嘴形。
+- Dragon HD 单句失败时只依次回退到一般 Azure 一次，再回退到 Windows 本地女性声线一次；一般 Azure 则只回退到本地声线一次。回退仅适用于该句尚未播放任何音频时；流式播放开始后若失败，系统会停止该句而不整句重播，避免循环、重复播放及重复计费。
+- Azure 与 Windows 本地合成都可以真正取消；过期操作标识、音频压力、有界缓冲及过长回复均有安全保护。API 密钥仍不会进入 SQLite、错误信息、日志、Git、安装包或对象文字表示。
+- Windows 仍是唯一完成真实功能、安装及发布验证的完整平台；macOS 与 Linux 软件包仍为功能受限 Preview。
+
+## English
+
+- Native OpenAI Realtime voice remains fully available and stays the default response voice with the lowest added latency. Users who prefer the existing Realtime voices are never forced onto Azure.
+- Two explicitly selectable hybrid modes are added: OpenAI Realtime handles live understanding, then standard Azure Speech or Dragon HD streams speech with its own currently selected region, encrypted key, and female voice. Changing the response-voice source saves immediately.
+- Hybrid mode queues completed safe short clauses in order within a bounded queue. Playback begins with the first 24 kHz PCM16 chunk and feeds the existing local 50 Hz lip analysis, reducing the added TTS wait without claiming zero latency.
+- The three Realtime response-voice modes remain isolated and never mix. Final text is committed only after the server confirms a fully completed response. Late events from cancelled, failed, incomplete, disconnected, or older responses cannot continue speech or drive lip motion.
+- A failed Dragon HD clause falls back once to standard Azure and then once to a local Windows female voice. Standard Azure falls back to the local voice only once. Fallback applies only before that clause has played any audio; if the stream fails after playback begins, MoHan stops the clause without replaying it in full, preventing loops, duplicate playback, and duplicate charges.
+- Azure and local Windows synthesis can now be cancelled effectively. Stale operation IDs, audio pressure, bounded buffers, and oversized responses are guarded safely. API keys still never enter SQLite, errors, logs, Git, installers, or object representations.
+- Windows remains the only full platform validated for real features, installation, and publication; macOS and Linux packages remain a limited cross-platform Preview.
+
+## 日本語
+
+- OpenAI Realtime のネイティブ音声を完全に維持し、既定かつ追加遅延が最も少ない応答音声とします。従来の Realtime 音声を好む利用者へ Azure を強制しません。
+- 明示的に選べる二つの混合モードを追加します。OpenAI Realtime が即時理解を担当し、通常 Azure Speech または Dragon HD が、それぞれ現在選択中の独立したリージョン、暗号化キー、女性音声でストリーミング発話します。応答音声の供給元を切り替えると直ちに保存します。
+- 混合モードは、完成した安全な短い句を有界キューへ順番に追加します。最初の 24 kHz PCM16 断片が届くと再生を開始して既存の本機 50 Hz 口形解析へ渡し、追加の TTS 待ち時間を抑えますが、ゼロ遅延はうたいません。
+- 三つの Realtime 応答音声モードは完全に分離し、混音しません。サーバーが応答の完全な完了を確認した場合だけ最終テキストを確定します。取消、失敗、未完了、切断、または古い応答から遅れて届いたイベントが発話や口形を続けることはありません。
+- Dragon HD の一つの句が失敗した場合は通常 Azure へ一度、その後 Windows 本機女性音声へ一度だけ代替します。通常 Azure は本機音声へ一度だけ代替します。この代替は、その句の音声がまだ一切再生されていない場合に限ります。再生開始後にストリームが失敗した場合は句全体を再生し直さず停止し、循環、重複再生、重複課金を防ぎます。
+- Azure と Windows 本機の合成を実際に取り消せるようにしました。古い操作 ID、音声負荷、有界バッファー、長すぎる応答を安全に防護します。API キーは引き続き SQLite、エラー、ログ、Git、インストーラー、オブジェクトの文字列表現へ入りません。
+- 実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけで、macOS と Linux のパッケージは引き続き機能限定 Preview です。

--- a/docs/releases/v3.1.2.md
+++ b/docs/releases/v3.1.2.md
@@ -10,6 +10,7 @@
 - Azure 與 Windows 本機合成都可真正取消；過期操作識別碼、音訊壓力、有界緩衝與過長回應均有安全防護。API 金鑰仍不會進入 SQLite、錯誤訊息、log、Git、安裝包或物件文字表示。
 - 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
 - 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
+- 修正 WiX MSI 的 Windows 開始功能表捷徑，使其直接沿用目標 EXE 內嵌的墨寒半身圖示，不再引用 MSI 的獨立圖示資源。
 - 本版完整提供繁體中文、簡體中文、英文與日文介面；v3.1.2 的發行流程以完整在地化、回歸、封裝、安全及發布政策檢查為必要門檻，並由對應的正式標籤建立可稽核的穩定版本。
 - Windows 仍是唯一完成既有公開版本真實功能、安裝及發布驗證的完整平台；本版 macOS 與 Linux 產物仍須通過最終發布門檻，且維持功能受限 Preview。
 
@@ -23,6 +24,7 @@
 - Azure 与 Windows 本地合成都可以真正取消；过期操作标识、音频压力、有界缓冲及过长回复均有安全保护。API 密钥仍不会进入 SQLite、错误信息、日志、Git、安装包或对象文字表示。
 - 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
 - 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
+- 修复 WiX MSI 的 Windows 开始菜单快捷方式，使其直接沿用目标 EXE 内嵌的墨寒半身图标，不再引用 MSI 的独立图标资源。
 - 本版本完整提供繁体中文、简体中文、英文与日文界面；v3.1.2 的发布流程以完整本地化、回归、打包、安全及发布策略检查为必要关卡，并由对应的正式标签创建可审计的稳定版本。
 - Windows 仍是唯一完成现有公开版本真实功能、安装及发布验证的完整平台；本版本 macOS 与 Linux 产物仍须通过最终发布关卡，并继续作为功能受限 Preview。
 
@@ -36,6 +38,7 @@
 - Azure and local Windows synthesis can now be cancelled effectively. Stale operation IDs, audio pressure, bounded buffers, and oversized responses are guarded safely. API keys still never enter SQLite, errors, logs, Git, installers, or object representations.
 - Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
 - Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
+- Fixes the WiX MSI Windows Start menu shortcut so it inherits MoHan's embedded half-body icon directly from the target EXE instead of referencing a separate MSI icon resource.
 - This release provides complete Traditional Chinese, Simplified Chinese, English, and Japanese interfaces. The v3.1.2 publication process requires complete localization, regression, packaging, security, and publication-policy checks, and its corresponding final tag creates an auditable Stable Release.
 - Windows remains the only full platform whose existing public releases have completed real-feature, installation, and publication validation. This release's macOS and Linux artifacts must still pass the final publication gates and remain limited cross-platform Previews.
 
@@ -49,5 +52,6 @@
 - Azure と Windows 本機の合成を実際に取り消せるようにしました。古い操作 ID、音声負荷、有界バッファー、長すぎる応答を安全に防護します。API キーは引き続き SQLite、エラー、ログ、Git、インストーラー、オブジェクトの文字列表現へ入りません。
 - 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
 - 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
+- WiX MSI の Windows スタートメニューショートカットを修正し、MSI 内の個別アイコンリソースではなく、対象 EXE に内蔵された墨寒の半身アイコンを直接継承するようにしました。
 - 本版は繁体字中国語、簡体字中国語、英語、日本語の完全な画面を提供します。v3.1.2 の公開工程では、完全なローカライズ、回帰、パッケージ、セキュリティ、公開ポリシーの検査を必須ゲートとし、対応する正式タグから監査可能な安定版を作成します。
 - 既存の公開版で実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけです。本版の macOS と Linux の成果物は最終公開ゲートに合格する必要があり、引き続き機能限定 Preview とします。

--- a/docs/releases/v3.1.2.md
+++ b/docs/releases/v3.1.2.md
@@ -10,7 +10,7 @@
 - Azure 與 Windows 本機合成都可真正取消；過期操作識別碼、音訊壓力、有界緩衝與過長回應均有安全防護。API 金鑰仍不會進入 SQLite、錯誤訊息、log、Git、安裝包或物件文字表示。
 - 修正語音結束後身體短暫回彈的程式根因：音訊結束時立即將發話動作目標釋放至中央，待實際位移收束後才切換狀態；Realtime、Windows 本機、OpenAI 與 Azure 共用同一結束流程，並取消狀態交接時重複的表情進場動作，避免同一影格出現兩個動作來源。
 - 新增 75%、100%、180% 縮放的逐影格座標回歸，驗證動作只會平滑、單調地返回中央，且所有角色圖層保持同步。本修正已納入自動化驗證，但仍待使用者以候選安裝包進行實機確認，不能宣稱實機已通過。
-- 四語介面修正仍在進行最後驗證；本文件是預備發行說明，不代表 CI 已全綠或 v3.1.2 已發布。只有完整在地化、回歸、封裝、安全與發布政策檢查全部成功後，才可依最終標籤建立正式版或候選版。
+- 本版完整提供繁體中文、簡體中文、英文與日文介面；v3.1.2 的發行流程以完整在地化、回歸、封裝、安全及發布政策檢查為必要門檻，並由對應的正式標籤建立可稽核的穩定版本。
 - Windows 仍是唯一完成既有公開版本真實功能、安裝及發布驗證的完整平台；本版 macOS 與 Linux 產物仍須通過最終發布門檻，且維持功能受限 Preview。
 
 ## 简体中文
@@ -23,7 +23,7 @@
 - Azure 与 Windows 本地合成都可以真正取消；过期操作标识、音频压力、有界缓冲及过长回复均有安全保护。API 密钥仍不会进入 SQLite、错误信息、日志、Git、安装包或对象文字表示。
 - 修复语音结束后身体短暂回弹的程序根因：音频结束时立即将发话动作目标释放至中央，待实际位移收束后才切换状态；Realtime、Windows 本地、OpenAI 与 Azure 共用同一结束流程，并取消状态交接时重复的表情进场动作，避免同一帧出现两个动作来源。
 - 新增 75%、100%、180% 缩放的逐帧坐标回归，验证动作只会平滑、单调地返回中央，且所有角色图层保持同步。本修正已纳入自动化验证，但仍待用户使用候选安装包进行真机确认，不能宣称真机已通过。
-- 四语界面修复仍在进行最终验证；本文档是预备发布说明，并不代表 CI 已全部通过或 v3.1.2 已发布。只有完整本地化、回归、打包、安全与发布策略检查全部成功后，才可根据最终标签创建正式版或候选版。
+- 本版本完整提供繁体中文、简体中文、英文与日文界面；v3.1.2 的发布流程以完整本地化、回归、打包、安全及发布策略检查为必要关卡，并由对应的正式标签创建可审计的稳定版本。
 - Windows 仍是唯一完成现有公开版本真实功能、安装及发布验证的完整平台；本版本 macOS 与 Linux 产物仍须通过最终发布关卡，并继续作为功能受限 Preview。
 
 ## English
@@ -36,7 +36,7 @@
 - Azure and local Windows synthesis can now be cancelled effectively. Stale operation IDs, audio pressure, bounded buffers, and oversized responses are guarded safely. API keys still never enter SQLite, errors, logs, Git, installers, or object representations.
 - Fixes the underlying motion-handoff cause of the brief body rebound after speech: speech motion begins releasing toward the centre as soon as audio ends, and state hand-off waits until the actual offset settles. Realtime, Windows local, OpenAI, and Azure share this completion path, while duplicate expression entrance motion is suppressed during hand-off so only one motion owner controls each frame.
 - Adds frame-by-frame coordinate regressions at 75%, 100%, and 180% scale, verifying that motion returns to centre smoothly and monotonically while all character layers remain aligned. Automated coverage includes this fix, but owner validation with a candidate installer remains pending; this does not claim that real-device validation has passed.
-- Four-language interface fixes remain under final validation. This is a prepared Release description; it does not mean CI is all green or v3.1.2 has been published. A Stable Release or release candidate may be created from the final tag only after complete localization, regression, packaging, security, and publication-policy checks all succeed.
+- This release provides complete Traditional Chinese, Simplified Chinese, English, and Japanese interfaces. The v3.1.2 publication process requires complete localization, regression, packaging, security, and publication-policy checks, and its corresponding final tag creates an auditable Stable Release.
 - Windows remains the only full platform whose existing public releases have completed real-feature, installation, and publication validation. This release's macOS and Linux artifacts must still pass the final publication gates and remain limited cross-platform Previews.
 
 ## 日本語
@@ -49,5 +49,5 @@
 - Azure と Windows 本機の合成を実際に取り消せるようにしました。古い操作 ID、音声負荷、有界バッファー、長すぎる応答を安全に防護します。API キーは引き続き SQLite、エラー、ログ、Git、インストーラー、オブジェクトの文字列表現へ入りません。
 - 発話終了後に身体が短時間跳ね戻る動作引き継ぎ上の根本原因を修正します。音声の終了時点で発話動作の目標を直ちに中央へ解放し、実際の変位が収束してから状態を切り替えます。Realtime、Windows 本機、OpenAI、Azure は同じ終了処理を共有し、状態引き継ぎ時の重複した表情開始動作を抑えて、同一フレームを一つの動作所有者だけが制御するようにします。
 - 75%、100%、180% の各表示倍率でフレームごとの座標回帰を追加し、全キャラクターレイヤーの同期を保ちながら動作が中央へ滑らかかつ単調に戻ることを検証します。修正は自動テスト対象ですが、候補インストーラーによる所有者の実機確認は未完了であり、実機検証済みとは表明しません。
-- 四言語画面の修正は最終検証中です。本書は公開準備用の説明であり、CI の全成功や v3.1.2 の公開完了を示しません。完全なローカライズ、回帰、パッケージ、セキュリティ、公開ポリシーの検査がすべて成功した後に限り、最終タグに従って正式版またはリリース候補版を作成できます。
+- 本版は繁体字中国語、簡体字中国語、英語、日本語の完全な画面を提供します。v3.1.2 の公開工程では、完全なローカライズ、回帰、パッケージ、セキュリティ、公開ポリシーの検査を必須ゲートとし、対応する正式タグから監査可能な安定版を作成します。
 - 既存の公開版で実機能、インストール、公開まで検証済みの完全対応プラットフォームは Windows だけです。本版の macOS と Linux の成果物は最終公開ゲートに合格する必要があり、引き続き機能限定 Preview とします。

--- a/face_motion.py
+++ b/face_motion.py
@@ -5,14 +5,12 @@ lazy from dataclasses import dataclass, replace
 lazy from face_rig import (
     ExpressionShape,
     FaceMotionFrame,
-    FacePose,
     MouthShape,
     Viseme,
     parse_pose,
     parse_viseme,
 )
 lazy from lip_sync import VisemeFrame
-
 
 VISEME_MOUTH_TARGETS = frozendict(
     {
@@ -71,7 +69,7 @@ class FaceMotionController:
             expression=str(expression),
             viseme=Viseme.CLOSED,
             mouth=MouthShape(),
-            expression_shape=_expression_target(expression, speaking=False),
+            expression_shape=_expression_target(expression),
         )
 
     def advance(
@@ -122,7 +120,7 @@ class FaceMotionController:
             corner_smile=0.0,
         ).clamped()
         expression_shape = replace(
-            _expression_target(expression, speaking=viseme is not Viseme.CLOSED),
+            _expression_target(expression),
             blink=blink,
         ).clamped()
         self.current = FaceMotionFrame(
@@ -136,7 +134,7 @@ class FaceMotionController:
 
     def close(self, *, pose: str, expression: str) -> FaceMotionFrame:
         closed = self.neutral(pose, expression)
-        expression_shape = _expression_target(expression, speaking=False)
+        expression_shape = _expression_target(expression)
         corner_smile = 0.62 if expression in HAPPY_EXPRESSIONS else 0.0
         self.current = replace(
             closed,
@@ -146,7 +144,7 @@ class FaceMotionController:
         return self.current
 
 
-def _expression_target(expression: str, *, speaking: bool) -> ExpressionShape:
+def _expression_target(expression: str) -> ExpressionShape:
     happy = expression in HAPPY_EXPRESSIONS
     return ExpressionShape(
         eye_smile=0.72 if happy else 0.0,

--- a/flagship_core.py
+++ b/flagship_core.py
@@ -15,6 +15,7 @@ lazy from urllib.parse import urlparse
 
 lazy from platform_contracts import PlatformServicePort
 lazy from platform_services import current_platform_services
+lazy from safe_error import sanitize_error
 lazy from time_utils import local_wall_time
 
 
@@ -378,16 +379,22 @@ class ActionExecutor:
                 "尚未安裝此工具的執行器",
             )
         handler, verifier = registered
+        handler_error: Exception | None = None
         try:
             result = handler(request)
             self._verify_result(request, result, verifier)
-            return result
         except Exception as exc:  # noqa: BLE001 -- tool boundary
+            handler_error = exc
+
+        if handler_error is not None:
+            safe_failure = str(sanitize_error(handler_error))
+            del handler_error
             return ActionResult(
                 request.request_id,
                 False,
-                f"工具執行失敗：{type(exc).__name__}: {exc}",
+                f"工具執行失敗：{safe_failure}",
             )
+        return result
 
     @staticmethod
     def _verify_result(

--- a/flagship_ui.py
+++ b/flagship_ui.py
@@ -76,6 +76,9 @@ lazy from flagship_core import (
     WindowsToolbox,
     parse_plan_json,
 )
+lazy from flagship_ui_localization import FlagshipTranslator
+lazy from safe_error import sanitize_error
+lazy from safe_error_localization import safe_error_message
 lazy from home_assistant import (
     HomeAssistantClient,
     HomeAssistantConfig,
@@ -216,7 +219,7 @@ class OAuthWorker(QRunnable):
                 token["client_secret"] = self.client_secret
             self.signals.done.emit(self.provider_id, token)
         except Exception as exc:  # noqa: BLE001 -- OAuth worker reports all failures
-            self.signals.failed.emit(self.provider_id, str(exc))
+            self.signals.failed.emit(self.provider_id, str(sanitize_error(exc)))
 
 
 class CloudHealthSignals(QObject):
@@ -226,16 +229,27 @@ class CloudHealthSignals(QObject):
 class CloudHealthWorker(QRunnable):
     """Probe cloud services concurrently so a slow API cannot freeze the UI."""
 
-    def __init__(self, provider_id: str, token: str):
+    def __init__(
+        self,
+        provider_id: str,
+        token: str,
+        language: str = "zh-TW",
+    ):
         super().__init__()
         self.provider_id = provider_id
         self.token = token
+        self._translator = FlagshipTranslator(language)
         self.signals = CloudHealthSignals()
 
     def _google_probes(self) -> dict[str, Any]:
         def gmail() -> str:
             payload = GmailConnector(self.token).request("GET", "/profile")
-            return str(payload.get("emailAddress", "Google 帳戶"))
+            return str(
+                payload.get(
+                    "emailAddress",
+                    self._translator.text("Google 帳戶"),
+                )
+            )
 
         def calendar() -> str:
             GoogleCalendarConnector(self.token).request(
@@ -247,7 +261,7 @@ class CloudHealthWorker(QRunnable):
                     "timeMin": local_aware_time().isoformat(),
                 },
             )
-            return "主要日曆可讀取"
+            return self._translator.text("主要日曆可讀取")
 
         def drive() -> str:
             GoogleDriveConnector(self.token).request(
@@ -259,7 +273,7 @@ class CloudHealthWorker(QRunnable):
                     "q": "trashed=false",
                 },
             )
-            return "雲端硬碟中繼資料可讀取"
+            return self._translator.text("雲端硬碟中繼資料可讀取")
 
         probes = {"Gmail": gmail, "Calendar": calendar, "Drive": drive}
         results: dict[str, Any] = {}
@@ -272,7 +286,10 @@ class CloudHealthWorker(QRunnable):
                 except Exception as exc:  # noqa: BLE001 -- isolate each health probe
                     results[name] = {
                         "ok": False,
-                        "detail": f"{type(exc).__name__}: {exc}",
+                        "detail": safe_error_message(
+                            self._translator.language,
+                            exc,
+                        ),
                     }
         return results
 
@@ -286,10 +303,16 @@ class CloudHealthWorker(QRunnable):
                         "GET",
                         "/me",
                     )
-                    identity = payload.get("displayName", "Microsoft 帳戶")
+                    identity = payload.get(
+                        "displayName",
+                        self._translator.text("Microsoft 帳戶"),
+                    )
                 else:
                     payload = GitHubConnector(self.token).viewer()
-                    identity = payload.get("login", "GitHub 帳戶")
+                    identity = payload.get(
+                        "login",
+                        self._translator.text("GitHub 帳戶"),
+                    )
                 results = {
                     PROVIDERS[self.provider_id].display_name: {
                         "ok": True,
@@ -300,75 +323,92 @@ class CloudHealthWorker(QRunnable):
                 results = {
                     PROVIDERS[self.provider_id].display_name: {
                         "ok": False,
-                        "detail": f"{type(exc).__name__}: {exc}",
+                        "detail": safe_error_message(
+                            self._translator.language,
+                            exc,
+                        ),
                     }
                 }
         self.signals.done.emit(self.provider_id, results)
 
 
 class WorkflowEditor(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, *, language: str = "zh-TW"):
         super().__init__(parent)
-        self.setWindowTitle("新增安全工作流程")
+        self._translator = FlagshipTranslator(language)
+        self.language = self._translator.language
+        self.setWindowTitle(self._t("新增安全工作流程"))
         self.resize(620, 560)
         root = QVBoxLayout(self)
         form = QFormLayout()
         self.name = QLineEdit()
         self.trigger = QComboBox()
-        self.trigger.addItems(["手動執行", "每天固定時間", "開始工作時"])
+        for canonical, label in (
+            ("manual", "手動執行"),
+            ("schedule", "每天固定時間"),
+            ("work_start", "開始工作時"),
+        ):
+            self.trigger.addItem(self._t(label), canonical)
         self.at = QTimeEdit()
         self.at.setDisplayFormat("HH:mm")
-        self.preview = QCheckBox("第一次與高風險操作先預覽")
+        self.preview = QCheckBox(self._t("第一次與高風險操作先預覽"))
         self.preview.setChecked(True)
-        form.addRow("流程名稱", self.name)
-        form.addRow("啟動方式", self.trigger)
-        form.addRow("執行時間", self.at)
+        form.addRow(self._t("流程名稱"), self.name)
+        form.addRow(self._t("啟動方式"), self.trigger)
+        form.addRow(self._t("執行時間"), self.at)
         form.addRow("", self.preview)
         root.addLayout(form)
 
         note = QLabel(
-            "每行一個步驟，格式：能力｜說明｜參數。\n"
-            "範例：open_web｜開啟工作網站｜https://example.com\n"
-            "範例：home_control｜開啟書房燈｜light.study,turn_on"
+            self._t(
+                "每行一個步驟，格式：能力｜說明｜參數。\n"
+                "範例：open_web｜開啟工作網站｜https://example.com\n"
+                "範例：home_control｜開啟書房燈｜light.study,turn_on"
+            )
         )
         note.setWordWrap(True)
         note.setStyleSheet("color:#356f8d;")
         self.steps = QTextEdit()
         self.steps.setPlaceholderText(
-            "open_web｜開啟工作網站｜https://example.com"
+            self._t("open_web｜開啟工作網站｜https://example.com")
         )
         root.addWidget(note)
         root.addWidget(self.steps, 1)
         buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.button(QDialogButtonBox.Save).setText(self._t("儲存"))
+        buttons.button(QDialogButtonBox.Cancel).setText(self._t("取消"))
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         root.addWidget(buttons)
 
+    def _t(self, source: str, /, **values: Any) -> str:
+        return self._translator.text(source, **values)
+
     def _trigger_definition(self) -> dict[str, Any]:
-        trigger_text = self.trigger.currentText()
-        if trigger_text == "每天固定時間":
+        trigger_type = str(self.trigger.currentData())
+        if trigger_type == "schedule":
             return {
                 "type": "schedule",
                 "time": self.at.time().toString("HH:mm"),
                 "weekdays": list(range(7)),
             }
-        if trigger_text == "開始工作時":
+        if trigger_type == "work_start":
             return {"type": "work_start"}
         return {"type": "manual"}
 
-    @staticmethod
     def _home_arguments(
+        self,
         capability: str,
         raw_argument: str,
     ) -> dict[str, Any]:
         try:
-            entity, service = (
-                value.strip()
-                for value in raw_argument.split(",", 1)
-            )
+            entity, service = (value.strip() for value in raw_argument.split(",", 1))
         except ValueError as exc:
             raise ValueError(
-                f"{capability} 參數格式必須是 entity_id,service"
+                self._t(
+                    "{capability} 參數格式必須是 entity_id,service",
+                    capability=capability,
+                )
             ) from exc
         return {
             "domain": entity.split(".", 1)[0],
@@ -376,9 +416,8 @@ class WorkflowEditor(QDialog):
             "data": {"entity_id": entity},
         }
 
-    @classmethod
     def _step_arguments(
-        cls,
+        self,
         capability: str,
         raw_argument: str,
     ) -> dict[str, Any]:
@@ -396,16 +435,22 @@ class WorkflowEditor(QDialog):
             "home_alarm",
             "home_heat",
         }:
-            return cls._home_arguments(capability, raw_argument)
+            return self._home_arguments(capability, raw_argument)
         try:
             arguments = json.loads(raw_argument)
         except json.JSONDecodeError as exc:
             raise ValueError(
-                f"{capability} 的參數必須是 JSON 物件"
+                self._t(
+                    "{capability} 的參數必須是 JSON 物件",
+                    capability=capability,
+                )
             ) from exc
         if not isinstance(arguments, dict):
             raise TypeError(
-                f"{capability} 的參數必須是 JSON 物件"
+                self._t(
+                    "{capability} 的參數必須是 JSON 物件",
+                    capability=capability,
+                )
             )
         return arguments
 
@@ -417,18 +462,16 @@ class WorkflowEditor(QDialog):
                 continue
             parts = [part.strip() for part in line.split("｜", 2)]
             if len(parts) != 3:
-                raise ValueError(f"步驟格式不正確：{line}")
+                raise ValueError(self._t("步驟格式不正確：{line}", line=line))
             capability, description, raw_argument = parts
-            steps.append(
-                {
-                    "capability": capability,
-                    "description": description,
-                    "arguments": self._step_arguments(
-                        capability,
-                        raw_argument,
-                    ),
-                }
-            )
+            steps.append({
+                "capability": capability,
+                "description": description,
+                "arguments": self._step_arguments(
+                    capability,
+                    raw_argument,
+                ),
+            })
         return steps
 
     def workflow(self) -> Workflow:
@@ -449,7 +492,7 @@ class FlagshipControlCenter(QWidget):
     remote_command_received = Signal(str)
     emergency_stop_requested = Signal()
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 -- stable API keeps dependencies explicit
         self,
         db,
         data_path: Path,
@@ -457,8 +500,12 @@ class FlagshipControlCenter(QWidget):
         *,
         platform_services: PlatformServicePort | None = None,
         secret_store_factory: SecretStoreFactoryPort | None = None,
+        language: str = "zh-TW",
     ):
+        """Build the center with an explicit, backward-compatible language."""
         super().__init__(parent)
+        self._translator = FlagshipTranslator(language)
+        self.language = self._translator.language
         self._initialize_services(
             db,
             data_path,
@@ -469,6 +516,12 @@ class FlagshipControlCenter(QWidget):
         self._build_control_center_ui()
         self._start_control_center_timers()
 
+    def _t(self, source: str, /, **values: Any) -> str:
+        return self._translator.text(source, **values)
+
+    def _system_text(self, message: str) -> str:
+        return self._translator.system_message(message)
+
     def _initialize_services(
         self,
         db,
@@ -478,9 +531,7 @@ class FlagshipControlCenter(QWidget):
     ) -> None:
         self.db = db
         self.data_path = data_path
-        self.platform_services = (
-            platform_services or current_platform_services()
-        )
+        self.platform_services = platform_services or current_platform_services()
         self.secret_store_factory = (
             secret_store_factory
             or platform_secret_store_factory(self.platform_services)
@@ -513,13 +564,12 @@ class FlagshipControlCenter(QWidget):
         self.cloud_test_timeout.setInterval(35_000)
         self.cloud_test_timeout.timeout.connect(self._cloud_test_timed_out)
         self.remote_server: RemoteControlServer | None = None
-        self.camera_presence = CameraPresenceController(self)
-        self.camera_presence.status_changed.connect(
-            self._camera_status_changed
+        self.camera_presence = CameraPresenceController(
+            self,
+            language=self.language,
         )
-        self.camera_presence.presence_changed.connect(
-            self._presence_changed
-        )
+        self.camera_presence.status_changed.connect(self._camera_status_changed)
+        self.camera_presence.presence_changed.connect(self._presence_changed)
         self._screen_cache = b""
         self._closed = False
         self._remote_status_cache: dict[str, Any] = {
@@ -532,7 +582,7 @@ class FlagshipControlCenter(QWidget):
 
     def _build_control_center_ui(self) -> None:
         root = QVBoxLayout(self)
-        emergency = QPushButton("緊急停止所有工具與遠端操作（Esc）")
+        emergency = QPushButton(self._t("緊急停止所有工具與遠端操作（Esc）"))
         emergency.setStyleSheet(
             "QPushButton{background:#772f3a;color:white;font-weight:bold;"
             "padding:10px;border-radius:8px;}"
@@ -540,13 +590,13 @@ class FlagshipControlCenter(QWidget):
         emergency.clicked.connect(self.emergency_stop)
         root.addWidget(emergency)
         self.tabs = QTabWidget()
-        self.tabs.addTab(self._overview_tab(), "任務中心")
-        self.tabs.addTab(self._workflow_tab(), "工作流程")
-        self.tabs.addTab(self._cloud_tab(), "雲端連接器")
-        self.tabs.addTab(self._home_tab(), "智慧家庭")
-        self.tabs.addTab(self._remote_tab(), "遠端與隱私")
-        self.tabs.addTab(self._security_tab(), "安全權限")
-        self.tabs.addTab(self._audit_tab(), "稽核紀錄")
+        self.tabs.addTab(self._overview_tab(), self._t("任務中心"))
+        self.tabs.addTab(self._workflow_tab(), self._t("工作流程"))
+        self.tabs.addTab(self._cloud_tab(), self._t("雲端連接器"))
+        self.tabs.addTab(self._home_tab(), self._t("智慧家庭"))
+        self.tabs.addTab(self._remote_tab(), self._t("遠端與隱私"))
+        self.tabs.addTab(self._security_tab(), self._t("安全權限"))
+        self.tabs.addTab(self._audit_tab(), self._t("稽核紀錄"))
         root.addWidget(self.tabs, 1)
 
     def _start_control_center_timers(self) -> None:
@@ -586,16 +636,14 @@ class FlagshipControlCenter(QWidget):
             audit=self.db.audit_event,
         )
         allowed_folders = [
-            str(row["target_value"])
-            for row in self.db.allowed_targets("folder")
+            str(row["target_value"]) for row in self.db.allowed_targets("folder")
         ]
         allowed_apps = {
             str(row["display_name"]): str(row["target_value"])
             for row in self.db.allowed_targets("app")
         }
         allowed_websites = [
-            str(row["target_value"])
-            for row in self.db.allowed_targets("web")
+            str(row["target_value"]) for row in self.db.allowed_targets("web")
         ]
         self.toolbox = WindowsToolbox(
             allowed_folders=allowed_folders,
@@ -616,30 +664,28 @@ class FlagshipControlCenter(QWidget):
         return ActionResult(
             request.request_id,
             True,
-            "已整理目前工作狀態",
+            self._t("已整理目前工作狀態"),
             self._remote_status_payload(),
         )
 
-    @staticmethod
-    def _clipboard_read(request: ActionRequest) -> ActionResult:
+    def _clipboard_read(self, request: ActionRequest) -> ActionResult:
         text = QApplication.clipboard().text()
         return ActionResult(
             request.request_id,
             True,
-            "已讀取剪貼簿文字",
+            self._t("已讀取剪貼簿文字"),
             {"text": text[:100000]},
         )
 
-    @staticmethod
-    def _clipboard_write(request: ActionRequest) -> ActionResult:
+    def _clipboard_write(self, request: ActionRequest) -> ActionResult:
         text = str(request.arguments.get("text", ""))
         if len(text) > 100000:
-            raise ValueError("剪貼簿文字不可超過 100,000 字")
+            raise ValueError(self._t("剪貼簿文字不可超過 100,000 字"))
         QApplication.clipboard().setText(text)
         return ActionResult(
             request.request_id,
             True,
-            "已寫入剪貼簿",
+            self._t("已寫入剪貼簿"),
         )
 
     @staticmethod
@@ -655,25 +701,27 @@ class FlagshipControlCenter(QWidget):
     def _overview_tab(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
-        title = QLabel("<b>墨寒旗艦任務中心</b>")
+        title = QLabel(self._t("<b>墨寒旗艦任務中心</b>"))
         title.setStyleSheet("font-size:18px;color:#2f6987;")
         note = QLabel(
-            "所有電腦、雲端、遠端與智慧家庭操作都必須經過："
-            "計畫 → 權限判斷 → 確認 → 執行 → 結果驗證 → 稽核。"
+            self._t(
+                "所有電腦、雲端、遠端與智慧家庭操作都必須經過："
+                "計畫 → 權限判斷 → 確認 → 執行 → 結果驗證 → 稽核。"
+            )
         )
         note.setWordWrap(True)
         self.health_summary = QLabel()
         self.health_summary.setWordWrap(True)
-        refresh = QPushButton("重新檢查系統狀態")
+        refresh = QPushButton(self._t("重新檢查系統狀態"))
         refresh.clicked.connect(self.refresh_health)
-        backup = QPushButton("立即建立可驗證備份")
+        backup = QPushButton(self._t("立即建立可驗證備份"))
         backup.clicked.connect(self.create_backup)
-        task_label = QLabel("<b>自然語言工具任務</b>")
+        task_label = QLabel(self._t("<b>自然語言工具任務</b>"))
         self.task_instruction = QLineEdit()
         self.task_instruction.setPlaceholderText(
-            "例如：幫我開啟工作資料夾，然後開啟指定工作網站"
+            self._t("例如：幫我開啟工作資料夾，然後開啟指定工作網站")
         )
-        self.plan_button = QPushButton("先產生安全計畫")
+        self.plan_button = QPushButton(self._t("先產生安全計畫"))
         self.plan_button.clicked.connect(
             lambda: self.plan_instruction(
                 self.task_instruction.text(),
@@ -700,12 +748,22 @@ class FlagshipControlCenter(QWidget):
                 self.data_path / "backups",
             ).create("manual")
         except Exception as exc:  # noqa: BLE001 -- user-visible backup boundary
-            QMessageBox.warning(self, "資料備份", f"備份失敗：{exc}")
+            QMessageBox.warning(
+                self,
+                self._t("資料備份"),
+                self._t(
+                    "備份失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                ),
+            )
             return
         QMessageBox.information(
             self,
-            "資料備份",
-            f"備份與完整性雜湊已建立：\n{target}",
+            self._t("資料備份"),
+            self._t(
+                "備份與完整性雜湊已建立：\n{target}",
+                target=target,
+            ),
         )
 
     def plan_instruction(self, text: str, *, source: str = "local") -> None:
@@ -728,8 +786,8 @@ class FlagshipControlCenter(QWidget):
         ):
             QMessageBox.information(
                 self,
-                "工具任務",
-                "這句話沒有明確要求執行操作，因此不會產生工具計畫。",
+                self._t("工具任務"),
+                self._t("這句話沒有明確要求執行操作，因此不會產生工具計畫。"),
             )
             return
         self.planner_busy = True
@@ -737,7 +795,7 @@ class FlagshipControlCenter(QWidget):
         generation = self._planner_generation
         if hasattr(self, "plan_button"):
             self.plan_button.setEnabled(False)
-            self.plan_button.setText("規劃中…")
+            self.plan_button.setText(self._t("規劃中…"))
 
         # 明確、唯讀且低風險的 Google 指令不需要再繞到 OpenAI 規劃。
         # 這也避免網路或模型暫時不穩時，基本郵件讀取被卡住。
@@ -753,11 +811,12 @@ class FlagshipControlCenter(QWidget):
             )
             QTimer.singleShot(
                 0,
-                lambda payload=local_plan, origin=source,
-                request_generation=generation: self._planner_done_if_current(
-                    payload,
-                    origin,
-                    request_generation,
+                lambda payload=local_plan, origin=source, request_generation=generation: (
+                    self._planner_done_if_current(
+                        payload,
+                        origin,
+                        request_generation,
+                    )
                 ),
             )
             return
@@ -769,6 +828,7 @@ class FlagshipControlCenter(QWidget):
             model=str(self.db.setting("ai_model", DEFAULT_TEXT_MODEL)),
             available_targets=self._planner_targets(),
             source=source,
+            language=self.language,
         )
         worker.signals.done.connect(
             lambda payload, origin=source, request_generation=generation: (
@@ -833,38 +893,36 @@ class FlagshipControlCenter(QWidget):
             return max(1, min(100, int(numeric.group(1))))
         return limit
 
-    @classmethod
     def _gmail_plan(
-        cls,
+        self,
         normalized: str,
         folded: str,
         read_requested: bool,
     ) -> dict[str, Any] | None:
-        mentions_mail = cls._contains_any(folded, GMAIL_MARKERS)
-        send_requested = (
-            cls._contains_any(normalized, GMAIL_SEND_MARKERS)
-            and not cls._contains_any(
-                normalized,
-                GMAIL_SEND_NEGATIONS,
-            )
+        mentions_mail = self._contains_any(folded, GMAIL_MARKERS)
+        send_requested = self._contains_any(
+            normalized, GMAIL_SEND_MARKERS
+        ) and not self._contains_any(
+            normalized,
+            GMAIL_SEND_NEGATIONS,
         )
-        assisted = cls._contains_any(
+        assisted = self._contains_any(
             normalized,
             ASSIST_INTENT_MARKERS,
         )
-        if not mentions_mail or send_requested or not (
-            read_requested or assisted
-        ):
+        if not mentions_mail or send_requested or not (read_requested or assisted):
             return None
-        days = cls._gmail_days(normalized)
-        limit = cls._gmail_limit(normalized)
+        days = self._gmail_days(normalized)
+        limit = self._gmail_limit(normalized)
         return {
-            "title": "讀取 Gmail 郵件",
+            "title": self._t("讀取 Gmail 郵件"),
             "steps": [
                 {
                     "capability": "email_read",
-                    "description": (
-                        f"讀取最近 {days} 天內最多 {limit} 封 Gmail 郵件"
+                    "description": self._t(
+                        "讀取最近 {days} 天內最多 {limit} 封 Gmail 郵件",
+                        days=days,
+                        limit=limit,
                     ),
                     "arguments": {
                         "provider": "google",
@@ -875,21 +933,20 @@ class FlagshipControlCenter(QWidget):
             ],
         }
 
-    @classmethod
     def _calendar_plan(
-        cls,
+        self,
         normalized: str,
         folded: str,
         read_requested: bool,
     ) -> dict[str, Any] | None:
-        assisted = cls._contains_any(
+        assisted = self._contains_any(
             normalized,
             ASSIST_INTENT_MARKERS,
         )
         if (
-            not cls._contains_any(folded, CALENDAR_MARKERS)
+            not self._contains_any(folded, CALENDAR_MARKERS)
             or not (read_requested or assisted)
-            or cls._contains_any(
+            or self._contains_any(
                 normalized,
                 CALENDAR_WRITE_MARKERS,
             )
@@ -909,12 +966,13 @@ class FlagshipControlCenter(QWidget):
             days = 1
         end = start + timedelta(days=days)
         return {
-            "title": "讀取 Google Calendar",
+            "title": self._t("讀取 Google Calendar"),
             "steps": [
                 {
                     "capability": "calendar_read",
-                    "description": (
-                        f"讀取 Google Calendar 未來 {days} 天行程"
+                    "description": self._t(
+                        "讀取 Google Calendar 未來 {days} 天行程",
+                        days=days,
                     ),
                     "arguments": {
                         "provider": "google",
@@ -925,21 +983,20 @@ class FlagshipControlCenter(QWidget):
             ],
         }
 
-    @classmethod
     def _drive_plan(
-        cls,
+        self,
         normalized: str,
         folded: str,
         read_requested: bool,
     ) -> dict[str, Any] | None:
-        assisted = cls._contains_any(
+        assisted = self._contains_any(
             normalized,
             ASSIST_INTENT_MARKERS,
         )
         if (
-            not cls._contains_any(folded, DRIVE_MARKERS)
+            not self._contains_any(folded, DRIVE_MARKERS)
             or not (read_requested or assisted)
-            or cls._contains_any(normalized, DRIVE_WRITE_MARKERS)
+            or self._contains_any(normalized, DRIVE_WRITE_MARKERS)
         ):
             return None
         quoted = re.search(
@@ -948,14 +1005,17 @@ class FlagshipControlCenter(QWidget):
         )
         name = quoted.group(1).strip() if quoted else ""
         return {
-            "title": "讀取 Google Drive",
+            "title": self._t("讀取 Google Drive"),
             "steps": [
                 {
                     "capability": "cloud_file_read",
                     "description": (
-                        f"搜尋 Google Drive 檔案：{name}"
+                        self._t(
+                            "搜尋 Google Drive 檔案：{name}",
+                            name=name,
+                        )
                         if name
-                        else "列出 Google Drive 最近修改的檔案"
+                        else self._t("列出 Google Drive 最近修改的檔案")
                     ),
                     "arguments": {
                         "provider": "google",
@@ -966,26 +1026,25 @@ class FlagshipControlCenter(QWidget):
             ],
         }
 
-    @classmethod
     def _known_safe_plan(
-        cls,
+        self,
         instruction: str,
     ) -> dict[str, Any] | None:
         """Return deterministic plans for simple read-only Google requests."""
         normalized = str(instruction).strip()
         folded = normalized.casefold()
-        read_requested = cls._contains_any(
+        read_requested = self._contains_any(
             normalized,
             READ_INTENT_MARKERS,
         )
         return (
-            cls._gmail_plan(normalized, folded, read_requested)
-            or cls._calendar_plan(
+            self._gmail_plan(normalized, folded, read_requested)
+            or self._calendar_plan(
                 normalized,
                 folded,
                 read_requested,
             )
-            or cls._drive_plan(
+            or self._drive_plan(
                 normalized,
                 folded,
                 read_requested,
@@ -1005,7 +1064,7 @@ class FlagshipControlCenter(QWidget):
                 f"- home：{self.ha_entities.item(index).text()}"
                 for index in range(min(200, self.ha_entities.count()))
             )
-        return "\n".join(lines) or "（目前沒有白名單目標）"
+        return "\n".join(lines) or self._t("（目前沒有白名單目標）")
 
     def _planner_done_if_current(
         self,
@@ -1025,7 +1084,14 @@ class FlagshipControlCenter(QWidget):
                 source=source,
             )
         except (TypeError, ValueError, json.JSONDecodeError) as exc:
-            QMessageBox.warning(self, "工具計畫", f"計畫驗證失敗：{exc}")
+            QMessageBox.warning(
+                self,
+                self._t("工具計畫"),
+                self._t(
+                    "計畫驗證失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                ),
+            )
             return
         if not plan.steps:
             self.db.audit_event(
@@ -1037,26 +1103,31 @@ class FlagshipControlCenter(QWidget):
             )
             QMessageBox.information(
                 self,
-                "工具計畫",
-                "資料不足或並非明確操作要求，因此沒有產生任何步驟。",
+                self._t("工具計畫"),
+                self._t("資料不足或並非明確操作要求，因此沒有產生任何步驟。"),
             )
             return
         preview = "\n".join(
-            f"{index}. {step.description}"
-            for index, step in enumerate(plan.steps, 1)
+            f"{index}. {step.description}" for index, step in enumerate(plan.steps, 1)
         )
-        if QMessageBox.question(
-            self,
-            "執行前計畫預覽",
-            f"{plan.title}\n\n{preview}\n\n"
-            "每一步仍會依個別權限與風險再次判斷。是否繼續？",
-        ) != QMessageBox.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                self._t("執行前計畫預覽"),
+                self._t(
+                    "{title}\n\n{preview}\n\n每一步仍會依個別權限與風險再次判斷。是否繼續？",
+                    title=plan.title,
+                    preview=preview,
+                ),
+            )
+            != QMessageBox.Yes
+        ):
             return
         results = self.executor.execute(plan)
         QMessageBox.information(
             self,
-            "任務結果",
-            "\n".join(result.message for result in results),
+            self._t("任務結果"),
+            "\n".join(self._system_text(result.message) for result in results),
         )
         self.refresh_audit()
 
@@ -1071,7 +1142,14 @@ class FlagshipControlCenter(QWidget):
 
     def _planner_failed(self, error: str) -> None:
         self._planner_reset()
-        QMessageBox.warning(self, "工具計畫", f"無法產生計畫：{error}")
+        QMessageBox.warning(
+            self,
+            self._t("工具計畫"),
+            self._t(
+                "無法產生計畫：{error}",
+                error=safe_error_message(self.language, error),
+            ),
+        )
 
     def _planner_timed_out(self) -> None:
         if not self.planner_busy:
@@ -1087,9 +1165,11 @@ class FlagshipControlCenter(QWidget):
         self._planner_reset()
         QMessageBox.warning(
             self,
-            "工具計畫逾時",
-            "等待 OpenAI 安全計畫超過 50 秒，已自動停止等待。"
-            "請確認網路、API 金鑰與文字模型後再試一次。",
+            self._t("工具計畫逾時"),
+            self._t(
+                "等待 OpenAI 安全計畫超過 50 秒，已自動停止等待。"
+                "請確認網路、API 金鑰與文字模型後再試一次。"
+            ),
         )
 
     def _planner_reset(self) -> None:
@@ -1098,29 +1178,35 @@ class FlagshipControlCenter(QWidget):
         self._planner_worker = None
         if hasattr(self, "plan_button"):
             self.plan_button.setEnabled(True)
-            self.plan_button.setText("先產生安全計畫")
+            self.plan_button.setText(self._t("先產生安全計畫"))
 
     def refresh_health(self) -> None:
         workflow_count = len(self.db.workflows(enabled_only=True))
         paired_count = sum(bool(row["enabled"]) for row in self.db.paired_devices())
         ha = self.db.connector("home_assistant")
-        ha_text = "已啟用" if ha and bool(ha["enabled"]) else "未啟用"
-        remote_text = "運作中" if self.remote_server and self.remote_server.running else "未啟用"
+        ha_text = self._t("已啟用" if ha and bool(ha["enabled"]) else "未啟用")
+        remote_text = self._t(
+            "運作中" if self.remote_server and self.remote_server.running else "未啟用"
+        )
         self.health_summary.setText(
-            f"Home Assistant：{ha_text}\n"
-            f"遠端服務：{remote_text}\n"
-            f"已啟用工作流程：{workflow_count}\n"
-            f"有效配對裝置：{paired_count}\n"
-            "安全狀態：高風險操作不允許免確認；任意命令列與付款永久禁止。"
+            self._t(
+                "Home Assistant：{home}\n遠端服務：{remote}\n"
+                "已啟用工作流程：{workflows}\n有效配對裝置：{devices}\n"
+                "安全狀態：高風險操作不允許免確認；任意命令列與付款永久禁止。",
+                home=ha_text,
+                remote=remote_text,
+                workflows=workflow_count,
+                devices=paired_count,
+            )
         )
 
     def _workflow_tab(self) -> QWidget:
         page = QWidget()
         layout = QVBoxLayout(page)
         top = QHBoxLayout()
-        add = QPushButton("新增工作流程")
-        run = QPushButton("執行選取流程")
-        delete = QPushButton("刪除選取流程")
+        add = QPushButton(self._t("新增工作流程"))
+        run = QPushButton(self._t("執行選取流程"))
+        delete = QPushButton(self._t("刪除選取流程"))
         top.addWidget(add)
         top.addWidget(run)
         top.addWidget(delete)
@@ -1138,21 +1224,26 @@ class FlagshipControlCenter(QWidget):
         self.workflow_list.clear()
         for row in self.db.workflows():
             workflow = Workflow.from_row(row)
+            trigger_type = str(workflow.trigger.get("type"))
             trigger = {
-                "manual": "手動",
-                "schedule": f"每天 {workflow.trigger.get('time', '')}",
-                "work_start": "開始工作時",
-                "app_start": "程式啟動時",
-            }.get(str(workflow.trigger.get("type")), "未知")
+                "manual": self._t("手動"),
+                "schedule": self._t(
+                    "每天 {time}",
+                    time=workflow.trigger.get("time", ""),
+                ),
+                "work_start": self._t("開始工作時"),
+                "app_start": self._t("程式啟動時"),
+            }.get(trigger_type, self._t("未知"))
             item = QListWidgetItem(
                 f"{'●' if workflow.enabled else '○'} "
-                f"{workflow.name}　｜　{trigger}　｜　{len(workflow.steps)} 步"
+                f"{workflow.name}　｜　{trigger}　｜　"
+                + self._t("{count} 步", count=len(workflow.steps))
             )
             item.setData(Qt.UserRole, int(row["id"]))
             self.workflow_list.addItem(item)
 
     def add_workflow(self) -> None:
-        dialog = WorkflowEditor(self)
+        dialog = WorkflowEditor(self, language=self.language)
         if dialog.exec() != QDialog.Accepted:
             return
         try:
@@ -1163,7 +1254,7 @@ class FlagshipControlCenter(QWidget):
                 enabled=workflow.enabled,
             )
         except (ValueError, json.JSONDecodeError) as exc:
-            QMessageBox.warning(self, "工作流程", str(exc))
+            QMessageBox.warning(self, self._t("工作流程"), str(exc))
             return
         self.refresh_workflows()
 
@@ -1177,7 +1268,11 @@ class FlagshipControlCenter(QWidget):
     def run_selected_workflow(self) -> None:
         workflow = self._selected_workflow()
         if workflow is None:
-            QMessageBox.information(self, "工作流程", "請先選取一個流程。")
+            QMessageBox.information(
+                self,
+                self._t("工作流程"),
+                self._t("請先選取一個流程。"),
+            )
             return
         self.run_workflow(workflow)
 
@@ -1185,35 +1280,49 @@ class FlagshipControlCenter(QWidget):
         try:
             plan = workflow.to_plan()
         except ValueError as exc:
-            QMessageBox.warning(self, "工作流程", str(exc))
+            QMessageBox.warning(self, self._t("工作流程"), str(exc))
             return
         if workflow.require_preview:
             preview = "\n".join(
                 f"{index}. {step.description}"
                 for index, step in enumerate(plan.steps, 1)
             )
-            if QMessageBox.question(
-                self,
-                "預覽工作流程",
-                f"{plan.title}\n\n{preview}\n\n是否執行？",
-            ) != QMessageBox.Yes:
+            if (
+                QMessageBox.question(
+                    self,
+                    self._t("預覽工作流程"),
+                    self._t(
+                        "{title}\n\n{preview}\n\n是否執行？",
+                        title=plan.title,
+                        preview=preview,
+                    ),
+                )
+                != QMessageBox.Yes
+            ):
                 return
         results = self.executor.execute(plan)
         if workflow.workflow_id:
             self.db.mark_workflow_run(workflow.workflow_id)
-        message = "\n".join(result.message for result in results)
-        QMessageBox.information(self, "任務結果", message or "沒有可執行步驟")
+        message = "\n".join(self._system_text(result.message) for result in results)
+        QMessageBox.information(
+            self,
+            self._t("任務結果"),
+            message or self._t("沒有可執行步驟"),
+        )
         self.refresh_audit()
 
     def delete_selected_workflow(self) -> None:
         workflow = self._selected_workflow()
         if workflow is None or workflow.workflow_id is None:
             return
-        if QMessageBox.question(
-            self,
-            "刪除工作流程",
-            f"確定刪除「{workflow.name}」？",
-        ) == QMessageBox.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                self._t("刪除工作流程"),
+                self._t("確定刪除「{name}」？", name=workflow.name),
+            )
+            == QMessageBox.Yes
+        ):
             self.db.delete_workflow(workflow.workflow_id)
             self.refresh_workflows()
 
@@ -1236,15 +1345,18 @@ class FlagshipControlCenter(QWidget):
     def _cloud_tab(self) -> QWidget:
         scroll, form = self._scroll_form()
         if self.platform_services.capabilities.secure_secret_storage:
-            secret_note = "權杖由作業系統安全加密保存，不寫入資料庫或設定檔。"
+            secret_note = self._t("權杖由作業系統安全加密保存，不寫入資料庫或設定檔。")
         else:
-            secret_note = (
-                f"{self.platform_services.capabilities.display_name} 的原生安全金鑰保存"
-                "尚未完成實機驗證，因此 OAuth 連線暫停；墨寒不會改用明文保存。"
+            secret_note = self._t(
+                "{platform} 的原生安全金鑰保存尚未完成實機驗證，因此 OAuth 連線暫停；"
+                "墨寒不會改用明文保存。",
+                platform=self.platform_services.capabilities.display_name,
             )
         intro = QLabel(
-            "Google、Microsoft 與 GitHub 預設停用。連線時使用瀏覽器 OAuth；"
-            + secret_note
+            self._t(
+                "Google、Microsoft 與 GitHub 預設停用。連線時使用瀏覽器 OAuth；{note}",
+                note=secret_note,
+            )
         )
         intro.setWordWrap(True)
         self.cloud_provider = QComboBox()
@@ -1255,12 +1367,12 @@ class FlagshipControlCenter(QWidget):
             )
         self.cloud_client_id = QLineEdit()
         self.cloud_client_id.setPlaceholderText(
-            "貼上你在服務商後台建立的 Desktop App Client ID"
+            self._t("貼上你在服務商後台建立的 Desktop App Client ID")
         )
         self.cloud_client_secret = QLineEdit()
         self.cloud_client_secret.setEchoMode(QLineEdit.Password)
         self.cloud_client_secret.setPlaceholderText(
-            "若服務商提供 Client Secret 才需填寫"
+            self._t("若服務商提供 Client Secret 才需填寫")
         )
         self.cloud_scopes = QTextEdit()
         self.cloud_scopes.setMaximumHeight(110)
@@ -1270,23 +1382,21 @@ class FlagshipControlCenter(QWidget):
         buttons = QWidget()
         line = QHBoxLayout(buttons)
         line.setContentsMargins(0, 0, 0, 0)
-        self.cloud_connect_button = QPushButton("開啟瀏覽器安全連線")
-        self.cloud_test_button = QPushButton("測試選取服務")
-        revoke = QPushButton("撤銷選取服務")
+        self.cloud_connect_button = QPushButton(self._t("開啟瀏覽器安全連線"))
+        self.cloud_test_button = QPushButton(self._t("測試選取服務"))
+        revoke = QPushButton(self._t("撤銷選取服務"))
         line.addWidget(self.cloud_connect_button)
         line.addWidget(self.cloud_test_button)
         line.addWidget(revoke)
         form.addRow(intro)
-        form.addRow("服務", self.cloud_provider)
+        form.addRow(self._t("服務"), self.cloud_provider)
         form.addRow("OAuth Client ID", self.cloud_client_id)
         form.addRow("OAuth Client Secret", self.cloud_client_secret)
-        form.addRow("授權範圍", self.cloud_scopes)
+        form.addRow(self._t("授權範圍"), self.cloud_scopes)
         form.addRow("", buttons)
-        form.addRow("狀態", self.cloud_status)
-        form.addRow("已設定服務", self.cloud_connections)
-        self.cloud_provider.currentIndexChanged.connect(
-            self._cloud_provider_changed
-        )
+        form.addRow(self._t("狀態"), self.cloud_status)
+        form.addRow(self._t("已設定服務"), self.cloud_connections)
+        self.cloud_provider.currentIndexChanged.connect(self._cloud_provider_changed)
         self.cloud_connect_button.clicked.connect(self.connect_cloud)
         self.cloud_test_button.clicked.connect(self.test_cloud)
         revoke.clicked.connect(self.revoke_cloud)
@@ -1319,8 +1429,10 @@ class FlagshipControlCenter(QWidget):
     def connect_cloud(self) -> None:
         if not self.platform_services.capabilities.secure_secret_storage:
             self.cloud_status.setText(
-                f"{self.platform_services.capabilities.display_name} 尚無經過實機驗證的"
-                "安全金鑰保存；OAuth 連線已安全停用。"
+                self._t(
+                    "{platform} 尚無經過實機驗證的安全金鑰保存；OAuth 連線已安全停用。",
+                    platform=self.platform_services.capabilities.display_name,
+                )
             )
             return
         provider_id = str(self.cloud_provider.currentData())
@@ -1328,8 +1440,8 @@ class FlagshipControlCenter(QWidget):
         if not client_id:
             QMessageBox.information(
                 self,
-                "雲端連接器",
-                "請先填入服務商後台建立的 OAuth Client ID。",
+                self._t("雲端連接器"),
+                self._t("請先填入服務商後台建立的 OAuth Client ID。"),
             )
             return
         scopes = [
@@ -1337,7 +1449,7 @@ class FlagshipControlCenter(QWidget):
             for line in self.cloud_scopes.toPlainText().splitlines()
             if line.strip()
         ]
-        self.cloud_status.setText("等待瀏覽器授權，請勿關閉墨寒……")
+        self.cloud_status.setText(self._t("等待瀏覽器授權，請勿關閉墨寒……"))
         worker = OAuthWorker(
             provider_id,
             client_id,
@@ -1354,11 +1466,14 @@ class FlagshipControlCenter(QWidget):
         token: dict[str, Any],
     ) -> None:
         try:
-            self._oauth_store(provider_id).save(
-                json.dumps(token, ensure_ascii=False)
-            )
+            self._oauth_store(provider_id).save(json.dumps(token, ensure_ascii=False))
         except OSError as exc:
-            self.cloud_status.setText(f"無法安全保存 OAuth 權杖：{exc}")
+            self.cloud_status.setText(
+                self._t(
+                    "無法安全保存 OAuth 權杖：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             self.db.audit_event(
                 "oauth_secret_store_unavailable",
                 {"provider": provider_id, "error_type": type(exc).__name__},
@@ -1373,30 +1488,35 @@ class FlagshipControlCenter(QWidget):
                 "client_id": token.get("client_id", ""),
                 "scopes": self.cloud_scopes.toPlainText().splitlines(),
             },
-            last_health="OAuth 已連線",
+            last_health=self._t("OAuth 已連線"),
         )
         self.cloud_client_secret.clear()
-        self.cloud_status.setText(f"{provider.display_name} 已安全連線")
+        self.cloud_status.setText(
+            self._t(
+                "{provider} 已安全連線",
+                provider=provider.display_name,
+            )
+        )
         self._register_cloud_tools()
         self.refresh_cloud_connections()
 
     def _cloud_failed(self, provider_id: str, error: str) -> None:
         self.cloud_status.setText(
-            f"{PROVIDERS[provider_id].display_name} 連線失敗：{error}"
+            self._t(
+                "{provider} 連線失敗：{error}",
+                provider=PROVIDERS[provider_id].display_name,
+                error=safe_error_message(self.language, error),
+            )
         )
 
     def _cloud_token(self, provider_id: str) -> str:
         raw = self._oauth_store(provider_id).load()
         if not raw:
-            raise PermissionError("尚未完成 OAuth 連線")
+            raise PermissionError(self._t("尚未完成 OAuth 連線"))
         payload = json.loads(raw)
         expires_in = int(payload.get("expires_in", 0) or 0)
         obtained_at = int(payload.get("obtained_at", 0) or 0)
-        if (
-            expires_in
-            and obtained_at
-            and time.time() >= obtained_at + expires_in - 90
-        ):
+        if expires_in and obtained_at and time.time() >= obtained_at + expires_in - 90:
             payload = refresh_oauth_token(PROVIDERS[provider_id], payload)
             try:
                 self._oauth_store(provider_id).save(
@@ -1404,15 +1524,21 @@ class FlagshipControlCenter(QWidget):
                 )
             except OSError as exc:
                 raise PermissionError(
-                    f"無法安全更新 OAuth 權杖：{exc}"
+                    self._t(
+                        "無法安全更新 OAuth 權杖：{error}",
+                        error=safe_error_message(self.language, exc),
+                    )
                 ) from exc
         token = str(payload.get("access_token", ""))
         if not token:
-            raise PermissionError("OAuth 權杖資料不完整")
+            raise PermissionError(self._t("OAuth 權杖資料不完整"))
         return token
 
     def _register_cloud_tools(self) -> None:
-        if any(self._oauth_store(provider_id).load() for provider_id in ("google", "microsoft")):
+        if any(
+            self._oauth_store(provider_id).load()
+            for provider_id in ("google", "microsoft")
+        ):
             self.executor.register("email_read", self._action_email_read)
             self.executor.register("email_send", self._action_email_send)
             self.executor.register("calendar_read", self._action_calendar_read)
@@ -1451,14 +1577,14 @@ class FlagshipControlCenter(QWidget):
                 provider = connected[0]
             elif len(connected) > 1:
                 raise ValueError(
-                    "Google 與 Microsoft 均已連線，請明確指定要使用哪個帳戶"
+                    self._t("Google 與 Microsoft 均已連線，請明確指定要使用哪個帳戶")
                 )
             else:
                 raise ValueError(
-                    "尚未連線 Google 或 Microsoft，或工具計畫未指定供應商"
+                    self._t("尚未連線 Google 或 Microsoft，或工具計畫未指定供應商")
                 )
         if provider not in {"google", "microsoft"}:
-            raise ValueError("此工具目前只支援 google 或 microsoft")
+            raise ValueError(self._t("此工具目前只支援 google 或 microsoft"))
         return provider
 
     @staticmethod
@@ -1482,12 +1608,16 @@ class FlagshipControlCenter(QWidget):
             datetime.fromisoformat(end)
             return start, end
 
-        range_name = str(
-            arguments.get("range")
-            or arguments.get("time_range")
-            or arguments.get("date_range")
-            or ""
-        ).casefold().strip()
+        range_name = (
+            str(
+                arguments.get("range")
+                or arguments.get("time_range")
+                or arguments.get("date_range")
+                or ""
+            )
+            .casefold()
+            .strip()
+        )
         now = local_aware_time()
         day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         aliases = {
@@ -1521,7 +1651,7 @@ class FlagshipControlCenter(QWidget):
         return ActionResult(
             request.request_id,
             True,
-            f"已讀取 {len(rows)} 封郵件摘要",
+            self._t("已讀取 {count} 封郵件摘要", count=len(rows)),
             {"messages": rows},
         )
 
@@ -1530,13 +1660,8 @@ class FlagshipControlCenter(QWidget):
         recipient = str(request.arguments.get("to", "")).strip()
         subject = str(request.arguments.get("subject", "")).strip()
         body = str(request.arguments.get("body", "")).strip()
-        if (
-            not recipient
-            or "@" not in recipient
-            or not subject
-            or not body
-        ):
-            raise ValueError("收件者、主旨與內容不可留空")
+        if not recipient or "@" not in recipient or not subject or not body:
+            raise ValueError(self._t("收件者、主旨與內容不可留空"))
         token = self._cloud_token(provider)
         if provider == "google":
             message = EmailMessage()
@@ -1546,23 +1671,21 @@ class FlagshipControlCenter(QWidget):
             draft = GmailConnector(token).create_draft(message.as_bytes())
             draft_id = str(draft.get("id", ""))
             if not draft_id:
-                raise RuntimeError("Gmail 未傳回草稿 ID")
+                raise RuntimeError(self._t("Gmail 未傳回草稿 ID"))
             result = GmailConnector(token).send_draft(draft_id)
             message_id = str(result.get("id", ""))
         else:
             payload = {
                 "subject": subject,
                 "body": {"contentType": "Text", "content": body},
-                "toRecipients": [
-                    {"emailAddress": {"address": recipient}}
-                ],
+                "toRecipients": [{"emailAddress": {"address": recipient}}],
             }
             MicrosoftGraphConnector(token).send_message(payload)
             message_id = "microsoft-sent"
         return ActionResult(
             request.request_id,
             True,
-            f"郵件已寄給 {recipient}",
+            self._t("郵件已寄給 {recipient}", recipient=recipient),
             {"message_id": message_id, "recipient": recipient},
         )
 
@@ -1580,7 +1703,7 @@ class FlagshipControlCenter(QWidget):
         return ActionResult(
             request.request_id,
             True,
-            f"已讀取 {len(rows)} 個行程",
+            self._t("已讀取 {count} 個行程", count=len(rows)),
             {"events": rows},
         )
 
@@ -1591,41 +1714,33 @@ class FlagshipControlCenter(QWidget):
         end = str(request.arguments.get("end", "")).strip()
         timezone = str(request.arguments.get("timezone", "Asia/Taipei"))
         if not title or not start or not end:
-            raise ValueError("行程標題、開始與結束時間不可留空")
+            raise ValueError(self._t("行程標題、開始與結束時間不可留空"))
         start_dt = datetime.fromisoformat(start)
         end_dt = datetime.fromisoformat(end)
         if end_dt <= start_dt:
-            raise ValueError("結束時間必須晚於開始時間")
+            raise ValueError(self._t("結束時間必須晚於開始時間"))
         token = self._cloud_token(provider)
         if provider == "google":
-            result = GoogleCalendarConnector(token).create_event(
-                {
-                    "summary": title,
-                    "description": str(
-                        request.arguments.get("description", "")
-                    ),
-                    "start": {"dateTime": start, "timeZone": timezone},
-                    "end": {"dateTime": end, "timeZone": timezone},
-                }
-            )
+            result = GoogleCalendarConnector(token).create_event({
+                "summary": title,
+                "description": str(request.arguments.get("description", "")),
+                "start": {"dateTime": start, "timeZone": timezone},
+                "end": {"dateTime": end, "timeZone": timezone},
+            })
         else:
-            result = MicrosoftGraphConnector(token).create_event(
-                {
-                    "subject": title,
-                    "body": {
-                        "contentType": "Text",
-                        "content": str(
-                            request.arguments.get("description", "")
-                        ),
-                    },
-                    "start": {"dateTime": start, "timeZone": timezone},
-                    "end": {"dateTime": end, "timeZone": timezone},
-                }
-            )
+            result = MicrosoftGraphConnector(token).create_event({
+                "subject": title,
+                "body": {
+                    "contentType": "Text",
+                    "content": str(request.arguments.get("description", "")),
+                },
+                "start": {"dateTime": start, "timeZone": timezone},
+                "end": {"dateTime": end, "timeZone": timezone},
+            })
         return ActionResult(
             request.request_id,
             True,
-            f"已建立行程：{title}",
+            self._t("已建立行程：{title}", title=title),
             {"event": result},
         )
 
@@ -1642,19 +1757,15 @@ class FlagshipControlCenter(QWidget):
         token = self._cloud_token(provider)
         if provider == "google":
             connector = GoogleDriveConnector(token)
-            rows = (
-                connector.search(name, limit)
-                if name
-                else connector.recent(limit)
-            )
+            rows = connector.search(name, limit) if name else connector.recent(limit)
         else:
             if not name:
-                raise ValueError("搜尋 OneDrive 時請提供檔案名稱")
+                raise ValueError(self._t("搜尋 OneDrive 時請提供檔案名稱"))
             rows = MicrosoftGraphConnector(token).search_drive(name)
         return ActionResult(
             request.request_id,
             True,
-            f"找到 {len(rows)} 個符合的雲端檔案",
+            self._t("找到 {count} 個符合的雲端檔案", count=len(rows)),
             {"files": rows},
         )
 
@@ -1663,7 +1774,7 @@ class FlagshipControlCenter(QWidget):
         raw_path = str(request.arguments.get("path", ""))
         path = self.toolbox._allowed_path(raw_path, must_exist=True)
         if not path.is_file():
-            raise ValueError("只能上傳白名單內的單一檔案")
+            raise ValueError(self._t("只能上傳白名單內的單一檔案"))
         content = path.read_bytes()
         mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
         token = self._cloud_token(provider)
@@ -1682,7 +1793,7 @@ class FlagshipControlCenter(QWidget):
         return ActionResult(
             request.request_id,
             True,
-            f"已上傳：{path.name}",
+            self._t("已上傳：{name}", name=path.name),
             {"file": result, "source": str(path)},
         )
 
@@ -1691,26 +1802,32 @@ class FlagshipControlCenter(QWidget):
         try:
             token = self._cloud_token(provider_id)
         except Exception as exc:  # noqa: BLE001 -- user-visible credential boundary
-            self.cloud_status.setText(f"測試失敗：{exc}")
+            self.cloud_status.setText(
+                self._t(
+                    "測試失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             return
         self._cloud_test_generation += 1
         generation = self._cloud_test_generation
         self.cloud_test_button.setEnabled(False)
-        self.cloud_test_button.setText("測試中…")
+        self.cloud_test_button.setText(self._t("測試中…"))
         self.cloud_status.setText(
-            "正在分別檢查 Gmail、Google Calendar 與 Google Drive……"
+            self._t("正在分別檢查 Gmail、Google Calendar 與 Google Drive……")
             if provider_id == "google"
-            else "正在檢查選取的服務……"
+            else self._t("正在檢查選取的服務……")
         )
-        worker = CloudHealthWorker(provider_id, token)
+        worker = CloudHealthWorker(provider_id, token, self.language)
         worker.setAutoDelete(False)
         self._cloud_test_worker = worker
         worker.signals.done.connect(
-            lambda result_provider, results,
-            request_generation=generation: self._cloud_test_done(
-                result_provider,
-                results,
-                request_generation,
+            lambda result_provider, results, request_generation=generation: (
+                self._cloud_test_done(
+                    result_provider,
+                    results,
+                    request_generation,
+                )
             )
         )
         self.cloud_test_timeout.start()
@@ -1727,10 +1844,14 @@ class FlagshipControlCenter(QWidget):
         self.cloud_test_timeout.stop()
         self._cloud_test_worker = None
         self.cloud_test_button.setEnabled(True)
-        self.cloud_test_button.setText("測試選取服務")
+        self.cloud_test_button.setText(self._t("測試選取服務"))
         lines = [
-            f"{name}：{'正常' if value.get('ok') else '失敗'}"
-            f"（{value.get('detail', '')}）"
+            self._t(
+                "{name}：{status}（{detail}）",
+                name=name,
+                status=self._t("正常" if value.get("ok") else "失敗"),
+                detail=value.get("detail", ""),
+            )
             for name, value in results.items()
         ]
         all_ok = bool(results) and all(
@@ -1748,7 +1869,9 @@ class FlagshipControlCenter(QWidget):
         )
         self.cloud_status.setText("\n".join(lines))
         self.refresh_cloud_connections()
-        title = "Google 三項服務測試" if provider_id == "google" else "雲端服務測試"
+        title = self._t(
+            "Google 三項服務測試" if provider_id == "google" else "雲端服務測試"
+        )
         if all_ok:
             QMessageBox.information(self, title, "\n".join(lines))
         else:
@@ -1756,8 +1879,11 @@ class FlagshipControlCenter(QWidget):
                 self,
                 title,
                 "\n".join(lines)
-                + "\n\n失敗項目通常代表該 API 尚未啟用、OAuth 範圍不足，"
-                "或網路暫時無法連線。",
+                + "\n\n"
+                + self._t(
+                    "失敗項目通常代表該 API 尚未啟用、OAuth 範圍不足，"
+                    "或網路暫時無法連線。"
+                ),
             )
 
     def _cloud_test_timed_out(self) -> None:
@@ -1766,9 +1892,9 @@ class FlagshipControlCenter(QWidget):
         self._cloud_test_worker = None
         if hasattr(self, "cloud_test_button"):
             self.cloud_test_button.setEnabled(True)
-            self.cloud_test_button.setText("測試選取服務")
+            self.cloud_test_button.setText(self._t("測試選取服務"))
         self.cloud_status.setText(
-            "雲端測試超過 35 秒，已停止等待；請查看個別服務的 API 與網路狀態。"
+            self._t("雲端測試超過 35 秒，已停止等待；請查看個別服務的 API 與網路狀態。")
         )
         self.db.audit_event(
             "cloud_health_timeout",
@@ -1777,11 +1903,17 @@ class FlagshipControlCenter(QWidget):
 
     def revoke_cloud(self) -> None:
         provider_id = str(self.cloud_provider.currentData())
-        if QMessageBox.question(
-            self,
-            "撤銷雲端服務",
-            f"確定移除 {PROVIDERS[provider_id].display_name} 的本機權杖？",
-        ) != QMessageBox.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                self._t("撤銷雲端服務"),
+                self._t(
+                    "確定移除 {provider} 的本機權杖？",
+                    provider=PROVIDERS[provider_id].display_name,
+                ),
+            )
+            != QMessageBox.Yes
+        ):
             return
         self._oauth_store(provider_id).clear()
         row = self.db.connector(provider_id)
@@ -1795,32 +1927,36 @@ class FlagshipControlCenter(QWidget):
         )
         self._configure_executor()
         self.refresh_cloud_connections()
-        self.cloud_status.setText("本機權杖已移除")
+        self.cloud_status.setText(self._t("本機權杖已移除"))
 
     def refresh_cloud_connections(self) -> None:
         self.cloud_connections.clear()
         for provider_id, provider in PROVIDERS.items():
             row = self.db.connector(provider_id)
             enabled = bool(row["enabled"]) if row else False
-            health = str(row["last_health"] or "尚未測試") if row else "未設定"
+            health = (
+                self._system_text(str(row["last_health"] or "尚未測試"))
+                if row
+                else self._t("未設定")
+            )
             self.cloud_connections.addItem(
-                f"{'已啟用' if enabled else '未啟用'}｜"
+                f"{self._t('已啟用' if enabled else '未啟用')}｜"
                 f"{provider.display_name}｜{health}"
             )
 
     def _home_tab(self) -> QWidget:
         scroll, form = self._scroll_form()
-        self.ha_enabled = QCheckBox("啟用 Home Assistant 整合")
+        self.ha_enabled = QCheckBox(self._t("啟用 Home Assistant 整合"))
         self.ha_url = QLineEdit()
-        self.ha_url.setPlaceholderText("例如：http://homeassistant.local:8123")
+        self.ha_url.setPlaceholderText(self._t("例如：http://homeassistant.local:8123"))
         self.ha_token = QLineEdit()
         self.ha_token.setEchoMode(QLineEdit.Password)
         self.ha_token.setPlaceholderText(
-            "已由作業系統安全保存（留空不變）"
+            self._t("已由作業系統安全保存（留空不變）")
             if self.ha_secret.load()
-            else "貼上 Home Assistant 長期存取權杖"
+            else self._t("貼上 Home Assistant 長期存取權杖")
         )
-        self.ha_tls = QCheckBox("驗證 HTTPS 憑證")
+        self.ha_tls = QCheckBox(self._t("驗證 HTTPS 憑證"))
         self.ha_tls.setChecked(True)
         row = self.db.connector("home_assistant")
         if row:
@@ -1831,25 +1967,27 @@ class FlagshipControlCenter(QWidget):
         buttons = QWidget()
         buttons_layout = QHBoxLayout(buttons)
         buttons_layout.setContentsMargins(0, 0, 0, 0)
-        save = QPushButton("保存連線設定")
-        test = QPushButton("測試連線")
-        load = QPushButton("讀取裝置")
+        save = QPushButton(self._t("保存連線設定"))
+        test = QPushButton(self._t("測試連線"))
+        load = QPushButton(self._t("讀取裝置"))
         buttons_layout.addWidget(save)
         buttons_layout.addWidget(test)
         buttons_layout.addWidget(load)
-        self.ha_status = QLabel("尚未測試")
+        self.ha_status = QLabel(self._t("尚未測試"))
         self.ha_entities = QListWidget()
         self.ha_entities.setMinimumHeight(260)
         form.addRow(self.ha_enabled)
-        form.addRow("Home Assistant 位址", self.ha_url)
-        form.addRow("長期存取權杖", self.ha_token)
+        form.addRow(self._t("Home Assistant 位址"), self.ha_url)
+        form.addRow(self._t("長期存取權杖"), self.ha_token)
         form.addRow("", self.ha_tls)
         form.addRow("", buttons)
-        form.addRow("連線狀態", self.ha_status)
-        form.addRow("裝置狀態", self.ha_entities)
+        form.addRow(self._t("連線狀態"), self.ha_status)
+        form.addRow(self._t("裝置狀態"), self.ha_entities)
         warning = QLabel(
-            "門鎖、警報與加熱設備永遠套用高風險政策。"
-            "墨寒不能因對話內容自行降低安全等級。"
+            self._t(
+                "門鎖、警報與加熱設備永遠套用高風險政策。"
+                "墨寒不能因對話內容自行降低安全等級。"
+            )
         )
         warning.setWordWrap(True)
         warning.setStyleSheet("color:#8a5a13;")
@@ -1858,9 +1996,10 @@ class FlagshipControlCenter(QWidget):
         test.clicked.connect(self.test_home_connection)
         load.clicked.connect(self.load_home_entities)
         if not self.platform_services.capabilities.secure_secret_storage:
-            unavailable = (
-                f"{self.platform_services.capabilities.display_name} 的安全金鑰保存尚未"
-                "完成實機驗證；Home Assistant 連線暫停，且不會儲存明文權杖。"
+            unavailable = self._t(
+                "{platform} 的安全金鑰保存尚未完成實機驗證；"
+                "Home Assistant 連線暫停，且不會儲存明文權杖。",
+                platform=self.platform_services.capabilities.display_name,
             )
             self.ha_enabled.setChecked(False)
             self.ha_enabled.setEnabled(False)
@@ -1873,22 +2012,29 @@ class FlagshipControlCenter(QWidget):
         url = self.ha_url.text().strip()
         token = self.ha_token.text().strip()
         if self.ha_enabled.isChecked() and not url:
-            QMessageBox.information(self, "Home Assistant", "請先填入連線位址。")
+            QMessageBox.information(
+                self,
+                "Home Assistant",
+                self._t("請先填入連線位址。"),
+            )
             return
         if token:
             try:
                 self.ha_secret.save(token)
             except OSError as exc:
-                self.ha_status.setText(f"無法安全保存權杖：{exc}")
+                safe_message = safe_error_message(self.language, exc)
+                self.ha_status.setText(
+                    self._t("無法安全保存權杖：{error}", error=safe_message)
+                )
                 QMessageBox.warning(
                     self,
                     "Home Assistant",
-                    f"無法安全保存權杖：{exc}",
+                    self._t("無法安全保存權杖：{error}", error=safe_message),
                 )
                 return
             self.ha_token.clear()
             self.ha_token.setPlaceholderText(
-                "已由作業系統安全保存（留空不變）"
+                self._t("已由作業系統安全保存（留空不變）")
             )
         self.db.save_connector(
             "home_assistant",
@@ -1901,15 +2047,15 @@ class FlagshipControlCenter(QWidget):
         )
         self._register_home_tools()
         self.refresh_health()
-        self.ha_status.setText("設定已保存")
+        self.ha_status.setText(self._t("設定已保存"))
 
     def _home_client(self) -> HomeAssistantClient:
         row = self.db.connector("home_assistant")
         token = self.ha_secret.load()
         if row is None or not bool(row["enabled"]):
-            raise PermissionError("Home Assistant 尚未啟用")
+            raise PermissionError(self._t("Home Assistant 尚未啟用"))
         if not token:
-            raise PermissionError("尚未保存 Home Assistant 權杖")
+            raise PermissionError(self._t("尚未保存 Home Assistant 權杖"))
         config = json.loads(row["configuration"])
         return HomeAssistantClient(
             HomeAssistantConfig(
@@ -1922,7 +2068,7 @@ class FlagshipControlCenter(QWidget):
     def _register_home_tools(self) -> None:
         try:
             client = self._home_client()
-        except (PermissionError, ValueError):
+        except PermissionError, ValueError:
             return
         self.executor.register("home_read", client.action_read)
         for capability in (
@@ -1942,16 +2088,26 @@ class FlagshipControlCenter(QWidget):
         try:
             healthy = self._home_client().health()
         except Exception as exc:  # noqa: BLE001 -- user-visible integration boundary
-            self.ha_status.setText(f"連線失敗：{exc}")
+            self.ha_status.setText(
+                self._t(
+                    "連線失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             return
-        self.ha_status.setText("連線正常" if healthy else "API 回應不正確")
+        self.ha_status.setText(self._t("連線正常" if healthy else "API 回應不正確"))
 
     def load_home_entities(self) -> None:
         self.ha_entities.clear()
         try:
             states = self._home_client().states()
         except Exception as exc:  # noqa: BLE001 -- user-visible integration boundary
-            self.ha_status.setText(f"讀取失敗：{exc}")
+            self.ha_status.setText(
+                self._t(
+                    "讀取失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             return
         for state in states:
             entity = str(state.get("entity_id", ""))
@@ -1974,12 +2130,18 @@ class FlagshipControlCenter(QWidget):
             self.ha_entities.addItem(f"{name}　｜　{entity}　｜　{state.get('state')}")
         issues = home_health_issues(states)
         issue_text = (
-            "；".join(issue["message"] for issue in issues[:5])
+            "；".join(
+                self._translator.home_issue(issue["message"]) for issue in issues[:5]
+            )
             if issues
-            else "未發現離線或低電量裝置"
+            else self._t("未發現離線或低電量裝置")
         )
         self.ha_status.setText(
-            f"已讀取 {self.ha_entities.count()} 個可用項目。{issue_text}"
+            self._t(
+                "已讀取 {count} 個可用項目。{issues}",
+                count=self.ha_entities.count(),
+                issues=issue_text,
+            )
         )
 
     def _remote_port_control(self) -> QWidget:
@@ -1994,8 +2156,8 @@ class FlagshipControlCenter(QWidget):
         self.remote_port_up = QPushButton("▲")
         self.remote_port_down = QPushButton("▼")
         for button, tooltip in (
-            (self.remote_port_up, "增加連線埠"),
-            (self.remote_port_down, "減少連線埠"),
+            (self.remote_port_up, self._t("增加連線埠")),
+            (self.remote_port_down, self._t("減少連線埠")),
         ):
             button.setFixedWidth(46)
             button.setAutoRepeat(True)
@@ -2010,35 +2172,37 @@ class FlagshipControlCenter(QWidget):
         return port_control
 
     def _initialize_remote_fields(self) -> None:
-        self.remote_enabled = QCheckBox("啟用手機／私人網路遠端服務")
+        self.remote_enabled = QCheckBox(self._t("啟用手機／私人網路遠端服務"))
         self.remote_host = QComboBox()
         self.remote_host.addItem(
-            "僅本機測試（127.0.0.1）",
+            self._t("僅本機測試（127.0.0.1）"),
             "127.0.0.1",
         )
         self.remote_host.addItem(
-            "私人網路／Tailscale（0.0.0.0）",
+            self._t("私人網路／Tailscale（0.0.0.0）"),
             "0.0.0.0",
         )
         self.remote_trusted = QCheckBox(
-            "我確認已使用 Tailscale、Home Assistant Cloud 或其他加密私人網路"
+            self._t("我確認已使用 Tailscale、Home Assistant Cloud 或其他加密私人網路")
         )
-        self.remote_commands = QCheckBox("允許傳送文字指令")
+        self.remote_commands = QCheckBox(self._t("允許傳送文字指令"))
         self.remote_commands.setChecked(True)
-        self.remote_screen = QCheckBox("允許查看墨寒程式視窗（不擷取整個桌面）")
-        self.remote_files = QCheckBox("允許下載白名單內的非敏感檔案")
-        self.camera_enabled = QCheckBox("允許本機攝影機在場偵測")
+        self.remote_screen = QCheckBox(
+            self._t("允許查看墨寒程式視窗（不擷取整個桌面）")
+        )
+        self.remote_files = QCheckBox(self._t("允許下載白名單內的非敏感檔案"))
+        self.camera_enabled = QCheckBox(self._t("允許本機攝影機在場偵測"))
         self.face_identity = QCheckBox(
-            "本機臉部身分辨識（需另裝可稽核的辨識外掛）"
+            self._t("本機臉部身分辨識（需另裝可稽核的辨識外掛）")
         )
         self.camera_enabled.setChecked(
             bool(self.db.setting("camera_presence_enabled", False))
         )
         self.face_identity.setChecked(False)
         self.face_identity.setEnabled(False)
-        self.camera_status = QLabel("攝影機已關閉")
+        self.camera_status = QLabel(self._t("攝影機已關閉"))
         self.camera_status.setWordWrap(True)
-        self.remote_status = QLabel("遠端功能預設關閉")
+        self.remote_status = QLabel(self._t("遠端功能預設關閉"))
         self.remote_status.setWordWrap(True)
         self.device_list = QListWidget()
 
@@ -2046,9 +2210,9 @@ class FlagshipControlCenter(QWidget):
         controls = QWidget()
         line = QHBoxLayout(controls)
         line.setContentsMargins(0, 0, 0, 0)
-        start = QPushButton("啟動／套用")
-        stop = QPushButton("停止遠端服務")
-        pair = QPushButton("配對新手機")
+        start = QPushButton(self._t("啟動／套用"))
+        stop = QPushButton(self._t("停止遠端服務"))
+        pair = QPushButton(self._t("配對新手機"))
         line.addWidget(start)
         line.addWidget(stop)
         line.addWidget(pair)
@@ -2063,29 +2227,31 @@ class FlagshipControlCenter(QWidget):
         port_control: QWidget,
         controls: QWidget,
     ) -> None:
-        apply_camera = QPushButton("套用攝影機隱私設定")
-        revoke = QPushButton("撤銷選取裝置")
+        apply_camera = QPushButton(self._t("套用攝影機隱私設定"))
+        revoke = QPushButton(self._t("撤銷選取裝置"))
         form.addRow(self.remote_enabled)
-        form.addRow("監聽範圍", self.remote_host)
-        form.addRow("連線埠", port_control)
+        form.addRow(self._t("監聽範圍"), self.remote_host)
+        form.addRow(self._t("連線埠"), port_control)
         form.addRow("", self.remote_trusted)
         form.addRow("", self.remote_commands)
         form.addRow("", self.remote_screen)
         form.addRow("", self.remote_files)
-        form.addRow(QLabel("<b>攝影機與身分辨識</b>"))
+        form.addRow(QLabel(self._t("<b>攝影機與身分辨識</b>")))
         form.addRow("", self.camera_enabled)
         form.addRow("", self.face_identity)
         form.addRow("", apply_camera)
-        form.addRow("攝影機狀態", self.camera_status)
+        form.addRow(self._t("攝影機狀態"), self.camera_status)
         camera_note = QLabel(
-            "攝影機預設關閉；啟用時必須顯示狀態。畫面不會默默上傳，"
-            "也不會辨識未登錄的陌生人。"
+            self._t(
+                "攝影機預設關閉；啟用時必須顯示狀態。畫面不會默默上傳，"
+                "也不會辨識未登錄的陌生人。"
+            )
         )
         camera_note.setWordWrap(True)
         form.addRow(camera_note)
         form.addRow("", controls)
-        form.addRow("服務狀態", self.remote_status)
-        form.addRow("已配對裝置", self.device_list)
+        form.addRow(self._t("服務狀態"), self.remote_status)
+        form.addRow(self._t("已配對裝置"), self.device_list)
         form.addRow("", revoke)
         revoke.clicked.connect(self.revoke_device)
         apply_camera.clicked.connect(self.apply_camera_settings)
@@ -2116,43 +2282,77 @@ class FlagshipControlCenter(QWidget):
             self.camera_enabled.setChecked(False)
             QMessageBox.information(
                 self,
-                "攝影機權限",
-                f"安全政策已阻擋：{decision.reason}",
+                self._t("攝影機權限"),
+                self._t(
+                    "安全政策已阻擋：{reason}",
+                    reason=self._system_text(decision.reason),
+                ),
             )
             return
-        if QMessageBox.question(
-            self,
-            "啟用攝影機",
-            "墨寒只會在本機分析粗略移動與明暗，不保存影像、"
-            "不傳送雲端，也不辨識陌生人。是否啟用？",
-        ) != QMessageBox.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                self._t("啟用攝影機"),
+                self._t(
+                    "墨寒只會在本機分析粗略移動與明暗，不保存影像、"
+                    "不傳送雲端，也不辨識陌生人。是否啟用？"
+                ),
+            )
+            != QMessageBox.Yes
+        ):
             self.camera_enabled.setChecked(False)
             return
         try:
             self.camera_presence.start()
         except RuntimeError as exc:
             self.camera_enabled.setChecked(False)
-            self.camera_status.setText(str(exc))
+            self.camera_status.setText(
+                self._t(
+                    "攝影機啟動失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             return
         self.db.set_setting("camera_presence_enabled", True)
         self.db.set_setting("face_identity_enabled", False)
 
     def _camera_status_changed(self, status: str) -> None:
         if hasattr(self, "camera_status"):
-            self.camera_status.setText(status)
+            self.camera_status.setText(self._camera_status_text(status))
+
+    def _camera_status_text(self, status: str) -> str:
+        value = str(status)
+        if value == "攝影機已關閉":
+            return self._t("攝影機已關閉")
+        if value.startswith("攝影機錯誤："):
+            return self._t(
+                "攝影機錯誤：{error}",
+                error=value.removeprefix("攝影機錯誤："),
+            )
+        prefix = "攝影機使用中："
+        suffix = "（僅本機在場偵測）"
+        if value.startswith(prefix) and value.endswith(suffix):
+            return self._t(
+                "攝影機使用中：{device}（僅本機在場偵測）",
+                device=value[len(prefix) : -len(suffix)],
+            )
+        return value
 
     def _presence_changed(self, present: bool) -> None:
         self.db.set_setting("camera_presence_state", bool(present))
         if hasattr(self, "camera_status"):
             base = self.camera_status.text().split("｜", 1)[0]
             self.camera_status.setText(
-                f"{base}｜{'偵測到有人在場' if present else '暫未偵測到在場'}"
+                self._t(
+                    "{base}｜偵測到有人在場" if present else "{base}｜暫未偵測到在場",
+                    base=base,
+                )
             )
 
     def start_remote(self) -> None:
         self.stop_remote(silent=True)
         if not self.remote_enabled.isChecked():
-            self.remote_status.setText("遠端服務未啟用")
+            self.remote_status.setText(self._t("遠端服務未啟用"))
             return
         host = str(self.remote_host.currentData())
         trusted = self.remote_trusted.isChecked()
@@ -2184,14 +2384,23 @@ class FlagshipControlCenter(QWidget):
             self.remote_server.start()
         except (OSError, PermissionError) as exc:
             self.remote_server = None
-            self.remote_status.setText(f"啟動失敗：{exc}")
+            self.remote_status.setText(
+                self._t(
+                    "啟動失敗：{error}",
+                    error=safe_error_message(self.language, exc),
+                )
+            )
             return
         self.db.set_setting("remote_port", self.remote_port.value())
         self.db.set_setting("camera_presence_enabled", self.camera_enabled.isChecked())
         self.db.set_setting("face_identity_enabled", self.face_identity.isChecked())
         self.remote_status.setText(
-            f"已啟動：http://{host}:{self.remote_port.value()}\n"
-            "只有已配對且具備相應權限的裝置可以存取。"
+            self._t(
+                "已啟動：http://{host}:{port}\n"
+                "只有已配對且具備相應權限的裝置可以存取。",
+                host=host,
+                port=self.remote_port.value(),
+            )
         )
         self.refresh_health()
 
@@ -2200,12 +2409,17 @@ class FlagshipControlCenter(QWidget):
             self.remote_server.stop()
             self.remote_server = None
         if hasattr(self, "remote_status") and not silent:
-            self.remote_status.setText("遠端服務已停止，既有權杖未刪除但無法連線。")
+            self.remote_status.setText(
+                self._t("遠端服務已停止，既有權杖未刪除但無法連線。")
+            )
         if hasattr(self, "health_summary"):
             self.refresh_health()
 
     def pair_device(self) -> None:
-        name, ok = self._simple_text_dialog("配對新裝置", "裝置名稱")
+        name, ok = self._simple_text_dialog(
+            self._t("配對新裝置"),
+            self._t("裝置名稱"),
+        )
         if not ok:
             return
         permissions = ["status"]
@@ -2218,9 +2432,11 @@ class FlagshipControlCenter(QWidget):
         token = TokenRegistry(self.db).pair(name, permissions)
         QMessageBox.information(
             self,
-            "一次性配對權杖",
-            "請只在可信任裝置輸入下列權杖。關閉視窗後不會再次顯示：\n\n"
-            + token,
+            self._t("一次性配對權杖"),
+            self._t(
+                "請只在可信任裝置輸入下列權杖。關閉視窗後不會再次顯示：\n\n{token}",
+                token=token,
+            ),
         )
         self.refresh_devices()
 
@@ -2232,6 +2448,8 @@ class FlagshipControlCenter(QWidget):
         editor = QLineEdit()
         root.addWidget(editor)
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.button(QDialogButtonBox.Ok).setText(self._t("確定"))
+        buttons.button(QDialogButtonBox.Cancel).setText(self._t("取消"))
         buttons.accepted.connect(dialog.accept)
         buttons.rejected.connect(dialog.reject)
         root.addWidget(buttons)
@@ -2242,8 +2460,12 @@ class FlagshipControlCenter(QWidget):
         self.device_list.clear()
         for row in self.db.paired_devices():
             item = QListWidgetItem(
-                f"{'有效' if row['enabled'] else '已撤銷'}｜"
-                f"{row['device_name']}｜最後連線：{row['last_seen_at'] or '從未'}"
+                self._t(
+                    "{status}｜{device}｜最後連線：{last_seen}",
+                    status=self._t("有效" if row["enabled"] else "已撤銷"),
+                    device=row["device_name"],
+                    last_seen=row["last_seen_at"] or self._t("從未"),
+                )
             )
             item.setData(Qt.UserRole, int(row["id"]))
             self.device_list.addItem(item)
@@ -2272,7 +2494,10 @@ class FlagshipControlCenter(QWidget):
 
     def _queue_remote_command(self, text: str, device_name: str) -> dict[str, Any]:
         self._remote_commands.put((text, device_name))
-        return {"accepted": True, "message": "已送交墨寒並等待本機權限判斷"}
+        return {
+            "accepted": True,
+            "message": self._t("已送交墨寒並等待本機權限判斷"),
+        }
 
     def _drain_remote_commands(self) -> None:
         if self._closed:
@@ -2287,7 +2512,11 @@ class FlagshipControlCenter(QWidget):
                 {"device": device, "text": text[:500]},
             )
             self.remote_command_received.emit(
-                f"[遠端裝置：{device}] {text}"
+                self._t(
+                    "[遠端裝置：{device}] {text}",
+                    device=device,
+                    text=text,
+                )
             )
 
     def _refresh_screen_cache(self) -> None:
@@ -2310,21 +2539,21 @@ class FlagshipControlCenter(QWidget):
 
     def _screen_bytes(self) -> bytes:
         if not self._screen_cache:
-            raise PermissionError("尚無可用的程式視窗畫面")
+            raise PermissionError(self._t("尚無可用的程式視窗畫面"))
         return self._screen_cache
 
     def _security_target_section(self, form: QFormLayout) -> None:
-        target_heading = QLabel("<b>允許操作的資料夾與程式</b>")
+        target_heading = QLabel(self._t("<b>允許操作的資料夾與程式</b>"))
         target_heading.setStyleSheet("color:#2f6987;font-size:15px;")
         self.target_list = QListWidget()
         self.target_list.setMinimumHeight(130)
         target_buttons = QWidget()
         target_line = QHBoxLayout(target_buttons)
         target_line.setContentsMargins(0, 0, 0, 0)
-        add_folder = QPushButton("加入資料夾")
-        add_app = QPushButton("加入程式")
-        add_web = QPushButton("加入網站")
-        remove_target = QPushButton("移除選取項目")
+        add_folder = QPushButton(self._t("加入資料夾"))
+        add_app = QPushButton(self._t("加入程式"))
+        add_web = QPushButton(self._t("加入網站"))
+        remove_target = QPushButton(self._t("移除選取項目"))
         target_line.addWidget(add_folder)
         target_line.addWidget(add_app)
         target_line.addWidget(add_web)
@@ -2343,34 +2572,40 @@ class FlagshipControlCenter(QWidget):
         form: QFormLayout,
         stored: dict[str, Any],
     ) -> None:
-        permission_heading = QLabel("<b>能力權限</b>")
+        permission_heading = QLabel(self._t("<b>能力權限</b>"))
         permission_heading.setStyleSheet("color:#2f6987;font-size:15px;")
         form.addRow(permission_heading)
         for capability, label in CORE_PERMISSION_LABELS.items():
             combo = QComboBox()
-            combo.addItems(["禁止", "每次詢問", "允許"])
-            risk = self.policy.evaluate(
-                ActionRequest(capability, label)
-            ).risk
+            for canonical in ("禁止", "每次詢問", "允許"):
+                combo.addItem(self._t(canonical), canonical)
+            risk = self.policy.evaluate(ActionRequest(capability, label)).risk
             default = (
-                "允許"
-                if risk.value == 1
-                else "每次詢問"
-                if risk.value < 4
-                else "禁止"
+                "允許" if risk.value == 1 else "每次詢問" if risk.value < 4 else "禁止"
             )
-            combo.setCurrentText(str(stored.get(capability, default)))
+            stored_mode = str(stored.get(capability, default))
+            stored_index = combo.findData(stored_mode)
+            combo.setCurrentIndex(max(stored_index, 0))
             if risk.value >= 3:
-                combo.setToolTip("即使選擇允許，高風險政策仍會要求確認。")
+                combo.setToolTip(self._t("即使選擇允許，高風險政策仍會要求確認。"))
             self._permission_controls[capability] = combo
-            form.addRow(f"{label}（{RISK_NAMES[risk]}）", combo)
+            form.addRow(
+                self._t(
+                    "{label}（{risk}）",
+                    label=self._t(label),
+                    risk=self._t(RISK_NAMES[risk]),
+                ),
+                combo,
+            )
 
     def _security_footer(self, form: QFormLayout) -> None:
-        save = QPushButton("保存安全權限")
+        save = QPushButton(self._t("保存安全權限"))
         save.clicked.connect(self.save_security)
         note = QLabel(
-            "付款、購買、密碼匯出、停用安全防護、任意 PowerShell／管理員命令"
-            "永遠禁止自動執行，無法由此頁解除。"
+            self._t(
+                "付款、購買、密碼匯出、停用安全防護、任意 PowerShell／管理員命令"
+                "永遠禁止自動執行，無法由此頁解除。"
+            )
         )
         note.setWordWrap(True)
         note.setStyleSheet("color:#8a5a13;")
@@ -2389,13 +2624,17 @@ class FlagshipControlCenter(QWidget):
         self.target_list.clear()
         for row in self.db.allowed_targets():
             kind = {
-                "folder": "資料夾",
-                "app": "程式",
-                "web": "網站",
+                "folder": self._t("資料夾"),
+                "app": self._t("程式"),
+                "web": self._t("網站"),
             }.get(str(row["target_type"]), str(row["target_type"]))
+            access_mode = {
+                "read": self._t("只讀"),
+                "write": self._t("可寫"),
+                "control": self._t("控制"),
+            }.get(str(row["access_mode"]), str(row["access_mode"]))
             item = QListWidgetItem(
-                f"{kind}｜{row['display_name']}｜{row['target_value']}｜"
-                f"{row['access_mode']}"
+                f"{kind}｜{row['display_name']}｜{row['target_value']}｜{access_mode}"
             )
             item.setData(Qt.UserRole, int(row["id"]))
             self.target_list.addItem(item)
@@ -2403,13 +2642,13 @@ class FlagshipControlCenter(QWidget):
     def add_allowed_folder(self) -> None:
         path = QFileDialog.getExistingDirectory(
             self,
-            "選擇允許墨寒操作的資料夾",
+            self._t("選擇允許墨寒操作的資料夾"),
         )
         if not path:
             return
         mode, ok = self._simple_text_dialog(
-            "資料夾權限",
-            "輸入 read（只讀）或 write（可建立、移動與重新命名）",
+            self._t("資料夾權限"),
+            self._t("輸入 read（只讀）或 write（可建立、移動與重新命名）"),
         )
         if not ok:
             return
@@ -2426,19 +2665,19 @@ class FlagshipControlCenter(QWidget):
     def add_allowed_app(self) -> None:
         path, _filter = QFileDialog.getOpenFileName(
             self,
-            "選擇允許墨寒啟動的程式",
+            self._t("選擇允許墨寒啟動的程式"),
             "",
             (
-                "Windows 程式 (*.exe);;所有檔案 (*)"
+                self._t("Windows 程式 (*.exe);;所有檔案 (*)")
                 if self.platform_services.capabilities.platform_id == "windows"
-                else "應用程式／可執行檔 (*);;所有檔案 (*)"
+                else self._t("應用程式／可執行檔 (*);;所有檔案 (*)")
             ),
         )
         if not path:
             return
         name, ok = self._simple_text_dialog(
-            "程式別名",
-            "日後對墨寒說的程式名稱",
+            self._t("程式別名"),
+            self._t("日後對墨寒說的程式名稱"),
         )
         if not ok or not name:
             return
@@ -2453,8 +2692,8 @@ class FlagshipControlCenter(QWidget):
 
     def add_allowed_web(self) -> None:
         url, ok = self._simple_text_dialog(
-            "加入允許網站",
-            "輸入完整 HTTPS 網址（可限制到指定路徑）",
+            self._t("加入允許網站"),
+            self._t("輸入完整 HTTPS 網址（可限制到指定路徑）"),
         )
         if not ok or not url:
             return
@@ -2462,8 +2701,8 @@ class FlagshipControlCenter(QWidget):
         if parsed.scheme != "https" or not parsed.netloc:
             QMessageBox.information(
                 self,
-                "網站白名單",
-                "公開網站只接受完整 HTTPS 網址。",
+                self._t("網站白名單"),
+                self._t("公開網站只接受完整 HTTPS 網址。"),
             )
             return
         self.db.add_allowed_target(
@@ -2479,11 +2718,14 @@ class FlagshipControlCenter(QWidget):
         item = self.target_list.currentItem()
         if item is None:
             return
-        if QMessageBox.question(
-            self,
-            "移除允許項目",
-            "確定撤銷墨寒對此項目的存取權？",
-        ) != QMessageBox.Yes:
+        if (
+            QMessageBox.question(
+                self,
+                self._t("移除允許項目"),
+                self._t("確定撤銷墨寒對此項目的存取權？"),
+            )
+            != QMessageBox.Yes
+        ):
             return
         self.db.remove_allowed_target(int(item.data(Qt.UserRole)))
         self.refresh_allowed_targets()
@@ -2491,13 +2733,13 @@ class FlagshipControlCenter(QWidget):
 
     def save_security(self) -> None:
         values = {
-            key: combo.currentText()
+            key: str(combo.currentData())
             for key, combo in self._permission_controls.items()
         }
         self.db.set_setting("flagship_permissions", values)
         self._configure_executor()
         self.speak_requested.emit(
-            "安全權限已保存。妾會守住這條界線。",
+            self._t("安全權限已保存。妾會守住這條界線。"),
             "happy",
         )
 
@@ -2505,7 +2747,7 @@ class FlagshipControlCenter(QWidget):
         page = QWidget()
         layout = QVBoxLayout(page)
         top = QHBoxLayout()
-        refresh = QPushButton("重新整理")
+        refresh = QPushButton(self._t("重新整理"))
         top.addWidget(refresh)
         top.addStretch()
         self.audit_view = QTextBrowser()
@@ -2527,10 +2769,9 @@ class FlagshipControlCenter(QWidget):
             except json.JSONDecodeError:
                 summary = str(row["payload"])[:500]
             lines.append(
-                f"<p><b>{row['created_at']}｜{row['event_type']}</b><br>"
-                f"{summary}</p>"
+                f"<p><b>{row['created_at']}｜{row['event_type']}</b><br>{summary}</p>"
             )
-        self.audit_view.setHtml("".join(lines) or "<p>尚無工具操作紀錄。</p>")
+        self.audit_view.setHtml("".join(lines) or self._t("<p>尚無工具操作紀錄。</p>"))
 
     def _confirm_action(
         self,
@@ -2539,9 +2780,9 @@ class FlagshipControlCenter(QWidget):
         index: int,
     ) -> bool:
         title = (
-            "高風險操作二次確認"
+            self._t("高風險操作二次確認")
             if decision.confirmation_count > 1 and index > 1
-            else "墨寒請求執行工具"
+            else self._t("墨寒請求執行工具")
         )
         detail = json.dumps(
             request.arguments,
@@ -2552,10 +2793,14 @@ class FlagshipControlCenter(QWidget):
         answer = QMessageBox.question(
             self,
             title,
-            f"風險：{RISK_NAMES[decision.risk]}\n"
-            f"來源：{request.source}\n"
-            f"操作：{request.description}\n\n"
-            f"參數預覽：\n{detail}\n\n是否允許？",
+            self._t(
+                "風險：{risk}\n來源：{source}\n操作：{description}\n\n"
+                "參數預覽：\n{detail}\n\n是否允許？",
+                risk=self._t(RISK_NAMES[decision.risk]),
+                source=request.source,
+                description=request.description,
+                detail=detail,
+            ),
         )
         return answer == QMessageBox.Yes
 
@@ -2570,11 +2815,14 @@ class FlagshipControlCenter(QWidget):
             {"at": local_wall_time().isoformat(timespec="seconds")},
         )
         self.emergency_stop_requested.emit()
-        self.speak_requested.emit("已停手。所有工具與遠端連線均已中止。", "worried")
+        self.speak_requested.emit(
+            self._t("已停手。所有工具與遠端連線均已中止。"),
+            "worried",
+        )
         QMessageBox.information(
             self,
-            "緊急停止",
-            "所有進行中的工具任務與遠端服務均已停止。",
+            self._t("緊急停止"),
+            self._t("所有進行中的工具任務與遠端服務均已停止。"),
         )
 
     def _register_home_action_from_request(

--- a/flagship_ui.py
+++ b/flagship_ui.py
@@ -77,8 +77,6 @@ lazy from flagship_core import (
     parse_plan_json,
 )
 lazy from flagship_ui_localization import FlagshipTranslator
-lazy from safe_error import sanitize_error
-lazy from safe_error_localization import safe_error_message
 lazy from home_assistant import (
     HomeAssistantClient,
     HomeAssistantConfig,
@@ -93,6 +91,8 @@ lazy from remote_control import (
     RemoteServerServices,
     TokenRegistry,
 )
+lazy from safe_error import sanitize_error
+lazy from safe_error_localization import safe_error_message
 lazy from secret_store import platform_secret_store_factory
 lazy from time_utils import local_aware_time, local_wall_time
 lazy from windows_tools import WindowTools
@@ -1254,7 +1254,11 @@ class FlagshipControlCenter(QWidget):
                 enabled=workflow.enabled,
             )
         except (ValueError, json.JSONDecodeError) as exc:
-            QMessageBox.warning(self, self._t("工作流程"), str(exc))
+            QMessageBox.warning(
+                self,
+                self._t("工作流程"),
+                safe_error_message(self.language, exc),
+            )
             return
         self.refresh_workflows()
 
@@ -1280,7 +1284,11 @@ class FlagshipControlCenter(QWidget):
         try:
             plan = workflow.to_plan()
         except ValueError as exc:
-            QMessageBox.warning(self, self._t("工作流程"), str(exc))
+            QMessageBox.warning(
+                self,
+                self._t("工作流程"),
+                safe_error_message(self.language, exc),
+            )
             return
         if workflow.require_preview:
             preview = "\n".join(
@@ -2364,6 +2372,7 @@ class FlagshipControlCenter(QWidget):
             allow_commands=self.remote_commands.isChecked(),
             allow_screen=self.remote_screen.isChecked(),
             allow_files=self.remote_files.isChecked(),
+            language=self.language,
         )
         folders = [
             str(row["target_value"])

--- a/flagship_ui_localization.py
+++ b/flagship_ui_localization.py
@@ -1,0 +1,1186 @@
+from __future__ import annotations
+
+lazy import re
+lazy from dataclasses import dataclass
+lazy from typing import Any
+
+lazy from language_support import canonical_ui_language
+
+_TRANSLATION_INDEX = frozendict({"zh-CN": 0, "en": 1, "ja-JP": 2})
+
+
+def _translations(
+    simplified_chinese: str,
+    english: str,
+    japanese: str,
+) -> tuple[str, str, str]:
+    return simplified_chinese, english, japanese
+
+
+# Traditional Chinese is the canonical source text and remains the default.
+# Every non-default language is kept beside it so missing translations fail
+# immediately instead of silently leaking the wrong language into the UI.
+FLAGSHIP_TRANSLATIONS = frozendict({
+    # Common controls and top-level navigation.
+    "儲存": _translations("保存", "Save", "保存"),
+    "取消": _translations("取消", "Cancel", "キャンセル"),
+    "確定": _translations("确定", "OK", "OK"),
+    "緊急停止所有工具與遠端操作（Esc）": _translations(
+        "紧急停止所有工具与远程操作（Esc）",
+        "Emergency stop for all tools and remote operations (Esc)",
+        "すべてのツールとリモート操作を緊急停止（Esc）",
+    ),
+    "任務中心": _translations("任务中心", "Task Center", "タスクセンター"),
+    "工作流程": _translations("工作流", "Workflows", "ワークフロー"),
+    "雲端連接器": _translations("云端连接器", "Cloud Connectors", "クラウド接続"),
+    "智慧家庭": _translations("智能家居", "Smart Home", "スマートホーム"),
+    "遠端與隱私": _translations(
+        "远程与隐私", "Remote & Privacy", "リモートとプライバシー"
+    ),
+    "安全權限": _translations("安全权限", "Security Permissions", "セキュリティ権限"),
+    "稽核紀錄": _translations("审计记录", "Audit Log", "監査ログ"),
+    # Workflow editor.
+    "新增安全工作流程": _translations(
+        "新增安全工作流",
+        "Add a Safe Workflow",
+        "安全なワークフローを追加",
+    ),
+    "手動執行": _translations("手动执行", "Run manually", "手動で実行"),
+    "每天固定時間": _translations(
+        "每天固定时间", "Daily at a set time", "毎日指定時刻"
+    ),
+    "開始工作時": _translations("开始工作时", "When work starts", "作業開始時"),
+    "第一次與高風險操作先預覽": _translations(
+        "首次与高风险操作先预览",
+        "Preview the first run and high-risk actions",
+        "初回実行と高リスク操作を事前確認",
+    ),
+    "流程名稱": _translations("流程名称", "Workflow name", "ワークフロー名"),
+    "啟動方式": _translations("启动方式", "Trigger", "起動条件"),
+    "執行時間": _translations("执行时间", "Run time", "実行時刻"),
+    "每行一個步驟，格式：能力｜說明｜參數。\n"
+    "範例：open_web｜開啟工作網站｜https://example.com\n"
+    "範例：home_control｜開啟書房燈｜light.study,turn_on": _translations(
+        "每行一个步骤，格式：能力｜说明｜参数。\n"
+        "示例：open_web｜打开工作网站｜https://example.com\n"
+        "示例：home_control｜打开书房灯｜light.study,turn_on",
+        "Enter one step per line as: capability | description | arguments.\n"
+        "Example: open_web | Open the work site | https://example.com\n"
+        "Example: home_control | Turn on the study light | light.study,turn_on",
+        "1 行に 1 ステップを「機能｜説明｜引数」の形式で入力します。\n"
+        "例：open_web｜作業サイトを開く｜https://example.com\n"
+        "例：home_control｜書斎の照明をつける｜light.study,turn_on",
+    ),
+    "open_web｜開啟工作網站｜https://example.com": _translations(
+        "open_web｜打开工作网站｜https://example.com",
+        "open_web | Open the work site | https://example.com",
+        "open_web｜作業サイトを開く｜https://example.com",
+    ),
+    "{capability} 參數格式必須是 entity_id,service": _translations(
+        "{capability} 参数格式必须是 entity_id,service",
+        "{capability} arguments must use entity_id,service",
+        "{capability} の引数は entity_id,service 形式で指定してください",
+    ),
+    "{capability} 的參數必須是 JSON 物件": _translations(
+        "{capability} 的参数必须是 JSON 对象",
+        "Arguments for {capability} must be a JSON object",
+        "{capability} の引数は JSON オブジェクトで指定してください",
+    ),
+    "步驟格式不正確：{line}": _translations(
+        "步骤格式不正确：{line}",
+        "Invalid step format: {line}",
+        "ステップの形式が正しくありません：{line}",
+    ),
+    # Capability labels.
+    "讀取狀態與摘要": _translations(
+        "读取状态与摘要", "Read status and summary", "状態と概要を読み取る"
+    ),
+    "搜尋白名單資料夾": _translations(
+        "搜索白名单文件夹", "Search allowlisted folders", "許可済みフォルダーを検索"
+    ),
+    "開啟網站": _translations("打开网站", "Open websites", "Web サイトを開く"),
+    "開啟資料夾": _translations("打开文件夹", "Open folders", "フォルダーを開く"),
+    "啟動白名單程式": _translations(
+        "启动白名单程序", "Launch allowlisted apps", "許可済みアプリを起動"
+    ),
+    "列出可見視窗": _translations(
+        "列出可见窗口", "List visible windows", "表示中のウィンドウを一覧表示"
+    ),
+    "切換至指定視窗": _translations(
+        "切换至指定窗口", "Switch to a specified window", "指定ウィンドウに切り替える"
+    ),
+    "建立檔案": _translations("创建文件", "Create files", "ファイルを作成"),
+    "重新命名檔案": _translations("重命名文件", "Rename files", "ファイル名を変更"),
+    "移動檔案": _translations("移动文件", "Move files", "ファイルを移動"),
+    "建立行事曆事件": _translations(
+        "创建日历事件", "Create calendar events", "カレンダー予定を作成"
+    ),
+    "修改行事曆事件": _translations(
+        "修改日历事件", "Update calendar events", "カレンダー予定を変更"
+    ),
+    "讀取行事曆": _translations("读取日历", "Read calendars", "カレンダーを読み取る"),
+    "讀取電子郵件": _translations("读取电子邮件", "Read email", "メールを読み取る"),
+    "寄送電子郵件": _translations("发送电子邮件", "Send email", "メールを送信"),
+    "讀取雲端檔案": _translations(
+        "读取云端文件", "Read cloud files", "クラウドファイルを読み取る"
+    ),
+    "建立或修改雲端檔案": _translations(
+        "创建或修改云端文件",
+        "Create or update cloud files",
+        "クラウドファイルを作成・変更",
+    ),
+    "對外發布內容": _translations(
+        "对外发布内容", "Publish content externally", "外部へコンテンツを公開"
+    ),
+    "讀取智慧家庭狀態": _translations(
+        "读取智能家居状态", "Read smart-home status", "スマートホームの状態を読み取る"
+    ),
+    "控制一般智慧設備": _translations(
+        "控制一般智能设备", "Control standard smart devices", "一般スマート機器を操作"
+    ),
+    "控制門鎖": _translations("控制门锁", "Control door locks", "ドアロックを操作"),
+    "控制警報": _translations("控制警报", "Control alarms", "警報を操作"),
+    "控制加熱與高溫設備": _translations(
+        "控制加热与高温设备",
+        "Control heating and high-temperature devices",
+        "暖房・高温機器を操作",
+    ),
+    "使用攝影機": _translations("使用摄像头", "Use the camera", "カメラを使用"),
+    "遠端查看本程式畫面": _translations(
+        "远程查看本程序画面", "View this app remotely", "このアプリの画面をリモート表示"
+    ),
+    "遠端下載白名單檔案": _translations(
+        "远程下载白名单文件",
+        "Download allowlisted files remotely",
+        "許可済みファイルをリモート取得",
+    ),
+    "遠端寫入檔案": _translations(
+        "远程写入文件", "Write files remotely", "リモートでファイルを書き込む"
+    ),
+    "刪除檔案": _translations("删除文件", "Delete files", "ファイルを削除"),
+    "關機或重新啟動": _translations(
+        "关机或重新启动", "Shut down or restart", "シャットダウンまたは再起動"
+    ),
+    # Risk, permission, trigger and allowlist display labels.
+    "低風險": _translations("低风险", "Low risk", "低リスク"),
+    "一般變更": _translations("一般变更", "Standard change", "通常の変更"),
+    "外部影響": _translations("外部影响", "External impact", "外部への影響"),
+    "高風險": _translations("高风险", "High risk", "高リスク"),
+    "禁止": _translations("禁止", "Blocked", "禁止"),
+    "每次詢問": _translations("每次询问", "Ask every time", "毎回確認"),
+    "允許": _translations("允许", "Allow", "許可"),
+    "手動": _translations("手动", "Manual", "手動"),
+    "每天 {time}": _translations("每天 {time}", "Daily at {time}", "毎日 {time}"),
+    "程式啟動時": _translations("程序启动时", "When the app starts", "アプリ起動時"),
+    "未知": _translations("未知", "Unknown", "不明"),
+    "{count} 步": _translations("{count} 步", "{count} steps", "{count} ステップ"),
+    "資料夾": _translations("文件夹", "Folder", "フォルダー"),
+    "程式": _translations("程序", "App", "アプリ"),
+    "網站": _translations("网站", "Website", "Web サイト"),
+    "只讀": _translations("只读", "Read only", "読み取り専用"),
+    "可寫": _translations("可写", "Read and write", "読み書き可能"),
+    "控制": _translations("控制", "Control", "操作"),
+    # Overview and planner.
+    "<b>墨寒旗艦任務中心</b>": _translations(
+        "<b>墨寒旗舰任务中心</b>",
+        "<b>MoHan Flagship Task Center</b>",
+        "<b>墨寒フラッグシップ・タスクセンター</b>",
+    ),
+    "所有電腦、雲端、遠端與智慧家庭操作都必須經過："
+    "計畫 → 權限判斷 → 確認 → 執行 → 結果驗證 → 稽核。": _translations(
+        "所有电脑、云端、远程与智能家居操作都必须经过："
+        "计划 → 权限判断 → 确认 → 执行 → 结果验证 → 审计。",
+        "Every computer, cloud, remote, and smart-home action must pass through: "
+        "plan → permission check → confirmation → execution → result verification → audit.",
+        "PC、クラウド、リモート、スマートホームのすべての操作は、"
+        "計画 → 権限判定 → 確認 → 実行 → 結果検証 → 監査の順に処理されます。",
+    ),
+    "重新檢查系統狀態": _translations(
+        "重新检查系统状态", "Recheck system status", "システム状態を再確認"
+    ),
+    "立即建立可驗證備份": _translations(
+        "立即创建可验证备份",
+        "Create a verifiable backup now",
+        "検証可能なバックアップを今すぐ作成",
+    ),
+    "<b>自然語言工具任務</b>": _translations(
+        "<b>自然语言工具任务</b>",
+        "<b>Natural-language tool task</b>",
+        "<b>自然言語ツールタスク</b>",
+    ),
+    "例如：幫我開啟工作資料夾，然後開啟指定工作網站": _translations(
+        "例如：帮我打开工作文件夹，然后打开指定工作网站",
+        "For example: Open my work folder, then open the specified work website",
+        "例：作業フォルダーを開き、指定した作業サイトを開いて",
+    ),
+    "先產生安全計畫": _translations(
+        "先生成安全计划", "Create a safety plan first", "安全計画を先に作成"
+    ),
+    "資料備份": _translations("数据备份", "Data Backup", "データバックアップ"),
+    "備份失敗：{error}": _translations(
+        "备份失败：{error}",
+        "Backup failed: {error}",
+        "バックアップに失敗しました：{error}",
+    ),
+    "備份與完整性雜湊已建立：\n{target}": _translations(
+        "备份与完整性哈希已创建：\n{target}",
+        "Backup and integrity hash created:\n{target}",
+        "バックアップと整合性ハッシュを作成しました：\n{target}",
+    ),
+    "工具任務": _translations("工具任务", "Tool Task", "ツールタスク"),
+    "這句話沒有明確要求執行操作，因此不會產生工具計畫。": _translations(
+        "这句话没有明确要求执行操作，因此不会生成工具计划。",
+        "This message does not clearly request an action, so no tool plan will be created.",
+        "操作の実行を明確に求めていないため、ツール計画は作成しません。",
+    ),
+    "規劃中…": _translations("规划中…", "Planning…", "計画中…"),
+    "讀取 Gmail 郵件": _translations(
+        "读取 Gmail 邮件", "Read Gmail messages", "Gmail メールを読み取る"
+    ),
+    "讀取最近 {days} 天內最多 {limit} 封 Gmail 郵件": _translations(
+        "读取最近 {days} 天内最多 {limit} 封 Gmail 邮件",
+        "Read up to {limit} Gmail messages from the last {days} days",
+        "過去 {days} 日間の Gmail メールを最大 {limit} 件読み取る",
+    ),
+    "讀取 Google Calendar": _translations(
+        "读取 Google Calendar", "Read Google Calendar", "Google Calendar を読み取る"
+    ),
+    "讀取 Google Calendar 未來 {days} 天行程": _translations(
+        "读取 Google Calendar 未来 {days} 天的日程",
+        "Read Google Calendar events for the next {days} days",
+        "Google Calendar の今後 {days} 日間の予定を読み取る",
+    ),
+    "讀取 Google Drive": _translations(
+        "读取 Google Drive", "Read Google Drive", "Google Drive を読み取る"
+    ),
+    "搜尋 Google Drive 檔案：{name}": _translations(
+        "搜索 Google Drive 文件：{name}",
+        "Search Google Drive files: {name}",
+        "Google Drive のファイルを検索：{name}",
+    ),
+    "列出 Google Drive 最近修改的檔案": _translations(
+        "列出 Google Drive 最近修改的文件",
+        "List recently modified Google Drive files",
+        "Google Drive で最近変更されたファイルを一覧表示",
+    ),
+    "（目前沒有白名單目標）": _translations(
+        "（目前没有白名单目标）",
+        "(No allowlisted targets are configured)",
+        "（許可済み対象はまだありません）",
+    ),
+    "工具計畫": _translations("工具计划", "Tool Plan", "ツール計画"),
+    "計畫驗證失敗：{error}": _translations(
+        "计划验证失败：{error}",
+        "Plan validation failed: {error}",
+        "計画の検証に失敗しました：{error}",
+    ),
+    "資料不足或並非明確操作要求，因此沒有產生任何步驟。": _translations(
+        "信息不足或并非明确的操作要求，因此没有生成任何步骤。",
+        "There was not enough information or no explicit action request, so no steps were created.",
+        "情報が不足しているか操作要求が明確でないため、ステップは作成されませんでした。",
+    ),
+    "執行前計畫預覽": _translations(
+        "执行前计划预览", "Pre-execution Plan Preview", "実行前の計画確認"
+    ),
+    "{title}\n\n{preview}\n\n每一步仍會依個別權限與風險再次判斷。是否繼續？": _translations(
+        "{title}\n\n{preview}\n\n每一步仍会根据各自的权限与风险再次判断。是否继续？",
+        "{title}\n\n{preview}\n\nEach step will still be checked against its own permissions and risk. Continue?",
+        "{title}\n\n{preview}\n\n各ステップは個別の権限とリスクに基づいて再判定されます。続行しますか？",
+    ),
+    "任務結果": _translations("任务结果", "Task Results", "タスク結果"),
+    "無法產生計畫：{error}": _translations(
+        "无法生成计划：{error}",
+        "Could not create a plan: {error}",
+        "計画を作成できませんでした：{error}",
+    ),
+    "工具計畫逾時": _translations(
+        "工具计划超时", "Tool Plan Timed Out", "ツール計画がタイムアウトしました"
+    ),
+    "等待 OpenAI 安全計畫超過 50 秒，已自動停止等待。"
+    "請確認網路、API 金鑰與文字模型後再試一次。": _translations(
+        "等待 OpenAI 安全计划超过 50 秒，已自动停止等待。"
+        "请确认网络、API 密钥与文本模型后再试一次。",
+        "The OpenAI safety plan took longer than 50 seconds, so waiting was stopped. "
+        "Check the network, API key, and text model, then try again.",
+        "OpenAI の安全計画を 50 秒以上待機したため、自動的に待機を停止しました。"
+        "ネットワーク、API キー、テキストモデルを確認して再試行してください。",
+    ),
+    "Home Assistant：{home}\n遠端服務：{remote}\n已啟用工作流程：{workflows}\n"
+    "有效配對裝置：{devices}\n安全狀態：高風險操作不允許免確認；"
+    "任意命令列與付款永久禁止。": _translations(
+        "Home Assistant：{home}\n远程服务：{remote}\n已启用工作流：{workflows}\n"
+        "有效配对设备：{devices}\n安全状态：高风险操作不允许免确认；"
+        "任意命令行与付款永久禁止。",
+        "Home Assistant: {home}\nRemote service: {remote}\nEnabled workflows: {workflows}\n"
+        "Active paired devices: {devices}\nSecurity: high-risk actions always require confirmation; "
+        "arbitrary command lines and payments are permanently blocked.",
+        "Home Assistant：{home}\nリモートサービス：{remote}\n有効なワークフロー：{workflows}\n"
+        "有効なペアリング済み端末：{devices}\nセキュリティ：高リスク操作は必ず確認し、"
+        "任意のコマンドラインと支払いは常に禁止されます。",
+    ),
+    "已啟用": _translations("已启用", "Enabled", "有効"),
+    "未啟用": _translations("未启用", "Disabled", "無効"),
+    "運作中": _translations("运行中", "Running", "稼働中"),
+    "新增工作流程": _translations("新增工作流", "Add workflow", "ワークフローを追加"),
+    "執行選取流程": _translations(
+        "执行选中流程", "Run selected workflow", "選択したワークフローを実行"
+    ),
+    "刪除選取流程": _translations(
+        "删除选中流程", "Delete selected workflow", "選択したワークフローを削除"
+    ),
+    "請先選取一個流程。": _translations(
+        "请先选择一个流程。",
+        "Select a workflow first.",
+        "先にワークフローを選択してください。",
+    ),
+    "預覽工作流程": _translations(
+        "预览工作流", "Preview Workflow", "ワークフローを確認"
+    ),
+    "{title}\n\n{preview}\n\n是否執行？": _translations(
+        "{title}\n\n{preview}\n\n是否执行？",
+        "{title}\n\n{preview}\n\nRun this workflow?",
+        "{title}\n\n{preview}\n\nこのワークフローを実行しますか？",
+    ),
+    "沒有可執行步驟": _translations(
+        "没有可执行步骤", "No executable steps", "実行できるステップはありません"
+    ),
+    "刪除工作流程": _translations(
+        "删除工作流", "Delete Workflow", "ワークフローを削除"
+    ),
+    "確定刪除「{name}」？": _translations(
+        "确定删除“{name}”？", "Delete “{name}”?", "「{name}」を削除しますか？"
+    ),
+    # Cloud connectors.
+    "權杖由作業系統安全加密保存，不寫入資料庫或設定檔。": _translations(
+        "令牌由操作系统安全加密保存，不写入数据库或配置文件。",
+        "Tokens are encrypted by the operating system and are never written to the database or configuration files.",
+        "トークンは OS により安全に暗号化され、データベースや設定ファイルには保存されません。",
+    ),
+    "{platform} 的原生安全金鑰保存尚未完成實機驗證，因此 OAuth 連線暫停；"
+    "墨寒不會改用明文保存。": _translations(
+        "{platform} 的原生安全密钥保存尚未完成真机验证，因此 OAuth 连接暂停；"
+        "墨寒不会改用明文保存。",
+        "Native secure secret storage on {platform} has not yet passed real-device verification, "
+        "so OAuth connections are disabled; MoHan will not fall back to plaintext storage.",
+        "{platform} のネイティブ安全保管は実機検証が未完了のため、OAuth 接続を停止しています。"
+        "墨寒が平文保存へ切り替えることはありません。",
+    ),
+    "Google、Microsoft 與 GitHub 預設停用。連線時使用瀏覽器 OAuth；{note}": _translations(
+        "Google、Microsoft 与 GitHub 默认停用。连接时使用浏览器 OAuth；{note}",
+        "Google, Microsoft, and GitHub are disabled by default. Browser OAuth is used for connections; {note}",
+        "Google、Microsoft、GitHub は既定で無効です。接続にはブラウザー OAuth を使用します。{note}",
+    ),
+    "貼上你在服務商後台建立的 Desktop App Client ID": _translations(
+        "粘贴你在服务商后台创建的 Desktop App Client ID",
+        "Paste the Desktop App Client ID created in the provider console",
+        "サービス管理画面で作成した Desktop App Client ID を貼り付け",
+    ),
+    "若服務商提供 Client Secret 才需填寫": _translations(
+        "仅在服务商提供 Client Secret 时填写",
+        "Enter only if the provider supplies a Client Secret",
+        "サービスから Client Secret が発行された場合のみ入力",
+    ),
+    "開啟瀏覽器安全連線": _translations(
+        "打开浏览器安全连接", "Open secure browser connection", "ブラウザーで安全に接続"
+    ),
+    "測試選取服務": _translations(
+        "测试选中服务", "Test selected service", "選択したサービスをテスト"
+    ),
+    "撤銷選取服務": _translations(
+        "撤销选中服务", "Revoke selected service", "選択したサービスを解除"
+    ),
+    "服務": _translations("服务", "Service", "サービス"),
+    "授權範圍": _translations("授权范围", "OAuth scopes", "認可スコープ"),
+    "狀態": _translations("状态", "Status", "状態"),
+    "已設定服務": _translations(
+        "已配置服务", "Configured services", "設定済みサービス"
+    ),
+    "{platform} 尚無經過實機驗證的安全金鑰保存；OAuth 連線已安全停用。": _translations(
+        "{platform} 尚无通过真机验证的安全密钥保存；OAuth 连接已安全停用。",
+        "{platform} does not yet have real-device-verified secure secret storage; OAuth connections are safely disabled.",
+        "{platform} では安全な秘密情報保管の実機検証が未完了のため、OAuth 接続を安全に無効化しています。",
+    ),
+    "請先填入服務商後台建立的 OAuth Client ID。": _translations(
+        "请先填写服务商后台创建的 OAuth Client ID。",
+        "Enter the OAuth Client ID created in the provider console first.",
+        "サービス管理画面で作成した OAuth Client ID を先に入力してください。",
+    ),
+    "等待瀏覽器授權，請勿關閉墨寒……": _translations(
+        "等待浏览器授权，请勿关闭墨寒……",
+        "Waiting for browser authorization. Do not close MoHan…",
+        "ブラウザーでの認可を待っています。墨寒を閉じないでください…",
+    ),
+    "無法安全保存 OAuth 權杖：{error}": _translations(
+        "无法安全保存 OAuth 令牌：{error}",
+        "Could not securely store the OAuth token: {error}",
+        "OAuth トークンを安全に保存できませんでした：{error}",
+    ),
+    "{provider} 已安全連線": _translations(
+        "{provider} 已安全连接",
+        "{provider} connected securely",
+        "{provider} に安全に接続しました",
+    ),
+    "{provider} 連線失敗：{error}": _translations(
+        "{provider} 连接失败：{error}",
+        "{provider} connection failed: {error}",
+        "{provider} への接続に失敗しました：{error}",
+    ),
+    "測試失敗：{error}": _translations(
+        "测试失败：{error}", "Test failed: {error}", "テストに失敗しました：{error}"
+    ),
+    "測試中…": _translations("测试中…", "Testing…", "テスト中…"),
+    "正在分別檢查 Gmail、Google Calendar 與 Google Drive……": _translations(
+        "正在分别检查 Gmail、Google Calendar 与 Google Drive……",
+        "Checking Gmail, Google Calendar, and Google Drive separately…",
+        "Gmail、Google Calendar、Google Drive を個別に確認しています…",
+    ),
+    "正在檢查選取的服務……": _translations(
+        "正在检查选中的服务……",
+        "Checking the selected service…",
+        "選択したサービスを確認しています…",
+    ),
+    "{name}：{status}（{detail}）": _translations(
+        "{name}：{status}（{detail}）",
+        "{name}: {status} ({detail})",
+        "{name}：{status}（{detail}）",
+    ),
+    "正常": _translations("正常", "Healthy", "正常"),
+    "失敗": _translations("失败", "Failed", "失敗"),
+    "Google 三項服務測試": _translations(
+        "Google 三项服务测试", "Google Three-Service Test", "Google 3 サービスのテスト"
+    ),
+    "雲端服務測試": _translations(
+        "云端服务测试", "Cloud Service Test", "クラウドサービステスト"
+    ),
+    "失敗項目通常代表該 API 尚未啟用、OAuth 範圍不足，或網路暫時無法連線。": _translations(
+        "失败项目通常表示该 API 尚未启用、OAuth 范围不足，或网络暂时无法连接。",
+        "A failed item usually means its API is not enabled, the OAuth scopes are insufficient, or the network is temporarily unavailable.",
+        "失敗した項目は通常、API が未有効、OAuth スコープ不足、または一時的なネットワーク障害を示します。",
+    ),
+    "雲端測試超過 35 秒，已停止等待；請查看個別服務的 API 與網路狀態。": _translations(
+        "云端测试超过 35 秒，已停止等待；请检查各服务的 API 与网络状态。",
+        "The cloud test exceeded 35 seconds and was stopped. Check each service API and the network status.",
+        "クラウドテストが 35 秒を超えたため待機を停止しました。各サービスの API とネットワーク状態を確認してください。",
+    ),
+    "撤銷雲端服務": _translations(
+        "撤销云端服务", "Revoke Cloud Service", "クラウドサービスを解除"
+    ),
+    "確定移除 {provider} 的本機權杖？": _translations(
+        "确定移除 {provider} 的本地令牌？",
+        "Remove the local token for {provider}?",
+        "{provider} のローカルトークンを削除しますか？",
+    ),
+    "本機權杖已移除": _translations(
+        "本地令牌已移除", "Local token removed", "ローカルトークンを削除しました"
+    ),
+    "尚未測試": _translations("尚未测试", "Not tested", "未テスト"),
+    "未設定": _translations("未配置", "Not configured", "未設定"),
+    "已撤銷": _translations("已撤销", "Revoked", "解除済み"),
+    "OAuth 已連線": _translations("OAuth 已连接", "OAuth connected", "OAuth 接続済み"),
+    "尚未完成 OAuth 連線": _translations(
+        "尚未完成 OAuth 连接",
+        "OAuth connection has not been completed",
+        "OAuth 接続が完了していません",
+    ),
+    "無法安全更新 OAuth 權杖：{error}": _translations(
+        "无法安全更新 OAuth 令牌：{error}",
+        "Could not securely update the OAuth token: {error}",
+        "OAuth トークンを安全に更新できませんでした：{error}",
+    ),
+    "OAuth 權杖資料不完整": _translations(
+        "OAuth 令牌数据不完整",
+        "OAuth token data is incomplete",
+        "OAuth トークンのデータが不完全です",
+    ),
+    "Google 與 Microsoft 均已連線，請明確指定要使用哪個帳戶": _translations(
+        "Google 与 Microsoft 均已连接，请明确指定要使用哪个帐户",
+        "Both Google and Microsoft are connected; specify which account to use",
+        "Google と Microsoft の両方に接続されています。使用するアカウントを明示してください",
+    ),
+    "尚未連線 Google 或 Microsoft，或工具計畫未指定供應商": _translations(
+        "尚未连接 Google 或 Microsoft，或工具计划未指定供应商",
+        "Google or Microsoft is not connected, or the tool plan did not specify a provider",
+        "Google または Microsoft に未接続か、ツール計画でプロバイダーが指定されていません",
+    ),
+    "此工具目前只支援 google 或 microsoft": _translations(
+        "此工具目前仅支持 google 或 microsoft",
+        "This tool currently supports only google or microsoft",
+        "このツールは現在 google または microsoft のみ対応しています",
+    ),
+    "全部正常": _translations("全部正常", "All healthy", "すべて正常"),
+    "部分功能異常": _translations(
+        "部分功能异常", "Some features have issues", "一部の機能に問題があります"
+    ),
+    "主要日曆可讀取": _translations(
+        "主要日历可读取",
+        "Primary calendar is readable",
+        "メインカレンダーを読み取れます",
+    ),
+    "雲端硬碟中繼資料可讀取": _translations(
+        "云端硬盘元数据可读取",
+        "Drive metadata is readable",
+        "ドライブのメタデータを読み取れます",
+    ),
+    "Google 帳戶": _translations("Google 帐户", "Google account", "Google アカウント"),
+    "Microsoft 帳戶": _translations(
+        "Microsoft 帐户", "Microsoft account", "Microsoft アカウント"
+    ),
+    "GitHub 帳戶": _translations("GitHub 帐户", "GitHub account", "GitHub アカウント"),
+    # Home Assistant.
+    "啟用 Home Assistant 整合": _translations(
+        "启用 Home Assistant 集成",
+        "Enable Home Assistant integration",
+        "Home Assistant 連携を有効化",
+    ),
+    "例如：http://homeassistant.local:8123": _translations(
+        "例如：http://homeassistant.local:8123",
+        "Example: http://homeassistant.local:8123",
+        "例：http://homeassistant.local:8123",
+    ),
+    "已由作業系統安全保存（留空不變）": _translations(
+        "已由操作系统安全保存（留空不变）",
+        "Securely stored by the operating system (leave blank to keep it)",
+        "OS により安全に保存済み（空欄なら変更なし）",
+    ),
+    "貼上 Home Assistant 長期存取權杖": _translations(
+        "粘贴 Home Assistant 长期访问令牌",
+        "Paste the Home Assistant long-lived access token",
+        "Home Assistant の長期アクセストークンを貼り付け",
+    ),
+    "驗證 HTTPS 憑證": _translations(
+        "验证 HTTPS 证书", "Verify HTTPS certificate", "HTTPS 証明書を検証"
+    ),
+    "保存連線設定": _translations(
+        "保存连接设置", "Save connection settings", "接続設定を保存"
+    ),
+    "測試連線": _translations("测试连接", "Test connection", "接続をテスト"),
+    "讀取裝置": _translations("读取设备", "Load devices", "機器を読み取る"),
+    "Home Assistant 位址": _translations(
+        "Home Assistant 地址", "Home Assistant address", "Home Assistant アドレス"
+    ),
+    "長期存取權杖": _translations(
+        "长期访问令牌", "Long-lived access token", "長期アクセストークン"
+    ),
+    "連線狀態": _translations("连接状态", "Connection status", "接続状態"),
+    "裝置狀態": _translations("设备状态", "Device status", "機器の状態"),
+    "門鎖、警報與加熱設備永遠套用高風險政策。"
+    "墨寒不能因對話內容自行降低安全等級。": _translations(
+        "门锁、警报与加热设备始终应用高风险策略。墨寒不能因对话内容自行降低安全等级。",
+        "Door locks, alarms, and heating devices always use the high-risk policy. "
+        "MoHan cannot lower their security level based on conversation content.",
+        "ドアロック、警報、加熱機器には常に高リスク方針を適用します。"
+        "会話内容を理由に墨寒が安全レベルを下げることはできません。",
+    ),
+    "{platform} 的安全金鑰保存尚未完成實機驗證；Home Assistant 連線暫停，"
+    "且不會儲存明文權杖。": _translations(
+        "{platform} 的安全密钥保存尚未完成真机验证；Home Assistant 连接暂停，"
+        "且不会保存明文令牌。",
+        "Secure secret storage on {platform} has not passed real-device verification; "
+        "Home Assistant is disabled and plaintext tokens will not be stored.",
+        "{platform} の安全な秘密情報保管は実機検証が未完了です。Home Assistant 接続を停止し、"
+        "平文トークンは保存しません。",
+    ),
+    "請先填入連線位址。": _translations(
+        "请先填写连接地址。",
+        "Enter the connection address first.",
+        "接続先アドレスを先に入力してください。",
+    ),
+    "無法安全保存權杖：{error}": _translations(
+        "无法安全保存令牌：{error}",
+        "Could not securely store the token: {error}",
+        "トークンを安全に保存できませんでした：{error}",
+    ),
+    "設定已保存": _translations("设置已保存", "Settings saved", "設定を保存しました"),
+    "Home Assistant 尚未啟用": _translations(
+        "Home Assistant 尚未启用",
+        "Home Assistant is not enabled",
+        "Home Assistant は有効ではありません",
+    ),
+    "尚未保存 Home Assistant 權杖": _translations(
+        "尚未保存 Home Assistant 令牌",
+        "No Home Assistant token has been saved",
+        "Home Assistant トークンが保存されていません",
+    ),
+    "連線失敗：{error}": _translations(
+        "连接失败：{error}", "Connection failed: {error}", "接続に失敗しました：{error}"
+    ),
+    "連線正常": _translations("连接正常", "Connection healthy", "接続は正常です"),
+    "API 回應不正確": _translations(
+        "API 响应不正确", "Unexpected API response", "API 応答が正しくありません"
+    ),
+    "讀取失敗：{error}": _translations(
+        "读取失败：{error}", "Read failed: {error}", "読み取りに失敗しました：{error}"
+    ),
+    "未發現離線或低電量裝置": _translations(
+        "未发现离线或低电量设备",
+        "No offline or low-battery devices found",
+        "オフラインまたは低バッテリーの機器はありません",
+    ),
+    "已讀取 {count} 個可用項目。{issues}": _translations(
+        "已读取 {count} 个可用项目。{issues}",
+        "Loaded {count} available items. {issues}",
+        "利用可能な項目を {count} 件読み取りました。{issues}",
+    ),
+    "{name} 目前{state}": _translations(
+        "{name} 目前{state}",
+        "{name} is currently {state}",
+        "{name} の現在の状態：{state}",
+    ),
+    "{name} 電量只剩 {value}": _translations(
+        "{name} 电量仅剩 {value}",
+        "{name} has only {value} battery remaining",
+        "{name} のバッテリー残量は {value} です",
+    ),
+    # Remote access and camera privacy.
+    "增加連線埠": _translations("增加端口", "Increase port", "ポート番号を増やす"),
+    "減少連線埠": _translations("减少端口", "Decrease port", "ポート番号を減らす"),
+    "啟用手機／私人網路遠端服務": _translations(
+        "启用手机／私人网络远程服务",
+        "Enable phone/private-network remote service",
+        "スマートフォン／プライベートネットワークのリモート機能を有効化",
+    ),
+    "僅本機測試（127.0.0.1）": _translations(
+        "仅本机测试（127.0.0.1）",
+        "Local testing only (127.0.0.1)",
+        "ローカルテストのみ（127.0.0.1）",
+    ),
+    "私人網路／Tailscale（0.0.0.0）": _translations(
+        "私人网络／Tailscale（0.0.0.0）",
+        "Private network / Tailscale (0.0.0.0)",
+        "プライベートネットワーク／Tailscale（0.0.0.0）",
+    ),
+    "我確認已使用 Tailscale、Home Assistant Cloud 或其他加密私人網路": _translations(
+        "我确认已使用 Tailscale、Home Assistant Cloud 或其他加密私人网络",
+        "I confirm that I use Tailscale, Home Assistant Cloud, or another encrypted private network",
+        "Tailscale、Home Assistant Cloud、または別の暗号化プライベートネットワークを使用していることを確認します",
+    ),
+    "允許傳送文字指令": _translations(
+        "允许发送文本指令", "Allow text commands", "テキスト指示を許可"
+    ),
+    "允許查看墨寒程式視窗（不擷取整個桌面）": _translations(
+        "允许查看墨寒程序窗口（不截取整个桌面）",
+        "Allow viewing the MoHan app window (not the whole desktop)",
+        "墨寒のアプリ画面の表示を許可（デスクトップ全体は取得しません）",
+    ),
+    "允許下載白名單內的非敏感檔案": _translations(
+        "允许下载白名单内的非敏感文件",
+        "Allow downloads of non-sensitive allowlisted files",
+        "許可済みの非機密ファイルのダウンロードを許可",
+    ),
+    "允許本機攝影機在場偵測": _translations(
+        "允许本机摄像头在场检测",
+        "Allow local camera presence detection",
+        "ローカルカメラでの在席検知を許可",
+    ),
+    "本機臉部身分辨識（需另裝可稽核的辨識外掛）": _translations(
+        "本机人脸身份识别（需另装可审计的识别插件）",
+        "Local face identification (requires a separately installed, auditable recognition plugin)",
+        "ローカル顔識別（監査可能な認識プラグインの追加導入が必要）",
+    ),
+    "攝影機已關閉": _translations("摄像头已关闭", "Camera is off", "カメラはオフです"),
+    "遠端功能預設關閉": _translations(
+        "远程功能默认关闭",
+        "Remote features are off by default",
+        "リモート機能は既定でオフです",
+    ),
+    "啟動／套用": _translations("启动／应用", "Start / Apply", "起動／適用"),
+    "停止遠端服務": _translations(
+        "停止远程服务", "Stop remote service", "リモートサービスを停止"
+    ),
+    "配對新手機": _translations(
+        "配对新手机", "Pair a new phone", "新しいスマートフォンをペアリング"
+    ),
+    "套用攝影機隱私設定": _translations(
+        "应用摄像头隐私设置",
+        "Apply camera privacy settings",
+        "カメラのプライバシー設定を適用",
+    ),
+    "撤銷選取裝置": _translations(
+        "撤销选中设备", "Revoke selected device", "選択した端末を解除"
+    ),
+    "監聽範圍": _translations("监听范围", "Listening scope", "待受範囲"),
+    "連線埠": _translations("端口", "Port", "ポート"),
+    "<b>攝影機與身分辨識</b>": _translations(
+        "<b>摄像头与身份识别</b>", "<b>Camera & Identity</b>", "<b>カメラと本人識別</b>"
+    ),
+    "攝影機狀態": _translations("摄像头状态", "Camera status", "カメラの状態"),
+    "攝影機預設關閉；啟用時必須顯示狀態。畫面不會默默上傳，"
+    "也不會辨識未登錄的陌生人。": _translations(
+        "摄像头默认关闭；启用时必须显示状态。画面不会静默上传，"
+        "也不会识别未登记的陌生人。",
+        "The camera is off by default and its status must remain visible when enabled. "
+        "Images are never silently uploaded, and unregistered people are not identified.",
+        "カメラは既定でオフです。有効時は状態を常に表示します。映像を無断でアップロードせず、"
+        "未登録の人物を識別しません。",
+    ),
+    "服務狀態": _translations("服务状态", "Service status", "サービス状態"),
+    "已配對裝置": _translations("已配对设备", "Paired devices", "ペアリング済み端末"),
+    "攝影機權限": _translations("摄像头权限", "Camera Permission", "カメラ権限"),
+    "安全政策已阻擋：{reason}": _translations(
+        "安全策略已阻止：{reason}",
+        "Blocked by security policy: {reason}",
+        "セキュリティ方針によりブロックされました：{reason}",
+    ),
+    "啟用攝影機": _translations("启用摄像头", "Enable Camera", "カメラを有効化"),
+    "墨寒只會在本機分析粗略移動與明暗，不保存影像、"
+    "不傳送雲端，也不辨識陌生人。是否啟用？": _translations(
+        "墨寒只会在本机分析粗略移动与明暗，不保存图像、"
+        "不传送云端，也不识别陌生人。是否启用？",
+        "MoHan will analyze only coarse movement and brightness locally. Images are not saved, "
+        "sent to the cloud, or used to identify strangers. Enable the camera?",
+        "墨寒は端末内で大まかな動きと明暗のみを分析します。映像の保存やクラウド送信、"
+        "見知らぬ人の識別は行いません。カメラを有効にしますか？",
+    ),
+    "攝影機啟動失敗：{error}": _translations(
+        "摄像头启动失败：{error}",
+        "Could not start the camera: {error}",
+        "カメラを起動できませんでした：{error}",
+    ),
+    "攝影機錯誤：{error}": _translations(
+        "摄像头错误：{error}", "Camera error: {error}", "カメラエラー：{error}"
+    ),
+    "攝影機使用中：{device}（僅本機在場偵測）": _translations(
+        "摄像头使用中：{device}（仅本机在场检测）",
+        "Camera active: {device} (local presence detection only)",
+        "カメラ使用中：{device}（ローカル在席検知のみ）",
+    ),
+    "{base}｜偵測到有人在場": _translations(
+        "{base}｜检测到有人在场", "{base} | Presence detected", "{base}｜在席を検知"
+    ),
+    "{base}｜暫未偵測到在場": _translations(
+        "{base}｜暂未检测到在场",
+        "{base} | No presence detected",
+        "{base}｜現在は在席を検知していません",
+    ),
+    "遠端服務未啟用": _translations(
+        "远程服务未启用", "Remote service is not enabled", "リモートサービスは無効です"
+    ),
+    "啟動失敗：{error}": _translations(
+        "启动失败：{error}", "Start failed: {error}", "起動に失敗しました：{error}"
+    ),
+    "已啟動：http://{host}:{port}\n只有已配對且具備相應權限的裝置可以存取。": _translations(
+        "已启动：http://{host}:{port}\n只有已配对且具备相应权限的设备可以访问。",
+        "Started: http://{host}:{port}\nOnly paired devices with the required permissions can connect.",
+        "起動しました：http://{host}:{port}\n必要な権限を持つペアリング済み端末のみ接続できます。",
+    ),
+    "遠端服務已停止，既有權杖未刪除但無法連線。": _translations(
+        "远程服务已停止，现有令牌未删除但无法连接。",
+        "Remote service stopped. Existing tokens were not deleted, but cannot connect.",
+        "リモートサービスを停止しました。既存トークンは削除されていませんが、接続できません。",
+    ),
+    "配對新裝置": _translations(
+        "配对新设备", "Pair New Device", "新しい端末をペアリング"
+    ),
+    "裝置名稱": _translations("设备名称", "Device name", "端末名"),
+    "一次性配對權杖": _translations(
+        "一次性配对令牌", "One-time Pairing Token", "一回限りのペアリングトークン"
+    ),
+    "請只在可信任裝置輸入下列權杖。關閉視窗後不會再次顯示：\n\n{token}": _translations(
+        "请只在可信任设备输入下列令牌。关闭窗口后不会再次显示：\n\n{token}",
+        "Enter the following token only on a trusted device. It will not be shown again after this window closes:\n\n{token}",
+        "次のトークンは信頼できる端末にのみ入力してください。この画面を閉じると再表示できません：\n\n{token}",
+    ),
+    "有效": _translations("有效", "Active", "有効"),
+    "從未": _translations("从未", "Never", "なし"),
+    "{status}｜{device}｜最後連線：{last_seen}": _translations(
+        "{status}｜{device}｜最后连接：{last_seen}",
+        "{status} | {device} | Last connection: {last_seen}",
+        "{status}｜{device}｜最終接続：{last_seen}",
+    ),
+    "已送交墨寒並等待本機權限判斷": _translations(
+        "已提交给墨寒并等待本机权限判断",
+        "Sent to MoHan and awaiting local permission checks",
+        "墨寒へ送信し、ローカル権限の判定を待っています",
+    ),
+    "[遠端裝置：{device}] {text}": _translations(
+        "[远程设备：{device}] {text}",
+        "[Remote device: {device}] {text}",
+        "[リモート端末：{device}] {text}",
+    ),
+    "尚無可用的程式視窗畫面": _translations(
+        "尚无可用的程序窗口画面",
+        "No app-window image is available",
+        "利用可能なアプリ画面がありません",
+    ),
+    # Security and auditing.
+    "<b>允許操作的資料夾與程式</b>": _translations(
+        "<b>允许操作的文件夹与程序</b>",
+        "<b>Allowed folders and apps</b>",
+        "<b>操作を許可するフォルダーとアプリ</b>",
+    ),
+    "加入資料夾": _translations("添加文件夹", "Add folder", "フォルダーを追加"),
+    "加入程式": _translations("添加程序", "Add app", "アプリを追加"),
+    "加入網站": _translations("添加网站", "Add website", "Web サイトを追加"),
+    "移除選取項目": _translations(
+        "移除选中项目", "Remove selected item", "選択項目を削除"
+    ),
+    "<b>能力權限</b>": _translations(
+        "<b>能力权限</b>", "<b>Capability permissions</b>", "<b>機能権限</b>"
+    ),
+    "{label}（{risk}）": _translations(
+        "{label}（{risk}）", "{label} ({risk})", "{label}（{risk}）"
+    ),
+    "即使選擇允許，高風險政策仍會要求確認。": _translations(
+        "即使选择允许，高风险策略仍会要求确认。",
+        "High-risk policy still requires confirmation even when Allow is selected.",
+        "「許可」を選択しても、高リスク方針により確認が必要です。",
+    ),
+    "保存安全權限": _translations(
+        "保存安全权限", "Save security permissions", "セキュリティ権限を保存"
+    ),
+    "付款、購買、密碼匯出、停用安全防護、任意 PowerShell／管理員命令"
+    "永遠禁止自動執行，無法由此頁解除。": _translations(
+        "付款、购买、密码导出、停用安全防护、任意 PowerShell／管理员命令"
+        "始终禁止自动执行，无法在此页面解除。",
+        "Payments, purchases, password exports, disabling safeguards, arbitrary PowerShell, "
+        "and administrator commands can never run automatically and cannot be enabled here.",
+        "支払い、購入、パスワードの書き出し、安全保護の無効化、任意の PowerShell／管理者コマンドは"
+        "常に自動実行禁止で、この画面から解除できません。",
+    ),
+    "選擇允許墨寒操作的資料夾": _translations(
+        "选择允许墨寒操作的文件夹",
+        "Choose a folder MoHan may access",
+        "墨寒に操作を許可するフォルダーを選択",
+    ),
+    "資料夾權限": _translations("文件夹权限", "Folder Permission", "フォルダー権限"),
+    "輸入 read（只讀）或 write（可建立、移動與重新命名）": _translations(
+        "输入 read（只读）或 write（可创建、移动与重命名）",
+        "Enter read (read only) or write (create, move, and rename)",
+        "read（読み取り専用）または write（作成・移動・名前変更可）を入力",
+    ),
+    "選擇允許墨寒啟動的程式": _translations(
+        "选择允许墨寒启动的程序",
+        "Choose an app MoHan may launch",
+        "墨寒に起動を許可するアプリを選択",
+    ),
+    "Windows 程式 (*.exe);;所有檔案 (*)": _translations(
+        "Windows 程序 (*.exe);;所有文件 (*)",
+        "Windows apps (*.exe);;All files (*)",
+        "Windows アプリ (*.exe);;すべてのファイル (*)",
+    ),
+    "應用程式／可執行檔 (*);;所有檔案 (*)": _translations(
+        "应用程序／可执行文件 (*);;所有文件 (*)",
+        "Apps / executables (*);;All files (*)",
+        "アプリ／実行ファイル (*);;すべてのファイル (*)",
+    ),
+    "程式別名": _translations("程序别名", "App Alias", "アプリの別名"),
+    "日後對墨寒說的程式名稱": _translations(
+        "日后对墨寒说的程序名称",
+        "The app name you will use when speaking to MoHan",
+        "今後、墨寒に伝えるアプリ名",
+    ),
+    "加入允許網站": _translations(
+        "添加允许网站", "Add Allowed Website", "許可する Web サイトを追加"
+    ),
+    "輸入完整 HTTPS 網址（可限制到指定路徑）": _translations(
+        "输入完整 HTTPS 地址（可限制到指定路径）",
+        "Enter a complete HTTPS URL (optionally restricted to a path)",
+        "完全な HTTPS URL を入力（特定パスに制限可能）",
+    ),
+    "網站白名單": _translations(
+        "网站白名单", "Website Allowlist", "Web サイト許可リスト"
+    ),
+    "公開網站只接受完整 HTTPS 網址。": _translations(
+        "公开网站仅接受完整 HTTPS 地址。",
+        "Public websites require a complete HTTPS URL.",
+        "公開 Web サイトには完全な HTTPS URL のみ使用できます。",
+    ),
+    "移除允許項目": _translations(
+        "移除允许项目", "Remove Allowed Item", "許可項目を削除"
+    ),
+    "確定撤銷墨寒對此項目的存取權？": _translations(
+        "确定撤销墨寒对此项目的访问权？",
+        "Revoke MoHan's access to this item?",
+        "この項目に対する墨寒のアクセス権を取り消しますか？",
+    ),
+    "安全權限已保存。妾會守住這條界線。": _translations(
+        "安全权限已保存。妾会守住这条界线。",
+        "Security permissions saved. I will hold this boundary.",
+        "セキュリティ権限を保存しました。妾がこの境界を守ります。",
+    ),
+    "重新整理": _translations("刷新", "Refresh", "更新"),
+    "<p>尚無工具操作紀錄。</p>": _translations(
+        "<p>尚无工具操作记录。</p>",
+        "<p>No tool activity has been recorded.</p>",
+        "<p>ツール操作の記録はまだありません。</p>",
+    ),
+    "高風險操作二次確認": _translations(
+        "高风险操作二次确认",
+        "Second Confirmation for High-Risk Action",
+        "高リスク操作の再確認",
+    ),
+    "墨寒請求執行工具": _translations(
+        "墨寒请求执行工具",
+        "MoHan Requests Tool Execution",
+        "墨寒がツール実行を要求しています",
+    ),
+    "風險：{risk}\n來源：{source}\n操作：{description}\n\n參數預覽：\n{detail}\n\n是否允許？": _translations(
+        "风险：{risk}\n来源：{source}\n操作：{description}\n\n参数预览：\n{detail}\n\n是否允许？",
+        "Risk: {risk}\nSource: {source}\nAction: {description}\n\nArgument preview:\n{detail}\n\nAllow this action?",
+        "リスク：{risk}\n送信元：{source}\n操作：{description}\n\n引数の確認：\n{detail}\n\n許可しますか？",
+    ),
+    "已停手。所有工具與遠端連線均已中止。": _translations(
+        "已停止。所有工具与远程连接均已中止。",
+        "Stopped. All tools and remote connections have been terminated.",
+        "停止しました。すべてのツールとリモート接続を終了しました。",
+    ),
+    "緊急停止": _translations("紧急停止", "Emergency Stop", "緊急停止"),
+    "所有進行中的工具任務與遠端服務均已停止。": _translations(
+        "所有进行中的工具任务与远程服务均已停止。",
+        "All active tool tasks and remote services have been stopped.",
+        "実行中のすべてのツールタスクとリモートサービスを停止しました。",
+    ),
+    # Results generated in this module.
+    "已整理目前工作狀態": _translations(
+        "已整理当前工作状态",
+        "Current work status summarized",
+        "現在の作業状態を整理しました",
+    ),
+    "已讀取剪貼簿文字": _translations(
+        "已读取剪贴板文本",
+        "Clipboard text read",
+        "クリップボードのテキストを読み取りました",
+    ),
+    "已寫入剪貼簿": _translations(
+        "已写入剪贴板", "Written to the clipboard", "クリップボードに書き込みました"
+    ),
+    "剪貼簿文字不可超過 100,000 字": _translations(
+        "剪贴板文本不可超过 100,000 字",
+        "Clipboard text cannot exceed 100,000 characters",
+        "クリップボードのテキストは 100,000 文字を超えられません",
+    ),
+    "已讀取 {count} 封郵件摘要": _translations(
+        "已读取 {count} 封邮件摘要",
+        "Read {count} email summaries",
+        "メールの概要を {count} 件読み取りました",
+    ),
+    "收件者、主旨與內容不可留空": _translations(
+        "收件人、主题与内容不可留空",
+        "Recipient, subject, and body are required",
+        "宛先、件名、本文は必須です",
+    ),
+    "Gmail 未傳回草稿 ID": _translations(
+        "Gmail 未返回草稿 ID",
+        "Gmail did not return a draft ID",
+        "Gmail から下書き ID が返されませんでした",
+    ),
+    "郵件已寄給 {recipient}": _translations(
+        "邮件已发送给 {recipient}",
+        "Email sent to {recipient}",
+        "{recipient} にメールを送信しました",
+    ),
+    "已讀取 {count} 個行程": _translations(
+        "已读取 {count} 个日程",
+        "Read {count} calendar events",
+        "予定を {count} 件読み取りました",
+    ),
+    "行程標題、開始與結束時間不可留空": _translations(
+        "日程标题、开始与结束时间不可留空",
+        "Event title, start time, and end time are required",
+        "予定のタイトル、開始時刻、終了時刻は必須です",
+    ),
+    "結束時間必須晚於開始時間": _translations(
+        "结束时间必须晚于开始时间",
+        "The end time must be later than the start time",
+        "終了時刻は開始時刻より後にしてください",
+    ),
+    "已建立行程：{title}": _translations(
+        "已创建日程：{title}",
+        "Calendar event created: {title}",
+        "予定を作成しました：{title}",
+    ),
+    "搜尋 OneDrive 時請提供檔案名稱": _translations(
+        "搜索 OneDrive 时请提供文件名",
+        "Provide a file name when searching OneDrive",
+        "OneDrive を検索する際はファイル名を指定してください",
+    ),
+    "找到 {count} 個符合的雲端檔案": _translations(
+        "找到 {count} 个匹配的云端文件",
+        "Found {count} matching cloud files",
+        "一致するクラウドファイルが {count} 件見つかりました",
+    ),
+    "只能上傳白名單內的單一檔案": _translations(
+        "只能上传白名单内的单个文件",
+        "Only one allowlisted file can be uploaded",
+        "許可リスト内の単一ファイルのみアップロードできます",
+    ),
+    "已上傳：{name}": _translations(
+        "已上传：{name}", "Uploaded: {name}", "アップロードしました：{name}"
+    ),
+    # Known messages emitted by domain services and displayed by this UI.
+    "任務已由使用者取消": _translations(
+        "任务已由用户取消",
+        "Task cancelled by the user",
+        "ユーザーがタスクをキャンセルしました",
+    ),
+    "重複請求已安全略過": _translations(
+        "重复请求已安全跳过",
+        "Duplicate request safely skipped",
+        "重複した要求を安全にスキップしました",
+    ),
+    "使用者未授權執行": _translations(
+        "用户未授权执行",
+        "Execution was not authorized by the user",
+        "ユーザーが実行を許可しませんでした",
+    ),
+    "尚未安裝此工具的執行器": _translations(
+        "尚未安装此工具的执行器",
+        "No executor is installed for this tool",
+        "このツールの実行機能はインストールされていません",
+    ),
+    "工具回報完成，但結果驗證未通過": _translations(
+        "工具报告完成，但结果验证未通过",
+        "The tool reported completion, but result verification failed",
+        "ツールは完了を報告しましたが、結果検証に失敗しました",
+    ),
+    "已開啟網站": _translations(
+        "已打开网站", "Website opened", "Web サイトを開きました"
+    ),
+    "已開啟資料夾：{value}": _translations(
+        "已打开文件夹：{value}",
+        "Folder opened: {value}",
+        "フォルダーを開きました：{value}",
+    ),
+    "已啟動：{value}": _translations(
+        "已启动：{value}", "Launched: {value}", "起動しました：{value}"
+    ),
+    "已建立檔案：{value}": _translations(
+        "已创建文件：{value}",
+        "File created: {value}",
+        "ファイルを作成しました：{value}",
+    ),
+    "找到 {count} 個符合項目": _translations(
+        "找到 {count} 个匹配项目",
+        "Found {count} matching items",
+        "一致する項目が {count} 件見つかりました",
+    ),
+    "已移動至：{value}": _translations(
+        "已移动至：{value}", "Moved to: {value}", "移動先：{value}"
+    ),
+    "目前有 {count} 個可見視窗": _translations(
+        "目前有 {count} 个可见窗口",
+        "There are {count} visible windows",
+        "表示中のウィンドウは {count} 個です",
+    ),
+    "已切換至：{value}": _translations(
+        "已切换至：{value}", "Switched to: {value}", "切り替え先：{value}"
+    ),
+    "已執行 {value}": _translations(
+        "已执行 {value}", "Executed {value}", "{value} を実行しました"
+    ),
+    "工具執行失敗：{detail}": _translations(
+        "工具执行失败：{detail}",
+        "Tool execution failed: {detail}",
+        "ツール実行に失敗しました：{detail}",
+    ),
+    # Policy reasons are internal canonical values translated only at display time.
+    "此能力永不允許自動執行": _translations(
+        "此能力永不允许自动执行",
+        "This capability can never run automatically",
+        "この機能は自動実行できません",
+    ),
+    "未知的指令來源": _translations(
+        "未知的指令来源", "Unknown command source", "指示の送信元が不明です"
+    ),
+    "目標位於受保護路徑": _translations(
+        "目标位于受保护路径",
+        "The target is in a protected path",
+        "対象は保護されたパスにあります",
+    ),
+    "權限設定為禁止": _translations(
+        "权限设置为禁止",
+        "Permission is set to Blocked",
+        "権限が「禁止」に設定されています",
+    ),
+    "通過本機權限政策": _translations(
+        "通过本机权限策略",
+        "Passed the local permission policy",
+        "ローカル権限方針を通過しました",
+    ),
+})
+
+
+_SYSTEM_PATTERNS = (
+    (r"^安全政策已阻擋：(?P<reason>.*)$", "安全政策已阻擋：{reason}"),
+    (r"^工具執行失敗：(?P<detail>.*)$", "工具執行失敗：{detail}"),
+    (r"^已開啟資料夾：(?P<value>.*)$", "已開啟資料夾：{value}"),
+    (r"^已啟動：(?P<value>.*)$", "已啟動：{value}"),
+    (r"^已建立檔案：(?P<value>.*)$", "已建立檔案：{value}"),
+    (r"^找到 (?P<count>\d+) 個符合項目$", "找到 {count} 個符合項目"),
+    (r"^已移動至：(?P<value>.*)$", "已移動至：{value}"),
+    (r"^目前有 (?P<count>\d+) 個可見視窗$", "目前有 {count} 個可見視窗"),
+    (r"^已切換至：(?P<value>.*)$", "已切換至：{value}"),
+    (r"^已執行 (?P<value>.*)$", "已執行 {value}"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FlagshipTranslator:
+    """Strict, centralized localization boundary for the flagship UI."""
+
+    language: str = "zh-TW"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "language",
+            canonical_ui_language(self.language),
+        )
+
+    def text(self, source: str, /, **values: Any) -> str:
+        template = source
+        if self.language != "zh-TW":
+            try:
+                template = FLAGSHIP_TRANSLATIONS[source][
+                    _TRANSLATION_INDEX[self.language]
+                ]
+            except KeyError as exc:
+                raise KeyError(
+                    f"Missing flagship translation for {source!r} in {self.language}"
+                ) from exc
+        return template.format_map(values) if values else template
+
+    def system_message(self, message: str) -> str:
+        """Translate known system prose while preserving data and error detail."""
+        value = str(message)
+        if self.language == "zh-TW":
+            return value
+        if value in FLAGSHIP_TRANSLATIONS:
+            return self.text(value)
+        for pattern, source in _SYSTEM_PATTERNS:
+            match = re.fullmatch(pattern, value)
+            if match is None:
+                continue
+            fields = match.groupdict()
+            if "reason" in fields:
+                fields["reason"] = self.system_message(fields["reason"])
+            return self.text(source, **fields)
+        return value
+
+    def home_issue(self, message: str) -> str:
+        value = str(message)
+        if self.language == "zh-TW":
+            return value
+        if " 電量只剩 " in value:
+            name, remaining = value.rsplit(" 電量只剩 ", 1)
+            return self.text(
+                "{name} 電量只剩 {value}",
+                name=name,
+                value=remaining,
+            )
+        if " 目前" in value:
+            name, state = value.rsplit(" 目前", 1)
+            return self.text("{name} 目前{state}", name=name, state=state)
+        return value
+
+
+def validate_flagship_translations() -> None:
+    """Fail fast when any catalog row is incomplete or blank."""
+    for source, translations in FLAGSHIP_TRANSLATIONS.items():
+        if not source or len(translations) != len(_TRANSLATION_INDEX):
+            raise ValueError(f"Invalid flagship translation row: {source!r}")
+        if any(not value.strip() for value in translations):
+            raise ValueError(f"Blank flagship translation: {source!r}")
+
+
+validate_flagship_translations()

--- a/home_assistant.py
+++ b/home_assistant.py
@@ -9,6 +9,7 @@ lazy from urllib.parse import urlparse
 lazy from urllib.request import Request, urlopen
 
 lazy from flagship_core import ActionRequest, ActionResult
+lazy from safe_error import sanitize_error
 
 HIGH_RISK_DOMAINS = frozenset({"lock", "alarm_control_panel"})
 HEAT_DOMAINS = frozenset({"climate", "water_heater"})
@@ -40,6 +41,16 @@ class HomeAssistantConfig:
 
 class HomeAssistantError(RuntimeError):
     pass
+
+
+def _sanitized_external_error(
+    error: BaseException | str,
+    *,
+    http_status: int | None = None,
+) -> str:
+    """Discard remote detail before an error crosses the service boundary."""
+    safe_input = UnicodeError() if isinstance(error, json.JSONDecodeError) else error
+    return str(sanitize_error(safe_input, http_status=http_status))
 
 
 class HomeAssistantClient:
@@ -76,24 +87,25 @@ class HomeAssistantClient:
         path: str,
         payload: dict[str, Any] | None = None,
     ) -> Any:
-        data = (
-            json.dumps(payload).encode("utf-8")
-            if payload is not None
-            else None
-        )
-        request = Request(
-            f"{self.base_url}{path}",
-            data=data,
-            method=method,
-            headers={
-                "Authorization": f"Bearer {self.config.token}",
-                "Content-Type": "application/json",
-            },
-        )
-        context = None
-        if not self.config.verify_tls:
-            context = ssl._create_unverified_context()
+        request_failure: str | None = None
         try:
+            data = (
+                json.dumps(payload).encode("utf-8")
+                if payload is not None
+                else None
+            )
+            request = Request(
+                f"{self.base_url}{path}",
+                data=data,
+                method=method,
+                headers={
+                    "Authorization": f"Bearer {self.config.token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            context = None
+            if not self.config.verify_tls:
+                context = ssl._create_unverified_context()
             with urlopen(
                 request,
                 timeout=self.config.timeout_seconds,
@@ -101,13 +113,15 @@ class HomeAssistantClient:
             ) as response:
                 raw = response.read()
                 return json.loads(raw.decode("utf-8")) if raw else None
-        except HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")[:500]
-            raise HomeAssistantError(
-                f"Home Assistant HTTP {exc.code}: {detail}"
-            ) from exc
-        except URLError as exc:
-            raise HomeAssistantError(f"無法連線 Home Assistant：{exc.reason}") from exc
+        except (
+            HTTPError,
+            URLError,
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            request_failure = _sanitized_external_error(exc)
+        raise HomeAssistantError(request_failure)
 
     def health(self) -> bool:
         response = self._request("GET", "/api/")

--- a/installer/LOCALIZATION.md
+++ b/installer/LOCALIZATION.md
@@ -15,7 +15,7 @@ Inno Setup EXE 是一般互動式安裝器。它會偵測 Windows 使用者語�
 
 選定語言只影響安裝器與解除安裝器介面。墨寒本身的首次啟動精靈仍是應用程式 UI 語言的權威來源。
 
-EXE 與 MSI 捷徑必須指向安裝完成後的執行檔，並使用安裝目錄內的 `assets/mohan-halfbody.ico`，不得保留建置機器或 GitHub runner 的絕對路徑。兩種捷徑與執行中視窗都使用 `FlamebladeStudio.MoHanDesktopAssistant` 工作列身分。Windows CI 必須讀回 EXE 捷徑的目標與圖示位置，並在解除安裝後確認捷徑已移除。
+EXE 與 MSI 捷徑必須指向安裝完成後的執行檔，並使用該執行檔內嵌的墨寒半身圖示，不得保留建置機器或 GitHub runner 的絕對路徑。兩種捷徑與執行中視窗都使用 `FlamebladeStudio.MoHanDesktopAssistant` 工作列身分。Windows CI 必須讀回兩種捷徑的目標與圖示位置，並在解除安裝後確認捷徑已移除。
 
 ### MSI 封裝
 
@@ -53,7 +53,7 @@ Inno Setup EXE 是常规交互式安装程序。它会检测 Windows 用户语�
 
 所选语言只影响安装程序与卸载程序界面。墨寒本身的首次运行向导仍是应用程序 UI 语言的权威来源。
 
-EXE 与 MSI 快捷方式必须指向安装完成后的可执行文件，并使用安装目录内的 `assets/mohan-halfbody.ico`，不得保留构建计算机或 GitHub runner 的绝对路径。两种快捷方式与运行中的窗口都使用 `FlamebladeStudio.MoHanDesktopAssistant` 任务栏身份。Windows CI 必须读回 EXE 快捷方式的目标与图标位置，并在卸载后确认快捷方式已删除。
+EXE 与 MSI 快捷方式必须指向安装完成后的可执行文件，并使用该可执行文件内嵌的墨寒半身图标，不得保留构建计算机或 GitHub runner 的绝对路径。两种快捷方式与运行中的窗口都使用 `FlamebladeStudio.MoHanDesktopAssistant` 任务栏身份。Windows CI 必须读回两种快捷方式的目标与图标位置，并在卸载后确认快捷方式已删除。
 
 ### MSI 封装
 
@@ -91,7 +91,7 @@ The Inno Setup EXE is the normal interactive installer. It detects the Windows u
 
 The selected language affects only the installer and uninstaller interface. MoHan's own first-run wizard remains the authority for the application UI language.
 
-EXE and MSI shortcuts must target the installed executable and use `assets/mohan-halfbody.ico` from the installation directory; they must never retain an absolute build-machine or GitHub runner path. Both shortcut formats and the running window use the `FlamebladeStudio.MoHanDesktopAssistant` taskbar identity. Windows CI must read back the EXE shortcut target and icon location and confirm that uninstall removes the shortcut.
+EXE and MSI shortcuts must target the installed executable and use the MoHan half-body icon embedded in that executable; they must never retain an absolute build-machine or GitHub runner path. Both shortcut formats and the running window use the `FlamebladeStudio.MoHanDesktopAssistant` taskbar identity. Windows CI must read back both shortcut targets and icon locations and confirm that uninstall removes each shortcut.
 
 ### MSI package
 
@@ -129,7 +129,7 @@ Inno Setup EXE は通常の対話式インストーラーです。Windows のユ
 
 選択した言語が影響するのは、インストーラーとアンインストーラーの画面だけです。アプリケーション UI 言語の正式な決定元は、引き続き墨寒本体の初回起動ウィザードです。
 
-EXE と MSI のショートカットは、インストール済み実行ファイルを参照し、インストール先の `assets/mohan-halfbody.ico` を使用しなければなりません。ビルドマシンや GitHub runner の絶対パスを残してはなりません。両形式のショートカットと実行中ウィンドウは、`FlamebladeStudio.MoHanDesktopAssistant` のタスクバー ID を共有します。Windows CI は EXE ショートカットのリンク先とアイコン位置を読み戻し、アンインストール後にショートカットが削除されたことを確認します。
+EXE と MSI のショートカットは、インストール済み実行ファイルを参照し、その実行ファイルに埋め込まれた墨寒半身アイコンを使用しなければなりません。ビルドマシンや GitHub runner の絶対パスを残してはなりません。両形式のショートカットと実行中ウィンドウは、`FlamebladeStudio.MoHanDesktopAssistant` のタスクバー ID を共有します。Windows CI は両形式のショートカットのリンク先とアイコン位置を読み戻し、アンインストール後に各ショートカットが削除されたことを確認します。
 
 ### MSI パッケージ
 

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -45,9 +45,7 @@
         <Shortcut Id="ApplicationStartMenuShortcut"
                   Name="MoHan Desktop Assistant"
                   Target="[INSTALLFOLDER]$(var.ExecutableName)"
-                  WorkingDirectory="INSTALLFOLDER"
-                  Icon="MohanIcon"
-                  IconIndex="0">
+                  WorkingDirectory="INSTALLFOLDER">
           <ShortcutProperty Key="System.AppUserModel.ID"
                             Value="FlamebladeStudio.MoHanDesktopAssistant" />
         </Shortcut>

--- a/installer/test_installers.ps1
+++ b/installer/test_installers.ps1
@@ -139,12 +139,35 @@ foreach ($Transform in $MsiVariants) {
     )) {
         throw "MSI $Variant shortcut target escaped the install directory"
     }
-    if (-not [string]::Equals(
-        $MsiShortcut.IconLocation,
-        $ExpectedMsiIconLocation,
-        [StringComparison]::OrdinalIgnoreCase
-    )) {
-        throw "MSI $Variant shortcut icon is not the installed MoHan icon"
+    $ShortcutBytes = [IO.File]::ReadAllBytes($MsiShortcutPath)
+    [uint32]$ShellLinkHeaderSize = 0x0000004C
+    if (
+        $ShortcutBytes.Length -lt $ShellLinkHeaderSize -or
+        [BitConverter]::ToUInt32($ShortcutBytes, 0) -ne $ShellLinkHeaderSize
+    ) {
+        throw "MSI $Variant shortcut has an invalid Shell Link header"
+    }
+    [uint32]$LinkFlags = [BitConverter]::ToUInt32($ShortcutBytes, 20)
+    [uint32]$HasIconLocationFlag = 0x00000040
+    if (($LinkFlags -band $HasIconLocationFlag) -ne 0) {
+        throw "MSI $Variant shortcut contains an independent icon location"
+    }
+    $ReportedIconLocation = ([string]$MsiShortcut.IconLocation).Trim()
+    $IconLocationIsAllowed = (
+        [string]::IsNullOrEmpty($ReportedIconLocation) -or
+        [string]::Equals(
+            $ReportedIconLocation,
+            ",0",
+            [StringComparison]::Ordinal
+        ) -or
+        [string]::Equals(
+            $ReportedIconLocation,
+            $ExpectedMsiIconLocation,
+            [StringComparison]::OrdinalIgnoreCase
+        )
+    )
+    if (-not $IconLocationIsAllowed) {
+        throw "MSI $Variant shortcut icon escaped the installed MoHan executable"
     }
     $UninstallArguments = @(
         "/x", $MsiInstaller.FullName, "/qn", "/norestart"

--- a/installer/test_installers.ps1
+++ b/installer/test_installers.ps1
@@ -122,6 +122,30 @@ foreach ($Transform in $MsiVariants) {
     ) {
         throw "MSI $Variant application self-test failed"
     }
+    $MsiShortcutPath = Join-Path $ProgramsFolder (
+        "MoHan Desktop Assistant\MoHan Desktop Assistant.lnk"
+    )
+    if (-not (Test-Path -LiteralPath $MsiShortcutPath)) {
+        throw "MSI $Variant did not create the Start menu shortcut"
+    }
+    $MsiShortcut = (New-Object -ComObject WScript.Shell).CreateShortcut(
+        $MsiShortcutPath
+    )
+    $ExpectedMsiIconLocation = $InstalledMsiExe + ",0"
+    if (-not [string]::Equals(
+        $MsiShortcut.TargetPath,
+        $InstalledMsiExe,
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+        throw "MSI $Variant shortcut target escaped the install directory"
+    }
+    if (-not [string]::Equals(
+        $MsiShortcut.IconLocation,
+        $ExpectedMsiIconLocation,
+        [StringComparison]::OrdinalIgnoreCase
+    )) {
+        throw "MSI $Variant shortcut icon is not the installed MoHan icon"
+    }
     $UninstallArguments = @(
         "/x", $MsiInstaller.FullName, "/qn", "/norestart"
     )
@@ -132,6 +156,9 @@ foreach ($Transform in $MsiVariants) {
         -Wait -PassThru
     if ($Process.ExitCode -ne 0) {
         throw "MSI $Variant uninstall verification failed"
+    }
+    if (Test-Path -LiteralPath $MsiShortcutPath) {
+        throw "MSI $Variant uninstaller left the Start menu shortcut behind"
     }
 }
 

--- a/profile_transfer.py
+++ b/profile_transfer.py
@@ -14,6 +14,12 @@ lazy from typing import Any
 
 lazy from backup_manager import BackupManager
 lazy from contracts import ProfileDatabasePort
+lazy from safe_error import (
+    SafeDiagnostic,
+    SafeError,
+    SafeErrorType,
+    sanitize_error,
+)
 
 PROFILE_EXTENSION = ".mohan-profile"
 PROFILE_FORMAT_VERSION = 1
@@ -83,7 +89,28 @@ MACHINE_BOUND_TABLES = (
 
 
 class ProfileTransferError(RuntimeError):
-    pass
+    """Profile boundary failure that never retains an external error detail."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        safe_error: SafeError | None = None,
+    ) -> None:
+        self.safe_error = safe_error
+        super().__init__(str(safe_error) if safe_error is not None else message)
+
+
+def _external_profile_error(error: BaseException) -> ProfileTransferError:
+    """Discard external detail before it can reach UI or persistent state."""
+
+    safe = sanitize_error(error)
+    if isinstance(error, sqlite3.Error):
+        safe = SafeError(
+            SafeErrorType.OPERATING_SYSTEM_ERROR,
+            SafeDiagnostic.LOCAL_IO_FAILURE,
+        )
+    return ProfileTransferError("", safe_error=safe)
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,13 +184,16 @@ class PortableProfileManager:
         counts = payload.get("record_counts")
         if not isinstance(counts, Mapping):
             raise ProfileTransferError("攜帶檔缺少資料筆數資訊。")
+        failure: ProfileTransferError | None = None
         try:
             normalized_counts = frozendict(
                 (str(key), max(0, int(value)))
                 for key, value in counts.items()
             )
         except (TypeError, ValueError) as exc:
-            raise ProfileTransferError("攜帶檔資料筆數格式錯誤。") from exc
+            failure = _external_profile_error(exc)
+        if failure is not None:
+            raise failure
         return ProfileManifest(
             created_at=str(payload.get("created_at", "")),
             snapshot_id=str(payload.get("snapshot_id", ""))[:64],
@@ -352,25 +382,37 @@ class PortableProfileManager:
             temporary_target.unlink(missing_ok=True)
 
     def export_profile(self, target: Path) -> tuple[Path, ProfileManifest]:
-        destination = normalized_profile_path(Path(target))
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        installation_id = self._source_installation_id()
-        with TemporaryDirectory(prefix="mohan-profile-export-") as temp:
-            snapshot_path = Path(temp) / DATABASE_FILENAME
-            record_counts, profile = self._create_snapshot(snapshot_path)
-            manifest_payload = self._manifest_payload(
-                snapshot_path,
-                installation_id,
-                record_counts,
-                profile,
-            )
-            manifest = self._manifest_from_payload(manifest_payload)
-            self._write_archive(
-                destination,
-                snapshot_path,
-                manifest_payload,
-            )
-        return destination, manifest
+        failure: ProfileTransferError | None = None
+        result: tuple[Path, ProfileManifest] | None = None
+        try:
+            destination = normalized_profile_path(Path(target))
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            installation_id = self._source_installation_id()
+            with TemporaryDirectory(prefix="mohan-profile-export-") as temp:
+                snapshot_path = Path(temp) / DATABASE_FILENAME
+                record_counts, profile = self._create_snapshot(snapshot_path)
+                manifest_payload = self._manifest_payload(
+                    snapshot_path,
+                    installation_id,
+                    record_counts,
+                    profile,
+                )
+                manifest = self._manifest_from_payload(manifest_payload)
+                self._write_archive(
+                    destination,
+                    snapshot_path,
+                    manifest_payload,
+                )
+            result = destination, manifest
+        except ProfileTransferError:
+            raise
+        except (OSError, sqlite3.Error, ValueError, zipfile.LargeZipFile) as exc:
+            failure = _external_profile_error(exc)
+        if failure is not None:
+            raise failure
+        if result is None:
+            raise AssertionError("profile export finished without a result")
+        return result
 
     @staticmethod
     def _validated_source(source: Path) -> Path:
@@ -495,9 +537,12 @@ class PortableProfileManager:
         self,
         source: Path,
     ) -> tuple[ProfileManifest, Path, TemporaryDirectory]:
-        profile_path = self._validated_source(source)
-        temporary = TemporaryDirectory(prefix="mohan-profile-import-")
+        temporary: TemporaryDirectory | None = None
+        failure: ProfileTransferError | None = None
+        result: tuple[ProfileManifest, Path, TemporaryDirectory] | None = None
         try:
+            profile_path = self._validated_source(source)
+            temporary = TemporaryDirectory(prefix="mohan-profile-import-")
             payload, database_bytes = self._read_archive(profile_path)
             manifest = self._verified_manifest(payload, database_bytes)
             database_path = self._materialize_database(
@@ -505,19 +550,28 @@ class PortableProfileManager:
                 database_bytes,
             )
             self._validate_incoming_database(database_path, manifest)
-            return manifest, database_path, temporary
+            result = manifest, database_path, temporary
         except (
+            OSError,
+            sqlite3.Error,
             zipfile.BadZipFile,
+            zipfile.LargeZipFile,
             json.JSONDecodeError,
             UnicodeDecodeError,
+            ValueError,
         ) as exc:
-            temporary.cleanup()
-            raise ProfileTransferError(
-                "攜帶檔不是有效的墨寒進度檔。"
-            ) from exc
+            failure = _external_profile_error(exc)
+            if temporary is not None:
+                temporary.cleanup()
         except Exception:
-            temporary.cleanup()
+            if temporary is not None:
+                temporary.cleanup()
             raise
+        if failure is not None:
+            raise failure
+        if result is None:
+            raise AssertionError("profile inspection finished without a result")
+        return result
 
     def _assert_snapshot_not_imported(
         self,
@@ -696,6 +750,8 @@ class PortableProfileManager:
 
     def import_profile(self, source: Path) -> ProfileImportResult:
         manifest, database_path, temporary = self.inspect_profile(source)
+        failure: ProfileTransferError | None = None
+        result: ProfileImportResult | None = None
         try:
             self._assert_snapshot_not_imported(manifest)
             payload = self._load_profile_payload(database_path)
@@ -706,12 +762,21 @@ class PortableProfileManager:
                 payload,
                 manifest,
             )
-            return ProfileImportResult(
+            result = ProfileImportResult(
                 manifest=manifest,
                 backup_path=backup,
                 imported_counts=imported_counts,
             )
+        except ProfileTransferError:
+            raise
         except sqlite3.Error as exc:
-            raise ProfileTransferError(f"匯入資料庫失敗：{exc}") from exc
+            failure = _external_profile_error(exc)
+        except OSError as exc:
+            failure = _external_profile_error(exc)
         finally:
             temporary.cleanup()
+        if failure is not None:
+            raise failure
+        if result is None:
+            raise AssertionError("profile import finished without a result")
+        return result

--- a/profile_transfer_ui.py
+++ b/profile_transfer_ui.py
@@ -28,7 +28,34 @@ lazy from profile_transfer import (
     PortableProfileManager,
     ProfileTransferError,
 )
+lazy from safe_error import SafeError, sanitize_error
 lazy from time_utils import local_wall_time
+
+
+def localized_profile_failure(
+    language: str,
+    error: BaseException,
+) -> str:
+    """Return a four-language profile error without external error detail."""
+
+    safe: SafeError | None = None
+    if isinstance(error, ProfileTransferError):
+        safe = error.safe_error
+        if safe is None:
+            return localized_operation_error(
+                language,
+                str(error),
+                operation=AuxiliaryOperation.PROFILE,
+            )
+    else:
+        safe = sanitize_error(error)
+    if safe is None:
+        raise AssertionError("profile failure is missing safe metadata")
+    return localized_operation_error(
+        language,
+        safe,
+        operation=AuxiliaryOperation.PROFILE,
+    )
 
 
 class PortableProfilePanel(QWidget):
@@ -70,11 +97,19 @@ class PortableProfilePanel(QWidget):
     def _t(self, key: AuxiliaryText, **values: object) -> str:
         return auxiliary_text(self.language, key, **values)
 
-    def _profile_error(self, message: str) -> str:
-        return localized_operation_error(
-            self.language,
-            message,
-            operation=AuxiliaryOperation.PROFILE,
+    def _profile_error(self, error: BaseException) -> str:
+        return localized_profile_failure(self.language, error)
+
+    def _show_failure(
+        self,
+        title: AuxiliaryText,
+        message: AuxiliaryText,
+        error: BaseException,
+    ) -> None:
+        QMessageBox.warning(
+            self,
+            self._t(title),
+            self._t(message, reason=self._profile_error(error)),
         )
 
     def export_profile(self) -> None:
@@ -106,13 +141,10 @@ class PortableProfilePanel(QWidget):
         try:
             saved_path, manifest = self.manager.export_profile(Path(target))
         except (OSError, sqlite3.Error, ProfileTransferError) as exc:
-            QMessageBox.warning(
-                self,
-                self._t(AuxiliaryText.EXPORT_FAILED_TITLE),
-                self._t(
-                    AuxiliaryText.EXPORT_FAILED,
-                    reason=self._profile_error(str(exc)),
-                ),
+            self._show_failure(
+                AuxiliaryText.EXPORT_FAILED_TITLE,
+                AuxiliaryText.EXPORT_FAILED,
+                exc,
             )
             return
         total = sum(manifest.record_counts.values())
@@ -149,13 +181,10 @@ class PortableProfilePanel(QWidget):
             sqlite3.Error,
             ProfileTransferError,
         ) as exc:
-            QMessageBox.warning(
-                self,
-                self._t(AuxiliaryText.IMPORT_READ_FAILED_TITLE),
-                self._t(
-                    AuxiliaryText.IMPORT_READ_FAILED,
-                    reason=self._profile_error(str(exc)),
-                ),
+            self._show_failure(
+                AuxiliaryText.IMPORT_READ_FAILED_TITLE,
+                AuxiliaryText.IMPORT_READ_FAILED,
+                exc,
             )
             return
         total = sum(manifest.record_counts.values())
@@ -200,13 +229,10 @@ class PortableProfilePanel(QWidget):
             sqlite3.Error,
             ProfileTransferError,
         ) as exc:
-            QMessageBox.warning(
-                self,
-                self._t(AuxiliaryText.IMPORT_FAILED_TITLE),
-                self._t(
-                    AuxiliaryText.IMPORT_FAILED,
-                    reason=self._profile_error(str(exc)),
-                ),
+            self._show_failure(
+                AuxiliaryText.IMPORT_FAILED_TITLE,
+                AuxiliaryText.IMPORT_FAILED,
+                exc,
             )
             return
         QMessageBox.information(

--- a/profile_transfer_ui.py
+++ b/profile_transfer_ui.py
@@ -16,6 +16,12 @@ lazy from PySide6.QtWidgets import (
     QWidget,
 )
 
+lazy from auxiliary_ui_localization import (
+    AuxiliaryOperation,
+    AuxiliaryText,
+    auxiliary_text,
+    localized_operation_error,
+)
 lazy from contracts import ProfileDatabasePort
 lazy from profile_transfer import (
     PROFILE_EXTENSION,
@@ -33,51 +39,67 @@ class PortableProfilePanel(QWidget):
         db: ProfileDatabasePort,
         parent: QWidget | None = None,
         before_export: Callable[[], bool] | None = None,
+        language: str = "zh-TW",
     ):
         super().__init__(parent)
         self.db = db
         self.before_export = before_export
+        self.language = language
         self.manager = PortableProfileManager(
             db,
             db.path.parent / "backups",
         )
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        heading = QLabel("<b>攜帶、換機與進度接續</b>")
-        heading.setStyleSheet("color:#2f6987;font-size:15px;")
-        note = QLabel(
-            "匯出後只需攜帶一個檔案，即可在另一台電腦接續對話、"
-            "記憶、待辦、靈感與工作進度。API 金鑰、OAuth、"
-            "電腦權限、資料夾路徑與裝置設定不會被帶走。"
-        )
-        note.setWordWrap(True)
+        self.heading = QLabel(self._t(AuxiliaryText.PROFILE_HEADING))
+        self.heading.setStyleSheet("color:#2f6987;font-size:15px;")
+        self.note = QLabel(self._t(AuxiliaryText.PROFILE_NOTE))
+        self.note.setWordWrap(True)
         buttons = QHBoxLayout()
-        self.export_button = QPushButton("匯出墨寒攜帶檔")
-        self.import_button = QPushButton("匯入並接續進度")
+        self.export_button = QPushButton(self._t(AuxiliaryText.EXPORT_BUTTON))
+        self.import_button = QPushButton(self._t(AuxiliaryText.IMPORT_BUTTON))
         buttons.addWidget(self.export_button)
         buttons.addWidget(self.import_button)
         buttons.addStretch()
-        layout.addWidget(heading)
-        layout.addWidget(note)
+        layout.addWidget(self.heading)
+        layout.addWidget(self.note)
         layout.addLayout(buttons)
         self.export_button.clicked.connect(self.export_profile)
         self.import_button.clicked.connect(self.import_profile)
+
+    def _t(self, key: AuxiliaryText, **values: object) -> str:
+        return auxiliary_text(self.language, key, **values)
+
+    def _profile_error(self, message: str) -> str:
+        return localized_operation_error(
+            self.language,
+            message,
+            operation=AuxiliaryOperation.PROFILE,
+        )
 
     def export_profile(self) -> None:
         if self.before_export is not None and not self.before_export():
             return
         assistant_name = str(
-            self.db.setting("assistant_name", "墨寒")
-        ).strip() or "墨寒"
-        default_name = (
-            f"{assistant_name}-攜帶進度-"
-            f"{local_wall_time():%Y%m%d-%H%M%S}{PROFILE_EXTENSION}"
+            self.db.setting(
+                "assistant_name",
+                self._t(AuxiliaryText.DEFAULT_ASSISTANT_NAME),
+            )
+        ).strip() or self._t(AuxiliaryText.DEFAULT_ASSISTANT_NAME)
+        default_name = self._t(
+            AuxiliaryText.EXPORT_FILENAME,
+            assistant=assistant_name,
+            timestamp=f"{local_wall_time():%Y%m%d-%H%M%S}",
+            extension=PROFILE_EXTENSION,
         )
         target, _selected_filter = QFileDialog.getSaveFileName(
             self,
-            "匯出墨寒攜帶檔",
+            self._t(AuxiliaryText.EXPORT_DIALOG_TITLE),
             str(Path.home() / "Documents" / default_name),
-            f"墨寒攜帶檔 (*{PROFILE_EXTENSION})",
+            self._t(
+                AuxiliaryText.PROFILE_FILTER,
+                extension=PROFILE_EXTENSION,
+            ),
         )
         if not target:
             return
@@ -86,26 +108,33 @@ class PortableProfilePanel(QWidget):
         except (OSError, sqlite3.Error, ProfileTransferError) as exc:
             QMessageBox.warning(
                 self,
-                "匯出墨寒攜帶檔",
-                f"匯出失敗：{exc}",
+                self._t(AuxiliaryText.EXPORT_FAILED_TITLE),
+                self._t(
+                    AuxiliaryText.EXPORT_FAILED,
+                    reason=self._profile_error(str(exc)),
+                ),
             )
             return
         total = sum(manifest.record_counts.values())
         QMessageBox.information(
             self,
-            "匯出完成",
-            "墨寒攜帶檔已建立。\n\n"
-            f"位置：{saved_path}\n"
-            f"收錄資料與設定共 {total} 筆。\n\n"
-            "此檔案不含 API 金鑰、OAuth 權杖或本機電腦權限。",
+            self._t(AuxiliaryText.EXPORT_COMPLETE_TITLE),
+            self._t(
+                AuxiliaryText.EXPORT_COMPLETE,
+                path=saved_path,
+                count=total,
+            ),
         )
 
     def import_profile(self) -> None:
         source, _selected_filter = QFileDialog.getOpenFileName(
             self,
-            "匯入墨寒攜帶檔",
+            self._t(AuxiliaryText.IMPORT_DIALOG_TITLE),
             str(Path.home() / "Documents"),
-            f"墨寒攜帶檔 (*{PROFILE_EXTENSION})",
+            self._t(
+                AuxiliaryText.PROFILE_FILTER,
+                extension=PROFILE_EXTENSION,
+            ),
         )
         if not source:
             return
@@ -122,15 +151,18 @@ class PortableProfilePanel(QWidget):
         ) as exc:
             QMessageBox.warning(
                 self,
-                "匯入墨寒攜帶檔",
-                f"無法讀取攜帶檔：{exc}",
+                self._t(AuxiliaryText.IMPORT_READ_FAILED_TITLE),
+                self._t(
+                    AuxiliaryText.IMPORT_READ_FAILED,
+                    reason=self._profile_error(str(exc)),
+                ),
             )
             return
         total = sum(manifest.record_counts.values())
         source_label = (
             manifest.source_installation_id[:8]
             if manifest.source_installation_id
-            else "舊版攜帶檔"
+            else self._t(AuxiliaryText.LEGACY_SOURCE)
         )
         last_imported_at = str(
             self.db.setting("portable_last_import_created_at", "")
@@ -141,23 +173,20 @@ class PortableProfilePanel(QWidget):
             and manifest.created_at
             and manifest.created_at < last_imported_at
         ):
-            older_warning = (
-                "\n\n⚠ 此檔建立時間早於上次匯入的進度。"
-                "若繼續，較新的共同進度可能被取代。"
-            )
+            older_warning = self._t(AuxiliaryText.OLDER_WARNING)
         answer = QMessageBox.question(
             self,
-            "確認接續進度",
-            "即將以攜帶檔內的共同進度取代這台電腦目前的"
-            "對話、記憶、待辦與工作資料。\n\n"
-            f"建立時間：{manifest.created_at or '未知'}\n"
-            f"來源裝置識別：{source_label}\n"
-            f"助理名稱：{manifest.assistant_name or '未命名'}\n"
-            f"資料與設定：約 {total} 筆\n\n"
-            "匯入前會自動備份目前資料；這台電腦的 API 金鑰、"
-            "OAuth、權限、路徑與裝置設定將維持不變。"
-            f"{older_warning}\n\n"
-            "確定匯入嗎？",
+            self._t(AuxiliaryText.IMPORT_CONFIRM_TITLE),
+            self._t(
+                AuxiliaryText.IMPORT_CONFIRM,
+                created_at=manifest.created_at
+                or self._t(AuxiliaryText.UNKNOWN),
+                source=source_label,
+                assistant=manifest.assistant_name
+                or self._t(AuxiliaryText.UNNAMED),
+                count=total,
+                older_warning=older_warning,
+            ),
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
@@ -173,17 +202,20 @@ class PortableProfilePanel(QWidget):
         ) as exc:
             QMessageBox.warning(
                 self,
-                "匯入墨寒攜帶檔",
-                f"匯入失敗，原資料未變更：{exc}",
+                self._t(AuxiliaryText.IMPORT_FAILED_TITLE),
+                self._t(
+                    AuxiliaryText.IMPORT_FAILED,
+                    reason=self._profile_error(str(exc)),
+                ),
             )
             return
         QMessageBox.information(
             self,
-            "進度接續完成",
-            "墨寒的共同進度已匯入完成。\n\n"
-            f"原資料備份：{result.backup_path}\n\n"
-            "程式現在會安全關閉；請重新開啟墨寒，"
-            "即可從匯入後的進度繼續使用。",
+            self._t(AuxiliaryText.IMPORT_COMPLETE_TITLE),
+            self._t(
+                AuxiliaryText.IMPORT_COMPLETE,
+                path=result.backup_path,
+            ),
         )
         application = QApplication.instance()
         if application is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "3.1.1"
+version = "3.1.2"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"
@@ -23,7 +23,7 @@ keywords = [
   "speech",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: MIT License",
   "Operating System :: Microsoft :: Windows",
   "Programming Language :: Python :: 3.15",

--- a/realtime_speech_output.py
+++ b/realtime_speech_output.py
@@ -209,6 +209,7 @@ class RealtimeSpeechOutput(QObject):
     def configure(self, config: RealtimeSpeechOutputConfig) -> None:
         if config.mode not in REALTIME_OUTPUT_MODES:
             raise ValueError(f"Unsupported Realtime output mode: {config.mode}")
+        previous = self._config
         self.cancel(self._response_generation)
         self._config = RealtimeSpeechOutputConfig(
             mode=config.mode,
@@ -217,6 +218,22 @@ class RealtimeSpeechOutput(QObject):
             azure_hd=config.azure_hd,
             local=config.local,
         )
+        self._invalidate_changed_azure_catalogs(previous, self._config)
+
+    def _invalidate_changed_azure_catalogs(
+        self,
+        previous: RealtimeSpeechOutputConfig,
+        current: RealtimeSpeechOutputConfig,
+    ) -> None:
+        for engine, old_voice, new_voice in (
+            (self._azure_speech, previous.azure, current.azure),
+            (self._azure_hd_speech, previous.azure_hd, current.azure_hd),
+        ):
+            if old_voice == new_voice:
+                continue
+            invalidate = getattr(engine, "invalidate_voice_catalog", None)
+            if invalidate is not None:
+                invalidate()
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self._azure_speech.set_volume(volume_percent, muted)

--- a/realtime_speech_output.py
+++ b/realtime_speech_output.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+lazy import re
+lazy from collections import deque
+lazy from dataclasses import dataclass, field
+
+lazy from PySide6.QtCore import QObject, Signal
+
+lazy from contracts import AzureSpeechEnginePort, LocalSpeechEnginePort
+lazy from immutable_config import deep_freeze
+lazy from language_support import canonical_ui_language
+
+REALTIME_OUTPUT_OPENAI = "openai-realtime"
+REALTIME_OUTPUT_AZURE = "azure-speech"
+REALTIME_OUTPUT_AZURE_HD = "azure-dragon-hd"
+_REALTIME_OUTPUT_LOCAL = "system-local"
+_MAX_RESPONSE_TEXT_CHARACTERS = 32_768
+_MAX_PLAYBACK_SEGMENTS = 1_024
+REALTIME_OUTPUT_MODES = frozenset({
+    REALTIME_OUTPUT_OPENAI,
+    REALTIME_OUTPUT_AZURE,
+    REALTIME_OUTPUT_AZURE_HD,
+})
+_MESSAGES = deep_freeze({
+    "zh-TW": {
+        "preparing": "Realtime 已理解，Azure 正在準備發聲",
+        "speaking": "Azure 串流發聲中",
+        "missing": "所選 Realtime Azure 聲線尚未完成金鑰、區域與聲音設定。",
+        "hd_fallback": "Dragon HD 無法發聲，本輪改用一般 Azure Speech",
+        "local_fallback": "Azure 無法發聲，本輪改用 Windows 本機女性聲線",
+        "local_speaking": "Windows 本機女性聲線發聲中",
+        "failed": "Realtime 語音輸出失敗：{error}",
+        "queue_full": "Realtime 回應過長，已安全停止本輪語音。",
+        "ready": "已連線，妾在聽",
+    },
+    "zh-CN": {
+        "preparing": "Realtime 已理解，Azure 正在准备发声",
+        "speaking": "Azure 串流发声中",
+        "missing": "所选 Realtime Azure 声线尚未完成密钥、区域与声音设置。",
+        "hd_fallback": "Dragon HD 无法发声，本轮改用一般 Azure Speech",
+        "local_fallback": "Azure 无法发声，本轮改用 Windows 本机女性声线",
+        "local_speaking": "Windows 本机女性声线发声中",
+        "failed": "Realtime 语音输出失败：{error}",
+        "queue_full": "Realtime 回应过长，已安全停止本轮语音。",
+        "ready": "已连接，妾在听",
+    },
+    "en-US": {
+        "preparing": "Realtime understood; Azure is preparing speech",
+        "speaking": "Azure streaming speech",
+        "missing": "The selected Realtime Azure voice needs a key, region, and voice.",
+        "hd_fallback": "Dragon HD failed; using standard Azure Speech for this response",
+        "local_fallback": "Azure failed; using a local Windows female voice for this response",
+        "local_speaking": "Local Windows female voice is speaking",
+        "failed": "Realtime speech output failed: {error}",
+        "queue_full": "The Realtime response was too long, so this speech response was stopped safely.",
+        "ready": "Connected and listening",
+    },
+    "ja-JP": {
+        "preparing": "Realtime が理解し、Azure が音声を準備しています",
+        "speaking": "Azure ストリーミング音声を再生中",
+        "missing": "選択した Realtime Azure 音声にはキー、リージョン、音声設定が必要です。",
+        "hd_fallback": "Dragon HD が失敗したため、この返答は通常の Azure Speech を使用します",
+        "local_fallback": "Azure が失敗したため、この返答は Windows 本機女性音声を使用します",
+        "local_speaking": "Windows 本機女性音声を再生中",
+        "failed": "Realtime 音声出力に失敗しました：{error}",
+        "queue_full": "Realtime の応答が長すぎるため、この音声応答を安全に停止しました。",
+        "ready": "接続済み、聞いています",
+    },
+})
+
+
+def _message(locale: str, key: str, **values: object) -> str:
+    normalized = canonical_ui_language(locale)
+    catalog_key = "en-US" if normalized == "en" else normalized
+    catalog = _MESSAGES[catalog_key]
+    return catalog[key].format(**values)
+
+
+@dataclass(frozen=True, slots=True)
+class AzureRealtimeVoice:
+    api_key: str = field(repr=False)
+    region: str
+    voice: str
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.api_key.strip() and self.region.strip() and self.voice.strip())
+
+
+@dataclass(frozen=True, slots=True)
+class LocalRealtimeVoice:
+    available: bool = False
+    voice: str = ""
+    rate: int = -1
+
+
+@dataclass(frozen=True, slots=True)
+class RealtimeSpeechOutputConfig:
+    mode: str = REALTIME_OUTPUT_OPENAI
+    locale: str = "zh-TW"
+    azure: AzureRealtimeVoice = AzureRealtimeVoice("", "", "")
+    azure_hd: AzureRealtimeVoice = AzureRealtimeVoice("", "", "")
+    local: LocalRealtimeVoice = LocalRealtimeVoice()
+
+
+class RealtimeTextSegmenter:
+    """Turn streamed model text into short, speakable, ordered clauses."""
+
+    STRONG_ENDINGS = frozenset("。！？!?\n")
+    SOFT_ENDINGS = frozenset("，,；;：:")
+    SOFT_MINIMUM = 14
+    MAXIMUM = 36
+    CONTROL_MARKER = "[[MOHAN_"
+    CONTROL_TAG = re.compile(
+        r"\[\[\s*MOHAN_[^\]]*(?:\]\]|$)",
+        re.IGNORECASE,
+    )
+
+    def __init__(self) -> None:
+        self._pending = ""
+
+    def reset(self) -> None:
+        self._pending = ""
+
+    def feed(self, delta: str) -> tuple[str, ...]:
+        self._pending += str(delta or "")
+        ready: list[str] = []
+        while segment := self._next_segment():
+            ready.append(segment)
+        return tuple(ready)
+
+    def finish(self) -> tuple[str, ...]:
+        final = self.CONTROL_TAG.sub("", self._pending).strip()
+        self._pending = ""
+        return (final,) if final else ()
+
+    def _next_segment(self) -> str:
+        if not self._pending:
+            return ""
+        marker_at = self._pending.upper().find(self.CONTROL_MARKER)
+        if marker_at == 0 or self._pending.startswith("[["):
+            return ""
+        speakable = self._pending[:marker_at] if marker_at > 0 else self._pending
+        for index, character in enumerate(speakable):
+            length = index + 1
+            if character in self.STRONG_ENDINGS:
+                return self._take(length)
+            if character in self.SOFT_ENDINGS and length >= self.SOFT_MINIMUM:
+                return self._take(length)
+        if len(speakable) < self.MAXIMUM:
+            return ""
+        split_at = max(
+            speakable.rfind(" ", 0, self.MAXIMUM),
+            speakable.rfind("、", 0, self.MAXIMUM),
+        )
+        length = split_at + 1 if split_at >= self.SOFT_MINIMUM else self.MAXIMUM
+        return self._take(length)
+
+    def _take(self, length: int) -> str:
+        segment = self._pending[:length].strip()
+        self._pending = self._pending[length:].lstrip()
+        return segment
+
+
+class RealtimeSpeechOutput(QObject):
+    """Own the optional Azure playback route without touching native audio."""
+
+    speaking_changed = Signal(bool)
+    playback_guard_changed = Signal(bool)
+    viseme_cue = Signal(float, str)
+    status_changed = Signal(str)
+    failed = Signal(str)
+
+    def __init__(
+        self,
+        azure_speech: AzureSpeechEnginePort,
+        azure_hd_speech: AzureSpeechEnginePort,
+        local_speech: LocalSpeechEnginePort,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._azure_speech = azure_speech
+        self._azure_hd_speech = azure_hd_speech
+        self._local_speech = local_speech
+        self._config = RealtimeSpeechOutputConfig()
+        self._segmenter = RealtimeTextSegmenter()
+        self._queue: deque[str] = deque(maxlen=_MAX_PLAYBACK_SEGMENTS)
+        self._active_text = ""
+        self._active_engine: object | None = None
+        self._active_operation_id: int | None = None
+        self._active_audio_started = False
+        self._response_complete = False
+        self._response_open = False
+        self._response_rejected = False
+        self._response_text_characters = 0
+        self._response_generation = 0
+        self._route_mode = REALTIME_OUTPUT_OPENAI
+        self._speaking = False
+        self._playback_guard = False
+        for engine in (azure_speech, azure_hd_speech, local_speech):
+            if self._connect_operation_signals(engine):
+                continue
+            self._connect_legacy_signals(engine)
+
+    @property
+    def active(self) -> bool:
+        return self._config.mode != REALTIME_OUTPUT_OPENAI
+
+    def configure(self, config: RealtimeSpeechOutputConfig) -> None:
+        if config.mode not in REALTIME_OUTPUT_MODES:
+            raise ValueError(f"Unsupported Realtime output mode: {config.mode}")
+        self.cancel(self._response_generation)
+        self._config = RealtimeSpeechOutputConfig(
+            mode=config.mode,
+            locale=canonical_ui_language(config.locale),
+            azure=config.azure,
+            azure_hd=config.azure_hd,
+            local=config.local,
+        )
+
+    def set_volume(self, volume_percent: int, muted: bool = False) -> None:
+        self._azure_speech.set_volume(volume_percent, muted)
+        self._azure_hd_speech.set_volume(volume_percent, muted)
+        self._local_speech.set_volume(volume_percent, muted)
+
+    def _connect_operation_signals(self, engine: object) -> bool:
+        operation_started = getattr(engine, "operation_started", None)
+        operation_finished = getattr(engine, "operation_finished", None)
+        operation_failed = getattr(engine, "operation_failed", None)
+        operation_viseme = getattr(engine, "operation_viseme_cue", None)
+        operation_latency = getattr(
+            engine,
+            "operation_synthesis_latency_measured",
+            None,
+        )
+        operation_signals = (
+            operation_started,
+            operation_finished,
+            operation_failed,
+            operation_viseme,
+            operation_latency,
+        )
+        if any(signal is None for signal in operation_signals):
+            return False
+        operation_started.connect(
+            lambda operation_id, source=engine: self._operation_started(
+                source,
+                operation_id,
+            )
+        )
+        operation_finished.connect(
+            lambda operation_id, source=engine: self._engine_finished(
+                source,
+                operation_id,
+            )
+        )
+        operation_failed.connect(
+            lambda operation_id, message, source=engine: self._engine_failed(
+                source,
+                message,
+                operation_id,
+            )
+        )
+        operation_viseme.connect(
+            lambda operation_id, level, vowel, source=engine: self._viseme_cue(
+                source,
+                level,
+                vowel,
+                operation_id,
+            )
+        )
+        operation_latency.connect(
+            lambda operation_id, _latency, source=engine: self._audio_started(
+                source,
+                operation_id,
+            )
+        )
+        return True
+
+    def _connect_legacy_signals(self, engine: object) -> None:
+        engine.finished.connect(lambda source=engine: self._engine_finished(source))
+        engine.failed.connect(
+            lambda message, source=engine: self._engine_failed(
+                source,
+                message,
+            )
+        )
+        engine.viseme_cue.connect(
+            lambda level, vowel, source=engine: self._viseme_cue(
+                source,
+                level,
+                vowel,
+            )
+        )
+        latency_signal = getattr(engine, "synthesis_latency_measured", None)
+        if latency_signal is not None:
+            latency_signal.connect(
+                lambda _latency, source=engine: self._audio_started(source)
+            )
+
+    def begin_response(self, generation: int) -> None:
+        if not self.active:
+            return
+        generation = int(generation)
+        if generation <= self._response_generation:
+            return
+        self.cancel(generation)
+        self._response_complete = False
+        self._response_open = True
+        self._response_rejected = False
+        self._response_text_characters = 0
+        self._route_mode = self._config.mode
+        self.status_changed.emit(self._text("preparing"))
+
+    def add_text(self, generation: int, delta: str) -> None:
+        if not self.active:
+            return
+        if (
+            int(generation) != self._response_generation
+            or self._response_rejected
+            or not self._response_open
+        ):
+            return
+        text = str(delta or "")
+        if self._response_text_characters + len(text) > _MAX_RESPONSE_TEXT_CHARACTERS:
+            self._fail_queue_limit()
+            return
+        self._response_text_characters += len(text)
+        try:
+            self._queue_segments(self._segmenter.feed(text))
+        except OverflowError:
+            self._fail_queue_limit()
+            return
+        self._speak_next()
+
+    def finish_response(self, generation: int) -> None:
+        if not self.active:
+            return
+        if (
+            int(generation) != self._response_generation
+            or self._response_rejected
+            or not self._response_open
+        ):
+            return
+        try:
+            self._queue_segments(self._segmenter.finish())
+        except OverflowError:
+            self._fail_queue_limit()
+            return
+        self._response_complete = True
+        self._response_open = False
+        self._speak_next()
+        self._finish_if_idle()
+
+    def cancel(self, generation: int) -> None:
+        generation = int(generation)
+        if generation < self._response_generation:
+            return
+        self._response_generation = generation
+        self._segmenter.reset()
+        self._queue.clear()
+        self._active_text = ""
+        self._response_complete = False
+        self._response_open = False
+        self._response_rejected = True
+        self._response_text_characters = 0
+        self._route_mode = self._config.mode
+        active_engine = self._active_engine
+        self._active_engine = None
+        self._active_operation_id = None
+        self._active_audio_started = False
+        if active_engine is not None:
+            stop = getattr(active_engine, "stop", None)
+            if stop is not None:
+                stop()
+        self._set_speaking(False)
+        self._set_playback_guard(False)
+
+    def _selected_route(self) -> tuple[object, object]:
+        if self._route_mode == REALTIME_OUTPUT_AZURE_HD:
+            return self._azure_hd_speech, self._config.azure_hd
+        if self._route_mode == _REALTIME_OUTPUT_LOCAL:
+            return self._local_speech, self._config.local
+        return self._azure_speech, self._config.azure
+
+    def _speak_next(self) -> None:
+        if self._active_engine is not None or not self._queue:
+            return
+        engine, voice = self._selected_route()
+        if isinstance(voice, AzureRealtimeVoice) and not voice.configured:
+            self._fallback_or_fail(self._text("missing"))
+            return
+        if isinstance(voice, LocalRealtimeVoice) and not voice.available:
+            self._fallback_or_fail(self._text("missing"))
+            return
+        self._active_text = self._queue.popleft()
+        self._active_engine = engine
+        self._active_operation_id = None
+        self._active_audio_started = False
+        self._set_playback_guard(True)
+        if isinstance(voice, AzureRealtimeVoice):
+            engine.speak(
+                self._active_text,
+                voice.api_key,
+                voice.region,
+                voice.voice,
+                self._config.locale,
+            )
+        else:
+            engine.speak(self._active_text, voice.voice, voice.rate)
+
+    def _audio_started(
+        self,
+        source: object,
+        operation_id: int | None = None,
+    ) -> None:
+        if not self._is_active_operation(source, operation_id):
+            return
+        self._active_audio_started = True
+        self._set_speaking(True)
+        status_key = "local_speaking" if source is self._local_speech else "speaking"
+        self.status_changed.emit(self._text(status_key))
+
+    def _operation_started(
+        self,
+        source: object,
+        operation_id: int,
+    ) -> None:
+        if source is self._active_engine and self._active_operation_id is None:
+            self._active_operation_id = operation_id
+
+    def _viseme_cue(
+        self,
+        source: object,
+        level: float,
+        vowel: str,
+        operation_id: int | None = None,
+    ) -> None:
+        if not self._is_active_operation(source, operation_id):
+            return
+        if not self._speaking:
+            self._audio_started(source, operation_id)
+        self.viseme_cue.emit(level, vowel)
+
+    def _engine_finished(
+        self,
+        source: object,
+        operation_id: int | None = None,
+    ) -> None:
+        if not self._is_active_operation(source, operation_id):
+            return
+        self._active_engine = None
+        self._active_operation_id = None
+        self._active_audio_started = False
+        self._active_text = ""
+        self._speak_next()
+        self._finish_if_idle()
+
+    def _engine_failed(
+        self,
+        source: object,
+        message: str,
+        operation_id: int | None = None,
+    ) -> None:
+        if not self._is_active_operation(source, operation_id):
+            return
+        failed_text = self._active_text
+        audio_started = self._active_audio_started
+        self._active_engine = None
+        self._active_operation_id = None
+        self._active_audio_started = False
+        self._active_text = ""
+        if failed_text and not audio_started:
+            self._queue.appendleft(failed_text)
+        elif audio_started:
+            self._queue.clear()
+            self._segmenter.reset()
+            self._response_open = False
+            self._response_rejected = True
+            stop = getattr(source, "stop", None)
+            if stop is not None:
+                stop()
+            self._set_speaking(False)
+            self._set_playback_guard(False)
+            self.failed.emit(self._text("failed", error=message))
+            return
+        self._fallback_or_fail(message)
+
+    def _fallback_or_fail(self, message: str) -> None:
+        if (
+            self._route_mode == REALTIME_OUTPUT_AZURE_HD
+            and self._config.azure.configured
+        ):
+            self._route_mode = REALTIME_OUTPUT_AZURE
+            self.status_changed.emit(self._text("hd_fallback"))
+            self._speak_next()
+            return
+        if self._route_mode != _REALTIME_OUTPUT_LOCAL and self._config.local.available:
+            self._route_mode = _REALTIME_OUTPUT_LOCAL
+            self.status_changed.emit(self._text("local_fallback"))
+            self._speak_next()
+            return
+        self._queue.clear()
+        self._segmenter.reset()
+        self._response_open = False
+        self._response_rejected = True
+        self._set_speaking(False)
+        self._set_playback_guard(False)
+        self.failed.emit(self._text("failed", error=message))
+
+    def _queue_segments(self, segments: tuple[str, ...]) -> None:
+        if len(self._queue) + len(segments) > _MAX_PLAYBACK_SEGMENTS:
+            raise OverflowError("Realtime playback queue limit exceeded")
+        self._queue.extend(segments)
+
+    def _fail_queue_limit(self) -> None:
+        self.cancel(self._response_generation)
+        self.failed.emit(self._text("queue_full"))
+
+    def _is_active_operation(
+        self,
+        source: object,
+        operation_id: int | None,
+    ) -> bool:
+        if source is not self._active_engine:
+            return False
+        if operation_id is None:
+            return self._active_operation_id is None
+        return operation_id == self._active_operation_id
+
+    def _finish_if_idle(self) -> None:
+        if self._response_complete and self._active_engine is None and not self._queue:
+            self._set_speaking(False)
+            self._set_playback_guard(False)
+            self.status_changed.emit(self._text("ready"))
+
+    def _set_speaking(self, speaking: bool) -> None:
+        if self._speaking == speaking:
+            return
+        self._speaking = speaking
+        self.speaking_changed.emit(speaking)
+
+    def _set_playback_guard(self, active: bool) -> None:
+        if self._playback_guard == active:
+            return
+        self._playback_guard = active
+        self.playback_guard_changed.emit(active)
+
+    def _text(self, key: str, **values: object) -> str:
+        return _message(self._config.locale, key, **values)

--- a/realtime_voice.py
+++ b/realtime_voice.py
@@ -34,6 +34,7 @@ lazy from realtime_speech_output import (
     REALTIME_OUTPUT_MODES,
     REALTIME_OUTPUT_OPENAI,
 )
+lazy from safe_error import sanitize_error
 lazy from speech import transcribe_wav_bytes
 
 
@@ -628,13 +629,7 @@ class RealtimeVoiceClient(QObject):
 
         def on_error(_ws, error: object) -> None:
             if is_current_session() and self.running:
-                self._emit_failure(
-                    _realtime_message(
-                        self._locale,
-                        "generic_error",
-                        error=error,
-                    )
-                )
+                self._emit_failure(str(error))
 
         def on_close(_ws, _code, _message) -> None:
             if is_current_session():
@@ -674,7 +669,8 @@ class RealtimeVoiceClient(QObject):
             )
         except Exception as exc:  # noqa: BLE001 -- audio startup reports all failures
             self._emit_failure(
-                self._audio_error_message(exc, self._locale)
+                self._audio_error_message(exc, self._locale),
+                trusted=True,
             )
             self.stop()
 
@@ -932,7 +928,8 @@ class RealtimeVoiceClient(QObject):
             self._cancel_server_response()
             self._assistant_text = ""
             self._emit_failure(
-                _realtime_message(self._locale, "response_too_long")
+                _realtime_message(self._locale, "response_too_long"),
+                trusted=True,
             )
             return
         self._assistant_text += delta
@@ -948,7 +945,8 @@ class RealtimeVoiceClient(QObject):
         if len(text) > MAX_ASSISTANT_RESPONSE_CHARACTERS:
             self._cancel_server_response()
             self._emit_failure(
-                _realtime_message(self._locale, "response_too_long")
+                _realtime_message(self._locale, "response_too_long"),
+                trusted=True,
             )
             return
         if text:
@@ -1125,7 +1123,8 @@ class RealtimeVoiceClient(QObject):
         self._cancel_server_response()
         self._cancel_external_output(response_id, force_signal=True)
         self._emit_failure(
-            _realtime_message(self._locale, "response_too_long")
+            _realtime_message(self._locale, "response_too_long"),
+            trusted=True,
         )
 
     def _cancel_server_response(self) -> None:
@@ -1278,13 +1277,7 @@ class RealtimeVoiceClient(QObject):
             error.get("message")
             or _realtime_message(self._locale, "realtime_api_error")
         )
-        self._emit_failure(
-            _realtime_message(
-                self._locale,
-                "generic_error",
-                error=detail,
-            )
-        )
+        self._emit_failure(detail)
 
     def _handle_server_event(self, event: dict[str, Any]) -> None:
         kind = str(event.get("type", ""))
@@ -1513,7 +1506,8 @@ class RealtimeVoiceClient(QObject):
                 ws.send(json.dumps({"type": "response.cancel"}))
         self._finish_assistant_audio(force=True)
         self._emit_failure(
-            _realtime_message(self._locale, "playback_buffer_full")
+            _realtime_message(self._locale, "playback_buffer_full"),
+            trusted=True,
         )
         return False
 
@@ -1604,11 +1598,8 @@ class RealtimeVoiceClient(QObject):
             return
         self._finish_assistant_audio(force=True)
         self._emit_failure(
-            _realtime_message(
-                self._locale,
-                "playback_failed",
-                error=error,
-            )
+            self._audio_error_message(error, self._locale),
+            trusted=True,
         )
 
     def _close_audio(self) -> None:
@@ -1774,7 +1765,7 @@ class RealtimeVoiceClient(QObject):
             error = ""
         except Exception as exc:  # noqa: BLE001 -- transcription returns diagnostics
             text = ""
-            error = str(exc)
+            error = str(sanitize_error(exc))
         self._hybrid_result.emit(
             item_id,
             text,
@@ -1997,18 +1988,21 @@ class RealtimeVoiceClient(QObject):
             self.viseme_cue.emit(0.0, "CLOSED")
             self.speaking_changed.emit(False)
 
-    def _emit_failure(self, detail: str) -> None:
+    def _emit_failure(self, detail: str, *, trusted: bool = False) -> None:
         with self._failure_lock:
             if self._failure_emitted:
                 return
             self._failure_emitted = True
-        self.failed.emit(
-            self._friendly_error(
+        message = (
+            detail
+            if trusted
+            else self._friendly_error(
                 detail,
                 self._active_model,
                 self._locale,
             )
         )
+        self.failed.emit(message)
 
     @staticmethod
     def _friendly_error(
@@ -2035,9 +2029,9 @@ class RealtimeVoiceClient(QObject):
             return _realtime_message(
                 locale,
                 "server_rejected",
-                error=raw,
+                error=sanitize_error(raw),
             )
-        return raw
+        return str(sanitize_error(raw))
 
     @staticmethod
     def _audio_error_message(
@@ -2046,6 +2040,7 @@ class RealtimeVoiceClient(QObject):
     ) -> str:
         detail = str(error)
         lowered = detail.lower()
+        safe_detail = sanitize_error(error)
         if (
             "rawinputstream" in lowered
             or "directsound error" in lowered
@@ -2055,10 +2050,10 @@ class RealtimeVoiceClient(QObject):
             return _realtime_message(
                 locale,
                 "microphone_failed",
-                error=detail,
+                error=safe_detail,
             )
         return _realtime_message(
             locale,
             "audio_failed",
-            error=detail,
+            error=safe_detail,
         )

--- a/realtime_voice.py
+++ b/realtime_voice.py
@@ -12,8 +12,9 @@ lazy import time
 lazy import uuid
 lazy import wave
 lazy from collections import deque
+lazy from collections.abc import Callable
 lazy from contextlib import suppress
-lazy from dataclasses import dataclass, replace
+lazy from dataclasses import dataclass, field, replace
 lazy from difflib import SequenceMatcher
 lazy from typing import Any
 
@@ -22,11 +23,17 @@ lazy import websocket
 lazy from PySide6.QtCore import QObject, Signal
 
 lazy from audio_buffer import BoundedAudioQueue, PcmPacketizer
+lazy from immutable_config import deep_freeze
+lazy from language_support import canonical_ui_language
 lazy from lip_sync import (
     VISEME_CUES_PER_SECOND,
     infer_vowel_pcm16,
 )
 lazy from pcm_audio import rate_convert_pcm16, scale_pcm16
+lazy from realtime_speech_output import (
+    REALTIME_OUTPUT_MODES,
+    REALTIME_OUTPUT_OPENAI,
+)
 lazy from speech import transcribe_wav_bytes
 
 
@@ -40,16 +47,28 @@ class RealtimeSessionConfig:
     noise_reduction: str = "near_field"
     turn_detection: str = "server_vad"
     external_transcription: bool = True
+    output_mode: str = REALTIME_OUTPUT_OPENAI
+    locale: str = "zh-TW"
 
 
 @dataclass(frozen=True, slots=True)
 class RealtimeVoiceRequest:
-    api_key: str
+    api_key: str = field(repr=False)
     instructions: str
     memory_context: str
     session: RealtimeSessionConfig
     recent_context: str = ""
     echo_guard: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class _AudioSession:
+    playback_queue: BoundedAudioQueue[bytes | None]
+    input_queue: BoundedAudioQueue[bytes | None]
+    output_stream: object | None
+    input_stream: object
+    output_rate: int
+    input_rate: int
 
 
 AUDIO_DELTA_EVENTS = frozenset(
@@ -82,12 +101,226 @@ ASSISTANT_TRANSCRIPT_DONE_EVENTS = frozenset(
         "response.audio_transcript.done",
     }
 )
+ASSISTANT_TEXT_DELTA_EVENTS = frozenset(
+    {"response.output_text.delta", "response.text.delta"}
+)
+ASSISTANT_TEXT_DONE_EVENTS = frozenset(
+    {"response.output_text.done", "response.text.done"}
+)
+MAX_ASSISTANT_RESPONSE_CHARACTERS = 32_768
 USER_TRANSCRIPT_COMPLETED_EVENT = (
     "conversation.item.input_audio_transcription.completed"
 )
 USER_TRANSCRIPT_FAILED_EVENT = (
     "conversation.item.input_audio_transcription.failed"
 )
+
+_REALTIME_MESSAGES = deep_freeze({
+    "zh-TW": {
+        "missing_key": "請先儲存 OpenAI API 金鑰",
+        "missing_components": "Realtime 語音元件尚未安裝",
+        "connecting": "正在連線…",
+        "disconnected": "未連線",
+        "listening": "已連線，妾在聽",
+        "empty_transcript": "未取得有效轉錄，本輪不會自動回覆",
+        "transcription_failed": "轉錄失敗，本輪不會自動回覆：{error}",
+        "realtime_api_error": "Realtime API 發生錯誤",
+        "generic_error": "Realtime 發生錯誤：{error}",
+        "microphone_status": "麥克風狀態：{status}",
+        "sender_lag": "麥克風處理一度落後，已捨棄最舊音訊以恢復即時性",
+        "response_too_long": (
+            "Realtime 回應超過 32,768 字元安全上限，已停止本輪回應。"
+        ),
+        "playback_buffer_full": (
+            "Realtime 播放緩衝已達 1.5 秒安全上限，已停止本輪語音，"
+            "避免延遲持續累積或跳字。"
+        ),
+        "playback_failed": "播放語音失敗：{error}",
+        "clip_too_short": "語音片段太短，本輪不會自動回覆",
+        "transcribing": "高精度整句轉錄中…",
+        "hybrid_failed": "高精度轉錄失敗，本輪不會自動回覆：{error}",
+        "response_not_started": "文字已辨識，但無法觸發 Realtime 回覆",
+        "prompt_echo_skipped": "已略過疑似轉錄提示詞回灌",
+        "replying": "已辨識，墨寒正在回覆",
+        "model_access": (
+            "OpenAI 回報目前儲存的 API 金鑰無法使用「{model}」。"
+            "請確認 API 後台勾選模型的 Project，正是建立這支金鑰的同一個 "
+            "Project；再於該 Project 建立具適當權限的 API Key，並到墨寒的"
+            "「設定」頁重新儲存。"
+        ),
+        "quota": (
+            "OpenAI API 額度不足或專案預算已達上限。請檢查該 Project 的 "
+            "Billing、Budget 與 Realtime 模型用量限制。"
+        ),
+        "invalid_key": (
+            "目前儲存的 OpenAI API 金鑰無效或已撤銷。"
+            "請到「設定」頁重新貼上同一 Project 新建立的 API Key。"
+        ),
+        "server_rejected": "Realtime 連線被伺服器拒絕。詳細資訊：{error}",
+        "microphone_failed": (
+            "Windows 無法開啟麥克風。請到「設定 → 隱私權與安全性 → 麥克風」，"
+            "開啟麥克風存取權及「讓桌面應用程式存取麥克風」，並確認沒有其他"
+            "程式獨占麥克風。詳細資訊：{error}"
+        ),
+        "audio_failed": "音訊裝置無法啟動：{error}",
+    },
+    "zh-CN": {
+        "missing_key": "请先保存 OpenAI API 密钥",
+        "missing_components": "Realtime 语音组件尚未安装",
+        "connecting": "正在连接…",
+        "disconnected": "未连接",
+        "listening": "已连接，妾在听",
+        "empty_transcript": "未取得有效转录，本轮不会自动回复",
+        "transcription_failed": "转录失败，本轮不会自动回复：{error}",
+        "realtime_api_error": "Realtime API 发生错误",
+        "generic_error": "Realtime 发生错误：{error}",
+        "microphone_status": "麦克风状态：{status}",
+        "sender_lag": "麦克风处理一度落后，已舍弃最旧音频以恢复实时性",
+        "response_too_long": (
+            "Realtime 回复超过 32,768 字符安全上限，已停止本轮回复。"
+        ),
+        "playback_buffer_full": (
+            "Realtime 播放缓冲已达 1.5 秒安全上限，已停止本轮语音，"
+            "避免延迟持续累积或跳字。"
+        ),
+        "playback_failed": "播放语音失败：{error}",
+        "clip_too_short": "语音片段太短，本轮不会自动回复",
+        "transcribing": "高精度整句转录中…",
+        "hybrid_failed": "高精度转录失败，本轮不会自动回复：{error}",
+        "response_not_started": "文字已识别，但无法触发 Realtime 回复",
+        "prompt_echo_skipped": "已略过疑似转录提示词回灌",
+        "replying": "已识别，墨寒正在回复",
+        "model_access": (
+            "OpenAI 报告当前保存的 API 密钥无法使用“{model}”。"
+            "请确认 API 后台所选模型的 Project 与建立这支密钥的 Project 相同；"
+            "再于该 Project 建立具备适当权限的 API Key，并到墨寒的“设置”页"
+            "重新保存。"
+        ),
+        "quota": (
+            "OpenAI API 额度不足或项目预算已达上限。请检查该 Project 的 "
+            "Billing、Budget 与 Realtime 模型用量限制。"
+        ),
+        "invalid_key": (
+            "当前保存的 OpenAI API 密钥无效或已撤销。"
+            "请到“设置”页重新粘贴同一 Project 新建立的 API Key。"
+        ),
+        "server_rejected": "Realtime 连接被服务器拒绝。详细信息：{error}",
+        "microphone_failed": (
+            "Windows 无法打开麦克风。请到“设置 → 隐私和安全性 → 麦克风”，"
+            "开启麦克风访问权限及“允许桌面应用访问麦克风”，并确认没有其他"
+            "程序独占麦克风。详细信息：{error}"
+        ),
+        "audio_failed": "音频设备无法启动：{error}",
+    },
+    "en": {
+        "missing_key": "Save an OpenAI API key first",
+        "missing_components": "Realtime voice components are not installed",
+        "connecting": "Connecting…",
+        "disconnected": "Disconnected",
+        "listening": "Connected and listening",
+        "empty_transcript": "No usable transcript was received; this turn will not reply",
+        "transcription_failed": "Transcription failed; this turn will not reply: {error}",
+        "realtime_api_error": "A Realtime API error occurred",
+        "generic_error": "Realtime error: {error}",
+        "microphone_status": "Microphone status: {status}",
+        "sender_lag": "Microphone processing fell behind; the oldest audio was dropped to restore real-time operation",
+        "response_too_long": (
+            "The Realtime response exceeded the 32,768-character safety limit; "
+            "this response was stopped."
+        ),
+        "playback_buffer_full": (
+            "The Realtime playback buffer reached its 1.5-second safety limit; "
+            "this response was stopped to prevent growing delay or skipped words."
+        ),
+        "playback_failed": "Speech playback failed: {error}",
+        "clip_too_short": "The speech clip was too short; this turn will not reply",
+        "transcribing": "Transcribing the complete utterance…",
+        "hybrid_failed": "High-accuracy transcription failed; this turn will not reply: {error}",
+        "response_not_started": "Text was recognized, but the Realtime response could not be started",
+        "prompt_echo_skipped": "A probable transcription-prompt echo was skipped",
+        "replying": "Recognized; MoHan is replying",
+        "model_access": (
+            "The saved OpenAI API key cannot access “{model}”. Confirm that the "
+            "model and API key belong to the same Project, then save a suitably "
+            "authorized key again in MoHan Settings."
+        ),
+        "quota": (
+            "The OpenAI API quota is insufficient or the project budget limit "
+            "was reached. Check Billing, Budget, and Realtime model usage limits."
+        ),
+        "invalid_key": (
+            "The saved OpenAI API key is invalid or revoked. Save a new key from "
+            "the same Project in Settings."
+        ),
+        "server_rejected": "The Realtime server rejected the connection. Details: {error}",
+        "microphone_failed": (
+            "Windows could not open the microphone. In Settings → Privacy & "
+            "security → Microphone, enable microphone access and desktop-app "
+            "access, and confirm that no other program has exclusive control. "
+            "Details: {error}"
+        ),
+        "audio_failed": "The audio device could not start: {error}",
+    },
+    "ja-JP": {
+        "missing_key": "先に OpenAI API キーを保存してください",
+        "missing_components": "Realtime 音声コンポーネントがインストールされていません",
+        "connecting": "接続中…",
+        "disconnected": "未接続",
+        "listening": "接続済み、聞いています",
+        "empty_transcript": "有効な文字起こしを取得できなかったため、このターンには応答しません",
+        "transcription_failed": "文字起こしに失敗したため、このターンには応答しません：{error}",
+        "realtime_api_error": "Realtime API でエラーが発生しました",
+        "generic_error": "Realtime エラー：{error}",
+        "microphone_status": "マイクの状態：{status}",
+        "sender_lag": "マイク処理が遅れたため、リアルタイム性を戻すために最も古い音声を破棄しました",
+        "response_too_long": (
+            "Realtime の応答が 32,768 文字の安全上限を超えたため、"
+            "この応答を停止しました。"
+        ),
+        "playback_buffer_full": (
+            "Realtime の再生バッファーが 1.5 秒の安全上限に達したため、"
+            "遅延の増加や語の欠落を防ぐためにこの応答を停止しました。"
+        ),
+        "playback_failed": "音声の再生に失敗しました：{error}",
+        "clip_too_short": "音声区間が短すぎるため、このターンには応答しません",
+        "transcribing": "発話全体を高精度で文字起こししています…",
+        "hybrid_failed": "高精度文字起こしに失敗したため、このターンには応答しません：{error}",
+        "response_not_started": "文字は認識されましたが、Realtime の応答を開始できませんでした",
+        "prompt_echo_skipped": "文字起こしプロンプトの反響と思われる内容を除外しました",
+        "replying": "認識しました。墨寒が応答しています",
+        "model_access": (
+            "保存された OpenAI API キーでは「{model}」を利用できません。"
+            "モデルと API キーが同じ Project に属することを確認し、適切な権限を"
+            "持つキーを墨寒の設定で保存し直してください。"
+        ),
+        "quota": (
+            "OpenAI API の利用枠が不足しているか、プロジェクトの予算上限に"
+            "達しました。Billing、Budget、Realtime モデルの利用上限を確認してください。"
+        ),
+        "invalid_key": (
+            "保存された OpenAI API キーは無効か、取り消されています。"
+            "同じ Project で新しいキーを作成し、設定で保存し直してください。"
+        ),
+        "server_rejected": "Realtime サーバーが接続を拒否しました。詳細：{error}",
+        "microphone_failed": (
+            "Windows でマイクを開けませんでした。「設定 → プライバシーと"
+            "セキュリティ → マイク」でマイクとデスクトップアプリのアクセスを"
+            "有効にし、他のプログラムがマイクを占有していないことを確認して"
+            "ください。詳細：{error}"
+        ),
+        "audio_failed": "音声デバイスを開始できませんでした：{error}",
+    },
+})
+
+
+def _realtime_message(
+    locale: str,
+    key: str,
+    **values: object,
+) -> str:
+    catalog = _REALTIME_MESSAGES[canonical_ui_language(locale)]
+    message = catalog[key]
+    return message.format(**values) if values else message
 
 
 class RealtimeVoiceClient(QObject):
@@ -102,6 +335,10 @@ class RealtimeVoiceClient(QObject):
     speaking_changed = Signal(bool)
     viseme_cue = Signal(float, str)
     failed = Signal(str)
+    output_text_started = Signal(int)
+    output_text_delta = Signal(int, str)
+    output_text_done = Signal(int)
+    output_interrupted = Signal(int)
     _hybrid_result = Signal(str, str, str, int)
 
     def __init__(self, parent: QObject | None = None):
@@ -124,6 +361,7 @@ class RealtimeVoiceClient(QObject):
         self._failure_lock = threading.Lock()
         self._failure_emitted = False
         self._active_model = ""
+        self._locale = "zh-TW"
         self.echo_guard = True
         self._assistant_audio_active = threading.Event()
         self._playback_busy = threading.Event()
@@ -133,11 +371,15 @@ class RealtimeVoiceClient(QObject):
         self._server_audio_done = False
         self._input_resume_at = 0.0
         self._assistant_text = ""
+        self._response_state_lock = threading.Lock()
+        self._initialize_response_lifecycle()
+        self._external_playback_active = threading.Event()
         self._final_transcript_item_ids: set[str] = set()
         self._final_transcript_item_order: deque[str] = deque()
         self._transcription_prompt_source = ""
         self._transcription_prompt_sent = ""
         self.hybrid_transcription = True
+        self.native_audio_output = True
         self._hybrid_api_key = ""
         self._hybrid_model = "gpt-4o-mini-transcribe"
         self._hybrid_language = "zh"
@@ -157,9 +399,32 @@ class RealtimeVoiceClient(QObject):
             self._finish_hybrid_transcription
         )
 
+    def _initialize_response_lifecycle(self) -> None:
+        self._assistant_output_text = ""
+        self._text_response_open = False
+        self._active_response_id = ""
+        self._native_response_id = ""
+        self._terminal_response_ids: set[str] = set()
+        self._terminal_response_order: deque[str] = deque()
+        self._anonymous_response_blocked = False
+        self._output_interruption_emitted = False
+        self._output_generation = 0
+        self._active_output_generation = 0
+
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
         self.muted = bool(muted)
+
+    def set_external_playback_active(self, active: bool) -> None:
+        """Block echo-prone microphone upload during delegated playback."""
+        if active:
+            self._external_playback_active.set()
+            self._clear_server_input_buffer()
+            return
+        self._external_playback_active.clear()
+        if self.echo_guard:
+            self._input_resume_at = time.monotonic() + 0.9
+            self._clear_server_input_buffer()
 
     @staticmethod
     def dependencies_available() -> bool:
@@ -192,6 +457,12 @@ class RealtimeVoiceClient(QObject):
             external_transcription=bool(
                 session.external_transcription
             ),
+            output_mode=(
+                session.output_mode
+                if session.output_mode in REALTIME_OUTPUT_MODES
+                else REALTIME_OUTPUT_OPENAI
+            ),
+            locale=canonical_ui_language(session.locale),
         )
         return replace(
             request,
@@ -210,16 +481,31 @@ class RealtimeVoiceClient(QObject):
         self._playback_overflowed = False
         self._playback_packetizer.reset()
         self._active_model = session.model
+        self._locale = canonical_ui_language(session.locale)
         self.echo_guard = request.echo_guard
         self.hybrid_transcription = session.external_transcription
+        self.native_audio_output = session.output_mode == "openai-realtime"
         self._hybrid_api_key = request.api_key
         self._hybrid_model = session.transcription_model
         self._hybrid_language = session.transcription_language
         self._hybrid_prompt = session.transcription_prompt
         self._session_generation += 1
         self._assistant_audio_active.clear()
+        self._external_playback_active.clear()
         self._hybrid_transcription_active.clear()
         self._response_pending.clear()
+        self._assistant_text = ""
+        with self._response_state_lock:
+            self._assistant_output_text = ""
+            self._text_response_open = False
+            self._active_response_id = ""
+            self._native_response_id = ""
+            self._terminal_response_ids.clear()
+            self._terminal_response_order.clear()
+            self._anonymous_response_blocked = False
+            self._output_interruption_emitted = False
+            self._output_generation += 1
+            self._active_output_generation = 0
         with self._assistant_state_lock:
             self._assistant_audio_generation += 1
             self._last_assistant_audio_at = 0.0
@@ -235,11 +521,14 @@ class RealtimeVoiceClient(QObject):
     def start(self, request: RealtimeVoiceRequest) -> None:
         if self.running:
             return
+        self._locale = canonical_ui_language(request.session.locale)
         if not request.api_key.strip():
-            self.failed.emit("請先儲存 OpenAI API 金鑰")
+            self.failed.emit(_realtime_message(self._locale, "missing_key"))
             return
         if not self.dependencies_available():
-            self.failed.emit("Realtime 語音元件尚未安裝")
+            self.failed.emit(
+                _realtime_message(self._locale, "missing_components")
+            )
             return
         self._transcription_prompt_source = (
             request.session.transcription_prompt.strip()
@@ -250,7 +539,9 @@ class RealtimeVoiceClient(QObject):
         )
         self._reset_session_state(normalized_request)
         self.running = True
-        self.status_changed.emit("正在連線…")
+        self.status_changed.emit(
+            _realtime_message(self._locale, "connecting")
+        )
         generation = self._session_generation
         threading.Thread(
             target=self._connect,
@@ -258,12 +549,14 @@ class RealtimeVoiceClient(QObject):
             daemon=True,
         ).start()
 
-    def stop(self) -> None:
+    def stop(self) -> int:
         self.running = False
         self._session_generation += 1
         self._hybrid_transcription_active.clear()
         self._response_pending.clear()
         self._finish_assistant_audio(force=True)
+        barrier = self._cancel_external_output(force_signal=True)
+        self._external_playback_active.clear()
         ws = self.ws
         self.ws = None
         if ws:
@@ -271,7 +564,10 @@ class RealtimeVoiceClient(QObject):
             with suppress(Exception):
                 ws.close()
         self._close_audio()
-        self.status_changed.emit("未連線")
+        self.status_changed.emit(
+            _realtime_message(self._locale, "disconnected")
+        )
+        return barrier
 
     def _connect(
         self,
@@ -291,34 +587,37 @@ class RealtimeVoiceClient(QObject):
             + request.session.model
         )
 
-        def on_open(ws):
+        callbacks = self._websocket_callbacks(
+            request,
+            is_current_session,
+        )
+
+        websocket_app = websocket.WebSocketApp(
+            url,
+            header=[
+                f"Authorization: Bearer {request.api_key}",
+                f"OpenAI-Safety-Identifier: {safety_id}",
+            ],
+            **callbacks,
+        )
+        if not is_current_session():
+            return
+        self.ws = websocket_app
+        websocket_app.run_forever(ping_interval=20, ping_timeout=10)
+
+    def _websocket_callbacks(
+        self,
+        request: RealtimeVoiceRequest,
+        is_current_session: Callable[[], bool],
+    ) -> dict[str, Callable[..., None]]:
+        def on_open(ws) -> None:
             if not is_current_session():
                 with suppress(Exception):
                     ws.close()
                 return
-            self.ws = ws
-            full_instructions = self._compose_instructions(
-                request.instructions,
-                request.memory_context,
-                request.recent_context,
-            )
-            ws.send(
-                json.dumps(
-                    self._session_update_event(
-                        request.session,
-                        full_instructions,
-                    ),
-                    ensure_ascii=False,
-                )
-            )
-            try:
-                self._open_audio()
-                self.status_changed.emit("已連線，妾在聽")
-            except Exception as exc:  # noqa: BLE001 -- audio startup reports all failures
-                self._emit_failure(self._audio_error_message(exc))
-                self.stop()
+            self._open_realtime_session(ws, request)
 
-        def on_message(_ws, message):
+        def on_message(_ws, message: object) -> None:
             if not is_current_session():
                 return
             try:
@@ -327,34 +626,68 @@ class RealtimeVoiceClient(QObject):
                 return
             self._handle_server_event(event)
 
-        def on_error(_ws, error):
+        def on_error(_ws, error: object) -> None:
             if is_current_session() and self.running:
-                self._emit_failure(str(error))
+                self._emit_failure(
+                    _realtime_message(
+                        self._locale,
+                        "generic_error",
+                        error=error,
+                    )
+                )
 
-        def on_close(_ws, _code, _message):
-            if not is_current_session():
-                return
-            self.running = False
-            self.ws = None
-            self._close_audio()
-            self._finish_assistant_audio(force=True)
-            self.status_changed.emit("未連線")
+        def on_close(_ws, _code, _message) -> None:
+            if is_current_session():
+                self._close_realtime_session()
 
-        websocket_app = websocket.WebSocketApp(
-            url,
-            header=[
-                f"Authorization: Bearer {request.api_key}",
-                f"OpenAI-Safety-Identifier: {safety_id}",
-            ],
-            on_open=on_open,
-            on_message=on_message,
-            on_error=on_error,
-            on_close=on_close,
+        return {
+            "on_open": on_open,
+            "on_message": on_message,
+            "on_error": on_error,
+            "on_close": on_close,
+        }
+
+    def _open_realtime_session(
+        self,
+        ws: object,
+        request: RealtimeVoiceRequest,
+    ) -> None:
+        self.ws = ws
+        full_instructions = self._compose_instructions(
+            request.instructions,
+            request.memory_context,
+            request.recent_context,
         )
-        if not is_current_session():
-            return
-        self.ws = websocket_app
-        websocket_app.run_forever(ping_interval=20, ping_timeout=10)
+        ws.send(
+            json.dumps(
+                self._session_update_event(
+                    request.session,
+                    full_instructions,
+                ),
+                ensure_ascii=False,
+            )
+        )
+        try:
+            self._open_audio(playback_enabled=self.native_audio_output)
+            self.status_changed.emit(
+                _realtime_message(self._locale, "listening")
+            )
+        except Exception as exc:  # noqa: BLE001 -- audio startup reports all failures
+            self._emit_failure(
+                self._audio_error_message(exc, self._locale)
+            )
+            self.stop()
+
+    def _close_realtime_session(self) -> None:
+        self.running = False
+        self.ws = None
+        if not self.native_audio_output:
+            self._cancel_external_output(force_signal=True)
+        self._close_audio()
+        self._finish_assistant_audio(force=True)
+        self.status_changed.emit(
+            _realtime_message(self._locale, "disconnected")
+        )
 
     @staticmethod
     def _sanitize_realtime_transcription_prompt(prompt: str) -> str:
@@ -503,26 +836,26 @@ class RealtimeVoiceClient(QObject):
                 "type": config.noise_reduction,
             }
 
+        native_audio = config.output_mode == "openai-realtime"
         event = {
             "type": "session.update",
             "session": {
                 "type": "realtime",
                 "model": config.model,
-                "output_modalities": ["audio"],
+                "output_modalities": ["audio" if native_audio else "text"],
                 "instructions": instructions,
                 "reasoning": {"effort": "low"},
-                "audio": {
-                    "input": input_audio,
-                    "output": {
-                        "format": {
-                            "type": "audio/pcm",
-                            "rate": 24000,
-                        },
-                        "voice": config.voice,
-                    },
-                },
+                "audio": {"input": input_audio},
             },
         }
+        if native_audio:
+            event["session"]["audio"]["output"] = {
+                "format": {
+                    "type": "audio/pcm",
+                    "rate": 24000,
+                },
+                "voice": config.voice,
+            }
         if not config.external_transcription:
             event["session"]["include"] = [
                 "item.input_audio_transcription.logprobs"
@@ -530,6 +863,18 @@ class RealtimeVoiceClient(QObject):
         return event
 
     def _handle_audio_delta(self, event: dict[str, Any]) -> None:
+        if not self.native_audio_output:
+            return
+        response_id = self._event_response_id(event)
+        with self._response_state_lock:
+            if response_id:
+                if (
+                    response_id in self._terminal_response_ids
+                    or self._native_response_id
+                    and self._native_response_id != response_id
+                ):
+                    return
+                self._native_response_id = response_id
         delta = event.get("delta", "")
         if not delta or self._playback_overflowed:
             return
@@ -541,9 +886,32 @@ class RealtimeVoiceClient(QObject):
             if not self._queue_playback_chunk(chunk):
                 break
 
-    def _handle_audio_done(self, kind: str) -> None:
+    def _handle_audio_done(
+        self,
+        kind: str,
+        event: dict[str, Any] | None = None,
+    ) -> None:
+        if not self.native_audio_output:
+            if kind in AUDIO_CANCELLED_EVENTS:
+                self._cancel_external_output(
+                    self._event_response_id(event or {}),
+                    force_signal=True,
+                )
+            return
+        response_id = self._event_response_id(event or {})
+        with self._response_state_lock:
+            if response_id:
+                if response_id in self._terminal_response_ids:
+                    return
+                if self._native_response_id and self._native_response_id != response_id:
+                    return
+                self._native_response_id = response_id
+            terminal_id = response_id or self._native_response_id
+            self._remember_terminal_response_locked(terminal_id)
+            self._native_response_id = ""
         if kind in AUDIO_CANCELLED_EVENTS:
             self._playback_packetizer.reset()
+            self._discard_native_playback()
         else:
             remainder = self._playback_packetizer.flush()
             if remainder and not self._playback_overflowed:
@@ -556,7 +924,18 @@ class RealtimeVoiceClient(QObject):
         self,
         event: dict[str, Any],
     ) -> None:
-        self._assistant_text += str(event.get("delta", ""))
+        delta = str(event.get("delta", ""))
+        if (
+            len(self._assistant_text) + len(delta)
+            > MAX_ASSISTANT_RESPONSE_CHARACTERS
+        ):
+            self._cancel_server_response()
+            self._assistant_text = ""
+            self._emit_failure(
+                _realtime_message(self._locale, "response_too_long")
+            )
+            return
+        self._assistant_text += delta
 
     def _handle_assistant_transcript_done(
         self,
@@ -566,8 +945,245 @@ class RealtimeVoiceClient(QObject):
             event.get("transcript") or self._assistant_text
         ).strip()
         self._assistant_text = ""
+        if len(text) > MAX_ASSISTANT_RESPONSE_CHARACTERS:
+            self._cancel_server_response()
+            self._emit_failure(
+                _realtime_message(self._locale, "response_too_long")
+            )
+            return
         if text:
             self.assistant_transcript.emit(text)
+
+    @staticmethod
+    def _event_response_id(event: dict[str, Any]) -> str:
+        response = event.get("response")
+        nested_id = response.get("id") if isinstance(response, dict) else ""
+        return str(event.get("response_id") or nested_id or "").strip()
+
+    def _response_event_matches_locked(self, response_id: str) -> bool:
+        if not response_id:
+            return not self._anonymous_response_blocked
+        if response_id in self._terminal_response_ids:
+            return False
+        if self._active_response_id:
+            return self._active_response_id == response_id
+        if self._anonymous_response_blocked:
+            return False
+        self._active_response_id = response_id
+        return True
+
+    def _remember_terminal_response_locked(self, response_id: str) -> None:
+        if not response_id or response_id in self._terminal_response_ids:
+            return
+        if len(self._terminal_response_order) >= 256:
+            oldest = self._terminal_response_order.popleft()
+            self._terminal_response_ids.discard(oldest)
+        self._terminal_response_order.append(response_id)
+        self._terminal_response_ids.add(response_id)
+
+    def _prepare_external_response(self) -> None:
+        with self._response_state_lock:
+            self._assistant_output_text = ""
+            self._text_response_open = False
+            self._active_response_id = ""
+            self._anonymous_response_blocked = False
+            self._output_interruption_emitted = False
+
+    def _begin_output_generation_locked(self) -> tuple[int, bool]:
+        if self._active_output_generation:
+            return self._active_output_generation, False
+        self._output_generation += 1
+        self._active_output_generation = self._output_generation
+        return self._active_output_generation, True
+
+    def _handle_response_created(self, event: dict[str, Any]) -> None:
+        if self.native_audio_output:
+            response_id = self._event_response_id(event)
+            with self._response_state_lock:
+                if response_id not in self._terminal_response_ids:
+                    self._native_response_id = response_id
+            return
+        response_id = self._event_response_id(event)
+        output_generation = 0
+        response_started = False
+        with self._response_state_lock:
+            if not response_id:
+                if self._anonymous_response_blocked:
+                    return
+            elif (
+                response_id in self._terminal_response_ids
+                or (
+                    self._active_response_id
+                    and self._active_response_id != response_id
+                )
+            ):
+                return
+            else:
+                self._active_response_id = response_id
+                self._anonymous_response_blocked = False
+            output_generation, response_started = (
+                self._begin_output_generation_locked()
+            )
+            self._output_interruption_emitted = False
+        if response_started:
+            self.output_text_started.emit(output_generation)
+
+    def _handle_assistant_text_delta(self, event: dict[str, Any]) -> None:
+        if self.native_audio_output:
+            return
+        delta = str(event.get("delta", ""))
+        if not delta:
+            return
+        response_id = self._event_response_id(event)
+        output_generation = 0
+        response_started = False
+        oversized = False
+        with self._response_state_lock:
+            if not self._response_event_matches_locked(response_id):
+                return
+            output_generation, response_started = (
+                self._begin_output_generation_locked()
+            )
+            oversized = (
+                len(self._assistant_output_text) + len(delta)
+                > MAX_ASSISTANT_RESPONSE_CHARACTERS
+            )
+            if not oversized:
+                self._text_response_open = True
+                self._assistant_output_text += delta
+        if oversized:
+            self._reject_oversized_response(response_id)
+            return
+        if response_started:
+            self.output_text_started.emit(output_generation)
+        self.output_text_delta.emit(output_generation, delta)
+
+    def _handle_assistant_text_done(self, event: dict[str, Any]) -> None:
+        if self.native_audio_output:
+            return
+        response_id = self._event_response_id(event)
+        output_generation = 0
+        response_started = False
+        text_to_emit = ""
+        oversized = False
+        with self._response_state_lock:
+            if not self._response_event_matches_locked(response_id):
+                return
+            output_generation, response_started = (
+                self._begin_output_generation_locked()
+            )
+            text = str(event.get("text") or "")
+            oversized = len(text) > MAX_ASSISTANT_RESPONSE_CHARACTERS
+            if text and not oversized:
+                if not self._assistant_output_text:
+                    text_to_emit = text
+                self._assistant_output_text = text
+            self._text_response_open = True
+        if oversized:
+            self._reject_oversized_response(response_id)
+            return
+        if response_started:
+            self.output_text_started.emit(output_generation)
+        if text_to_emit:
+            self.output_text_delta.emit(output_generation, text_to_emit)
+
+    def _handle_response_done(self, event: dict[str, Any]) -> None:
+        response = event.get("response")
+        status = str(
+            response.get("status", "")
+            if isinstance(response, dict)
+            else ""
+        ).strip()
+        if self.native_audio_output:
+            kind = "response.done" if status in {"", "completed"} else "response.failed"
+            self._handle_audio_done(kind, event)
+            return
+        response_id = self._event_response_id(event)
+        if status != "completed":
+            self._cancel_external_output(
+                response_id,
+            )
+            return
+        with self._response_state_lock:
+            if not self._response_event_matches_locked(response_id):
+                return
+            text = self._assistant_output_text.strip()
+            output_generation = self._active_output_generation
+            self._remember_terminal_response_locked(response_id)
+            self._active_response_id = ""
+            self._assistant_output_text = ""
+            self._text_response_open = False
+            self._active_output_generation = 0
+            self._anonymous_response_blocked = True
+        self._response_pending.clear()
+        if text:
+            self.assistant_transcript.emit(text)
+        if output_generation:
+            self.output_text_done.emit(output_generation)
+
+    def _reject_oversized_response(self, response_id: str) -> None:
+        self._cancel_server_response()
+        self._cancel_external_output(response_id, force_signal=True)
+        self._emit_failure(
+            _realtime_message(self._locale, "response_too_long")
+        )
+
+    def _cancel_server_response(self) -> None:
+        ws = self.ws
+        if not ws or not ws.sock or not ws.sock.connected:
+            return
+        with suppress(Exception):
+            ws.send(json.dumps({"type": "response.cancel"}))
+
+    def _cancel_external_output(
+        self,
+        response_id: str = "",
+        *,
+        force_signal: bool = False,
+    ) -> int:
+        with self._response_state_lock:
+            if response_id:
+                if response_id in self._terminal_response_ids:
+                    return self._output_generation
+                if (
+                    self._active_response_id
+                    and self._active_response_id != response_id
+                ):
+                    self._remember_terminal_response_locked(response_id)
+                    return self._output_generation
+                if (
+                    not self._active_response_id
+                    and self._anonymous_response_blocked
+                ):
+                    self._remember_terminal_response_locked(response_id)
+                    return self._output_generation
+            terminal_id = response_id or self._active_response_id
+            self._remember_terminal_response_locked(terminal_id)
+            had_output = bool(
+                self._active_response_id
+                or self._text_response_open
+                or self._assistant_output_text
+                or self._response_pending.is_set()
+                or self._external_playback_active.is_set()
+            )
+            self._active_response_id = ""
+            self._assistant_output_text = ""
+            self._text_response_open = False
+            self._anonymous_response_blocked = True
+            should_advance = force_signal or had_output
+            should_emit = (
+                should_advance and not self._output_interruption_emitted
+            )
+            if should_advance:
+                self._output_generation += 1
+                self._active_output_generation = 0
+            if should_emit:
+                self._output_interruption_emitted = True
+            barrier = self._output_generation
+        self._response_pending.clear()
+        if should_emit:
+            self.output_interrupted.emit(barrier)
+        return barrier
 
     def _handle_user_transcript_completed(
         self,
@@ -590,7 +1206,7 @@ class RealtimeVoiceClient(QObject):
             self._discard_conversation_item(item_id)
             if not text:
                 self.status_changed.emit(
-                    "未取得有效轉錄，本輪不會自動回覆"
+                    _realtime_message(self._locale, "empty_transcript")
                 )
 
     def _handle_user_transcript_failed(
@@ -603,10 +1219,14 @@ class RealtimeVoiceClient(QObject):
         detail = str(
             error.get("message")
             or error.get("code")
-            or "無法辨識這段語音"
+            or _realtime_message(self._locale, "realtime_api_error")
         )
         self.status_changed.emit(
-            f"轉錄失敗，本輪不會自動回覆：{detail}"
+            _realtime_message(
+                self._locale,
+                "transcription_failed",
+                error=detail,
+            )
         )
         self._discard_conversation_item(
             str(event.get("item_id") or "")
@@ -616,6 +1236,8 @@ class RealtimeVoiceClient(QObject):
         self,
         event: dict[str, Any],
     ) -> None:
+        if not self.native_audio_output:
+            self._cancel_external_output(force_signal=True)
         # Only apply the playback tail to a real interruption. Doing so for
         # normal speech would erase the first 0.9 seconds of the next turn.
         if (
@@ -649,67 +1271,90 @@ class RealtimeVoiceClient(QObject):
         event: dict[str, Any],
     ) -> None:
         self._finish_assistant_audio(force=True)
+        if not self.native_audio_output:
+            self._cancel_external_output(force_signal=True)
         error = event.get("error") or {}
+        detail = str(
+            error.get("message")
+            or _realtime_message(self._locale, "realtime_api_error")
+        )
         self._emit_failure(
-            str(error.get("message", "Realtime API 發生錯誤"))
+            _realtime_message(
+                self._locale,
+                "generic_error",
+                error=detail,
+            )
         )
 
     def _handle_server_event(self, event: dict[str, Any]) -> None:
         kind = str(event.get("type", ""))
-        if kind in AUDIO_DELTA_EVENTS:
-            self._handle_audio_delta(event)
-        elif kind in AUDIO_DONE_EVENTS:
-            self._handle_audio_done(kind)
-        elif kind in ASSISTANT_TRANSCRIPT_DELTA_EVENTS:
-            self._handle_assistant_transcript_delta(event)
-        elif kind in ASSISTANT_TRANSCRIPT_DONE_EVENTS:
-            self._handle_assistant_transcript_done(event)
-        elif kind == USER_TRANSCRIPT_COMPLETED_EVENT:
-            self._handle_user_transcript_completed(event)
-        elif kind == USER_TRANSCRIPT_FAILED_EVENT:
-            self._handle_user_transcript_failed(event)
-        elif kind == "input_audio_buffer.speech_started":
-            self._handle_speech_started(event)
-        elif kind == "input_audio_buffer.speech_stopped":
-            self._handle_speech_stopped(event)
-        elif kind == "error":
-            self._handle_realtime_error(event)
+        handler = self._server_event_handler(kind)
+        if handler is not None:
+            handler(event)
 
-    def _open_audio(self) -> None:
+    def _server_event_handler(
+        self,
+        kind: str,
+    ) -> Callable[[dict[str, Any]], None] | None:
+        event_groups = (
+            (AUDIO_DELTA_EVENTS, self._handle_audio_delta),
+            (ASSISTANT_TRANSCRIPT_DELTA_EVENTS, self._handle_assistant_transcript_delta),
+            (ASSISTANT_TRANSCRIPT_DONE_EVENTS, self._handle_assistant_transcript_done),
+            (ASSISTANT_TEXT_DELTA_EVENTS, self._handle_assistant_text_delta),
+            (ASSISTANT_TEXT_DONE_EVENTS, self._handle_assistant_text_done),
+        )
+        for kinds, handler in event_groups:
+            if kind in kinds:
+                return handler
+        exact_handlers = {
+            "response.created": self._handle_response_created,
+            "response.done": self._handle_response_done,
+            USER_TRANSCRIPT_COMPLETED_EVENT: self._handle_user_transcript_completed,
+            USER_TRANSCRIPT_FAILED_EVENT: self._handle_user_transcript_failed,
+            "input_audio_buffer.speech_started": self._handle_speech_started,
+            "input_audio_buffer.speech_stopped": self._handle_speech_stopped,
+            "error": self._handle_realtime_error,
+        }
+        exact_handler = exact_handlers.get(kind)
+        if exact_handler is not None:
+            return exact_handler
+        if kind in AUDIO_DONE_EVENTS:
+            return lambda event: self._handle_audio_done(kind, event)
+        return None
+
+    def _open_audio(self, *, playback_enabled: bool = True) -> None:
         audio_queue: BoundedAudioQueue[bytes | None] = BoundedAudioQueue(
             self.PLAYBACK_QUEUE_CHUNKS
         )
         input_queue: BoundedAudioQueue[bytes | None] = BoundedAudioQueue(
             self.INPUT_QUEUE_CHUNKS
         )
-        input_device = self._preferred_device(sd, "input")
-        output_device = self._preferred_device(sd, "output")
-        input_rate = int(
-            sd.query_devices(input_device, "input")["default_samplerate"]
-        )
-        output_rate = int(
-            sd.query_devices(output_device, "output")["default_samplerate"]
+        input_device, input_rate = self._audio_device("input")
+        output_device, output_rate = (
+            self._audio_device("output")
+            if playback_enabled
+            else (None, 24_000)
         )
         output_stream = None
         input_stream = None
 
         def input_callback(indata, _frames, _time, status):
             if status:
-                self.status_changed.emit(f"麥克風狀態：{status}")
+                self.status_changed.emit(
+                    _realtime_message(
+                        self._locale,
+                        "microphone_status",
+                        status=status,
+                    )
+                )
             if self.running and not self._microphone_blocked():
                 input_queue.offer(bytes(indata), keep_latest=True)
 
         try:
-            output_stream = sd.RawOutputStream(
-                device=output_device,
-                samplerate=output_rate,
-                channels=1,
-                dtype="int16",
-                blocksize=max(
-                    1,
-                    output_rate * self.DEVICE_BLOCK_MILLISECONDS // 1000,
-                ),
-                latency="low",
+            output_stream = self._output_audio_stream(
+                output_device,
+                output_rate,
+                playback_enabled,
             )
             input_stream = sd.RawInputStream(
                 device=input_device,
@@ -723,38 +1368,91 @@ class RealtimeVoiceClient(QObject):
                 latency="low",
                 callback=input_callback,
             )
-            with self._audio_lock:
-                if not self.running:
-                    raise RuntimeError("Realtime 連線已停止")
-                self._audio_queue = audio_queue
-                self._input_queue = input_queue
-                self._output_stream = output_stream
-                self._input_stream = input_stream
-                output_stream.start()
-                input_stream.start()
+            self._activate_audio_streams(
+                _AudioSession(
+                    playback_queue=audio_queue,
+                    input_queue=input_queue,
+                    output_stream=output_stream,
+                    input_stream=input_stream,
+                    output_rate=output_rate,
+                    input_rate=input_rate,
+                )
+            )
+        except Exception:
+            self._discard_unstarted_audio_streams(input_stream, output_stream)
+            raise
+
+    def _audio_device(self, kind: str) -> tuple[object, int]:
+        device = self._preferred_device(sd, kind)
+        rate = int(sd.query_devices(device, kind)["default_samplerate"])
+        return device, rate
+
+    def _output_audio_stream(
+        self,
+        device: object,
+        rate: int,
+        enabled: bool,
+    ) -> object | None:
+        if not enabled:
+            return None
+        return sd.RawOutputStream(
+            device=device,
+            samplerate=rate,
+            channels=1,
+            dtype="int16",
+            blocksize=max(
+                1,
+                rate * self.DEVICE_BLOCK_MILLISECONDS // 1000,
+            ),
+            latency="low",
+        )
+
+    def _activate_audio_streams(
+        self,
+        audio: _AudioSession,
+    ) -> None:
+        with self._audio_lock:
+            if not self.running:
+                raise RuntimeError("Realtime 連線已停止")
+            self._audio_queue = audio.playback_queue
+            self._input_queue = audio.input_queue
+            self._output_stream = audio.output_stream
+            self._input_stream = audio.input_stream
+            if audio.output_stream is not None:
+                audio.output_stream.start()
+            audio.input_stream.start()
+        if audio.output_stream is not None:
             threading.Thread(
                 target=self._playback_loop,
-                args=(audio_queue, output_stream, output_rate),
+                args=(
+                    audio.playback_queue,
+                    audio.output_stream,
+                    audio.output_rate,
+                ),
                 daemon=True,
             ).start()
-            threading.Thread(
-                target=self._input_sender_loop,
-                args=(input_queue, input_rate),
-                daemon=True,
-            ).start()
-        except Exception:
-            with self._audio_lock:
-                if input_stream and self._input_stream is input_stream:
-                    self._input_stream = None
-                if output_stream and self._output_stream is output_stream:
-                    self._output_stream = None
-            for stream in (input_stream, output_stream):
-                if stream:
-                    # Preserve the original audio error; cleanup is best effort.
-                    with suppress(Exception):
-                        stream.abort()
-                        stream.close()
-            raise
+        threading.Thread(
+            target=self._input_sender_loop,
+            args=(audio.input_queue, audio.input_rate),
+            daemon=True,
+        ).start()
+
+    def _discard_unstarted_audio_streams(
+        self,
+        input_stream: object | None,
+        output_stream: object | None,
+    ) -> None:
+        with self._audio_lock:
+            if input_stream and self._input_stream is input_stream:
+                self._input_stream = None
+            if output_stream and self._output_stream is output_stream:
+                self._output_stream = None
+        for stream in (input_stream, output_stream):
+            if stream:
+                # Preserve the original audio error; cleanup is best effort.
+                with suppress(Exception):
+                    stream.abort()
+                    stream.close()
 
     def _input_sender_loop(
         self,
@@ -793,7 +1491,7 @@ class RealtimeVoiceClient(QObject):
                     if dropped > reported_drops:
                         reported_drops = dropped
                         self.status_changed.emit(
-                            "麥克風處理一度落後，已捨棄最舊音訊以恢復即時性"
+                            _realtime_message(self._locale, "sender_lag")
                         )
             except Exception:  # noqa: BLE001 -- connection loss ends sender loop
                 break
@@ -815,10 +1513,22 @@ class RealtimeVoiceClient(QObject):
                 ws.send(json.dumps({"type": "response.cancel"}))
         self._finish_assistant_audio(force=True)
         self._emit_failure(
-            "Realtime 播放緩衝已達 1.5 秒安全上限，已停止本輪語音，"
-            "避免延遲持續累積或跳字。"
+            _realtime_message(self._locale, "playback_buffer_full")
         )
         return False
+
+    def _discard_native_playback(self) -> None:
+        while True:
+            try:
+                self._audio_queue.get_nowait()
+            except queue.Empty:
+                break
+        self._finish_assistant_audio()
+        output_stream = self._output_stream
+        if output_stream is not None:
+            with suppress(Exception):
+                output_stream.abort()
+                output_stream.start()
 
     def _playback_loop(
         self,
@@ -835,9 +1545,19 @@ class RealtimeVoiceClient(QObject):
             audio = audio_queue.get()
             if audio is None:
                 break
+            with self._assistant_state_lock:
+                playback_generation = self._assistant_audio_generation
             self._playback_busy.set()
             try:
                 for offset in range(0, len(audio), animation_chunk_bytes):
+                    with self._assistant_state_lock:
+                        playback_cancelled = (
+                            playback_generation
+                            != self._assistant_audio_generation
+                        )
+                    if playback_cancelled:
+                        rate_state = None
+                        break
                     source_chunk = audio[offset : offset + animation_chunk_bytes]
                     if not source_chunk:
                         continue
@@ -864,13 +1584,32 @@ class RealtimeVoiceClient(QObject):
                         playback_chunk = scale_pcm16(playback_chunk, gain)
                     output_stream.write(playback_chunk)
             except Exception as exc:  # noqa: BLE001 -- playback reports all failures
-                self._finish_assistant_audio(force=True)
-                self._emit_failure(f"播放語音失敗：{exc}")
+                self._report_playback_error(exc, playback_generation)
                 break
             finally:
                 self._playback_busy.clear()
             if self._server_audio_done and audio_queue.empty():
                 self._finish_assistant_audio()
+
+    def _report_playback_error(
+        self,
+        error: Exception,
+        playback_generation: int,
+    ) -> None:
+        with self._assistant_state_lock:
+            playback_cancelled = (
+                playback_generation != self._assistant_audio_generation
+            )
+        if playback_cancelled:
+            return
+        self._finish_assistant_audio(force=True)
+        self._emit_failure(
+            _realtime_message(
+                self._locale,
+                "playback_failed",
+                error=error,
+            )
+        )
 
     def _close_audio(self) -> None:
         with self._audio_lock:
@@ -1002,12 +1741,14 @@ class RealtimeVoiceClient(QObject):
         pcm = self._pcm_for_audio_range(start_ms, end_ms)
         if len(pcm) < 24000:
             self.status_changed.emit(
-                "語音片段太短，本輪不會自動回覆"
+                _realtime_message(self._locale, "clip_too_short")
             )
             self._discard_conversation_item(item_id)
             return
         self._hybrid_transcription_active.set()
-        self.status_changed.emit("高精度整句轉錄中…")
+        self.status_changed.emit(
+            _realtime_message(self._locale, "transcribing")
+        )
         wav_audio = self._pcm16_to_wav(pcm)
         generation = self._session_generation
         threading.Thread(
@@ -1054,7 +1795,11 @@ class RealtimeVoiceClient(QObject):
             self._hybrid_transcription_active.clear()
             self._discard_conversation_item(item_id)
             self.status_changed.emit(
-                f"高精度轉錄失敗，本輪不會自動回覆：{error}"
+                _realtime_message(
+                    self._locale,
+                    "hybrid_failed",
+                    error=error,
+                )
             )
             return
         accepted = self._emit_completed_user_transcript(
@@ -1066,7 +1811,10 @@ class RealtimeVoiceClient(QObject):
             self._hybrid_transcription_active.clear()
             if not requested:
                 self.status_changed.emit(
-                    "文字已辨識，但無法觸發 Realtime 回覆"
+                    _realtime_message(
+                        self._locale,
+                        "response_not_started",
+                    )
                 )
         else:
             self._hybrid_transcription_active.clear()
@@ -1080,6 +1828,7 @@ class RealtimeVoiceClient(QObject):
                 self.echo_guard
                 and (
                     self._assistant_audio_active.is_set()
+                    or self._external_playback_active.is_set()
                     or time.monotonic() < self._input_resume_at
                 )
             )
@@ -1098,7 +1847,7 @@ class RealtimeVoiceClient(QObject):
             self._transcription_prompt_sent,
         ):
             self.status_changed.emit(
-                "已略過疑似轉錄提示詞回灌"
+                _realtime_message(self._locale, "prompt_echo_skipped")
             )
             return False
         if item_id:
@@ -1120,12 +1869,19 @@ class RealtimeVoiceClient(QObject):
         if not ws or not ws.sock or not ws.sock.connected:
             return False
         self._response_pending.set()
+        if not self.native_audio_output:
+            self._prepare_external_response()
         try:
-            ws.send(json.dumps({"type": "response.create"}))
+            response: dict[str, Any] = {"type": "response.create"}
+            if not self.native_audio_output:
+                response["response"] = {"output_modalities": ["text"]}
+            ws.send(json.dumps(response))
         except Exception:  # noqa: BLE001 -- failed request clears pending state
             self._response_pending.clear()
             return False
-        self.status_changed.emit("已辨識，墨寒正在回覆")
+        self.status_changed.emit(
+            _realtime_message(self._locale, "replying")
+        )
         return True
 
     def _discard_conversation_item(self, item_id: str) -> bool:
@@ -1246,39 +2002,48 @@ class RealtimeVoiceClient(QObject):
             if self._failure_emitted:
                 return
             self._failure_emitted = True
-        self.failed.emit(self._friendly_error(detail, self._active_model))
+        self.failed.emit(
+            self._friendly_error(
+                detail,
+                self._active_model,
+                self._locale,
+            )
+        )
 
     @staticmethod
-    def _friendly_error(detail: str, model: str) -> str:
+    def _friendly_error(
+        detail: str,
+        model: str,
+        locale: str = "zh-TW",
+    ) -> str:
         raw = str(detail)
         lowered = raw.lower()
         if (
             "model_not_found" in lowered
             or "does not exist or you do not have access" in lowered
         ):
-            return (
-                f"OpenAI 回報目前儲存的 API 金鑰無法使用「{model}」。"
-                "這兩款 Realtime 2.1 模型本身是有效的；請確認 API 後台"
-                "勾選模型的 Project，正是建立這支金鑰的同一個 Project。"
-                "建議在該 Project 重新建立一支權限為 All 的 API Key，"
-                "到墨寒的「設定」頁重新儲存，再啟動 Realtime。"
+            return _realtime_message(
+                locale,
+                "model_access",
+                model=model,
             )
         if "insufficient_quota" in lowered or "exceeded your current quota" in lowered:
-            return (
-                "OpenAI API 額度不足或專案預算已達上限。請檢查該 Project "
-                "的 Billing、Budget 與 Realtime 模型用量限制。"
-            )
+            return _realtime_message(locale, "quota")
         if "401" in lowered or "invalid_api_key" in lowered:
-            return (
-                "目前儲存的 OpenAI API 金鑰無效或已撤銷。"
-                "請到「設定」頁重新貼上同一 Project 新建立的 API Key。"
-            )
+            return _realtime_message(locale, "invalid_key")
         if "fin=1 opcode=8" in lowered:
-            return f"Realtime 連線被伺服器拒絕。詳細資訊：{raw}"
+            return _realtime_message(
+                locale,
+                "server_rejected",
+                error=raw,
+            )
         return raw
 
     @staticmethod
-    def _audio_error_message(error: Exception) -> str:
+    def _audio_error_message(
+        error: Exception,
+        locale: str = "zh-TW",
+    ) -> str:
         detail = str(error)
         lowered = detail.lower()
         if (
@@ -1287,10 +2052,13 @@ class RealtimeVoiceClient(QObject):
             or "mme error" in lowered
             or "invalid device" in lowered
         ):
-            return (
-                "Windows 無法開啟麥克風。請到「設定 → 隱私權與安全性 → "
-                "麥克風」，開啟麥克風存取權及「讓桌面應用程式存取麥克風」，"
-                "並確認沒有其他程式獨占麥克風。詳細資訊："
-                + detail
+            return _realtime_message(
+                locale,
+                "microphone_failed",
+                error=detail,
             )
-        return f"音訊裝置無法啟動：{detail}"
+        return _realtime_message(
+            locale,
+            "audio_failed",
+            error=detail,
+        )

--- a/remote_control.py
+++ b/remote_control.py
@@ -6,15 +6,19 @@ lazy import json
 lazy import os
 lazy import secrets
 lazy import sqlite3
+lazy import stat
 lazy import threading
 lazy import time
 lazy from collections.abc import Callable, Iterator, Mapping
+lazy from contextlib import suppress
 lazy from dataclasses import dataclass
 lazy from http import HTTPStatus
 lazy from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 lazy from pathlib import Path
-lazy from typing import Any
+lazy from typing import Any, BinaryIO
 lazy from urllib.parse import parse_qs, urlparse
+
+lazy from language_support import canonical_ui_language
 
 StatusProvider = Callable[[], dict[str, Any]]
 CommandHandler = Callable[[str, str], dict[str, Any]]
@@ -47,6 +51,19 @@ PROTECTED_REMOTE_PARTS = frozenset({
     "passwords",
 })
 PROTECTED_REMOTE_SUFFIXES = frozenset({".kdbx", ".key", ".pem", ".pfx"})
+REMOTE_FILE_UNAVAILABLE_MESSAGES = frozendict({
+    "zh-TW": "檔案目前無法提供",
+    "zh-CN": "文件目前无法提供",
+    "en-US": "The file is currently unavailable.",
+    "ja-JP": "現在このファイルを提供できません。",
+})
+REMOTE_FILE_UNAVAILABLE = REMOTE_FILE_UNAVAILABLE_MESSAGES["zh-TW"]
+
+
+def remote_file_unavailable(language: str) -> str:
+    normalized = canonical_ui_language(language)
+    key = "en-US" if normalized == "en" else normalized
+    return REMOTE_FILE_UNAVAILABLE_MESSAGES[key]
 
 MOBILE_PAGE = """<!doctype html>
 <html lang="zh-Hant-TW"><meta charset="utf-8">
@@ -93,6 +110,7 @@ class RemoteServerConfig:
     allow_screen: bool = False
     allow_files: bool = False
     max_requests_per_minute: int = 60
+    language: str = "zh-TW"
 
 
 @dataclass(frozen=True, slots=True)
@@ -469,25 +487,49 @@ class RemoteRequestHandler(BaseHTTPRequestHandler):
             )
             return
         raw_path = parse_qs(query_string).get("path", [""])[0]
+        stream: BinaryIO | None = None
+        content_length = 0
+        open_failed = False
         try:
             target = owner._allowed_file(raw_path)
-            content_length = target.stat().st_size
-        except (OSError, PermissionError) as exc:
+            stream = target.open("rb")
+            opened_file = os.fstat(stream.fileno())
+            if stat.S_ISREG(opened_file.st_mode):
+                content_length = opened_file.st_size
+            else:
+                open_failed = True
+        except (OSError, RuntimeError, ValueError):
+            open_failed = True
+
+        if open_failed or stream is None:
+            if stream is not None:
+                with suppress(OSError):
+                    stream.close()
             self._json(
                 HTTPStatus.FORBIDDEN,
-                {"error": str(exc)},
+                {"error": remote_file_unavailable(owner.config.language)},
             )
             return
+
         content_type, disposition = owner._download_metadata(target)
-        self._send_headers(
-            HTTPStatus.OK,
-            content_length,
-            content_type,
-            {"Content-Disposition": disposition},
-        )
-        with target.open("rb") as stream:
-            while chunk := stream.read(64 * 1024):
-                self.wfile.write(chunk)
+        try:
+            with stream:
+                self._send_headers(
+                    HTTPStatus.OK,
+                    content_length,
+                    content_type,
+                    {"Content-Disposition": disposition},
+                )
+                remaining = content_length
+                while remaining and (
+                    chunk := stream.read(min(64 * 1024, remaining))
+                ):
+                    self.wfile.write(chunk)
+                    remaining -= len(chunk)
+        except (OSError, RuntimeError, ValueError):
+            # Headers may already be committed. Close the truncated response
+            # without exposing the local I/O failure through a server traceback.
+            self.close_connection = True
 
     def do_GET(self) -> None:
         parsed = urlparse(self.path)

--- a/safe_error.py
+++ b/safe_error.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+lazy import inspect
+lazy import re
+lazy from dataclasses import dataclass
+lazy from enum import StrEnum
+
+__all__ = [
+    "SafeDiagnostic",
+    "SafeError",
+    "SafeErrorType",
+    "sanitize_error",
+]
+
+type ErrorInput = BaseException | str
+type _Classification = tuple["SafeErrorType", "SafeDiagnostic"]
+
+
+class SafeErrorType(StrEnum):
+    """Approved, language-independent error types exposed outside services."""
+
+    HTTP_ERROR = "http_error"
+    TIMEOUT_ERROR = "timeout_error"
+    CONNECTION_ERROR = "connection_error"
+    AUTHENTICATION_ERROR = "authentication_error"
+    AUTHORIZATION_ERROR = "authorization_error"
+    RATE_LIMIT_ERROR = "rate_limit_error"
+    NOT_FOUND_ERROR = "not_found_error"
+    CANCELLED_ERROR = "cancelled_error"
+    DECODING_ERROR = "decoding_error"
+    VALIDATION_ERROR = "validation_error"
+    OPERATING_SYSTEM_ERROR = "operating_system_error"
+    RUNTIME_ERROR = "runtime_error"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+class SafeDiagnostic(StrEnum):
+    """Finite diagnostic codes suitable for logs and localized UI mapping."""
+
+    AUTHENTICATION_REQUIRED = "authentication_required"
+    ACCESS_DENIED = "access_denied"
+    RATE_LIMITED = "rate_limited"
+    REQUEST_TIMEOUT = "request_timeout"
+    NETWORK_UNAVAILABLE = "network_unavailable"
+    RESOURCE_NOT_FOUND = "resource_not_found"
+    CONFLICT = "conflict"
+    INVALID_INPUT = "invalid_input"
+    INVALID_RESPONSE = "invalid_response"
+    OPERATION_CANCELLED = "operation_cancelled"
+    LOCAL_IO_FAILURE = "local_io_failure"
+    REMOTE_SERVICE_FAILURE = "remote_service_failure"
+    UNEXPECTED_RESPONSE = "unexpected_response"
+    INTERNAL_FAILURE = "internal_failure"
+    UNKNOWN_FAILURE = "unknown_failure"
+
+
+@dataclass(frozen=True, slots=True)
+class SafeError:
+    """A sanitized error value that never retains the original error text."""
+
+    error_type: SafeErrorType
+    diagnostic: SafeDiagnostic
+    http_status: int | None = None
+
+    def __str__(self) -> str:
+        parts = [
+            f"type={self.error_type.value}",
+            f"diagnostic={self.diagnostic.value}",
+        ]
+        if self.http_status is not None:
+            parts.append(f"http_status={self.http_status}")
+        return "; ".join(parts)
+
+
+_HTTP_STATUS_PATTERN = re.compile(
+    r"\bHTTP(?:/\d(?:\.\d)?)?(?:\s+STATUS)?[\s:=_-]+([1-5]\d{2})\b",
+    re.IGNORECASE,
+)
+
+_EXCEPTION_CLASSIFICATIONS: tuple[
+    tuple[type[BaseException], SafeErrorType, SafeDiagnostic], ...
+] = (
+    (TimeoutError, SafeErrorType.TIMEOUT_ERROR, SafeDiagnostic.REQUEST_TIMEOUT),
+    (
+        ConnectionError,
+        SafeErrorType.CONNECTION_ERROR,
+        SafeDiagnostic.NETWORK_UNAVAILABLE,
+    ),
+    (
+        PermissionError,
+        SafeErrorType.AUTHORIZATION_ERROR,
+        SafeDiagnostic.ACCESS_DENIED,
+    ),
+    (
+        FileNotFoundError,
+        SafeErrorType.NOT_FOUND_ERROR,
+        SafeDiagnostic.RESOURCE_NOT_FOUND,
+    ),
+    (
+        UnicodeError,
+        SafeErrorType.DECODING_ERROR,
+        SafeDiagnostic.INVALID_RESPONSE,
+    ),
+    (ValueError, SafeErrorType.VALIDATION_ERROR, SafeDiagnostic.INVALID_INPUT),
+    (TypeError, SafeErrorType.VALIDATION_ERROR, SafeDiagnostic.INVALID_INPUT),
+)
+
+_NAMED_CLASSIFICATIONS: tuple[
+    tuple[frozenset[str], SafeErrorType, SafeDiagnostic], ...
+] = (
+    (
+        frozenset({"HTTPError", "BadStatusError", "WebSocketBadStatusException"}),
+        SafeErrorType.HTTP_ERROR,
+        SafeDiagnostic.UNEXPECTED_RESPONSE,
+    ),
+    (
+        frozenset({"APITimeoutError", "WebSocketTimeoutException"}),
+        SafeErrorType.TIMEOUT_ERROR,
+        SafeDiagnostic.REQUEST_TIMEOUT,
+    ),
+    (
+        frozenset({
+            "APIConnectionError",
+            "URLError",
+            "WebSocketAddressException",
+            "WebSocketConnectionClosedException",
+        }),
+        SafeErrorType.CONNECTION_ERROR,
+        SafeDiagnostic.NETWORK_UNAVAILABLE,
+    ),
+    (
+        frozenset({"AuthenticationError"}),
+        SafeErrorType.AUTHENTICATION_ERROR,
+        SafeDiagnostic.AUTHENTICATION_REQUIRED,
+    ),
+    (
+        frozenset({"PermissionDeniedError"}),
+        SafeErrorType.AUTHORIZATION_ERROR,
+        SafeDiagnostic.ACCESS_DENIED,
+    ),
+    (
+        frozenset({"RateLimitError"}),
+        SafeErrorType.RATE_LIMIT_ERROR,
+        SafeDiagnostic.RATE_LIMITED,
+    ),
+    (
+        frozenset({"NotFoundError"}),
+        SafeErrorType.NOT_FOUND_ERROR,
+        SafeDiagnostic.RESOURCE_NOT_FOUND,
+    ),
+    (
+        frozenset({"CancelledError", "CanceledError"}),
+        SafeErrorType.CANCELLED_ERROR,
+        SafeDiagnostic.OPERATION_CANCELLED,
+    ),
+    (
+        frozenset({"JSONDecodeError"}),
+        SafeErrorType.DECODING_ERROR,
+        SafeDiagnostic.INVALID_RESPONSE,
+    ),
+)
+
+_TEXT_CLASSIFICATIONS: tuple[
+    tuple[tuple[str, ...], SafeErrorType, SafeDiagnostic], ...
+] = (
+    (
+        ("rate limit", "too many requests"),
+        SafeErrorType.RATE_LIMIT_ERROR,
+        SafeDiagnostic.RATE_LIMITED,
+    ),
+    (
+        (
+            "unauthorized",
+            "authentication failed",
+            "invalid api key",
+            "invalid token",
+            "expired token",
+        ),
+        SafeErrorType.AUTHENTICATION_ERROR,
+        SafeDiagnostic.AUTHENTICATION_REQUIRED,
+    ),
+    (
+        ("forbidden", "permission denied", "access denied"),
+        SafeErrorType.AUTHORIZATION_ERROR,
+        SafeDiagnostic.ACCESS_DENIED,
+    ),
+    (
+        ("timeout", "timed out"),
+        SafeErrorType.TIMEOUT_ERROR,
+        SafeDiagnostic.REQUEST_TIMEOUT,
+    ),
+    (
+        ("connection", "network unreachable", "name resolution", "dns failure"),
+        SafeErrorType.CONNECTION_ERROR,
+        SafeDiagnostic.NETWORK_UNAVAILABLE,
+    ),
+    (
+        ("not found",),
+        SafeErrorType.NOT_FOUND_ERROR,
+        SafeDiagnostic.RESOURCE_NOT_FOUND,
+    ),
+    (
+        ("cancelled", "canceled"),
+        SafeErrorType.CANCELLED_ERROR,
+        SafeDiagnostic.OPERATION_CANCELLED,
+    ),
+)
+
+
+def _valid_http_status(value: object) -> int | None:
+    if type(value) is not int:
+        return None
+    return value if 100 <= value <= 599 else None
+
+
+def _status_from_object(error: ErrorInput) -> int | None:
+    if isinstance(error, str):
+        return None
+
+    candidates = [
+        inspect.getattr_static(error, attribute, None)
+        for attribute in ("status", "status_code", "code")
+    ]
+    response = inspect.getattr_static(error, "response", None)
+    candidates.append(inspect.getattr_static(response, "status_code", None))
+
+    for candidate in candidates:
+        status = _valid_http_status(candidate)
+        if status is not None:
+            return status
+    return None
+
+
+def _safe_text(error: ErrorInput) -> str:
+    if isinstance(error, str):
+        return error
+    arguments = BaseException.args.__get__(error, type(error))
+    return " ".join(argument for argument in arguments if type(argument) is str)
+
+
+def _status_from_text(text: str) -> int | None:
+    match = _HTTP_STATUS_PATTERN.search(text)
+    return int(match.group(1)) if match else None
+
+
+def _http_diagnostic(status: int) -> SafeDiagnostic:
+    diagnostic = SafeDiagnostic.UNEXPECTED_RESPONSE
+    match status:
+        case 401 | 407:
+            diagnostic = SafeDiagnostic.AUTHENTICATION_REQUIRED
+        case 403 | 451:
+            diagnostic = SafeDiagnostic.ACCESS_DENIED
+        case 404 | 410:
+            diagnostic = SafeDiagnostic.RESOURCE_NOT_FOUND
+        case 408 | 504:
+            diagnostic = SafeDiagnostic.REQUEST_TIMEOUT
+        case 409:
+            diagnostic = SafeDiagnostic.CONFLICT
+        case 429:
+            diagnostic = SafeDiagnostic.RATE_LIMITED
+        case value if 400 <= value < 500:
+            diagnostic = SafeDiagnostic.INVALID_INPUT
+        case value if 500 <= value < 600:
+            diagnostic = SafeDiagnostic.REMOTE_SERVICE_FAILURE
+    return diagnostic
+
+
+def _classification_by_exception(error: ErrorInput) -> _Classification | None:
+    if isinstance(error, str):
+        return None
+
+    for exception_type, error_type, diagnostic in _EXCEPTION_CLASSIFICATIONS:
+        if isinstance(error, exception_type):
+            return error_type, diagnostic
+
+    name = type(error).__name__
+    for names, error_type, diagnostic in _NAMED_CLASSIFICATIONS:
+        if name in names:
+            return error_type, diagnostic
+    return None
+
+
+def _classification_by_text(text: str) -> _Classification | None:
+    normalized = text.casefold()
+    for fragments, error_type, diagnostic in _TEXT_CLASSIFICATIONS:
+        if any(fragment in normalized for fragment in fragments):
+            return error_type, diagnostic
+    return None
+
+
+def _fallback_classification(error: ErrorInput) -> _Classification:
+    if isinstance(error, OSError):
+        classification = (
+            SafeErrorType.OPERATING_SYSTEM_ERROR,
+            SafeDiagnostic.LOCAL_IO_FAILURE,
+        )
+    elif isinstance(error, RuntimeError):
+        classification = (
+            SafeErrorType.RUNTIME_ERROR,
+            SafeDiagnostic.INTERNAL_FAILURE,
+        )
+    else:
+        classification = (
+            SafeErrorType.UNKNOWN_ERROR,
+            SafeDiagnostic.UNKNOWN_FAILURE,
+        )
+    return classification
+
+
+def sanitize_error(
+    error: ErrorInput,
+    *,
+    http_status: int | None = None,
+) -> SafeError:
+    """Return only approved metadata; discard all untrusted error detail.
+
+    The returned value never stores or echoes the original exception, message,
+    response body, URL, headers, credentials, email address, or local path.
+    User-facing layers should localize ``error_type`` and ``diagnostic`` rather
+    than display provider text.
+    """
+
+    text = _safe_text(error)
+    status = _valid_http_status(http_status)
+    if status is None:
+        status = _status_from_object(error)
+    if status is None:
+        status = _status_from_text(text)
+
+    if status is not None:
+        return SafeError(
+            error_type=SafeErrorType.HTTP_ERROR,
+            diagnostic=_http_diagnostic(status),
+            http_status=status,
+        )
+
+    classification = _classification_by_exception(error)
+    if classification is None:
+        classification = _classification_by_text(text)
+    if classification is None:
+        classification = _fallback_classification(error)
+    return SafeError(*classification)

--- a/safe_error_localization.py
+++ b/safe_error_localization.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+lazy from collections.abc import Mapping
+
+lazy from language_support import canonical_ui_language
+lazy from safe_error import (
+    SafeDiagnostic,
+    SafeError,
+    SafeErrorType,
+    sanitize_error,
+)
+
+__all__ = ["safe_error_message"]
+
+
+def _text(
+    traditional_chinese: str,
+    simplified_chinese: str,
+    english: str,
+    japanese: str,
+) -> Mapping[str, str]:
+    return frozendict({
+        "zh-TW": traditional_chinese,
+        "zh-CN": simplified_chinese,
+        "en": english,
+        "ja-JP": japanese,
+    })
+
+
+_MESSAGES: Mapping[SafeDiagnostic, Mapping[str, str]] = frozendict({
+    SafeDiagnostic.AUTHENTICATION_REQUIRED: _text(
+        "驗證資料無效或已失效，請重新檢查設定。",
+        "验证资料无效或已失效，请重新检查设置。",
+        "Authentication is missing or no longer valid. Check the settings and try again.",
+        "認証情報が無効、または期限切れです。設定を確認して再試行してください。",
+    ),
+    SafeDiagnostic.ACCESS_DENIED: _text(
+        "服務拒絕這項操作，請檢查帳號或權限。",
+        "服务拒绝此操作，请检查账号或权限。",
+        "The service denied this operation. Check the account and permissions.",
+        "サービスがこの操作を拒否しました。アカウントと権限を確認してください。",
+    ),
+    SafeDiagnostic.RATE_LIMITED: _text(
+        "服務目前請求過多或已達使用上限，請稍後重試。",
+        "服务当前请求过多或已达到使用上限，请稍后重试。",
+        "The service is busy or its usage limit was reached. Try again later.",
+        "サービスが混雑しているか、使用上限に達しました。しばらくしてから再試行してください。",
+    ),
+    SafeDiagnostic.REQUEST_TIMEOUT: _text(
+        "服務回應逾時，請稍後重試。",
+        "服务响应超时，请稍后重试。",
+        "The service timed out. Try again later.",
+        "サービスの応答がタイムアウトしました。しばらくしてから再試行してください。",
+    ),
+    SafeDiagnostic.NETWORK_UNAVAILABLE: _text(
+        "無法連線至服務，請檢查網路後重試。",
+        "无法连接到服务，请检查网络后重试。",
+        "The service could not be reached. Check the network and try again.",
+        "サービスに接続できません。ネットワークを確認して再試行してください。",
+    ),
+    SafeDiagnostic.RESOURCE_NOT_FOUND: _text(
+        "找不到指定資源，或目前帳號無權使用。",
+        "找不到指定资源，或当前账号无权使用。",
+        "The requested resource was not found or is unavailable to this account.",
+        "指定したリソースが見つからないか、このアカウントでは使用できません。",
+    ),
+    SafeDiagnostic.CONFLICT: _text(
+        "服務狀態發生衝突，請重新整理後再試。",
+        "服务状态发生冲突，请刷新后重试。",
+        "The service state changed unexpectedly. Refresh and try again.",
+        "サービスの状態が競合しました。更新してから再試行してください。",
+    ),
+    SafeDiagnostic.INVALID_INPUT: _text(
+        "輸入或設定不完整，請檢查後重試。",
+        "输入或设置不完整，请检查后重试。",
+        "The input or settings are incomplete. Check them and try again.",
+        "入力または設定が不完全です。確認して再試行してください。",
+    ),
+    SafeDiagnostic.INVALID_RESPONSE: _text(
+        "服務回傳無法辨識的內容，請稍後重試。",
+        "服务返回了无法识别的内容，请稍后重试。",
+        "The service returned an unreadable response. Try again later.",
+        "サービスから読み取れない応答が返されました。しばらくしてから再試行してください。",
+    ),
+    SafeDiagnostic.OPERATION_CANCELLED: _text(
+        "操作已取消。",
+        "操作已取消。",
+        "The operation was cancelled.",
+        "操作はキャンセルされました。",
+    ),
+    SafeDiagnostic.LOCAL_IO_FAILURE: _text(
+        "本機檔案或裝置操作失敗，請檢查權限與可用空間。",
+        "本地文件或设备操作失败，请检查权限与可用空间。",
+        "A local file or device operation failed. Check permissions and available space.",
+        "ローカルのファイルまたはデバイス操作に失敗しました。権限と空き容量を確認してください。",
+    ),
+    SafeDiagnostic.REMOTE_SERVICE_FAILURE: _text(
+        "遠端服務暫時無法使用，請稍後重試。",
+        "远程服务暂时不可用，请稍后重试。",
+        "The remote service is temporarily unavailable. Try again later.",
+        "リモートサービスを一時的に利用できません。しばらくしてから再試行してください。",
+    ),
+    SafeDiagnostic.UNEXPECTED_RESPONSE: _text(
+        "服務回傳非預期結果，請稍後重試。",
+        "服务返回了意外结果，请稍后重试。",
+        "The service returned an unexpected result. Try again later.",
+        "サービスから予期しない結果が返されました。しばらくしてから再試行してください。",
+    ),
+    SafeDiagnostic.INTERNAL_FAILURE: _text(
+        "墨寒執行此操作時發生內部錯誤，請重試。",
+        "墨寒执行此操作时发生内部错误，请重试。",
+        "MoHan encountered an internal error while performing this operation. Try again.",
+        "墨寒がこの操作を実行中に内部エラーが発生しました。再試行してください。",
+    ),
+    SafeDiagnostic.UNKNOWN_FAILURE: _text(
+        "操作未能完成，請重試。",
+        "操作未能完成，请重试。",
+        "The operation could not be completed. Try again.",
+        "操作を完了できませんでした。再試行してください。",
+    ),
+})
+
+
+def safe_error_message(
+    language: str,
+    error: BaseException | str | SafeError,
+    *,
+    http_status: int | None = None,
+) -> str:
+    """Return a four-language message without retaining provider detail."""
+
+    safe = error if isinstance(error, SafeError) else _safe_error(error, http_status)
+    locale = canonical_ui_language(language)
+    message = _MESSAGES[safe.diagnostic][locale]
+    diagnostic = (
+        f"type={safe.error_type.value}; "
+        f"diagnostic={safe.diagnostic.value}"
+    )
+    if safe.http_status is None:
+        return f"{message} [{diagnostic}]"
+    return f"{message} [{diagnostic}; HTTP {safe.http_status}]"
+
+
+def _safe_error(error: BaseException | str, http_status: int | None) -> SafeError:
+    if isinstance(error, str):
+        decoded = _decode_safe_error(error)
+        if decoded is not None:
+            return decoded
+    return sanitize_error(error, http_status=http_status)
+
+
+def _decode_safe_error(value: str) -> SafeError | None:
+    """Decode only the finite token emitted by ``str(SafeError)``."""
+
+    fields: dict[str, str] = {}
+    for item in value.split("; "):
+        name, separator, field_value = item.partition("=")
+        if not separator or name in fields:
+            return None
+        fields[name] = field_value
+    if not {"type", "diagnostic"} <= fields.keys():
+        return None
+    if fields.keys() - {"type", "diagnostic", "http_status"}:
+        return None
+    try:
+        status_text = fields.get("http_status")
+        status = int(status_text) if status_text is not None else None
+        if status is not None and not 100 <= status <= 599:
+            return None
+        return SafeError(
+            SafeErrorType(fields["type"]),
+            SafeDiagnostic(fields["diagnostic"]),
+            status,
+        )
+    except (TypeError, ValueError):
+        return None

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "3.1.1"
+version = "3.1.2"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/service_container.py
+++ b/service_container.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 lazy import sqlite3
-lazy from dataclasses import dataclass
+lazy from dataclasses import dataclass, field
 lazy from pathlib import Path
 
 lazy from PySide6.QtCore import QObject
@@ -19,7 +19,11 @@ lazy from contracts import (
     SpeechProviderRegistryPort,
 )
 lazy from db import StudioDB
-lazy from language_support import localized_transcription_prompt
+lazy from language_support import (
+    DEFAULT_UI_LANGUAGE,
+    canonical_ui_language,
+    localized_transcription_prompt,
+)
 lazy from platform_contracts import PlatformServicePort
 lazy from platform_services import current_platform_services
 lazy from realtime_speech_output import RealtimeSpeechOutput
@@ -45,7 +49,7 @@ class CompanionServices:
     """Explicit dependencies owned by one companion-window runtime."""
 
     db: StudioDB
-    secret_store: SecretStorePort
+    secret_store: SecretStorePort = field(repr=False)
     local_tts: LocalSpeechEnginePort
     cloud_tts: CloudSpeechEnginePort
     realtime: RealtimeVoicePort
@@ -55,18 +59,29 @@ class CompanionServices:
     speech_providers: SpeechProviderRegistryPort | None = None
     azure_speech: AzureSpeechEnginePort | None = None
     azure_hd_speech: AzureSpeechEnginePort | None = None
-    azure_secret_store: SecretStorePort | None = None
-    azure_hd_secret_store: SecretStorePort | None = None
-    secret_store_factory: SecretStoreFactoryPort | None = None
+    azure_secret_store: SecretStorePort | None = field(
+        default=None,
+        repr=False,
+    )
+    azure_hd_secret_store: SecretStorePort | None = field(
+        default=None,
+        repr=False,
+    )
+    secret_store_factory: SecretStoreFactoryPort | None = field(
+        default=None,
+        repr=False,
+    )
     platform_services: PlatformServicePort | None = None
 
 
 def _local_speech_engine(
     platform_services: PlatformServicePort,
     parent: QObject | None,
+    *,
+    language: str,
 ) -> LocalSpeechEnginePort:
     if platform_services.capabilities.system_local_speech:
-        return WindowsTTS(parent)
+        return WindowsTTS(parent, language=language)
     return UnavailableSystemTTS(
         f"{platform_services.capabilities.display_name} 本機語音"
         "尚未完成實機驗證。",
@@ -77,11 +92,17 @@ def _local_speech_engine(
 def _realtime_speech_output(
     platform_services: PlatformServicePort,
     parent: QObject | None,
+    *,
+    language: str,
 ) -> RealtimeSpeechOutput:
     return RealtimeSpeechOutput(
         AzureSpeechTTS(parent),
         AzureSpeechTTS(parent),
-        _local_speech_engine(platform_services, parent),
+        _local_speech_engine(
+            platform_services,
+            parent,
+            language=language,
+        ),
         parent,
     )
 
@@ -91,10 +112,18 @@ def create_default_services(
     listener_script: Path,
     parent: QObject | None = None,
     platform_services: PlatformServicePort | None = None,
+    *,
+    ui_language: str | None = None,
 ) -> CompanionServices:
     runtime_platform = platform_services or current_platform_services()
     data_path.mkdir(parents=True, exist_ok=True)
     db = StudioDB(data_path / "mohan.db")
+    language_value = (
+        ui_language
+        if ui_language is not None
+        else db.setting("ui_language", DEFAULT_UI_LANGUAGE)
+    )
+    service_language = canonical_ui_language(str(language_value))
     # Migrate at the composition boundary so headless and UI startup paths
     # share the same canonical provider setting.
     migrate_speech_provider_setting(db)
@@ -168,9 +197,14 @@ def create_default_services(
             ),
         ),
         parent=parent,
+        language=service_language,
     )
-    local_tts = _local_speech_engine(runtime_platform, parent)
-    cloud_tts = OpenAITTS(parent)
+    local_tts = _local_speech_engine(
+        runtime_platform,
+        parent,
+        language=service_language,
+    )
+    cloud_tts = OpenAITTS(parent, language=service_language)
     azure_tts = AzureSpeechTTS(parent)
     azure_hd_tts = AzureSpeechTTS(parent)
     system_capabilities = SpeechProviderCapabilities(
@@ -197,6 +231,7 @@ def create_default_services(
         realtime_speech_output=_realtime_speech_output(
             runtime_platform,
             parent,
+            language=service_language,
         ),
         backup_manager=backup_manager,
         speech_providers=create_builtin_speech_registry(

--- a/service_container.py
+++ b/service_container.py
@@ -22,6 +22,7 @@ lazy from db import StudioDB
 lazy from language_support import localized_transcription_prompt
 lazy from platform_contracts import PlatformServicePort
 lazy from platform_services import current_platform_services
+lazy from realtime_speech_output import RealtimeSpeechOutput
 lazy from realtime_voice import RealtimeVoiceClient
 lazy from secret_store import platform_secret_store_factory
 lazy from speech import (
@@ -49,6 +50,7 @@ class CompanionServices:
     cloud_tts: CloudSpeechEnginePort
     realtime: RealtimeVoicePort
     listener: SpeechListenerPort
+    realtime_speech_output: RealtimeSpeechOutput | None = None
     backup_manager: BackupManager | None = None
     speech_providers: SpeechProviderRegistryPort | None = None
     azure_speech: AzureSpeechEnginePort | None = None
@@ -57,6 +59,31 @@ class CompanionServices:
     azure_hd_secret_store: SecretStorePort | None = None
     secret_store_factory: SecretStoreFactoryPort | None = None
     platform_services: PlatformServicePort | None = None
+
+
+def _local_speech_engine(
+    platform_services: PlatformServicePort,
+    parent: QObject | None,
+) -> LocalSpeechEnginePort:
+    if platform_services.capabilities.system_local_speech:
+        return WindowsTTS(parent)
+    return UnavailableSystemTTS(
+        f"{platform_services.capabilities.display_name} 本機語音"
+        "尚未完成實機驗證。",
+        parent,
+    )
+
+
+def _realtime_speech_output(
+    platform_services: PlatformServicePort,
+    parent: QObject | None,
+) -> RealtimeSpeechOutput:
+    return RealtimeSpeechOutput(
+        AzureSpeechTTS(parent),
+        AzureSpeechTTS(parent),
+        _local_speech_engine(platform_services, parent),
+        parent,
+    )
 
 
 def create_default_services(
@@ -142,14 +169,7 @@ def create_default_services(
         ),
         parent=parent,
     )
-    if runtime_platform.capabilities.system_local_speech:
-        local_tts: LocalSpeechEnginePort = WindowsTTS(parent)
-    else:
-        local_tts = UnavailableSystemTTS(
-            f"{runtime_platform.capabilities.display_name} 本機語音"
-            "尚未完成實機驗證。",
-            parent,
-        )
+    local_tts = _local_speech_engine(runtime_platform, parent)
     cloud_tts = OpenAITTS(parent)
     azure_tts = AzureSpeechTTS(parent)
     azure_hd_tts = AzureSpeechTTS(parent)
@@ -174,6 +194,10 @@ def create_default_services(
         cloud_tts=cloud_tts,
         realtime=RealtimeVoiceClient(parent),
         listener=listener,
+        realtime_speech_output=_realtime_speech_output(
+            runtime_platform,
+            parent,
+        ),
         backup_manager=backup_manager,
         speech_providers=create_builtin_speech_registry(
             local_tts,

--- a/service_status_localization.py
+++ b/service_status_localization.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+lazy from collections.abc import Mapping
+lazy from enum import StrEnum
+lazy from string import Formatter
+
+lazy from language_support import canonical_ui_language
+lazy from safe_error import SafeError, sanitize_error
+
+
+class ServiceStatus(StrEnum):
+    """User-facing status and error messages emitted by backend services."""
+
+    AI_PLANNING = "ai_planning"
+    AI_PLANNER_KEY_MISSING = "ai_planner_key_missing"
+    AI_PLAN_RESPONSE_MISSING = "ai_plan_response_missing"
+    AI_PLAN_FORMAT_INVALID = "ai_plan_format_invalid"
+    AI_PLAN_STEP_INVALID = "ai_plan_step_invalid"
+    AI_PLAN_ARGUMENTS_INVALID = "ai_plan_arguments_invalid"
+    AI_RESPONSE_EMPTY = "ai_response_empty"
+    CAMERA_COMPONENT_UNAVAILABLE = "camera_component_unavailable"
+    CAMERA_NOT_FOUND = "camera_not_found"
+    CAMERA_STARTING = "camera_starting"
+    CAMERA_ERROR = "camera_error"
+    CAMERA_ACTIVE = "camera_active"
+    CAMERA_CLOSED = "camera_closed"
+    SPEECH_EMPTY_MANUAL_CAPTURE = "speech_empty_manual_capture"
+    SPEECH_NOT_DETECTED = "speech_not_detected"
+    SPEECH_OPENAI_KEY_INVALID = "speech_openai_key_invalid"
+    SPEECH_OPENAI_NOT_AUTHORIZED = "speech_openai_not_authorized"
+    SPEECH_OPENAI_MODEL_NOT_FOUND = "speech_openai_model_not_found"
+    SPEECH_OPENAI_QUOTA_EXHAUSTED = "speech_openai_quota_exhausted"
+    SPEECH_OPENAI_RATE_LIMITED = "speech_openai_rate_limited"
+    SPEECH_OPENAI_SERVICE_ERROR = "speech_openai_service_error"
+    SPEECH_OPENAI_HTTP_ERROR = "speech_openai_http_error"
+    SPEECH_OPENAI_CONNECTION_ERROR = "speech_openai_connection_error"
+    SPEECH_OPENAI_TIMEOUT = "speech_openai_timeout"
+    SPEECH_OPENAI_EMPTY_RESULT = "speech_openai_empty_result"
+    SPEECH_PLAYBACK_UNAVAILABLE = "speech_playback_unavailable"
+    SPEECH_WINDOWS_FEMALE_VOICE_MISSING = (
+        "speech_windows_female_voice_missing"
+    )
+    SPEECH_WINDOWS_LEGACY_FAILED = "speech_windows_legacy_failed"
+    SPEECH_ONECORE_VOICE_MISSING = "speech_onecore_voice_missing"
+    SPEECH_ONECORE_FAILED = "speech_onecore_failed"
+    SPEECH_WINDOWS_SYNTHESIS_TIMEOUT = (
+        "speech_windows_synthesis_timeout"
+    )
+    SPEECH_WINDOWS_WAV_UNSUPPORTED = "speech_windows_wav_unsupported"
+    SPEECH_OPENAI_KEY_MISSING = "speech_openai_key_missing"
+    SPEECH_CAPTURE_STOPPING = "speech_capture_stopping"
+    SPEECH_OPENAI_KEY_MISSING_SENTENCE = (
+        "speech_openai_key_missing_sentence"
+    )
+    SPEECH_WINDOWS_FALLBACK_DISABLED = (
+        "speech_windows_fallback_disabled"
+    )
+    SPEECH_RECORDING = "speech_recording"
+    SPEECH_RECOGNITION_START_FAILED = (
+        "speech_recognition_start_failed"
+    )
+    SPEECH_WINDOWS_LISTENING = "speech_windows_listening"
+    SPEECH_WINDOWS_FALLBACK = "speech_windows_fallback"
+    SPEECH_RECORDING_COMPONENT_MISSING = (
+        "speech_recording_component_missing"
+    )
+    SPEECH_WINDOWS_MICROPHONE_ERROR = "speech_windows_microphone_error"
+    SPEECH_RECOGNIZING = "speech_recognizing"
+    SPEECH_TRANSCRIPTION_SUCCEEDED = "speech_transcription_succeeded"
+    SPEECH_WINDOWS_RECOGNIZER_MISSING = (
+        "speech_windows_recognizer_missing"
+    )
+    SPEECH_WINDOWS_MICROPHONE_DENIED = (
+        "speech_windows_microphone_denied"
+    )
+    SPEECH_WINDOWS_RECOGNITION_ERROR = (
+        "speech_windows_recognition_error"
+    )
+    SPEECH_WINDOWS_RECOGNITION_START_ERROR = (
+        "speech_windows_recognition_start_error"
+    )
+    SPEECH_NOT_UNDERSTOOD = "speech_not_understood"
+
+
+SUPPORTED_SERVICE_LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+
+
+def _text(
+    traditional_chinese: str,
+    simplified_chinese: str,
+    english: str,
+    japanese: str,
+) -> Mapping[str, str]:
+    return frozendict({
+        "zh-TW": traditional_chinese,
+        "zh-CN": simplified_chinese,
+        "en": english,
+        "ja-JP": japanese,
+    })
+
+
+_TEXT: Mapping[ServiceStatus, Mapping[str, str]] = frozendict({
+    ServiceStatus.AI_PLANNING: _text(
+        "規劃中…",
+        "规划中…",
+        "Planning…",
+        "計画を作成中…",
+    ),
+    ServiceStatus.AI_PLANNER_KEY_MISSING: _text(
+        "尚未設定 OpenAI API 金鑰，無法理解自由語句工具任務",
+        "尚未设置 OpenAI API 密钥，无法理解自由语句工具任务",
+        "The OpenAI API key is not configured, so free-form tool requests cannot be understood",
+        "OpenAI API キーが未設定のため、自由文によるツール操作を理解できません",
+    ),
+    ServiceStatus.AI_PLAN_RESPONSE_MISSING: _text(
+        "API 未傳回唯一的安全任務計畫",
+        "API 未返回唯一的安全任务计划",
+        "The API did not return exactly one safe task plan",
+        "API から安全なタスク計画が一つだけ返されませんでした",
+    ),
+    ServiceStatus.AI_PLAN_FORMAT_INVALID: _text(
+        "任務計畫格式錯誤",
+        "任务计划格式错误",
+        "The task plan format is invalid",
+        "タスク計画の形式が正しくありません",
+    ),
+    ServiceStatus.AI_PLAN_STEP_INVALID: _text(
+        "任務步驟格式錯誤",
+        "任务步骤格式错误",
+        "A task step has an invalid format",
+        "タスク手順の形式が正しくありません",
+    ),
+    ServiceStatus.AI_PLAN_ARGUMENTS_INVALID: _text(
+        "工具參數必須是 JSON 物件",
+        "工具参数必须是 JSON 对象",
+        "Tool arguments must be a JSON object",
+        "ツール引数は JSON オブジェクトでなければなりません",
+    ),
+    ServiceStatus.AI_RESPONSE_EMPTY: _text(
+        "API 沒有傳回文字",
+        "API 没有返回文字",
+        "The API returned no text",
+        "API からテキストが返されませんでした",
+    ),
+    ServiceStatus.CAMERA_COMPONENT_UNAVAILABLE: _text(
+        "此封裝未包含 QtMultimedia 攝影機元件",
+        "此软件包未包含 QtMultimedia 摄像头组件",
+        "This package does not include the QtMultimedia camera component",
+        "このパッケージには QtMultimedia カメラコンポーネントが含まれていません",
+    ),
+    ServiceStatus.CAMERA_NOT_FOUND: _text(
+        "找不到可用攝影機",
+        "找不到可用摄像头",
+        "No available camera was found",
+        "利用可能なカメラが見つかりません",
+    ),
+    ServiceStatus.CAMERA_STARTING: _text(
+        "正在啟動攝影機…",
+        "正在启动摄像头…",
+        "Starting camera…",
+        "カメラを起動中…",
+    ),
+    ServiceStatus.CAMERA_ERROR: _text(
+        "攝影機錯誤：{detail}",
+        "摄像头错误：{detail}",
+        "Camera error: {detail}",
+        "カメラエラー：{detail}",
+    ),
+    ServiceStatus.CAMERA_ACTIVE: _text(
+        "攝影機使用中：{device}（僅本機在場偵測）",
+        "摄像头使用中：{device}（仅用于本地在场检测）",
+        "Camera active: {device} (local presence detection only)",
+        "カメラ使用中：{device}（本機内の在席検知のみ）",
+    ),
+    ServiceStatus.CAMERA_CLOSED: _text(
+        "攝影機已關閉",
+        "摄像头已关闭",
+        "Camera closed",
+        "カメラを停止しました",
+    ),
+    ServiceStatus.SPEECH_EMPTY_MANUAL_CAPTURE: _text(
+        "尚未偵測到說話聲，沒有送出空白錄音。",
+        "尚未检测到说话声，没有提交空白录音。",
+        "No speech was detected, so an empty recording was not submitted.",
+        "発話を検出していないため、空の録音は送信しませんでした。",
+    ),
+    ServiceStatus.SPEECH_NOT_DETECTED: _text(
+        "沒有偵測到說話聲，請靠近麥克風後再試一次。",
+        "没有检测到说话声，请靠近麦克风后再试一次。",
+        "No speech was detected. Move closer to the microphone and try again.",
+        "発話を検出できませんでした。マイクに近づいて、もう一度お試しください。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_KEY_INVALID: _text(
+        "OpenAI API 金鑰無效或已被撤銷（HTTP 401）。",
+        "OpenAI API 密钥无效或已被撤销（HTTP 401）。",
+        "The OpenAI API key is invalid or has been revoked (HTTP 401).",
+        "OpenAI API キーが無効であるか、取り消されています（HTTP 401）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_NOT_AUTHORIZED: _text(
+        "OpenAI Project 未授權使用語音轉錄（HTTP 403）。",
+        "OpenAI Project 未获授权使用语音转录（HTTP 403）。",
+        "The OpenAI Project is not authorized to use speech transcription (HTTP 403).",
+        "OpenAI Project には音声文字起こしを使用する権限がありません（HTTP 403）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_MODEL_NOT_FOUND: _text(
+        "OpenAI 找不到轉錄模型，或此 Project 無權使用（HTTP 404）。",
+        "OpenAI 找不到转录模型，或此 Project 无权使用（HTTP 404）。",
+        "OpenAI could not find the transcription model, or this Project cannot use it (HTTP 404).",
+        "OpenAI で文字起こしモデルが見つからないか、この Project に利用権限がありません（HTTP 404）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_QUOTA_EXHAUSTED: _text(
+        "OpenAI API 額度不足或尚未啟用計費（HTTP 429）。",
+        "OpenAI API 额度不足或尚未启用计费（HTTP 429）。",
+        "The OpenAI API quota is insufficient or billing is not enabled (HTTP 429).",
+        "OpenAI API の利用枠が不足しているか、課金が有効になっていません（HTTP 429）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_RATE_LIMITED: _text(
+        "OpenAI 語音轉錄請求過於頻繁，已達速率限制（HTTP 429）。",
+        "OpenAI 语音转录请求过于频繁，已达到速率限制（HTTP 429）。",
+        "OpenAI speech transcription requests reached the rate limit (HTTP 429).",
+        "OpenAI 音声文字起こしのリクエストがレート制限に達しました（HTTP 429）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_SERVICE_ERROR: _text(
+        "OpenAI 語音轉錄服務暫時異常（HTTP {status}）。",
+        "OpenAI 语音转录服务暂时异常（HTTP {status}）。",
+        "The OpenAI speech transcription service is temporarily unavailable (HTTP {status}).",
+        "OpenAI 音声文字起こしサービスで一時的な障害が発生しています（HTTP {status}）。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_HTTP_ERROR: _text(
+        "OpenAI 轉錄失敗（HTTP {status}）：{detail}",
+        "OpenAI 转录失败（HTTP {status}）：{detail}",
+        "OpenAI transcription failed (HTTP {status}): {detail}",
+        "OpenAI の文字起こしに失敗しました（HTTP {status}）：{detail}",
+    ),
+    ServiceStatus.SPEECH_OPENAI_CONNECTION_ERROR: _text(
+        "無法連線到 OpenAI：{detail}",
+        "无法连接到 OpenAI：{detail}",
+        "Could not connect to OpenAI: {detail}",
+        "OpenAI に接続できません：{detail}",
+    ),
+    ServiceStatus.SPEECH_OPENAI_TIMEOUT: _text(
+        "OpenAI 轉錄連線逾時。",
+        "OpenAI 转录连接超时。",
+        "The OpenAI transcription connection timed out.",
+        "OpenAI 文字起こしへの接続がタイムアウトしました。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_EMPTY_RESULT: _text(
+        "OpenAI 已成功連線，但沒有從這段錄音辨識出文字。",
+        "OpenAI 已成功连接，但没有从这段录音中识别出文字。",
+        "OpenAI connected successfully but recognized no text in this recording.",
+        "OpenAI への接続には成功しましたが、この録音からテキストを認識できませんでした。",
+    ),
+    ServiceStatus.SPEECH_PLAYBACK_UNAVAILABLE: _text(
+        "此平台的音訊播放介面尚未完成實機驗證；未播放這段語音。",
+        "此平台的音频播放接口尚未完成真机验证；未播放这段语音。",
+        "Audio playback on this platform has not completed real-device validation; this speech was not played.",
+        "このプラットフォームの音声再生機能は実機検証が完了していないため、この音声は再生しませんでした。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_FEMALE_VOICE_MISSING: _text(
+        "Windows 沒有偵測到已明確標示為女性的本機語音。",
+        "Windows 未检测到明确标记为女性的本地语音。",
+        "Windows did not detect a local voice explicitly marked as female.",
+        "Windows で女性と明示された本機音声を検出できませんでした。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_LEGACY_FAILED: _text(
+        "Windows 傳統語音播放失敗。",
+        "Windows 传统语音播放失败。",
+        "Windows legacy speech playback failed.",
+        "Windows の従来音声の再生に失敗しました。",
+    ),
+    ServiceStatus.SPEECH_ONECORE_VOICE_MISSING: _text(
+        "找不到 OneCore 聲音：{voice}",
+        "找不到 OneCore 声音：{voice}",
+        "OneCore voice not found: {voice}",
+        "OneCore 音声が見つかりません：{voice}",
+    ),
+    ServiceStatus.SPEECH_ONECORE_FAILED: _text(
+        "OneCore 語音合成失敗。",
+        "OneCore 语音合成失败。",
+        "OneCore speech synthesis failed.",
+        "OneCore 音声合成に失敗しました。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_SYNTHESIS_TIMEOUT: _text(
+        "Windows 本機語音合成逾時。",
+        "Windows 本地语音合成超时。",
+        "Windows local speech synthesis timed out.",
+        "Windows 本機音声の合成がタイムアウトしました。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_WAV_UNSUPPORTED: _text(
+        "Windows 本機語音回傳了不支援的 WAV 格式。",
+        "Windows 本地语音返回了不支持的 WAV 格式。",
+        "Windows local speech returned an unsupported WAV format.",
+        "Windows 本機音声から未対応の WAV 形式が返されました。",
+    ),
+    ServiceStatus.SPEECH_OPENAI_KEY_MISSING: _text(
+        "尚未設定 OpenAI API 金鑰",
+        "尚未设置 OpenAI API 密钥",
+        "The OpenAI API key has not been configured",
+        "OpenAI API キーが設定されていません",
+    ),
+    ServiceStatus.SPEECH_CAPTURE_STOPPING: _text(
+        "正在結束收音並送出…",
+        "正在结束收音并提交…",
+        "Finishing audio capture and submitting…",
+        "収音を終了して送信中…",
+    ),
+    ServiceStatus.SPEECH_OPENAI_KEY_MISSING_SENTENCE: _text(
+        "未設定 OpenAI API 金鑰。",
+        "未设置 OpenAI API 密钥。",
+        "The OpenAI API key has not been configured.",
+        "OpenAI API キーが設定されていません。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_FALLBACK_DISABLED: _text(
+        "Windows 備援目前已關閉。",
+        "Windows 备用识别目前已关闭。",
+        "Windows fallback recognition is currently disabled.",
+        "Windows 代替認識は現在無効です。",
+    ),
+    ServiceStatus.SPEECH_RECORDING: _text(
+        "收音中…再次點擊麥克風可立即送出",
+        "收音中…再次点击麦克风可立即提交",
+        "Listening… Click the microphone again to submit now",
+        "収音中…マイクをもう一度押すと、すぐに送信します",
+    ),
+    ServiceStatus.SPEECH_RECOGNITION_START_FAILED: _text(
+        "無法啟動語音辨識",
+        "无法启动语音识别",
+        "Could not start speech recognition",
+        "音声認識を開始できません",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_LISTENING: _text(
+        "收音與辨識中…",
+        "收音与识别中…",
+        "Listening and recognizing…",
+        "収音して認識中…",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_FALLBACK: _text(
+        "{detail} 正在使用 Windows 備援辨識…",
+        "{detail} 正在使用 Windows 备用识别…",
+        "{detail} Using Windows fallback recognition…",
+        "{detail} Windows 代替認識を使用中…",
+    ),
+    ServiceStatus.SPEECH_RECORDING_COMPONENT_MISSING: _text(
+        "缺少麥克風錄音元件 sounddevice。",
+        "缺少麦克风录音组件 sounddevice。",
+        "The sounddevice microphone recording component is missing.",
+        "マイク録音コンポーネント sounddevice がありません。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_MICROPHONE_ERROR: _text(
+        "無法使用 Windows 預設麥克風：{detail}",
+        "无法使用 Windows 默认麦克风：{detail}",
+        "Could not use the Windows default microphone: {detail}",
+        "Windows の既定のマイクを使用できません：{detail}",
+    ),
+    ServiceStatus.SPEECH_RECOGNIZING: _text(
+        "辨識中…",
+        "识别中…",
+        "Recognizing…",
+        "認識中…",
+    ),
+    ServiceStatus.SPEECH_TRANSCRIPTION_SUCCEEDED: _text(
+        "OpenAI 轉錄成功：{model}",
+        "OpenAI 转录成功：{model}",
+        "OpenAI transcription succeeded: {model}",
+        "OpenAI の文字起こしに成功しました：{model}",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_RECOGNIZER_MISSING: _text(
+        "Windows 尚未安裝中文語音辨識套件，請先在語言設定加入中文語音功能。",
+        "Windows 尚未安装中文语音识别包，请先在语言设置中添加中文语音功能。",
+        "Windows does not have the Chinese speech recognition package installed. Add Chinese speech in Language settings first.",
+        "Windows に中国語音声認識パッケージがありません。先に言語設定で中国語の音声機能を追加してください。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_MICROPHONE_DENIED: _text(
+        "Windows 拒絕墨寒使用麥克風。請到「設定 → 隱私權與安全性 → 麥克風」，開啟麥克風存取權、讓應用程式存取麥克風，以及讓桌面應用程式存取麥克風。",
+        "Windows 拒绝墨寒使用麦克风。请前往“设置 → 隐私和安全性 → 麦克风”，开启麦克风访问权限、允许应用访问麦克风，以及允许桌面应用访问麦克风。",
+        "Windows denied MoHan access to the microphone. In Settings → Privacy & security → Microphone, enable Microphone access, Let apps access your microphone, and Let desktop apps access your microphone.",
+        "Windows が墨寒のマイク使用を拒否しました。「設定 → プライバシーとセキュリティ → マイク」で、マイクへのアクセス、アプリのマイクアクセス、デスクトップアプリのマイクアクセスを有効にしてください。",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_RECOGNITION_ERROR: _text(
+        "Windows 語音辨識無法使用：{detail}",
+        "Windows 语音识别无法使用：{detail}",
+        "Windows speech recognition is unavailable: {detail}",
+        "Windows 音声認識を使用できません：{detail}",
+    ),
+    ServiceStatus.SPEECH_WINDOWS_RECOGNITION_START_ERROR: _text(
+        "Windows 語音辨識啟動失敗：{detail}",
+        "Windows 语音识别启动失败：{detail}",
+        "Windows speech recognition failed to start: {detail}",
+        "Windows 音声認識の起動に失敗しました：{detail}",
+    ),
+    ServiceStatus.SPEECH_NOT_UNDERSTOOD: _text(
+        "寒方才未聽清，請再說一次。",
+        "寒刚才没有听清，请再说一次。",
+        "I did not hear that clearly. Please try again.",
+        "よく聞き取れませんでした。もう一度お話しください。",
+    ),
+})
+
+
+def _format_fields(template: str) -> frozenset[str]:
+    return frozenset(
+        field_name
+        for _literal, field_name, _format_spec, _conversion
+        in Formatter().parse(template)
+        if field_name is not None
+    )
+
+
+def _validate_catalog() -> None:
+    expected_languages = tuple(SUPPORTED_SERVICE_LANGUAGES)
+    for key, translations in _TEXT.items():
+        if tuple(translations) != expected_languages:
+            raise RuntimeError(
+                f"{key} must define service text in canonical language order"
+            )
+        expected_fields = _format_fields(translations["zh-TW"])
+        for language, template in translations.items():
+            if _format_fields(template) != expected_fields:
+                raise RuntimeError(
+                    f"{key} has inconsistent format fields for {language}"
+                )
+
+
+_validate_catalog()
+
+_UNTRUSTED_DYNAMIC_FIELDS: Mapping[ServiceStatus, frozenset[str]] = frozendict({
+    ServiceStatus.CAMERA_ERROR: frozenset({"detail"}),
+    ServiceStatus.SPEECH_OPENAI_HTTP_ERROR: frozenset({"detail"}),
+    ServiceStatus.SPEECH_OPENAI_CONNECTION_ERROR: frozenset({"detail"}),
+    ServiceStatus.SPEECH_WINDOWS_MICROPHONE_ERROR: frozenset({"detail"}),
+    ServiceStatus.SPEECH_WINDOWS_RECOGNITION_ERROR: frozenset({"detail"}),
+    ServiceStatus.SPEECH_WINDOWS_RECOGNITION_START_ERROR: frozenset({"detail"}),
+})
+
+
+def _sanitized_values(
+    key: ServiceStatus,
+    values: Mapping[str, object],
+) -> dict[str, object]:
+    unsafe_fields = _UNTRUSTED_DYNAMIC_FIELDS.get(key, frozenset())
+    return {
+        name: (
+            value
+            if isinstance(value, SafeError)
+            else sanitize_error(
+                value if isinstance(value, BaseException | str) else str(value),
+                http_status=(
+                    int(values["status"])
+                    if key is ServiceStatus.SPEECH_OPENAI_HTTP_ERROR
+                    and isinstance(values.get("status"), int)
+                    else None
+                ),
+            )
+        )
+        if name in unsafe_fields
+        else value
+        for name, value in values.items()
+    }
+
+
+def service_status(
+    language: str,
+    key: ServiceStatus,
+    /,
+    **values: object,
+) -> str:
+    """Return localized service text without exposing provider diagnostics."""
+
+    locale = canonical_ui_language(language)
+    return _TEXT[key][locale].format(**_sanitized_values(key, values))
+
+
+def append_service_status(
+    language: str,
+    detail: str,
+    key: ServiceStatus,
+    *,
+    separate: bool = False,
+) -> str:
+    """Append fixed UI guidance without translating its dynamic detail."""
+
+    separator = (
+        " "
+        if separate or canonical_ui_language(language) == "en"
+        else ""
+    )
+    return f"{detail}{separator}{service_status(language, key)}"

--- a/settings_ui_localization.py
+++ b/settings_ui_localization.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+lazy from collections.abc import Mapping
+lazy from enum import StrEnum
+lazy from string import Formatter
+
+lazy from language_support import canonical_ui_language
+
+
+class SettingsText(StrEnum):
+    """Complete, typed text contract for desktop and work settings."""
+
+    AUTOSTART_LABEL = "autostart_label"
+    AUTOSTART_WINDOWS = "autostart_windows"
+    AUTOSTART_UNAVAILABLE = "autostart_unavailable"
+    AUTOSTART_ERROR_TITLE = "autostart_error_title"
+    AUTOSTART_ERROR = "autostart_error"
+    TOPMOST_LABEL = "topmost_label"
+    TOPMOST_SMART = "topmost_smart"
+    TOPMOST_ALWAYS = "topmost_always"
+    TOPMOST_NEVER = "topmost_never"
+    CHARACTER_SCALE_LABEL = "character_scale_label"
+    CHARACTER_SCALE_RESET = "character_scale_reset"
+    CHARACTER_SCALE_RESET_TOOLTIP = "character_scale_reset_tooltip"
+    PROACTIVE_LABEL = "proactive_label"
+    PROACTIVE_QUIET = "proactive_quiet"
+    PROACTIVE_BALANCED = "proactive_balanced"
+    PROACTIVE_ACTIVE = "proactive_active"
+    BACKGROUND_ASSISTANT_LABEL = "background_assistant_label"
+    BACKGROUND_ASSISTANT_ENABLED = "background_assistant_enabled"
+    BACKGROUND_MODE_LABEL = "background_mode_label"
+    BACKGROUND_MODE_FOLLOWS_PROACTIVE = (
+        "background_mode_follows_proactive"
+    )
+    BACKGROUND_WATCH_APPS_LABEL = "background_watch_apps_label"
+    BACKGROUND_WATCH_APPS_PLACEHOLDER = (
+        "background_watch_apps_placeholder"
+    )
+    BACKGROUND_DIAGNOSTIC_LABEL = "background_diagnostic_label"
+    BACKGROUND_DIAGNOSTIC_PLACEHOLDER = (
+        "background_diagnostic_placeholder"
+    )
+    BACKGROUND_SAFETY_NOTE = "background_safety_note"
+    PHYSICS_LABEL = "physics_label"
+    PHYSICS_SLEEVES_NAME = "physics_sleeves_name"
+    PHYSICS_SLEEVES_DESCRIPTION = "physics_sleeves_description"
+    PHYSICS_HAIR_NAME = "physics_hair_name"
+    PHYSICS_HAIR_DESCRIPTION = "physics_hair_description"
+    PHYSICS_ORNAMENT_NAME = "physics_ornament_name"
+    PHYSICS_ORNAMENT_DESCRIPTION = "physics_ornament_description"
+    PHYSICS_EYE_TRACKING_NAME = "physics_eye_tracking_name"
+    PHYSICS_EYE_TRACKING_DESCRIPTION = "physics_eye_tracking_description"
+    PHYSICS_FACE_PARALLAX_NAME = "physics_face_parallax_name"
+    PHYSICS_FACE_PARALLAX_DESCRIPTION = (
+        "physics_face_parallax_description"
+    )
+    PHYSICS_NOTE = "physics_note"
+    WORK_FOLDER_LABEL = "work_folder_label"
+    WORK_FOLDER_PLACEHOLDER = "work_folder_placeholder"
+    WORK_FOLDER_BROWSE = "work_folder_browse"
+    WORK_FOLDER_OPEN = "work_folder_open"
+    WORK_FOLDER_BROWSE_TITLE = "work_folder_browse_title"
+    WORK_FOLDER_INVALID_TITLE = "work_folder_invalid_title"
+    WORK_FOLDER_INVALID_MESSAGE = "work_folder_invalid_message"
+    AI_CORE_LABEL = "ai_core_label"
+    PERSONA_LABEL = "persona_label"
+    PERSONA_PLACEHOLDER = "persona_placeholder"
+    PROFILE_REQUIRED_TITLE = "profile_required_title"
+    PROFILE_REQUIRED_MESSAGE = "profile_required_message"
+
+
+LANGUAGE_ORDER = ("zh-TW", "zh-CN", "en", "ja-JP")
+
+TOPMOST_MODE_KEYS = (
+    SettingsText.TOPMOST_SMART,
+    SettingsText.TOPMOST_ALWAYS,
+    SettingsText.TOPMOST_NEVER,
+)
+
+PROACTIVE_MODE_KEYS = (
+    SettingsText.PROACTIVE_QUIET,
+    SettingsText.PROACTIVE_BALANCED,
+    SettingsText.PROACTIVE_ACTIVE,
+)
+
+PHYSICS_TEXT_KEYS: Mapping[
+    str,
+    tuple[SettingsText, SettingsText],
+] = frozendict({
+    "physics_sleeves": (
+        SettingsText.PHYSICS_SLEEVES_NAME,
+        SettingsText.PHYSICS_SLEEVES_DESCRIPTION,
+    ),
+    "physics_hair": (
+        SettingsText.PHYSICS_HAIR_NAME,
+        SettingsText.PHYSICS_HAIR_DESCRIPTION,
+    ),
+    "physics_ornament": (
+        SettingsText.PHYSICS_ORNAMENT_NAME,
+        SettingsText.PHYSICS_ORNAMENT_DESCRIPTION,
+    ),
+    "physics_eye_tracking": (
+        SettingsText.PHYSICS_EYE_TRACKING_NAME,
+        SettingsText.PHYSICS_EYE_TRACKING_DESCRIPTION,
+    ),
+    "physics_face_parallax": (
+        SettingsText.PHYSICS_FACE_PARALLAX_NAME,
+        SettingsText.PHYSICS_FACE_PARALLAX_DESCRIPTION,
+    ),
+})
+
+
+_ZH_TW: Mapping[SettingsText, str] = frozendict({
+    SettingsText.AUTOSTART_LABEL: "自動啟動",
+    SettingsText.AUTOSTART_WINDOWS: "Windows 登入後自動啟動",
+    SettingsText.AUTOSTART_UNAVAILABLE: (
+        "{platform} 自動啟動尚未完成實機驗證"
+    ),
+    SettingsText.AUTOSTART_ERROR_TITLE: "自動啟動",
+    SettingsText.AUTOSTART_ERROR: "無法更新自動啟動：{reason}",
+    SettingsText.TOPMOST_LABEL: "桌面置頂方式",
+    SettingsText.TOPMOST_SMART: "智慧置頂（推薦）",
+    SettingsText.TOPMOST_ALWAYS: "永遠置頂",
+    SettingsText.TOPMOST_NEVER: "不置頂",
+    SettingsText.CHARACTER_SCALE_LABEL: "桌面{assistant}顯示大小",
+    SettingsText.CHARACTER_SCALE_RESET: "恢復 100%",
+    SettingsText.CHARACTER_SCALE_RESET_TOOLTIP: (
+        "將桌面{assistant}恢復為原始顯示大小"
+    ),
+    SettingsText.PROACTIVE_LABEL: "主動協助程度",
+    SettingsText.PROACTIVE_QUIET: "安靜（只提醒必要事項）",
+    SettingsText.PROACTIVE_BALANCED: "平衡（推薦）",
+    SettingsText.PROACTIVE_ACTIVE: "積極（主動建議）",
+    SettingsText.BACKGROUND_ASSISTANT_LABEL: "背景多工助理",
+    SettingsText.BACKGROUND_ASSISTANT_ENABLED: (
+        "啟用背景多工助理（預設關閉）"
+    ),
+    SettingsText.BACKGROUND_MODE_LABEL: "背景助理模式",
+    SettingsText.BACKGROUND_MODE_FOLLOWS_PROACTIVE: (
+        "依照主動協助程度"
+    ),
+    SettingsText.BACKGROUND_WATCH_APPS_LABEL: "監測程式名稱",
+    SettingsText.BACKGROUND_WATCH_APPS_PLACEHOLDER: (
+        "以逗號分隔，例如：Visual Studio Code, GitHub Desktop"
+    ),
+    SettingsText.BACKGROUND_DIAGNOSTIC_LABEL: "IDE 診斷報告",
+    SettingsText.BACKGROUND_DIAGNOSTIC_PLACEHOLDER: (
+        "選填：IDE 匯出的 .txt 或 .log 診斷報告完整路徑"
+    ),
+    SettingsText.BACKGROUND_SAFETY_NOTE: (
+        "背景助理只讀取可見程式名稱與您明確指定的診斷報告；"
+        "不會截取編輯器內容、不會自動修改檔案，也會遵守勿擾模式與冷卻時間。"
+    ),
+    SettingsText.PHYSICS_LABEL: "電影級物理",
+    SettingsText.PHYSICS_SLEEVES_NAME: "袖擺呼吸與慣性",
+    SettingsText.PHYSICS_SLEEVES_DESCRIPTION: (
+        "依呼吸與移動柔和帶動袖擺，呈現布料重量與慣性。"
+    ),
+    SettingsText.PHYSICS_HAIR_NAME: "長髮柔性擺動",
+    SettingsText.PHYSICS_HAIR_DESCRIPTION: (
+        "讓長髮隨姿勢與移動自然擺動，避免僵硬晃動。"
+    ),
+    SettingsText.PHYSICS_ORNAMENT_NAME: "髮飾與流蘇慣性",
+    SettingsText.PHYSICS_ORNAMENT_DESCRIPTION: (
+        "讓髮飾與流蘇以較小幅度延遲跟隨頭部動作。"
+    ),
+    SettingsText.PHYSICS_EYE_TRACKING_NAME: "眼球追蹤滑鼠",
+    SettingsText.PHYSICS_EYE_TRACKING_DESCRIPTION: (
+        "讓視線平滑追蹤滑鼠位置，不會影響實際游標操作。"
+    ),
+    SettingsText.PHYSICS_FACE_PARALLAX_NAME: "臉部柔和視差",
+    SettingsText.PHYSICS_FACE_PARALLAX_DESCRIPTION: (
+        "依視線與姿勢加入輕微臉部視差，提升 2.5D 深度感。"
+    ),
+    SettingsText.PHYSICS_NOTE: (
+        "旗艦物理預設全部開啟；可依效能需要個別關閉。"
+    ),
+    SettingsText.WORK_FOLDER_LABEL: "工作資料夾",
+    SettingsText.WORK_FOLDER_PLACEHOLDER: "常用工作資料夾路徑",
+    SettingsText.WORK_FOLDER_BROWSE: "瀏覽…",
+    SettingsText.WORK_FOLDER_OPEN: "開啟工作資料夾",
+    SettingsText.WORK_FOLDER_BROWSE_TITLE: "選擇工作資料夾",
+    SettingsText.WORK_FOLDER_INVALID_TITLE: "工作資料夾",
+    SettingsText.WORK_FOLDER_INVALID_MESSAGE: (
+        "請先填入有效的資料夾路徑。"
+    ),
+    SettingsText.AI_CORE_LABEL: "AI 智能核心",
+    SettingsText.PERSONA_LABEL: "AI 人格提示詞",
+    SettingsText.PERSONA_PLACEHOLDER: (
+        "設定助理的角色背景、語氣、工作方式與界線。"
+    ),
+    SettingsText.PROFILE_REQUIRED_TITLE: "尚缺必要資料",
+    SettingsText.PROFILE_REQUIRED_MESSAGE: (
+        "助理名稱與助理對你的稱呼不可留空。"
+    ),
+})
+
+
+_ZH_CN: Mapping[SettingsText, str] = frozendict({
+    SettingsText.AUTOSTART_LABEL: "自动启动",
+    SettingsText.AUTOSTART_WINDOWS: "Windows 登录后自动启动",
+    SettingsText.AUTOSTART_UNAVAILABLE: (
+        "{platform} 自动启动尚未完成真机验证"
+    ),
+    SettingsText.AUTOSTART_ERROR_TITLE: "自动启动",
+    SettingsText.AUTOSTART_ERROR: "无法更新自动启动：{reason}",
+    SettingsText.TOPMOST_LABEL: "桌面置顶方式",
+    SettingsText.TOPMOST_SMART: "智能置顶（推荐）",
+    SettingsText.TOPMOST_ALWAYS: "始终置顶",
+    SettingsText.TOPMOST_NEVER: "不置顶",
+    SettingsText.CHARACTER_SCALE_LABEL: "桌面{assistant}显示大小",
+    SettingsText.CHARACTER_SCALE_RESET: "恢复 100%",
+    SettingsText.CHARACTER_SCALE_RESET_TOOLTIP: (
+        "将桌面{assistant}恢复为原始显示大小"
+    ),
+    SettingsText.PROACTIVE_LABEL: "主动协助程度",
+    SettingsText.PROACTIVE_QUIET: "安静（仅提醒必要事项）",
+    SettingsText.PROACTIVE_BALANCED: "均衡（推荐）",
+    SettingsText.PROACTIVE_ACTIVE: "积极（主动建议）",
+    SettingsText.BACKGROUND_ASSISTANT_LABEL: "后台多任务助手",
+    SettingsText.BACKGROUND_ASSISTANT_ENABLED: (
+        "启用后台多任务助手（默认关闭）"
+    ),
+    SettingsText.BACKGROUND_MODE_LABEL: "后台助手模式",
+    SettingsText.BACKGROUND_MODE_FOLLOWS_PROACTIVE: (
+        "跟随主动协助程度"
+    ),
+    SettingsText.BACKGROUND_WATCH_APPS_LABEL: "监测程序名称",
+    SettingsText.BACKGROUND_WATCH_APPS_PLACEHOLDER: (
+        "用逗号分隔，例如：Visual Studio Code, GitHub Desktop"
+    ),
+    SettingsText.BACKGROUND_DIAGNOSTIC_LABEL: "IDE 诊断报告",
+    SettingsText.BACKGROUND_DIAGNOSTIC_PLACEHOLDER: (
+        "可选：IDE 导出的 .txt 或 .log 诊断报告完整路径"
+    ),
+    SettingsText.BACKGROUND_SAFETY_NOTE: (
+        "后台助手只读取可见程序名称和您明确指定的诊断报告；"
+        "不会截取编辑器内容，不会自动修改文件，并会遵守免打扰模式和冷却时间。"
+    ),
+    SettingsText.PHYSICS_LABEL: "电影级物理效果",
+    SettingsText.PHYSICS_SLEEVES_NAME: "袖摆呼吸与惯性",
+    SettingsText.PHYSICS_SLEEVES_DESCRIPTION: (
+        "根据呼吸与移动柔和带动袖摆，呈现布料重量与惯性。"
+    ),
+    SettingsText.PHYSICS_HAIR_NAME: "长发柔性摆动",
+    SettingsText.PHYSICS_HAIR_DESCRIPTION: (
+        "让长发随姿势与移动自然摆动，避免僵硬晃动。"
+    ),
+    SettingsText.PHYSICS_ORNAMENT_NAME: "发饰与流苏惯性",
+    SettingsText.PHYSICS_ORNAMENT_DESCRIPTION: (
+        "让发饰与流苏以较小幅度延迟跟随头部动作。"
+    ),
+    SettingsText.PHYSICS_EYE_TRACKING_NAME: "眼球跟踪鼠标",
+    SettingsText.PHYSICS_EYE_TRACKING_DESCRIPTION: (
+        "让视线平滑跟踪鼠标位置，不会影响实际指针操作。"
+    ),
+    SettingsText.PHYSICS_FACE_PARALLAX_NAME: "脸部柔和视差",
+    SettingsText.PHYSICS_FACE_PARALLAX_DESCRIPTION: (
+        "根据视线与姿势加入轻微脸部视差，提升 2.5D 深度感。"
+    ),
+    SettingsText.PHYSICS_NOTE: (
+        "旗舰物理效果默认全部启用；可根据性能需要单独关闭。"
+    ),
+    SettingsText.WORK_FOLDER_LABEL: "工作文件夹",
+    SettingsText.WORK_FOLDER_PLACEHOLDER: "常用工作文件夹路径",
+    SettingsText.WORK_FOLDER_BROWSE: "浏览…",
+    SettingsText.WORK_FOLDER_OPEN: "打开工作文件夹",
+    SettingsText.WORK_FOLDER_BROWSE_TITLE: "选择工作文件夹",
+    SettingsText.WORK_FOLDER_INVALID_TITLE: "工作文件夹",
+    SettingsText.WORK_FOLDER_INVALID_MESSAGE: (
+        "请先填写有效的文件夹路径。"
+    ),
+    SettingsText.AI_CORE_LABEL: "AI 智能核心",
+    SettingsText.PERSONA_LABEL: "AI 人格提示词",
+    SettingsText.PERSONA_PLACEHOLDER: (
+        "设置助手的角色背景、语气、工作方式与界限。"
+    ),
+    SettingsText.PROFILE_REQUIRED_TITLE: "缺少必要信息",
+    SettingsText.PROFILE_REQUIRED_MESSAGE: (
+        "助手名称和助手对你的称呼不能为空。"
+    ),
+})
+
+
+_EN: Mapping[SettingsText, str] = frozendict({
+    SettingsText.AUTOSTART_LABEL: "Start automatically",
+    SettingsText.AUTOSTART_WINDOWS: (
+        "Start automatically after Windows sign-in"
+    ),
+    SettingsText.AUTOSTART_UNAVAILABLE: (
+        "Autostart on {platform} has not been verified on a physical device"
+    ),
+    SettingsText.AUTOSTART_ERROR_TITLE: "Autostart",
+    SettingsText.AUTOSTART_ERROR: "Could not update autostart: {reason}",
+    SettingsText.TOPMOST_LABEL: "Keep on top",
+    SettingsText.TOPMOST_SMART: "Smart on top (Recommended)",
+    SettingsText.TOPMOST_ALWAYS: "Always on top",
+    SettingsText.TOPMOST_NEVER: "Never on top",
+    SettingsText.CHARACTER_SCALE_LABEL: "Desktop {assistant} size",
+    SettingsText.CHARACTER_SCALE_RESET: "Reset to 100%",
+    SettingsText.CHARACTER_SCALE_RESET_TOOLTIP: (
+        "Restore desktop {assistant} to its original display size"
+    ),
+    SettingsText.PROACTIVE_LABEL: "Proactive assistance",
+    SettingsText.PROACTIVE_QUIET: "Quiet (Essential reminders only)",
+    SettingsText.PROACTIVE_BALANCED: "Balanced (Recommended)",
+    SettingsText.PROACTIVE_ACTIVE: "Active (Proactive suggestions)",
+    SettingsText.BACKGROUND_ASSISTANT_LABEL: (
+        "Background multitasking assistant"
+    ),
+    SettingsText.BACKGROUND_ASSISTANT_ENABLED: (
+        "Enable background multitasking assistant (Off by default)"
+    ),
+    SettingsText.BACKGROUND_MODE_LABEL: "Background assistant mode",
+    SettingsText.BACKGROUND_MODE_FOLLOWS_PROACTIVE: (
+        "Follow proactive assistance level"
+    ),
+    SettingsText.BACKGROUND_WATCH_APPS_LABEL: "Apps to monitor",
+    SettingsText.BACKGROUND_WATCH_APPS_PLACEHOLDER: (
+        "Comma-separated, for example: Visual Studio Code, GitHub Desktop"
+    ),
+    SettingsText.BACKGROUND_DIAGNOSTIC_LABEL: "IDE diagnostic report",
+    SettingsText.BACKGROUND_DIAGNOSTIC_PLACEHOLDER: (
+        "Optional: full path to an IDE-exported .txt or .log diagnostic report"
+    ),
+    SettingsText.BACKGROUND_SAFETY_NOTE: (
+        "The background assistant reads only visible app names and diagnostic "
+        "reports you explicitly select. It does not capture editor content or "
+        "modify files automatically, and it respects Do Not Disturb and cooldowns."
+    ),
+    SettingsText.PHYSICS_LABEL: "Cinematic physics",
+    SettingsText.PHYSICS_SLEEVES_NAME: "Sleeve breathing and inertia",
+    SettingsText.PHYSICS_SLEEVES_DESCRIPTION: (
+        "Gently moves the sleeves with breathing and motion to convey fabric "
+        "weight and inertia."
+    ),
+    SettingsText.PHYSICS_HAIR_NAME: "Soft long-hair movement",
+    SettingsText.PHYSICS_HAIR_DESCRIPTION: (
+        "Moves long hair naturally with pose and motion while avoiding rigid "
+        "movement."
+    ),
+    SettingsText.PHYSICS_ORNAMENT_NAME: "Hair ornament and tassel inertia",
+    SettingsText.PHYSICS_ORNAMENT_DESCRIPTION: (
+        "Lets hair ornaments and tassels follow head movement with a subtle delay."
+    ),
+    SettingsText.PHYSICS_EYE_TRACKING_NAME: "Mouse eye tracking",
+    SettingsText.PHYSICS_EYE_TRACKING_DESCRIPTION: (
+        "Moves the gaze smoothly toward the pointer without affecting mouse input."
+    ),
+    SettingsText.PHYSICS_FACE_PARALLAX_NAME: "Gentle facial parallax",
+    SettingsText.PHYSICS_FACE_PARALLAX_DESCRIPTION: (
+        "Adds subtle facial parallax from gaze and pose to enhance 2.5D depth."
+    ),
+    SettingsText.PHYSICS_NOTE: (
+        "All flagship physics effects are enabled by default and can be "
+        "disabled individually when needed for performance."
+    ),
+    SettingsText.WORK_FOLDER_LABEL: "Work folder",
+    SettingsText.WORK_FOLDER_PLACEHOLDER: "Path to your usual work folder",
+    SettingsText.WORK_FOLDER_BROWSE: "Browse…",
+    SettingsText.WORK_FOLDER_OPEN: "Open work folder",
+    SettingsText.WORK_FOLDER_BROWSE_TITLE: "Choose work folder",
+    SettingsText.WORK_FOLDER_INVALID_TITLE: "Work folder",
+    SettingsText.WORK_FOLDER_INVALID_MESSAGE: (
+        "Enter a valid folder path first."
+    ),
+    SettingsText.AI_CORE_LABEL: "AI core",
+    SettingsText.PERSONA_LABEL: "AI persona prompt",
+    SettingsText.PERSONA_PLACEHOLDER: (
+        "Define the assistant's background, tone, working style, and boundaries."
+    ),
+    SettingsText.PROFILE_REQUIRED_TITLE: "Required information missing",
+    SettingsText.PROFILE_REQUIRED_MESSAGE: (
+        "Assistant name and how the assistant addresses you are required."
+    ),
+})
+
+
+_JA: Mapping[SettingsText, str] = frozendict({
+    SettingsText.AUTOSTART_LABEL: "自動起動",
+    SettingsText.AUTOSTART_WINDOWS: "Windows サインイン後に自動起動",
+    SettingsText.AUTOSTART_UNAVAILABLE: (
+        "{platform} の自動起動は実機での動作確認が完了していません"
+    ),
+    SettingsText.AUTOSTART_ERROR_TITLE: "自動起動",
+    SettingsText.AUTOSTART_ERROR: "自動起動を更新できませんでした：{reason}",
+    SettingsText.TOPMOST_LABEL: "常に手前に表示",
+    SettingsText.TOPMOST_SMART: "スマート表示（推奨）",
+    SettingsText.TOPMOST_ALWAYS: "常に手前に表示",
+    SettingsText.TOPMOST_NEVER: "手前に固定しない",
+    SettingsText.CHARACTER_SCALE_LABEL: (
+        "デスクトップ上の{assistant}の表示サイズ"
+    ),
+    SettingsText.CHARACTER_SCALE_RESET: "100% に戻す",
+    SettingsText.CHARACTER_SCALE_RESET_TOOLTIP: (
+        "デスクトップ上の{assistant}を元の表示サイズに戻します"
+    ),
+    SettingsText.PROACTIVE_LABEL: "先回り支援の程度",
+    SettingsText.PROACTIVE_QUIET: "静か（必要な通知のみ）",
+    SettingsText.PROACTIVE_BALANCED: "バランス（推奨）",
+    SettingsText.PROACTIVE_ACTIVE: "積極的（先回りして提案）",
+    SettingsText.BACKGROUND_ASSISTANT_LABEL: (
+        "バックグラウンド・マルチタスク支援"
+    ),
+    SettingsText.BACKGROUND_ASSISTANT_ENABLED: (
+        "バックグラウンド・マルチタスク支援を有効にする（初期設定：無効）"
+    ),
+    SettingsText.BACKGROUND_MODE_LABEL: "バックグラウンド支援モード",
+    SettingsText.BACKGROUND_MODE_FOLLOWS_PROACTIVE: (
+        "先回り支援の程度に従う"
+    ),
+    SettingsText.BACKGROUND_WATCH_APPS_LABEL: "監視するアプリ名",
+    SettingsText.BACKGROUND_WATCH_APPS_PLACEHOLDER: (
+        "カンマ区切り（例：Visual Studio Code, GitHub Desktop）"
+    ),
+    SettingsText.BACKGROUND_DIAGNOSTIC_LABEL: "IDE 診断レポート",
+    SettingsText.BACKGROUND_DIAGNOSTIC_PLACEHOLDER: (
+        "任意：IDE から出力した .txt または .log 診断レポートの完全なパス"
+    ),
+    SettingsText.BACKGROUND_SAFETY_NOTE: (
+        "バックグラウンド支援は、表示中のアプリ名と明示的に指定した診断レポート"
+        "のみを読み取ります。エディターの内容を取得したり、ファイルを自動変更したり"
+        "せず、通知抑制モードとクールダウン時間も守ります。"
+    ),
+    SettingsText.PHYSICS_LABEL: "映画品質の物理表現",
+    SettingsText.PHYSICS_SLEEVES_NAME: "袖の呼吸連動と慣性",
+    SettingsText.PHYSICS_SLEEVES_DESCRIPTION: (
+        "呼吸や動きに合わせて袖を穏やかに揺らし、布の重さと慣性を表現します。"
+    ),
+    SettingsText.PHYSICS_HAIR_NAME: "長髪の柔らかな揺れ",
+    SettingsText.PHYSICS_HAIR_DESCRIPTION: (
+        "姿勢や動きに合わせて長い髪を自然に揺らし、硬い動きを抑えます。"
+    ),
+    SettingsText.PHYSICS_ORNAMENT_NAME: "髪飾りと房飾りの慣性",
+    SettingsText.PHYSICS_ORNAMENT_DESCRIPTION: (
+        "頭の動きに少し遅れて、髪飾りと房飾りを小さく揺らします。"
+    ),
+    SettingsText.PHYSICS_EYE_TRACKING_NAME: "視線のマウス追従",
+    SettingsText.PHYSICS_EYE_TRACKING_DESCRIPTION: (
+        "実際のマウス操作に影響を与えず、視線をポインターへ滑らかに追従させます。"
+    ),
+    SettingsText.PHYSICS_FACE_PARALLAX_NAME: "顔の穏やかな視差",
+    SettingsText.PHYSICS_FACE_PARALLAX_DESCRIPTION: (
+        "視線と姿勢に応じて顔へ控えめな視差を加え、2.5D の奥行きを高めます。"
+    ),
+    SettingsText.PHYSICS_NOTE: (
+        "主要な物理効果はすべて初期状態で有効です。性能に応じて個別に無効化できます。"
+    ),
+    SettingsText.WORK_FOLDER_LABEL: "作業フォルダー",
+    SettingsText.WORK_FOLDER_PLACEHOLDER: "通常使用する作業フォルダーのパス",
+    SettingsText.WORK_FOLDER_BROWSE: "参照…",
+    SettingsText.WORK_FOLDER_OPEN: "作業フォルダーを開く",
+    SettingsText.WORK_FOLDER_BROWSE_TITLE: "作業フォルダーを選択",
+    SettingsText.WORK_FOLDER_INVALID_TITLE: "作業フォルダー",
+    SettingsText.WORK_FOLDER_INVALID_MESSAGE: (
+        "有効なフォルダーのパスを先に入力してください。"
+    ),
+    SettingsText.AI_CORE_LABEL: "AI コア",
+    SettingsText.PERSONA_LABEL: "AI ペルソナプロンプト",
+    SettingsText.PERSONA_PLACEHOLDER: (
+        "アシスタントの背景、口調、仕事の進め方、守るべき境界を設定します。"
+    ),
+    SettingsText.PROFILE_REQUIRED_TITLE: "必須情報が不足しています",
+    SettingsText.PROFILE_REQUIRED_MESSAGE: (
+        "アシスタント名と、アシスタントからの呼び名を入力してください。"
+    ),
+})
+
+
+TRANSLATIONS: Mapping[str, Mapping[SettingsText, str]] = frozendict({
+    "zh-TW": _ZH_TW,
+    "zh-CN": _ZH_CN,
+    "en": _EN,
+    "ja-JP": _JA,
+})
+
+
+def _format_fields(template: str) -> tuple[str, ...]:
+    return tuple(
+        field_name
+        for _literal, field_name, _format_spec, _conversion in Formatter().parse(
+            template
+        )
+        if field_name is not None
+    )
+
+
+def _validate_translation_contract() -> None:
+    expected_keys = frozenset(SettingsText)
+    reference_fields = {
+        key: _format_fields(template)
+        for key, template in _ZH_TW.items()
+    }
+    for language, translations in TRANSLATIONS.items():
+        actual_keys = frozenset(translations)
+        if actual_keys != expected_keys:
+            missing = sorted(key.value for key in expected_keys - actual_keys)
+            extra = sorted(key.value for key in actual_keys - expected_keys)
+            raise RuntimeError(
+                f"Incomplete settings UI translations for {language}: "
+                f"missing={missing}, extra={extra}"
+            )
+        mismatched_fields = sorted(
+            key.value
+            for key, template in translations.items()
+            if _format_fields(template) != reference_fields[key]
+        )
+        if mismatched_fields:
+            raise RuntimeError(
+                f"Inconsistent settings UI format fields for {language}: "
+                f"keys={mismatched_fields}"
+            )
+
+
+_validate_translation_contract()
+
+
+def settings_text(
+    language: str,
+    key: SettingsText,
+    **values: object,
+) -> str:
+    """Return one localized settings string from the complete key set."""
+
+    template = TRANSLATIONS[canonical_ui_language(language)][key]
+    return template.format(**values)
+
+
+__all__ = (
+    "LANGUAGE_ORDER",
+    "PHYSICS_TEXT_KEYS",
+    "PROACTIVE_MODE_KEYS",
+    "TOPMOST_MODE_KEYS",
+    "TRANSLATIONS",
+    "SettingsText",
+    "settings_text",
+)

--- a/speech.py
+++ b/speech.py
@@ -650,32 +650,177 @@ def preferred_windows_voice(
     return voices[0][0] if voices else ""
 
 
+class _SpeechCancelled(Exception):
+    """End one obsolete local-speech generation without user-facing errors."""
+
+
 class WindowsTTS(QObject):
     failed = Signal(str)
     finished = Signal()
     viseme_cue = Signal(float, str)
+    _failed_ready = Signal(int, str)
+    _finished_ready = Signal(int)
+    _viseme_ready = Signal(int, float, str)
 
     def __init__(self, parent: QObject | None = None):
         super().__init__(parent)
         self.volume_percent = 125
         self.muted = False
+        self._state_lock = threading.RLock()
+        self._generation = 0
+        self._active_process: subprocess.Popen[bytes] | None = None
+        self._active_stream: sd.RawOutputStream | None = None
+        self._failed_ready.connect(self._deliver_failed)
+        self._finished_ready.connect(self._deliver_finished)
+        self._viseme_ready.connect(self._deliver_viseme)
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_percent = max(0, min(160, int(volume_percent)))
         self.muted = bool(muted)
 
     def speak(self, text: str, voice_name: str = "", rate: int = -1) -> None:
+        generation = self._begin_generation()
         if os.name != "nt" or not text.strip():
-            self.finished.emit()
+            self._emit_finished(generation)
             return
         threading.Thread(
             target=self._run,
-            args=(text, voice_name, rate),
+            args=(text, voice_name, rate, generation),
             daemon=True,
         ).start()
 
-    def _run(self, text: str, voice_name: str, rate: int) -> None:
+    def stop(self) -> None:
+        self._begin_generation()
+
+    def _begin_generation(self) -> int:
+        with self._state_lock:
+            self._generation += 1
+            generation = self._generation
+            process = self._active_process
+            stream = self._active_stream
+            self._active_process = None
+            self._active_stream = None
+        self._terminate_process(process)
+        self._abort_stream(stream)
+        return generation
+
+    def _is_current(self, generation: int) -> bool:
+        with self._state_lock:
+            return generation == self._generation
+
+    def _ensure_current(self, generation: int) -> None:
+        if not self._is_current(generation):
+            raise _SpeechCancelled
+
+    def _emit_finished(self, generation: int) -> None:
+        if self._is_current(generation):
+            self._finished_ready.emit(generation)
+
+    def _deliver_finished(self, generation: int) -> None:
+        with self._state_lock:
+            if generation == self._generation:
+                self.finished.emit()
+
+    def _emit_failed(self, generation: int, message: str) -> None:
+        if self._is_current(generation):
+            self._failed_ready.emit(generation, message)
+
+    def _deliver_failed(self, generation: int, message: str) -> None:
+        with self._state_lock:
+            if generation == self._generation:
+                self.failed.emit(message)
+
+    def _emit_viseme(
+        self,
+        generation: int,
+        level: float,
+        vowel: str,
+    ) -> None:
+        if self._is_current(generation):
+            self._viseme_ready.emit(generation, level, vowel)
+
+    def _deliver_viseme(
+        self,
+        generation: int,
+        level: float,
+        vowel: str,
+    ) -> None:
+        with self._state_lock:
+            if generation == self._generation:
+                self.viseme_cue.emit(level, vowel)
+
+    def _register_process(
+        self,
+        generation: int,
+        process: subprocess.Popen[bytes],
+    ) -> bool:
+        with self._state_lock:
+            if generation != self._generation:
+                return False
+            self._active_process = process
+            return True
+
+    def _release_process(
+        self,
+        process: subprocess.Popen[bytes],
+    ) -> None:
+        with self._state_lock:
+            if self._active_process is process:
+                self._active_process = None
+
+    def _register_stream(
+        self,
+        generation: int,
+        stream: sd.RawOutputStream,
+    ) -> bool:
+        with self._state_lock:
+            if generation != self._generation:
+                return False
+            self._active_stream = stream
+            return True
+
+    def _release_stream(self, stream: sd.RawOutputStream) -> None:
+        with self._state_lock:
+            if self._active_stream is stream:
+                self._active_stream = None
+
+    @staticmethod
+    def _terminate_process(
+        process: subprocess.Popen[bytes] | None,
+    ) -> None:
+        if process is None or process.poll() is not None:
+            return
         try:
+            process.terminate()
+        except OSError:
+            # The worker still has the generation gate, so a process that
+            # exited during this race cannot publish obsolete results.
+            return
+
+    @staticmethod
+    def _abort_stream(stream: sd.RawOutputStream | None) -> None:
+        if stream is None:
+            return
+        try:
+            stream.abort()
+        except (OSError, RuntimeError, sd.PortAudioError):
+            # PortAudio can report that another thread already closed the
+            # stream. The generation gate remains the authoritative stop.
+            return
+
+    def _run(
+        self,
+        text: str,
+        voice_name: str,
+        rate: int,
+        generation: int | None = None,
+    ) -> None:
+        # Keep the established direct-call contract used by diagnostics while
+        # treating such a call as a new, independently cancellable utterance.
+        if generation is None:
+            generation = self._begin_generation()
+        try:
+            self._ensure_current(generation)
             installed = windows_voices()
             selected_voice = preferred_windows_voice(
                 installed,
@@ -691,11 +836,22 @@ class WindowsTTS(QObject):
                 self._run_onecore(
                     text,
                     voice_name.removeprefix("OneCore::"),
+                    generation,
                 )
             else:
-                self._run_sapi(text, voice_name, rate)
-            self.finished.emit()
-        except (OSError, subprocess.SubprocessError, RuntimeError) as exc:
+                self._run_sapi(text, voice_name, rate, generation)
+            self._emit_finished(generation)
+        except _SpeechCancelled:
+            return
+        except (
+            OSError,
+            RuntimeError,
+            subprocess.SubprocessError,
+            wave.Error,
+            sd.PortAudioError,
+        ) as exc:
+            if not self._is_current(generation):
+                return
             if voice_name.startswith("OneCore::"):
                 try:
                     desktop_voices = [
@@ -704,15 +860,29 @@ class WindowsTTS(QObject):
                         if not voice[0].startswith("OneCore::")
                     ]
                     fallback = preferred_windows_voice(desktop_voices)
-                    self._run_sapi(text, fallback, rate)
-                    self.finished.emit()
+                    self._run_sapi(text, fallback, rate, generation)
+                    self._emit_finished(generation)
                     return
-                except (OSError, subprocess.SubprocessError, RuntimeError):
+                except _SpeechCancelled:
+                    return
+                except (
+                    OSError,
+                    RuntimeError,
+                    subprocess.SubprocessError,
+                    wave.Error,
+                    sd.PortAudioError,
+                ):
                     pass
-            self.failed.emit(str(exc))
-            self.finished.emit()
+            self._emit_failed(generation, str(exc))
+            self._emit_finished(generation)
 
-    def _run_sapi(self, text: str, voice_name: str, rate: int) -> None:
+    def _run_sapi(
+        self,
+        text: str,
+        voice_name: str,
+        rate: int,
+        generation: int,
+    ) -> None:
         fd, name = tempfile.mkstemp(prefix="mohan-sapi-", suffix=".wav")
         os.close(fd)
         audio_path = Path(name)
@@ -736,21 +906,26 @@ class WindowsTTS(QObject):
         )
         command = base64.b64encode(script.encode("utf-16le")).decode("ascii")
         try:
-            result = subprocess.run(
-                ["powershell.exe", "-NoProfile", "-EncodedCommand", command],
-                capture_output=True,
-                creationflags=CREATE_NO_WINDOW,
-                timeout=120,
-                check=False,
+            self._synthesize_with_powershell(
+                command,
+                audio_path,
+                generation,
+                "Windows 傳統語音播放失敗。",
+                240,
             )
-            if result.returncode or not audio_path.exists():
-                detail = result.stderr.decode("utf-8", errors="replace")[:240]
-                raise RuntimeError(detail or "Windows 傳統語音播放失敗。")
-            self._play_wave_bytes(audio_path.read_bytes(), audio_path)
+            self._play_wave_bytes(
+                audio_path.read_bytes(),
+                generation,
+            )
         finally:
             audio_path.unlink(missing_ok=True)
 
-    def _run_onecore(self, text: str, voice_name: str) -> None:
+    def _run_onecore(
+        self,
+        text: str,
+        voice_name: str,
+        generation: int,
+    ) -> None:
         fd, name = tempfile.mkstemp(prefix="mohan-onecore-", suffix=".wav")
         os.close(fd)
         audio_path = Path(name)
@@ -793,32 +968,111 @@ class WindowsTTS(QObject):
         )
         command = base64.b64encode(script.encode("utf-16le")).decode("ascii")
         try:
-            result = subprocess.run(
-                ["powershell.exe", "-NoProfile", "-EncodedCommand", command],
-                capture_output=True,
-                creationflags=CREATE_NO_WINDOW,
-                timeout=120,
-                check=False,
+            self._synthesize_with_powershell(
+                command,
+                audio_path,
+                generation,
+                "OneCore 語音合成失敗。",
+                3000,
             )
-            if result.returncode or not audio_path.exists():
-                detail = result.stderr.decode("utf-8", errors="replace")[:3000]
-                raise RuntimeError(detail or "OneCore 語音合成失敗。")
-            self._play_wave_bytes(audio_path.read_bytes(), audio_path)
+            self._play_wave_bytes(
+                audio_path.read_bytes(),
+                generation,
+            )
         finally:
             audio_path.unlink(missing_ok=True)
+
+    def _synthesize_with_powershell(
+        self,
+        command: str,
+        audio_path: Path,
+        generation: int,
+        failure_message: str,
+        detail_limit: int,
+    ) -> None:
+        self._ensure_current(generation)
+        process = subprocess.Popen(
+            ["powershell.exe", "-NoProfile", "-EncodedCommand", command],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=CREATE_NO_WINDOW,
+        )
+        if not self._register_process(generation, process):
+            self._terminate_process(process)
+            raise _SpeechCancelled
+        try:
+            try:
+                _stdout, stderr = process.communicate(timeout=120)
+            except subprocess.TimeoutExpired as exc:
+                self._terminate_process(process)
+                process.communicate()
+                self._ensure_current(generation)
+                raise RuntimeError("Windows 本機語音合成逾時。") from exc
+        finally:
+            self._release_process(process)
+        self._ensure_current(generation)
+        if process.returncode or not audio_path.exists():
+            detail = stderr.decode("utf-8", errors="replace")[:detail_limit]
+            raise RuntimeError(detail or failure_message)
 
     def _play_wave_bytes(
         self,
         audio: bytes,
-        audio_path: Path | None = None,
+        generation: int,
     ) -> None:
-        play_wave_with_visemes(
+        playback_audio = apply_wav_volume(
             audio,
             self.volume_percent,
             self.muted,
-            self.viseme_cue.emit,
-            audio_path,
         )
+        with (
+            wave.open(io.BytesIO(audio), "rb") as cue_source,
+            wave.open(io.BytesIO(playback_audio), "rb") as source,
+        ):
+            channels = source.getnchannels()
+            sample_rate = source.getframerate()
+            if (
+                source.getsampwidth() != 2
+                or source.getcomptype() != "NONE"
+                or cue_source.getnchannels() != channels
+                or cue_source.getsampwidth() != 2
+                or cue_source.getframerate() != sample_rate
+                or cue_source.getcomptype() != "NONE"
+            ):
+                raise RuntimeError(
+                    "Windows 本機語音回傳了不支援的 WAV 格式。"
+                )
+            frames_per_cue = max(
+                1,
+                sample_rate // VISEME_CUES_PER_SECOND,
+            )
+            stream = sd.RawOutputStream(
+                samplerate=sample_rate,
+                channels=channels,
+                dtype="int16",
+                blocksize=frames_per_cue,
+            )
+            if not self._register_stream(generation, stream):
+                stream.close()
+                raise _SpeechCancelled
+            try:
+                self._ensure_current(generation)
+                stream.start()
+                while chunk := source.readframes(frames_per_cue):
+                    self._ensure_current(generation)
+                    cue_chunk = cue_source.readframes(frames_per_cue)
+                    level, vowel = infer_vowel_pcm16(
+                        _mono_wave_chunk(cue_chunk, channels),
+                        sample_rate,
+                    )
+                    self._emit_viseme(generation, level, vowel)
+                    stream.write(chunk)
+                self._ensure_current(generation)
+                stream.stop()
+                self._emit_viseme(generation, 0.0, "CLOSED")
+            finally:
+                self._release_stream(stream)
+                stream.close()
 
     def _emit_wave_cues(
         self,
@@ -858,6 +1112,9 @@ class UnavailableSystemTTS(QObject):
         if text.strip():
             self.failed.emit(self.reason)
         self.finished.emit()
+
+    def stop(self) -> None:
+        """Match the local speech contract when no adapter is available."""
 
 
 class OpenAITTS(QObject):

--- a/speech.py
+++ b/speech.py
@@ -27,6 +27,12 @@ lazy from lip_sync import (
     infer_vowel_pcm16,
 )
 lazy from pcm_audio import PcmAudioError, scale_pcm16, stereo_to_mono_pcm16
+lazy from safe_error import sanitize_error
+lazy from service_status_localization import (
+    ServiceStatus,
+    append_service_status,
+    service_status,
+)
 
 if os.name == "nt":
     lazy import winsound
@@ -105,6 +111,7 @@ class SpeechEndpointDetector:
     quiet_blocks: int = 0
     threshold: float = 120.0
     baseline: list[float] = field(default_factory=list)
+    language: str = "zh-TW"
 
     def _handle_manual_stop(self, stop_requested: bool) -> bool:
         if not stop_requested:
@@ -112,7 +119,10 @@ class SpeechEndpointDetector:
         if self.speech_started:
             return True
         raise RuntimeError(
-            "尚未偵測到說話聲，沒有送出空白錄音。"
+            service_status(
+                self.language,
+                ServiceStatus.SPEECH_EMPTY_MANUAL_CAPTURE,
+            )
         )
 
     def _calibrate(self, level: float) -> bool:
@@ -161,48 +171,80 @@ class SpeechEndpointDetector:
                 return True
         elif captured_blocks >= self.limits.initial_silence_blocks:
             raise RuntimeError(
-                "沒有偵測到說話聲，請靠近麥克風後再試一次。"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_NOT_DETECTED,
+                )
             )
         if self.speech_started:
             self.speech_blocks += 1
         return False
 
 
+@dataclass(frozen=True, slots=True)
+class SpeechTranscriptionLocale:
+    """Provider transcription language paired with its UI locale."""
+
+    provider_language: str = ""
+    ui_language: str = "zh-TW"
+
+
 def transcription_http_error_message(
     status: int,
     detail: str,
+    *,
+    language: str = "zh-TW",
 ) -> str:
     lowered = detail.lower()
     match status:
         case 401:
-            message = "OpenAI API 金鑰無效或已被撤銷（HTTP 401）。"
+            key = ServiceStatus.SPEECH_OPENAI_KEY_INVALID
         case 403:
-            message = "OpenAI Project 未授權使用語音轉錄（HTTP 403）。"
+            key = ServiceStatus.SPEECH_OPENAI_NOT_AUTHORIZED
         case 404:
-            message = "OpenAI 找不到轉錄模型，或此 Project 無權使用（HTTP 404）。"
+            key = ServiceStatus.SPEECH_OPENAI_MODEL_NOT_FOUND
         case 429 if any(
             marker in lowered
             for marker in ("insufficient_quota", "quota", "billing")
         ):
-            message = "OpenAI API 額度不足或尚未啟用計費（HTTP 429）。"
+            key = ServiceStatus.SPEECH_OPENAI_QUOTA_EXHAUSTED
         case 429:
-            message = "OpenAI 語音轉錄請求過於頻繁，已達速率限制（HTTP 429）。"
+            key = ServiceStatus.SPEECH_OPENAI_RATE_LIMITED
         case _ if status >= 500:
-            message = f"OpenAI 語音轉錄服務暫時異常（HTTP {status}）。"
+            safe = sanitize_error(detail, http_status=status)
+            return (
+                service_status(
+                    language,
+                    ServiceStatus.SPEECH_OPENAI_SERVICE_ERROR,
+                    status=status,
+                )
+                + f" [{safe}]"
+            )
         case _:
-            compact = " ".join(detail.split())[:180]
-            message = f"OpenAI 轉錄失敗（HTTP {status}）：{compact}"
-    return message
+            return service_status(
+                language,
+                ServiceStatus.SPEECH_OPENAI_HTTP_ERROR,
+                status=status,
+                detail=str(sanitize_error(detail, http_status=status)),
+            )
+    return service_status(language, key)
 
 
 def transcribe_wav_bytes(
     audio: bytes,
     api_key: str,
     model: str,
-    language: str = "",
+    language: str | SpeechTranscriptionLocale = "",
     prompt: str = "",
 ) -> str:
     """Transcribe a complete WAV utterance through the accurate endpoint."""
+    locale = (
+        language
+        if isinstance(language, SpeechTranscriptionLocale)
+        else SpeechTranscriptionLocale(
+            provider_language=language,
+        )
+    )
     boundary = f"----MohanBoundary{os.urandom(12).hex()}"
     parts: list[bytes] = []
 
@@ -220,8 +262,8 @@ def transcribe_wav_bytes(
         )
 
     add_field("model", model or SpeechListener.TRANSCRIPTION_MODEL)
-    if language:
-        add_field("language", language)
+    if locale.provider_language:
+        add_field("language", locale.provider_language)
     if prompt:
         add_field("prompt", prompt)
     parts.extend(
@@ -253,19 +295,38 @@ def transcribe_wav_bytes(
             result = json.load(response)
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(
-            transcription_http_error_message(exc.code, detail)
-        ) from exc
+        failure = transcription_http_error_message(
+            exc.code,
+            detail,
+            language=locale.ui_language,
+        )
+        result = None
     except URLError as exc:
-        raise RuntimeError(
-            f"無法連線到 OpenAI：{exc.reason}"
-        ) from exc
+        failure = service_status(
+            locale.ui_language,
+            ServiceStatus.SPEECH_OPENAI_CONNECTION_ERROR,
+            detail=sanitize_error(exc),
+        )
+        result = None
     except TimeoutError as exc:
-        raise RuntimeError("OpenAI 轉錄連線逾時。") from exc
+        del exc
+        failure = service_status(
+            locale.ui_language,
+            ServiceStatus.SPEECH_OPENAI_TIMEOUT,
+        )
+        result = None
+    else:
+        failure = ""
+    if failure:
+        raise RuntimeError(failure)
+    assert result is not None
     text = str(result.get("text", "")).strip()
     if not text:
         raise RuntimeError(
-            "OpenAI 已成功連線，但沒有從這段錄音辨識出文字。"
+            service_status(
+                locale.ui_language,
+                ServiceStatus.SPEECH_OPENAI_EMPTY_RESULT,
+            )
         )
     return text
 
@@ -374,6 +435,10 @@ def emit_wave_viseme_cues(
             timeline_ready.set()
 
 
+class _SpeechPlaybackUnavailable(OSError):
+    """The current platform has no verified audio playback adapter."""
+
+
 def play_wave_with_visemes(
     audio: bytes,
     volume_percent: int,
@@ -384,8 +449,11 @@ def play_wave_with_visemes(
     """Play provider WAV audio through the single lip-sync implementation."""
 
     if winsound is None:
-        raise OSError(
-            "此平台的音訊播放介面尚未完成實機驗證；未播放這段語音。"
+        raise _SpeechPlaybackUnavailable(
+            service_status(
+                "zh-TW",
+                ServiceStatus.SPEECH_PLAYBACK_UNAVAILABLE,
+            )
         )
 
     playback_audio = apply_wav_volume(audio, volume_percent, muted)
@@ -662,8 +730,14 @@ class WindowsTTS(QObject):
     _finished_ready = Signal(int)
     _viseme_ready = Signal(int, float, str)
 
-    def __init__(self, parent: QObject | None = None):
+    def __init__(
+        self,
+        parent: QObject | None = None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
+        self.language = language
         self.volume_percent = 125
         self.muted = False
         self._state_lock = threading.RLock()
@@ -828,9 +902,15 @@ class WindowsTTS(QObject):
                 "",
             )
             if not selected_voice:
-                raise RuntimeError(
-                    "Windows 沒有偵測到已明確標示為女性的本機語音。"
+                self._emit_failed(
+                    generation,
+                    service_status(
+                        self.language,
+                        ServiceStatus.SPEECH_WINDOWS_FEMALE_VOICE_MISSING,
+                    ),
                 )
+                self._emit_finished(generation)
+                return
             voice_name = selected_voice
             if voice_name.startswith("OneCore::"):
                 self._run_onecore(
@@ -873,7 +953,7 @@ class WindowsTTS(QObject):
                     sd.PortAudioError,
                 ):
                     pass
-            self._emit_failed(generation, str(exc))
+            self._emit_failed(generation, str(sanitize_error(exc)))
             self._emit_finished(generation)
 
     def _run_sapi(
@@ -910,7 +990,10 @@ class WindowsTTS(QObject):
                 command,
                 audio_path,
                 generation,
-                "Windows 傳統語音播放失敗。",
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_LEGACY_FAILED,
+                ),
                 240,
             )
             self._play_wave_bytes(
@@ -935,6 +1018,13 @@ class WindowsTTS(QObject):
         path_encoded = base64.b64encode(
             str(audio_path).encode("utf-8")
         ).decode("ascii")
+        missing_voice_encoded = base64.b64encode(
+            service_status(
+                self.language,
+                ServiceStatus.SPEECH_ONECORE_VOICE_MISSING,
+                voice=voice_name,
+            ).encode("utf-8")
+        ).decode("ascii")
         script = (
             "Add-Type -AssemblyName System.Runtime.WindowsRuntime;"
             "$null=[Windows.Media.SpeechSynthesis.SpeechSynthesizer,"
@@ -951,11 +1041,12 @@ class WindowsTTS(QObject):
             f"$text=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{text_encoded}'));"
             f"$voiceName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{voice_encoded}'));"
             f"$path=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{path_encoded}'));"
+            f"$missingVoice=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{missing_voice_encoded}'));"
             "$synth=[Windows.Media.SpeechSynthesis.SpeechSynthesizer]::new();"
             "$voice=[Windows.Media.SpeechSynthesis.SpeechSynthesizer]::AllVoices|"
             "Where-Object{$_.DisplayName -eq $voiceName -or $_.Id -like ('*'+$voiceName+'*')}|"
             "Select-Object -First 1;"
-            "if(-not $voice){throw ('找不到 OneCore 聲音：'+$voiceName)};"
+            "if(-not $voice){throw $missingVoice};"
             "$synth.Voice=$voice;"
             "$stream=Await ($synth.SynthesizeTextToStreamAsync($text)) "
             "([Windows.Media.SpeechSynthesis.SpeechSynthesisStream]);"
@@ -972,7 +1063,10 @@ class WindowsTTS(QObject):
                 command,
                 audio_path,
                 generation,
-                "OneCore 語音合成失敗。",
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_ONECORE_FAILED,
+                ),
                 3000,
             )
             self._play_wave_bytes(
@@ -1007,13 +1101,20 @@ class WindowsTTS(QObject):
                 self._terminate_process(process)
                 process.communicate()
                 self._ensure_current(generation)
-                raise RuntimeError("Windows 本機語音合成逾時。") from exc
+                raise RuntimeError(
+                    service_status(
+                        self.language,
+                        ServiceStatus.SPEECH_WINDOWS_SYNTHESIS_TIMEOUT,
+                    )
+                ) from exc
         finally:
             self._release_process(process)
         self._ensure_current(generation)
         if process.returncode or not audio_path.exists():
             detail = stderr.decode("utf-8", errors="replace")[:detail_limit]
-            raise RuntimeError(detail or failure_message)
+            raise RuntimeError(
+                str(sanitize_error(detail)) if detail else failure_message
+            )
 
     def _play_wave_bytes(
         self,
@@ -1040,7 +1141,10 @@ class WindowsTTS(QObject):
                 or cue_source.getcomptype() != "NONE"
             ):
                 raise RuntimeError(
-                    "Windows 本機語音回傳了不支援的 WAV 格式。"
+                    service_status(
+                        self.language,
+                        ServiceStatus.SPEECH_WINDOWS_WAV_UNSUPPORTED,
+                    )
                 )
             frames_per_cue = max(
                 1,
@@ -1122,8 +1226,14 @@ class OpenAITTS(QObject):
     finished = Signal()
     viseme_cue = Signal(float, str)
 
-    def __init__(self, parent: QObject | None = None):
+    def __init__(
+        self,
+        parent: QObject | None = None,
+        *,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
+        self.language = language
         self.volume_percent = 125
         self.muted = False
 
@@ -1139,7 +1249,12 @@ class OpenAITTS(QObject):
         instructions: str = "",
     ) -> None:
         if not text.strip() or not api_key.strip():
-            self.failed.emit("尚未設定 OpenAI API 金鑰")
+            self.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_OPENAI_KEY_MISSING,
+                )
+            )
             return
         threading.Thread(
             target=self._run,
@@ -1175,6 +1290,13 @@ class OpenAITTS(QObject):
                 self.viseme_cue.emit,
             )
             self.finished.emit()
+        except _SpeechPlaybackUnavailable:
+            self.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_PLAYBACK_UNAVAILABLE,
+                )
+            )
         except (
             URLError,
             HTTPError,
@@ -1183,7 +1305,7 @@ class OpenAITTS(QObject):
             TimeoutError,
             wave.Error,
         ) as exc:
-            self.failed.emit(str(exc))
+            self.failed.emit(str(sanitize_error(exc)))
 
     def _emit_wave_cues(
         self,
@@ -1220,8 +1342,11 @@ class SpeechListener(QObject):
         script_path: Path,
         providers: SpeechListenerProviders | None = None,
         parent: QObject | None = None,
+        *,
+        language: str = "zh-TW",
     ):
         super().__init__(parent)
+        self.language = language
         resolved = providers or SpeechListenerProviders()
         self.script_path = script_path
         self.api_key_provider = resolved.api_key
@@ -1255,7 +1380,12 @@ class SpeechListener(QObject):
     def toggle_listening(self) -> None:
         if self._recording_active.is_set():
             self._stop_recording.set()
-            self.status_changed.emit("正在結束收音並送出…")
+            self.status_changed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_CAPTURE_STOPPING,
+                )
+            )
             return
         if self._busy.is_set():
             return
@@ -1270,12 +1400,21 @@ class SpeechListener(QObject):
         api_key = (self.api_key_provider() or os.getenv("OPENAI_API_KEY", "")).strip()
         if mode.startswith("OpenAI"):
             if not api_key:
-                reason = "未設定 OpenAI API 金鑰。"
+                reason = service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_OPENAI_KEY_MISSING_SENTENCE,
+                )
                 self.diagnostic_changed.emit(reason)
                 if self.windows_fallback_provider():
                     self._start_windows(fallback_reason=reason)
                 else:
-                    self.failed.emit(reason + "Windows 備援目前已關閉。")
+                    self.failed.emit(
+                        append_service_status(
+                            self.language,
+                            reason,
+                            ServiceStatus.SPEECH_WINDOWS_FALLBACK_DISABLED,
+                        )
+                    )
                 return
             # Freeze every SQLite-backed provider on the Qt/main thread.
             # Accessing StudioDB from the recording worker raises SQLite's
@@ -1293,7 +1432,10 @@ class SpeechListener(QObject):
             self.listening_changed.emit(True)
             self.recording_changed.emit(True)
             self.status_changed.emit(
-                "收音中…再次點擊麥克風可立即送出"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_RECORDING,
+                )
             )
             threading.Thread(
                 target=self._listen_with_openai,
@@ -1322,13 +1464,29 @@ class SpeechListener(QObject):
         self.audio_path = audio_path
         self.process = QProcess(self)
         self.process.finished.connect(self._finished)
-        self.process.errorOccurred.connect(lambda _e: self.failed.emit("無法啟動語音辨識"))
+        self.process.errorOccurred.connect(
+            lambda _error: self.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_RECOGNITION_START_FAILED,
+                )
+            )
+        )
         if audio_path is None:
             self.listening_changed.emit(True)
-            self.status_changed.emit("收音與辨識中…")
+            self.status_changed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_LISTENING,
+                )
+            )
         else:
             self.status_changed.emit(
-                f"{fallback_reason} 正在使用 Windows 備援辨識…"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_FALLBACK,
+                    detail=fallback_reason,
+                )
             )
         arguments = [
             "-NoProfile",
@@ -1361,12 +1519,16 @@ class SpeechListener(QObject):
             return 0.0
         return (sum(sample * sample for sample in samples) / len(samples)) ** 0.5
 
-    @staticmethod
-    def _require_recording_dependency() -> None:
+    def _require_recording_dependency(self) -> None:
         try:
             _ = sd.RawInputStream
         except (AttributeError, ImportError) as exc:
-            raise RuntimeError("缺少麥克風錄音元件 sounddevice。") from exc
+            raise RuntimeError(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_RECORDING_COMPONENT_MISSING,
+                )
+            ) from exc
 
     def _recording_limits(self) -> RecordingLimits:
         block_seconds = self.RECORD_BLOCK_SECONDS
@@ -1392,7 +1554,10 @@ class SpeechListener(QObject):
         block_size: int,
     ) -> tuple[bytes, ...]:
         limits = self._recording_limits()
-        detector = SpeechEndpointDetector(limits)
+        detector = SpeechEndpointDetector(
+            limits,
+            language=self.language,
+        )
         frames: list[bytes] = []
         with sd.RawInputStream(
             samplerate=sample_rate,
@@ -1412,7 +1577,10 @@ class SpeechListener(QObject):
                     break
         if not detector.speech_started:
             raise RuntimeError(
-                "沒有偵測到說話聲，請靠近麥克風後再試一次。"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_NOT_DETECTED,
+                )
             )
         return tuple(frames)
 
@@ -1446,7 +1614,13 @@ class SpeechListener(QObject):
         except RuntimeError:
             raise
         except Exception as exc:
-            raise RuntimeError(f"無法使用 Windows 預設麥克風：{exc}") from exc
+            raise RuntimeError(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_MICROPHONE_ERROR,
+                    detail=sanitize_error(exc),
+                )
+            ) from exc
         return self._write_recording(frames, sample_rate)
 
     def _transcribe(
@@ -1470,13 +1644,25 @@ class SpeechListener(QObject):
             audio_path.read_bytes(),
             api_key,
             resolved_model,
-            language or "",
+            SpeechTranscriptionLocale(
+                provider_language=language or "",
+                ui_language=self.language,
+            ),
             prompt or "",
         )
 
     @staticmethod
-    def _http_error_message(status: int, detail: str) -> str:
-        return transcription_http_error_message(status, detail)
+    def _http_error_message(
+        status: int,
+        detail: str,
+        *,
+        language: str = "zh-TW",
+    ) -> str:
+        return transcription_http_error_message(
+            status,
+            detail,
+            language=language,
+        )
 
     def _listen_with_openai(
         self,
@@ -1491,7 +1677,12 @@ class SpeechListener(QObject):
             audio_path = self._record_wav()
             self._recording_active.clear()
             self.recording_changed.emit(False)
-            self.status_changed.emit("辨識中…")
+            self.status_changed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_RECOGNIZING,
+                )
+            )
             text = self._transcribe(
                 audio_path,
                 api_key,
@@ -1500,7 +1691,11 @@ class SpeechListener(QObject):
                 prompt=prompt,
             )
             self.diagnostic_changed.emit(
-                f"OpenAI 轉錄成功：{model}"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_TRANSCRIPTION_SUCCEEDED,
+                    model=model,
+                )
             )
             self.recognized.emit(text)
             audio_path.unlink(missing_ok=True)
@@ -1509,7 +1704,7 @@ class SpeechListener(QObject):
         except Exception as exc:  # noqa: BLE001 -- worker restores UI state on failure
             self._recording_active.clear()
             self.recording_changed.emit(False)
-            reason = str(exc)
+            reason = str(sanitize_error(exc))
             self.diagnostic_changed.emit(reason)
             if audio_path and audio_path.exists():
                 if fallback_enabled:
@@ -1518,7 +1713,14 @@ class SpeechListener(QObject):
                 else:
                     audio_path.unlink(missing_ok=True)
                     self._busy.clear()
-                    self.failed.emit(reason + " Windows 備援目前已關閉。")
+                    self.failed.emit(
+                        append_service_status(
+                            self.language,
+                            reason,
+                            ServiceStatus.SPEECH_WINDOWS_FALLBACK_DISABLED,
+                            separate=True,
+                        )
+                    )
                     self.listening_changed.emit(False)
             else:
                 self._busy.clear()
@@ -1543,21 +1745,42 @@ class SpeechListener(QObject):
         self.process = None
         if text == "__ERROR__:NO_RECOGNIZER":
             self.failed.emit(
-                "Windows 尚未安裝中文語音辨識套件，請先在語言設定加入中文語音功能。"
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_RECOGNIZER_MISSING,
+                )
             )
         elif text.startswith("__ERROR__:"):
             detail = text.removeprefix("__ERROR__:")
             if "0x80070005" in detail or "Access is denied" in detail:
                 self.failed.emit(
-                    "Windows 拒絕墨寒使用麥克風。請到「設定 → "
-                    "隱私權與安全性 → 麥克風」，開啟麥克風存取權、"
-                    "讓應用程式存取麥克風，以及讓桌面應用程式存取麥克風。"
+                    service_status(
+                        self.language,
+                        ServiceStatus.SPEECH_WINDOWS_MICROPHONE_DENIED,
+                    )
                 )
             else:
-                self.failed.emit("Windows 語音辨識無法使用：" + detail)
+                self.failed.emit(
+                    service_status(
+                        self.language,
+                        ServiceStatus.SPEECH_WINDOWS_RECOGNITION_ERROR,
+                        detail=sanitize_error(detail),
+                    )
+                )
         elif text and text != "__EMPTY__":
             self.recognized.emit(text)
         elif stderr:
-            self.failed.emit(f"Windows 語音辨識啟動失敗：{stderr[:180]}")
+            self.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_WINDOWS_RECOGNITION_START_ERROR,
+                    detail=sanitize_error(stderr),
+                )
+            )
         else:
-            self.failed.emit("寒方才未聽清，請再說一次。")
+            self.failed.emit(
+                service_status(
+                    self.language,
+                    ServiceStatus.SPEECH_NOT_UNDERSTOOD,
+                )
+            )

--- a/speech_providers.py
+++ b/speech_providers.py
@@ -78,7 +78,7 @@ class SpeechRequest:
     text: str
     voice: str = ""
     rate: int = -1
-    api_key: str = ""
+    api_key: str = field(default="", repr=False)
     instructions: str = ""
     options: Mapping[str, str] = field(default_factory=dict)
 
@@ -177,6 +177,7 @@ class AzureSpeechProvider:
             request.api_key,
             str(request.options.get("region", "")),
             request.voice,
+            str(request.options.get("locale", "zh-TW")),
         )
 
 

--- a/tests/check_packaged_migration.py
+++ b/tests/check_packaged_migration.py
@@ -76,7 +76,7 @@ def verify() -> None:
     text_model = connection.execute(
         "SELECT value FROM settings WHERE key='ai_model'"
     ).fetchone()
-    traditional_chat = connection.execute(
+    preserved_chat = connection.execute(
         "SELECT content FROM chat_log ORDER BY id DESC LIMIT 1"
     ).fetchone()
     connection.close()
@@ -87,8 +87,8 @@ def verify() -> None:
     assert tts_voice is not None and "coral" in tts_voice[0]
     assert realtime_voice is not None and "coral" in realtime_voice[0]
     assert text_model is not None and "gpt-5.6-luna" in text_model[0]
-    assert traditional_chat is not None and traditional_chat[0] == (
-        "會保持專注，開啟軟體和滑鼠。"
+    assert preserved_chat is not None and preserved_chat[0] == (
+        "会保持专注，打开软件和鼠标。"
     )
     print("PACKAGED_MIGRATION_DATA_OK")
 

--- a/tests/test_action_planner_contract.py
+++ b/tests/test_action_planner_contract.py
@@ -78,8 +78,9 @@ def run() -> None:
     ):
         timeout_worker.run()
     assert len(errors) == 1
-    assert "TimeoutError" in errors[0]
-    assert "連線等待逾時" in errors[0]
+    assert "type=timeout_error" in errors[0]
+    assert "diagnostic=request_timeout" in errors[0]
+    assert "連線等待逾時" not in errors[0]
     print("ACTION_PLANNER_CONTRACT_OK")
 
 

--- a/tests/test_auxiliary_ui_localization.py
+++ b/tests/test_auxiliary_ui_localization.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+lazy import os
+lazy import re
+lazy import sys
+lazy from pathlib import Path
+lazy from string import Formatter
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+lazy from PySide6.QtWidgets import QApplication
+
+lazy from auxiliary_ui_localization import (
+    TRANSLATIONS,
+    AuxiliaryText,
+    auxiliary_text,
+)
+lazy from db import StudioDB
+lazy from profile_transfer import ProfileTransferError
+lazy from profile_transfer_ui import PortableProfilePanel
+lazy from updater import ReleaseInfo
+lazy from updater_ui import UpdatePanel
+
+LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]")
+
+
+def format_fields(template: str) -> frozenset[str]:
+    return frozenset(
+        field_name
+        for _literal, field_name, _format_spec, _conversion in Formatter().parse(
+            template
+        )
+        if field_name is not None
+    )
+
+
+def assert_complete_translation_contract() -> None:
+    expected = set(AuxiliaryText)
+    assert tuple(TRANSLATIONS) == LANGUAGES
+    for language in LANGUAGES:
+        assert set(TRANSLATIONS[language]) == expected
+        assert all(TRANSLATIONS[language].values())
+    for key in AuxiliaryText:
+        fields = format_fields(TRANSLATIONS["zh-TW"][key])
+        assert all(
+            format_fields(TRANSLATIONS[language][key]) == fields
+            for language in LANGUAGES
+        ), key
+        values = {field: f"<{field}>" for field in fields}
+        for language in LANGUAGES:
+            TRANSLATIONS[language][key].format(**values)
+    english_contract = "\n".join(TRANSLATIONS["en"].values())
+    assert not CJK.search(english_contract), english_contract
+    for filename in ("updater_ui.py", "profile_transfer_ui.py"):
+        source = (ROOT / filename).read_text(encoding="utf-8")
+        assert not CJK.search(source), filename
+
+
+def visible_update_text(panel: UpdatePanel) -> tuple[str, ...]:
+    return (
+        panel.title.text(),
+        panel.current.text(),
+        panel.channel_label.text(),
+        *(panel.channel.itemText(index) for index in range(panel.channel.count())),
+        panel.automatic.text(),
+        panel.check_button.text(),
+        panel.download_button.text(),
+        panel.status.text(),
+        panel.notes.placeholderText(),
+    )
+
+
+def visible_profile_text(panel: PortableProfilePanel) -> tuple[str, ...]:
+    return (
+        panel.heading.text(),
+        panel.note.text(),
+        panel.export_button.text(),
+        panel.import_button.text(),
+    )
+
+
+def assert_primary_controls(
+    update_panel: UpdatePanel,
+    profile_panel: PortableProfilePanel,
+    language: str,
+) -> None:
+    assert update_panel.title.text() == auxiliary_text(
+        language,
+        AuxiliaryText.UPDATE_TITLE,
+    )
+    assert update_panel.channel.itemData(0) == "stable"
+    assert update_panel.channel.itemData(1) == "preview"
+    assert update_panel.check_button.text() == auxiliary_text(
+        language,
+        AuxiliaryText.CHECK_NOW,
+    )
+    assert update_panel.download_button.text() == auxiliary_text(
+        language,
+        AuxiliaryText.DOWNLOAD_INSTALL,
+    )
+    assert profile_panel.heading.text() == auxiliary_text(
+        language,
+        AuxiliaryText.PROFILE_HEADING,
+    )
+    assert profile_panel.export_button.text() == auxiliary_text(
+        language,
+        AuxiliaryText.EXPORT_BUTTON,
+    )
+    assert profile_panel.import_button.text() == auxiliary_text(
+        language,
+        AuxiliaryText.IMPORT_BUTTON,
+    )
+
+
+def assert_english_has_no_han_characters(
+    update_panel: UpdatePanel,
+    profile_panel: PortableProfilePanel,
+) -> None:
+    # Product names, versions, SHA256, GitHub, API, OAuth, and RC are Latin
+    # identifiers and need no exception. English auxiliary UI must contain no
+    # Han characters at all.
+    english_text = visible_update_text(update_panel) + visible_profile_text(
+        profile_panel
+    )
+    assert not CJK.search("\n".join(english_text)), english_text
+
+
+def assert_update_runtime_messages(panel: UpdatePanel, language: str) -> None:
+    panel.release = ReleaseInfo(
+        version="3.2.0",
+        tag="v3.2.0",
+        release_url="https://github.com/example/release",
+        notes="",
+        published_at="2026-08-12T00:00:00Z",
+        prerelease=False,
+        installers=(),
+    )
+    with patch(
+        "PySide6.QtWidgets.QMessageBox.information"
+    ) as information:
+        panel._check_completed(panel.release)
+    assert panel.status.text() == auxiliary_text(
+        language,
+        AuxiliaryText.NEW_VERSION,
+        version="3.2.0",
+    )
+    assert panel.notes.toPlainText() == auxiliary_text(
+        language,
+        AuxiliaryText.NO_RELEASE_NOTES,
+    )
+    assert information.call_args.args[1:] == (
+        auxiliary_text(language, AuxiliaryText.NEW_VERSION_TITLE),
+        auxiliary_text(
+            language,
+            AuxiliaryText.NEW_VERSION_AVAILABLE,
+            version="3.2.0",
+        ),
+    )
+
+    with patch(
+        "PySide6.QtWidgets.QMessageBox.warning"
+    ) as warning:
+        panel._operation_failed("無法連線至 GitHub 更新服務。")
+    source_failure = "無法連線至 GitHub 更新服務。"
+    failure_text = (
+        source_failure
+        if language == "zh-TW"
+        else auxiliary_text(
+            language,
+            AuxiliaryText.UPDATE_ERROR_CONNECTION,
+        )
+    )
+    assert panel.status.text() == failure_text
+    assert warning.call_args.args[1:] == (
+        auxiliary_text(language, AuxiliaryText.UPDATE_DIALOG_TITLE),
+        failure_text,
+    )
+    if language == "en":
+        assert not CJK.search(failure_text)
+
+
+def assert_profile_runtime_messages(
+    panel: PortableProfilePanel,
+    language: str,
+) -> None:
+    with (
+        patch(
+            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
+            return_value=("C:/portable.mohan-profile", ""),
+        ),
+        patch.object(
+            panel.manager,
+            "export_profile",
+            side_effect=ProfileTransferError("攜帶檔雜湊驗證失敗"),
+        ),
+        patch("PySide6.QtWidgets.QMessageBox.warning") as warning,
+    ):
+        panel.export_profile()
+    source_failure = "攜帶檔雜湊驗證失敗"
+    expected_reason = (
+        source_failure
+        if language == "zh-TW"
+        else auxiliary_text(
+            language,
+            AuxiliaryText.PROFILE_ERROR_SECURITY,
+        )
+    )
+    assert warning.call_args.args[1:] == (
+        auxiliary_text(language, AuxiliaryText.EXPORT_FAILED_TITLE),
+        auxiliary_text(
+            language,
+            AuxiliaryText.EXPORT_FAILED,
+            reason=expected_reason,
+        ),
+    )
+    if language == "en":
+        assert not CJK.search(
+            "\n".join(str(value) for value in warning.call_args.args[1:])
+        )
+
+
+def assert_language(
+    app: QApplication,
+    db: StudioDB,
+    root: Path,
+    language: str,
+) -> None:
+    update_panel = UpdatePanel(db, root, language=language)
+    profile_panel = PortableProfilePanel(db, language=language)
+    try:
+        assert_primary_controls(update_panel, profile_panel, language)
+        if language == "en":
+            assert_english_has_no_han_characters(update_panel, profile_panel)
+        assert_update_runtime_messages(update_panel, language)
+        assert_profile_runtime_messages(profile_panel, language)
+    finally:
+        update_panel.close()
+        profile_panel.close()
+        app.processEvents()
+
+
+def assert_default_language_is_backward_compatible(
+    db: StudioDB,
+    root: Path,
+) -> None:
+    update_panel = UpdatePanel(db, root)
+    profile_panel = PortableProfilePanel(db)
+    try:
+        assert update_panel.title.text() == "<b>軟體更新</b>"
+        assert profile_panel.export_button.text() == "匯出墨寒攜帶檔"
+    finally:
+        update_panel.close()
+        profile_panel.close()
+
+
+def run() -> None:
+    assert_complete_translation_contract()
+    app = QApplication.instance() or QApplication([])
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp:
+        root = Path(temp)
+        db = StudioDB(root / "mohan.db")
+        try:
+            for language in LANGUAGES:
+                assert_language(app, db, root, language)
+            assert_default_language_is_backward_compatible(db, root)
+        finally:
+            db.close()
+    print("AUXILIARY_UI_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_azure_speech.py
+++ b/tests/test_azure_speech.py
@@ -9,6 +9,8 @@ lazy from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+lazy from PySide6.QtCore import QCoreApplication
+
 lazy from azure_regions import (
     azure_region_identifiers,
     azure_region_options,
@@ -573,6 +575,18 @@ class _ObservedAzureSpeechTTS(AzureSpeechTTS):
             self.worker_finished.set()
 
 
+class _ObservedCatalogAzureSpeechTTS(AzureSpeechTTS):
+    def __init__(self, catalog_service: _BlockingCatalogService) -> None:
+        super().__init__(catalog_service=catalog_service)
+        self.catalog_worker_finished = threading.Event()
+
+    def _query_voice_catalog(self, *args: object) -> None:
+        try:
+            super()._query_voice_catalog(*args)
+        finally:
+            self.catalog_worker_finished.set()
+
+
 def _assert_dynamic_voice_query_does_not_block_speak() -> None:
     dynamic_voice = "zh-CN-XiaobeiNeural"
     catalog_service = _BlockingCatalogService(dynamic_voice)
@@ -589,6 +603,28 @@ def _assert_dynamic_voice_query_does_not_block_speak() -> None:
     engine.stop()
     catalog_service.release.set()
     assert engine.worker_finished.wait(timeout=1.0)
+
+
+def _assert_stale_catalog_query_cannot_emit_after_invalidation() -> None:
+    app = QCoreApplication.instance() or QCoreApplication([])
+    catalog_service = _BlockingCatalogService("zh-CN-XiaobeiNeural")
+    engine = _ObservedCatalogAzureSpeechTTS(catalog_service)
+    ready: list[AzureVoiceCatalog] = []
+    engine.voice_catalog_ready.connect(ready.append)
+
+    engine.refresh_voice_catalog(
+        "old-key",
+        "eastasia",
+        "zh-TW",
+        hd_only=False,
+    )
+    assert catalog_service.entered.wait(timeout=1.0)
+    engine.invalidate_voice_catalog()
+    catalog_service.release.set()
+
+    assert engine.catalog_worker_finished.wait(timeout=1.0)
+    app.processEvents()
+    assert ready == []
 
 
 def run() -> None:
@@ -613,6 +649,7 @@ def run() -> None:
     _assert_audio_queue_is_bounded_under_pressure()
     _assert_dynamic_voice_trust_is_credential_bound()
     _assert_dynamic_voice_query_does_not_block_speak()
+    _assert_stale_catalog_query_cannot_emit_after_invalidation()
     print("AZURE_SPEECH_OK")
 
 

--- a/tests/test_azure_speech.py
+++ b/tests/test_azure_speech.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 lazy import sys
+lazy import threading
+lazy import time
 lazy from pathlib import Path
 lazy from types import SimpleNamespace
 lazy from unittest.mock import patch
@@ -15,12 +17,15 @@ lazy from azure_regions import (
 lazy from azure_speech import (
     AZURE_FEMALE_VOICES,
     AzureSpeechTTS,
+    _PushAudioReader,
+    _SynthesisRequest,
     azure_female_voices,
     azure_hd_female_voices,
     azure_speech_error_message,
     build_azure_ssml,
     normalize_azure_region,
 )
+lazy from azure_voice_catalog import AzureVoiceCatalog
 lazy from ui_localization import ui_text
 
 
@@ -90,22 +95,10 @@ def _assert_female_voice_catalog() -> None:
     assert all(":DragonHD" in voice for voice in all_hd_voices)
     assert all("Flash" not in voice for voice in non_flash_hd_voices)
     assert len(non_flash_hd_voices) < len(all_hd_voices)
-    assert all(
-        voice.startswith("zh-CN-")
-        for voice in azure_hd_female_voices("zh-TW")
-    )
-    assert all(
-        voice.startswith("zh-CN-")
-        for voice in azure_hd_female_voices("zh-CN")
-    )
-    assert all(
-        voice.startswith("en-US-")
-        for voice in azure_hd_female_voices("en")
-    )
-    assert all(
-        voice.startswith("ja-JP-")
-        for voice in azure_hd_female_voices("ja-JP")
-    )
+    assert all(voice.startswith("zh-CN-") for voice in azure_hd_female_voices("zh-TW"))
+    assert all(voice.startswith("zh-CN-") for voice in azure_hd_female_voices("zh-CN"))
+    assert all(voice.startswith("en-US-") for voice in azure_hd_female_voices("en"))
+    assert all(voice.startswith("ja-JP-") for voice in azure_hd_female_voices("ja-JP"))
     assert azure_region_supports_hd_flash("southeastasia")
     assert not azure_region_supports_hd_flash("centralindia")
 
@@ -123,6 +116,7 @@ def _assert_ssml_safety() -> None:
         pass
     else:
         raise AssertionError("A voice outside the female allowlist was accepted")
+    assert not hasattr(AzureSpeechTTS, "register_verified_voices")
 
 
 def _assert_localized_errors_and_ui() -> None:
@@ -140,9 +134,7 @@ def _assert_localized_errors_and_ui() -> None:
         "zh-CN",
     )
     assert "キー" in azure_speech_error_message(401, "secret", "ja-JP")
-    assert ui_text("en", "azure_engine", "fallback") == (
-        "Azure Speech (Preview)"
-    )
+    assert ui_text("en", "azure_engine", "fallback") == ("Azure Speech (Preview)")
     assert ui_text("zh-CN", "azure_remove_key", "fallback") == (
         "移除 Azure Speech 密钥"
     )
@@ -161,6 +153,19 @@ def _assert_localized_errors_and_ui() -> None:
         "secret_auto_save_hint",
         "fallback",
     )
+
+
+def _assert_cross_language_voice_uses_ui_error_locale() -> None:
+    engine, _finished, failures = _create_engine()
+    engine.speak(
+        "跨語系測試。",
+        "",
+        "",
+        "zh-CN-XiaoxiaoNeural",
+        "zh-TW",
+    )
+    assert "金鑰" in failures[-1]
+    assert "密钥" not in failures[-1]
 
 
 def _create_engine() -> tuple[AzureSpeechTTS, list[bool], list[str]]:
@@ -266,10 +271,14 @@ def _assert_successful_streaming_synthesis(
         ) as playback,
     ):
         engine._run(
-            "主上，妾在。",
-            "not-a-real-key",
-            "eastasia",
-            "zh-TW-HsiaoChenNeural",
+            _SynthesisRequest(
+                text="主上，妾在。",
+                api_key="not-a-real-key",
+                region="eastasia",
+                voice="zh-TW-HsiaoChenNeural",
+                locale="zh-TW",
+            ),
+            0,
         )
 
     playback.assert_called_once()
@@ -281,17 +290,334 @@ def _assert_successful_streaming_synthesis(
     assert measured_latencies == [engine.last_synthesis_latency_ms]
 
 
+def _assert_operation_ids_are_monotonic() -> None:
+    engine = AzureSpeechTTS()
+    operation_ids: list[int] = []
+    engine.operation_started.connect(operation_ids.append)
+    with patch("azure_speech.threading.Thread") as thread_type:
+        engine.speak(
+            "第一輪",
+            "not-a-real-key",
+            "eastasia",
+            "zh-TW-HsiaoChenNeural",
+        )
+        engine.speak(
+            "第二輪",
+            "not-a-real-key",
+            "eastasia",
+            "zh-TW-HsiaoChenNeural",
+        )
+
+    assert operation_ids == [1, 2]
+    assert thread_type.call_count == 2
+
+
+def _assert_new_operation_cancels_previous_playback() -> None:
+    engine = AzureSpeechTTS()
+    operation_ids: list[int] = []
+    engine.operation_started.connect(operation_ids.append)
+    reader = _PushAudioReader()
+    synthesizer = SimpleNamespace(stop_speaking_async=lambda: None)
+    stopped: list[bool] = []
+    synthesizer.stop_speaking_async = lambda: stopped.append(True)
+    reader.write(memoryview(b"\x01\x00" * 480))
+    engine._active_reader = reader
+    engine._active_synthesizer = synthesizer
+
+    with patch("azure_speech.threading.Thread"):
+        engine.speak(
+            "新語音",
+            "not-a-real-key",
+            "eastasia",
+            "zh-TW-HsiaoChenNeural",
+        )
+
+    assert operation_ids == [1]
+    assert reader.read(bytearray(960)) == 0
+    assert stopped == [True]
+    assert engine._active_reader is None
+    assert engine._active_synthesizer is None
+
+
+def _assert_stale_operation_events_are_suppressed() -> None:
+    engine = AzureSpeechTTS()
+    started_operations: list[int] = []
+    operation_events: list[tuple[object, ...]] = []
+    legacy_events: list[tuple[object, ...]] = []
+    engine.operation_started.connect(started_operations.append)
+    engine.operation_synthesis_latency_measured.connect(
+        lambda operation_id, latency: operation_events.append((
+            "latency",
+            operation_id,
+            latency,
+        ))
+    )
+    engine.operation_viseme_cue.connect(
+        lambda operation_id, level, vowel: operation_events.append((
+            "viseme",
+            operation_id,
+            level,
+            vowel,
+        ))
+    )
+    engine.operation_finished.connect(
+        lambda operation_id: operation_events.append(("finished", operation_id))
+    )
+    engine.operation_failed.connect(
+        lambda operation_id, message: operation_events.append((
+            "failed",
+            operation_id,
+            message,
+        ))
+    )
+    engine.synthesis_latency_measured.connect(
+        lambda latency: legacy_events.append(("latency", latency))
+    )
+    engine.viseme_cue.connect(
+        lambda level, vowel: legacy_events.append(("viseme", level, vowel))
+    )
+    engine.finished.connect(lambda: legacy_events.append(("finished",)))
+    engine.failed.connect(lambda message: legacy_events.append(("failed", message)))
+
+    with patch("azure_speech.threading.Thread"):
+        engine.speak(
+            "舊語音",
+            "not-a-real-key",
+            "eastasia",
+            "zh-TW-HsiaoChenNeural",
+        )
+        engine.speak(
+            "新語音",
+            "not-a-real-key",
+            "eastasia",
+            "zh-TW-HsiaoChenNeural",
+        )
+    old_operation, current_operation = started_operations
+
+    engine._record_synthesis_latency(old_operation, 0.0)
+    engine._emit_viseme(old_operation, 0.9, "A")
+    engine._emit_finished(old_operation)
+    engine._emit_failed(old_operation, "stale failure")
+    assert operation_events == []
+    assert legacy_events == []
+
+    engine._record_synthesis_latency(current_operation, 0.0)
+    engine._emit_viseme(current_operation, 0.4, "I")
+    engine._emit_finished(current_operation)
+    engine._emit_failed(current_operation, "current failure")
+    assert [event[0] for event in operation_events] == [
+        "latency",
+        "viseme",
+        "finished",
+        "failed",
+    ]
+    assert [event[0] for event in legacy_events] == [
+        "latency",
+        "viseme",
+        "finished",
+        "failed",
+    ]
+
+
+def _assert_audio_queue_is_bounded_under_pressure() -> None:
+    reader = _PushAudioReader()
+    payload = b"\x01\x00" * (65_536 * 80 // 2)
+    writer = threading.Thread(
+        target=reader.write,
+        args=(memoryview(payload),),
+        daemon=True,
+    )
+    writer.start()
+    buffer = bytearray(65_536)
+    consumed = bytearray()
+    while writer.is_alive() or not reader._chunks.empty():
+        read = reader.read(buffer)
+        assert read <= len(buffer)
+        consumed.extend(buffer[:read])
+        assert reader._chunks.qsize() <= reader._chunks.maxsize == 64
+    writer.join(timeout=1.0)
+    reader.close()
+
+    assert not writer.is_alive()
+    assert bytes(consumed) == payload
+    assert reader.read(buffer) == 0
+
+
+class _CredentialBoundCatalogService:
+    def __init__(self, dynamic_voice: str) -> None:
+        self.dynamic_voice = dynamic_voice
+        self.queries: list[tuple[str, str, str, bool]] = []
+
+    def query(
+        self,
+        api_key: str,
+        region: str,
+        language: str,
+        *,
+        hd_only: bool,
+    ) -> AzureVoiceCatalog:
+        self.queries.append((api_key, region, language, hd_only))
+        expected_hd_only = ":DragonHD" in self.dynamic_voice
+        permitted = (
+            api_key == "key-a"
+            and region == "eastasia"
+            and hd_only == expected_hd_only
+        )
+        return AzureVoiceCatalog(
+            region=region,
+            language=language,
+            hd_only=hd_only,
+            voices=(self.dynamic_voice,) if permitted else ("zh-CN-OtherNeural",),
+            source="azure",
+        )
+
+    def invalidate(self, _region: str | None = None) -> None:
+        return
+
+
+def _assert_dynamic_voice_trust_is_credential_bound() -> None:
+    dynamic_voice = "zh-CN-XiaobeiNeural"
+    catalog_service = _CredentialBoundCatalogService(dynamic_voice)
+    engine = AzureSpeechTTS(catalog_service=catalog_service)
+
+    verified = engine._verified_ssml_for_request(
+        "已驗證",
+        "key-a",
+        "eastasia",
+        dynamic_voice,
+    )
+    assert dynamic_voice in verified.decode("utf-8")
+    for api_key, region in (
+        ("key-b", "eastasia"),
+        ("key-a", "westus2"),
+    ):
+        try:
+            engine._verified_ssml_for_request(
+                "不可沿用",
+                api_key,
+                region,
+                dynamic_voice,
+            )
+        except ValueError as exc:
+            assert str(exc) == "unsupported_voice"
+        else:
+            raise AssertionError("Dynamic voice trust crossed Azure resources")
+
+    assert catalog_service.queries == [
+        ("key-a", "eastasia", "zh-CN", False),
+        ("key-b", "eastasia", "zh-CN", False),
+        ("key-a", "westus2", "zh-CN", False),
+    ]
+    assert not hasattr(engine, "_verified_dynamic_voices")
+    assert "key-a" not in repr(engine.__dict__)
+
+    hd_voice = "zh-CN-Xiaobei:DragonHDLatestNeural"
+    hd_catalog_service = _CredentialBoundCatalogService(hd_voice)
+    hd_engine = AzureSpeechTTS(catalog_service=hd_catalog_service)
+    hd_ssml = hd_engine._verified_ssml_for_request(
+        "HD 已驗證",
+        "key-a",
+        "eastasia",
+        hd_voice,
+    )
+    assert hd_voice in hd_ssml.decode("utf-8")
+    assert hd_catalog_service.queries == [
+        ("key-a", "eastasia", "zh-CN", True),
+    ]
+
+
+class _BlockingCatalogService:
+    def __init__(self, dynamic_voice: str) -> None:
+        self.dynamic_voice = dynamic_voice
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.query_thread_id: int | None = None
+
+    def query(
+        self,
+        _api_key: str,
+        region: str,
+        language: str,
+        *,
+        hd_only: bool,
+    ) -> AzureVoiceCatalog:
+        self.query_thread_id = threading.get_ident()
+        self.entered.set()
+        if not self.release.wait(timeout=2.0):
+            raise TimeoutError("test catalog release timed out")
+        return AzureVoiceCatalog(
+            region=region,
+            language=language,
+            hd_only=hd_only,
+            voices=(self.dynamic_voice,),
+            source="azure",
+        )
+
+    def invalidate(self, _region: str | None = None) -> None:
+        return
+
+
+class _ObservedAzureSpeechTTS(AzureSpeechTTS):
+    def __init__(self, catalog_service: _BlockingCatalogService) -> None:
+        super().__init__(catalog_service=catalog_service)
+        self.worker_finished = threading.Event()
+
+    def _run(
+        self,
+        request: _SynthesisRequest,
+        operation_id: int,
+    ) -> None:
+        try:
+            super()._run(request, operation_id)
+        finally:
+            self.worker_finished.set()
+
+
+def _assert_dynamic_voice_query_does_not_block_speak() -> None:
+    dynamic_voice = "zh-CN-XiaobeiNeural"
+    catalog_service = _BlockingCatalogService(dynamic_voice)
+    engine = _ObservedAzureSpeechTTS(catalog_service)
+    caller_thread_id = threading.get_ident()
+
+    started = time.perf_counter()
+    engine.speak("背景驗證", "key-a", " EastAsia ", dynamic_voice)
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.25
+    assert catalog_service.entered.wait(timeout=1.0)
+    assert catalog_service.query_thread_id != caller_thread_id
+    engine.stop()
+    catalog_service.release.set()
+    assert engine.worker_finished.wait(timeout=1.0)
+
+
 def run() -> None:
     _assert_region_normalization()
     _assert_region_catalog()
     _assert_female_voice_catalog()
     _assert_ssml_safety()
     _assert_localized_errors_and_ui()
-    engine, finished, failures = _create_engine()
+    _assert_cross_language_voice_uses_ui_error_locale()
+    engine, _finished, failures = _create_engine()
     _assert_missing_credentials_do_not_request(engine, failures)
     _assert_invalid_region_fails_locally(engine, failures)
-    _assert_successful_streaming_synthesis(engine, finished, failures)
+    streaming_engine, streaming_finished, streaming_failures = _create_engine()
+    _assert_successful_streaming_synthesis(
+        streaming_engine,
+        streaming_finished,
+        streaming_failures,
+    )
+    _assert_operation_ids_are_monotonic()
+    _assert_new_operation_cancels_previous_playback()
+    _assert_stale_operation_events_are_suppressed()
+    _assert_audio_queue_is_bounded_under_pressure()
+    _assert_dynamic_voice_trust_is_credential_bound()
+    _assert_dynamic_voice_query_does_not_block_speak()
     print("AZURE_SPEECH_OK")
+
+
+def test_azure_speech_regressions() -> None:
+    run()
 
 
 if __name__ == "__main__":

--- a/tests/test_azure_voice_catalog.py
+++ b/tests/test_azure_voice_catalog.py
@@ -32,6 +32,7 @@ def _voice(short_name: str, locale: str, gender: str) -> object:
 
 
 def run() -> None:
+    FakeSynthesizer.query_count = 0
     FakeSynthesizer.voices = (
         _voice("zh-CN-NewWomanNeural", "zh-CN", "Female"),
         _voice("zh-TW-NewWomanNeural", "zh-TW", "Female"),
@@ -76,15 +77,36 @@ def run() -> None:
     )
     assert hd.voices == ("zh-CN-NewWoman:DragonHDLatestNeural",)
     assert all("Man" not in voice for voice in (*normal.voices, *hd.voices))
-    service.query(
+    same_credentials = service.query(
+        "secret-never-cached",
+        "westus2",
+        "zh-TW",
+        hd_only=True,
+    )
+    assert same_credentials is hd
+    assert FakeSynthesizer.query_count == 2
+
+    different_credentials = service.query(
         "a-different-secret",
         "westus2",
         "zh-TW",
         hd_only=True,
     )
-    assert FakeSynthesizer.query_count == 2
+    assert different_credentials is not hd
+    assert FakeSynthesizer.query_count == 3
+    assert service.query(
+        "a-different-secret",
+        "westus2",
+        "zh-TW",
+        hd_only=True,
+    ) is different_credentials
+    assert FakeSynthesizer.query_count == 3
+
+    cache_representation = repr(service._cache)
+    assert "secret-never-cached" not in cache_representation
+    assert "a-different-secret" not in cache_representation
     assert all(
-        "secret" not in repr(key)
+        "credential_fingerprint" not in repr(key)
         for key in service._cache
     )
     print("AZURE_VOICE_CATALOG_OK")

--- a/tests/test_azure_voice_catalog.py
+++ b/tests/test_azure_voice_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 lazy import sys
+lazy import threading
 lazy from pathlib import Path
 lazy from types import SimpleNamespace
 
@@ -29,6 +30,56 @@ def _voice(short_name: str, locale: str, gender: str) -> object:
         locale=locale,
         gender=SimpleNamespace(name=gender),
     )
+
+
+def _assert_invalidated_query_cannot_repopulate_cache() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingFuture:
+        def get(self) -> object:
+            entered.set()
+            if not release.wait(timeout=2.0):
+                raise TimeoutError("catalog test did not release")
+            return SimpleNamespace(
+                voices=(
+                    _voice("zh-TW-NewWomanNeural", "zh-TW", "Female"),
+                )
+            )
+
+    class BlockingSynthesizer:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def get_voices_async(self) -> BlockingFuture:
+            return BlockingFuture()
+
+    fake_sdk = SimpleNamespace(
+        SpeechConfig=lambda **kwargs: SimpleNamespace(**kwargs),
+        SpeechSynthesizer=BlockingSynthesizer,
+    )
+    service = AzureVoiceCatalogService(sdk_loader=lambda: fake_sdk)
+    results: list[object] = []
+    worker = threading.Thread(
+        target=lambda: results.append(
+            service.query(
+                "superseded-secret",
+                "eastasia",
+                "zh-TW",
+                hd_only=False,
+            )
+        ),
+        daemon=True,
+    )
+    worker.start()
+    assert entered.wait(timeout=1.0)
+    service.invalidate()
+    release.set()
+    worker.join(timeout=1.0)
+
+    assert not worker.is_alive()
+    assert len(results) == 1
+    assert service._cache == {}
 
 
 def run() -> None:
@@ -92,23 +143,24 @@ def run() -> None:
         "zh-TW",
         hd_only=True,
     )
-    assert different_credentials is not hd
-    assert FakeSynthesizer.query_count == 3
-    assert service.query(
+    assert different_credentials is hd
+    assert FakeSynthesizer.query_count == 2
+
+    service.invalidate("westus2")
+    refreshed_credentials = service.query(
         "a-different-secret",
         "westus2",
         "zh-TW",
         hd_only=True,
-    ) is different_credentials
+    )
+    assert refreshed_credentials is not hd
     assert FakeSynthesizer.query_count == 3
 
     cache_representation = repr(service._cache)
     assert "secret-never-cached" not in cache_representation
     assert "a-different-secret" not in cache_representation
-    assert all(
-        "credential_fingerprint" not in repr(key)
-        for key in service._cache
-    )
+    assert "credential" not in repr(service._cache).lower()
+    _assert_invalidated_query_cannot_repopulate_cache()
     print("AZURE_VOICE_CATALOG_OK")
 
 

--- a/tests/test_cloud_error_sanitization.py
+++ b/tests/test_cloud_error_sanitization.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+lazy import io
+lazy import json
+lazy import sys
+lazy import traceback
+lazy from pathlib import Path
+lazy from typing import Self
+lazy from unittest.mock import patch
+lazy from urllib.error import HTTPError, URLError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from cloud_connectors import (
+    PROVIDERS,
+    GoogleDriveConnector,
+    JsonApiClient,
+    OAuthError,
+    OAuthPKCEFlow,
+    _authorization_code,
+    refresh_oauth_token,
+)
+lazy from home_assistant import (
+    HomeAssistantClient,
+    HomeAssistantConfig,
+    HomeAssistantError,
+)
+
+
+class _Response:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _size: int = -1) -> bytes:
+        return self.payload
+
+
+def _sensitive_values() -> tuple[str, ...]:
+    marker = "SENSITIVE" + "-VALUE-42"
+    return (
+        marker,
+        "api" + f"_key={marker}",
+        "tok" + f"en={marker}",
+        "pass" + f"word={marker}",
+        "Coo" + f"kie=session-{marker}",
+        "owner" + "@example.invalid",
+        "C:" + "\\Users\\private-user\\AppData\\secret.json",
+        "/home/" + "private-user/.config/secret.json",
+    )
+
+
+def _external_body() -> bytes:
+    return json.dumps({
+        "error": "provider rejected request",
+        "detail": " | ".join(_sensitive_values()),
+    }).encode("utf-8")
+
+
+def _http_error(status: int) -> HTTPError:
+    marker = _sensitive_values()[0]
+    return HTTPError(
+        "https://provider.invalid/private?tok" + f"en={marker}",
+        status,
+        "Bearer " + marker,
+        None,
+        io.BytesIO(_external_body()),
+    )
+
+
+def _error_surface(error: BaseException) -> str:
+    return "\n".join((
+        str(error),
+        repr(error),
+        "".join(traceback.format_exception_only(type(error), error)),
+    ))
+
+
+def _assert_sanitized(
+    action,
+    error_type: type[Exception],
+    *,
+    expected: tuple[str, ...],
+) -> None:
+    try:
+        action()
+    except error_type as exc:
+        surface = _error_surface(exc)
+        assert exc.__cause__ is None
+        assert exc.__context__ is None
+    else:
+        raise AssertionError(f"{error_type.__name__} was not raised")
+
+    for fragment in expected:
+        assert fragment in surface
+    for sensitive in _sensitive_values():
+        assert sensitive not in surface
+    for forbidden in (
+        "provider.invalid",
+        "private-user",
+        "Bearer",
+        "session-",
+        "response body",
+    ):
+        assert forbidden not in surface
+
+
+def _assert_oauth_callback_is_sanitized() -> None:
+    detail = " ".join(_sensitive_values())
+    _assert_sanitized(
+        lambda: _authorization_code(
+            {
+                "state": "expected",
+                "error": "access_denied",
+                "error_description": detail,
+            },
+            "expected",
+        ),
+        OAuthError,
+        expected=("type=unknown_error", "diagnostic=unknown_failure"),
+    )
+
+
+def _assert_oauth_exchange_is_sanitized() -> None:
+    flow = OAuthPKCEFlow(PROVIDERS["google"], "public-client")
+    with patch("cloud_connectors.urlopen", side_effect=_http_error(401)):
+        _assert_sanitized(
+            lambda: flow._exchange(
+                "authorization-code",
+                "pkce-verifier",
+                "http://127.0.0.1/callback",
+            ),
+            OAuthError,
+            expected=(
+                "type=http_error",
+                "diagnostic=authentication_required",
+                "http_status=401",
+            ),
+        )
+
+
+def _assert_oauth_refresh_is_sanitized() -> None:
+    with patch("cloud_connectors.urlopen", side_effect=_http_error(429)):
+        _assert_sanitized(
+            lambda: refresh_oauth_token(
+                PROVIDERS["google"],
+                {
+                    "refresh_token": "opaque-refresh-value",
+                    "client_id": "public-client",
+                },
+            ),
+            OAuthError,
+            expected=(
+                "type=http_error",
+                "diagnostic=rate_limited",
+                "http_status=429",
+            ),
+        )
+
+
+def _assert_json_api_errors_are_sanitized() -> None:
+    client = JsonApiClient("opaque-access-value", "https://api.example.invalid")
+    with patch("cloud_connectors.urlopen", side_effect=_http_error(503)):
+        _assert_sanitized(
+            lambda: client.request("GET", "/private"),
+            OAuthError,
+            expected=(
+                "type=http_error",
+                "diagnostic=remote_service_failure",
+                "http_status=503",
+            ),
+        )
+
+    with patch(
+        "cloud_connectors.urlopen",
+        return_value=_Response(_external_body() + b" invalid-json"),
+    ):
+        _assert_sanitized(
+            lambda: client.request("GET", "/malformed"),
+            OAuthError,
+            expected=("type=decoding_error", "diagnostic=invalid_response"),
+        )
+
+    connection_detail = " | ".join(_sensitive_values())
+    with patch(
+        "cloud_connectors.urlopen",
+        side_effect=URLError(connection_detail),
+    ):
+        _assert_sanitized(
+            lambda: client.request_bytes(
+                "POST",
+                "/bytes",
+                b"content",
+                "application/octet-stream",
+            ),
+            OAuthError,
+            expected=(
+                "type=connection_error",
+                "diagnostic=network_unavailable",
+            ),
+        )
+
+
+def _assert_drive_upload_error_is_sanitized() -> None:
+    connector = GoogleDriveConnector("opaque-access-value")
+    with patch("cloud_connectors.urlopen", side_effect=_http_error(403)):
+        _assert_sanitized(
+            lambda: connector.upload_small("safe.txt", b"content"),
+            OAuthError,
+            expected=(
+                "type=http_error",
+                "diagnostic=access_denied",
+                "http_status=403",
+            ),
+        )
+
+
+def _assert_home_assistant_errors_are_sanitized() -> None:
+    client = HomeAssistantClient(
+        HomeAssistantConfig(
+            "https://home-assistant.example.invalid",
+            "opaque-home-token",
+        )
+    )
+    with patch("home_assistant.urlopen", side_effect=_http_error(404)):
+        _assert_sanitized(
+            lambda: client._request("GET", "/api/states/private"),
+            HomeAssistantError,
+            expected=(
+                "type=http_error",
+                "diagnostic=resource_not_found",
+                "http_status=404",
+            ),
+        )
+
+    with patch(
+        "home_assistant.urlopen",
+        side_effect=URLError(" | ".join(_sensitive_values())),
+    ):
+        _assert_sanitized(
+            lambda: client._request("GET", "/api/"),
+            HomeAssistantError,
+            expected=(
+                "type=connection_error",
+                "diagnostic=network_unavailable",
+            ),
+        )
+
+    with patch(
+        "home_assistant.urlopen",
+        return_value=_Response(_external_body() + b" malformed"),
+    ):
+        _assert_sanitized(
+            lambda: client._request("GET", "/api/"),
+            HomeAssistantError,
+            expected=("type=decoding_error", "diagnostic=invalid_response"),
+        )
+
+
+def _assert_success_paths_are_unchanged() -> None:
+    api = JsonApiClient("opaque-access-value", "https://api.example.invalid")
+    with patch(
+        "cloud_connectors.urlopen",
+        return_value=_Response(b'{"ok": true}'),
+    ):
+        assert api.request("GET", "/health") == {"ok": True}
+
+    home = HomeAssistantClient(
+        HomeAssistantConfig(
+            "https://home-assistant.example.invalid",
+            "opaque-home-token",
+        )
+    )
+    with patch(
+        "home_assistant.urlopen",
+        return_value=_Response(b'{"message": "API running."}'),
+    ):
+        assert home.health() is True
+
+
+def run() -> None:
+    _assert_oauth_callback_is_sanitized()
+    _assert_oauth_exchange_is_sanitized()
+    _assert_oauth_refresh_is_sanitized()
+    _assert_json_api_errors_are_sanitized()
+    _assert_drive_upload_error_is_sanitized()
+    _assert_home_assistant_errors_are_sanitized()
+    _assert_success_paths_are_unchanged()
+    print("CLOUD_ERROR_SANITIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -113,6 +113,7 @@ def _assert_ai_worker_defaults() -> None:
             api_key="sk-test",
         )
     )
+    assert "sk-test" not in repr(worker.request)
     worker.signals.done.connect(replies.append)
     fake_response = io.BytesIO(
         json.dumps({"output_text": "主上，妾在。"}).encode("utf-8")
@@ -557,6 +558,22 @@ def _assert_realtime_playback(realtime: RealtimeVoiceClient) -> None:
     realtime._playback_loop(muted_queue, muted_probe, 24000)
     realtime.running = False
     assert set(array("h", b"".join(muted_probe.chunks))) == {0}
+
+    cancellation_queue = _playback_queue()
+
+    class CancellingPlaybackProbe(PlaybackProbe):
+        def write(self, chunk: bytes) -> None:
+            super().write(chunk)
+            if len(self.chunks) == 1:
+                realtime._discard_native_playback()
+
+    cancellation_probe = CancellingPlaybackProbe()
+    realtime.set_volume(125, False)
+    realtime._begin_assistant_audio()
+    realtime.running = True
+    realtime._playback_loop(cancellation_queue, cancellation_probe, 24000)
+    realtime.running = False
+    assert len(cancellation_probe.chunks) == 1
 
 
 def _assert_traditional_text_normalization() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,8 +150,8 @@ def _assert_todos_and_ideas(db: StudioDB) -> None:
     assert db.list_ideas()[0]["title"] == "雨夜劍魂場景"
     db.update_idea(idea_id, "剑魂苏醒", "她在雨夜听见主上的声音。")
     edited_idea = db.idea(idea_id)
-    assert edited_idea["title"] == "劍魂甦醒"
-    assert edited_idea["content"] == "她在雨夜聽見主上的聲音。"
+    assert edited_idea["title"] == "剑魂苏醒"
+    assert edited_idea["content"] == "她在雨夜听见主上的声音。"
     disposable_idea = db.add_idea("待刪除靈感")
     assert db.delete_ideas([disposable_idea]) == 1
     assert db.idea(disposable_idea) is None
@@ -198,7 +198,7 @@ def _assert_settings_memory_and_chat(db: StudioDB) -> None:
     assert db.list_memories() == []
     db.log_chat("assistant", "劍主請先休息")
     db.log_chat("user", "你还记得自己的故事吗？")
-    assert db.recent_chat()[-1]["content"] == "你還記得自己的故事嗎？"
+    assert db.recent_chat()[-1]["content"] == "你还记得自己的故事吗？"
     retained_count = db.chat_count()
     db.log_chat("assistant", "這則稍後刪除")
     disposable_chat = int(db.recent_chat()[-1]["id"])
@@ -208,7 +208,7 @@ def _assert_settings_memory_and_chat(db: StudioDB) -> None:
 
 def _assert_reopened_chat_migration(temp_dir: str) -> None:
     migrated = StudioDB(Path(temp_dir) / "test.db")
-    assert migrated.recent_chat()[-2]["content"] == "主上請先休息"
+    assert migrated.recent_chat()[-2]["content"] == "劍主請先休息"
     migrated.close()
 
 
@@ -259,7 +259,9 @@ def _assert_database_contracts() -> None:
 
 
 def _assert_offline_reply_contract() -> None:
+    # The default argument is a compatibility contract for existing callers.
     assert format_duration(3720) == "1 小時 2 分"
+    assert format_duration(3720, "zh-TW") == "1 小時 2 分"
     assert "計時" in offline_reply("我開始工作了", "工作")
     assert "計時已啟" not in offline_reply(
         "我只是單純在文字框提到開始工作，沒有要啟動計時。",
@@ -583,7 +585,7 @@ def _assert_traditional_text_normalization() -> None:
     )
 
 
-def _assert_traditional_chat_migration() -> None:
+def _assert_legacy_chat_migration_preserves_content() -> None:
     with TemporaryDirectory() as temp_dir:
         traditional_path = Path(temp_dir) / "traditional-chat.db"
         traditional_db = StudioDB(traditional_path)
@@ -603,7 +605,7 @@ def _assert_traditional_chat_migration() -> None:
         traditional_db.close()
         traditional_db = StudioDB(traditional_path)
         assert traditional_db.recent_chat(1)[0]["content"] == (
-            "會保持專注，開啟軟體和滑鼠。"
+            "会保持专注，打开软件和鼠标。"
         )
         assert traditional_db.setting(
             "traditional_chat_v1215_migrated", False
@@ -639,7 +641,7 @@ def run() -> None:
     realtime = _assert_realtime_audio_lifecycle()
     _assert_realtime_playback(realtime)
     _assert_traditional_text_normalization()
-    _assert_traditional_chat_migration()
+    _assert_legacy_chat_migration_preserves_content()
     _assert_listener_script_contract()
     print("CORE_TESTS_OK")
 

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -5,12 +5,13 @@ lazy import sys
 lazy from dataclasses import dataclass
 lazy from pathlib import Path
 lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
 
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 lazy from PySide6.QtCore import QObject, Signal
-lazy from PySide6.QtWidgets import QApplication, QLineEdit
+lazy from PySide6.QtWidgets import QApplication, QLineEdit, QMessageBox
 
 lazy from app import CompanionWindow, SpeechCredentials
 lazy from db import StudioDB
@@ -41,12 +42,21 @@ class FakeSpeechEngine(QObject):
         super().__init__()
         self.volume_calls: list[tuple[int, bool]] = []
         self.speak_calls: list[tuple[tuple, dict]] = []
+        self.voice_catalog_regions: set[str] = set()
+        self.voice_catalog_invalidations: list[str | None] = []
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_calls.append((volume_percent, muted))
 
     def speak(self, *args, **kwargs) -> None:
         self.speak_calls.append((args, kwargs))
+
+    def invalidate_voice_catalog(self, region: str | None = None) -> None:
+        self.voice_catalog_invalidations.append(region)
+        if region is None:
+            self.voice_catalog_regions.clear()
+        else:
+            self.voice_catalog_regions.discard(region)
 
 
 class FakeRealtime(QObject):
@@ -299,6 +309,63 @@ def _assert_secret_fields_save_consistently_and_securely(
     )
     assert all(secret not in database_text for *_prefix, secret in fields)
 
+
+def _assert_azure_key_changes_invalidate_isolated_catalogs(
+    context: InjectedTestContext,
+) -> None:
+    dashboard = context.window.dashboard
+    standard = context.azure_tts
+    hd = context.azure_hd_tts
+
+    standard.voice_catalog_invalidations.clear()
+    hd.voice_catalog_invalidations.clear()
+    standard.voice_catalog_regions.clear()
+    hd.voice_catalog_regions.clear()
+    standard.voice_catalog_regions.update(("eastasia", "westus2"))
+    hd.voice_catalog_regions.update(("centralindia", "southeastasia"))
+    dashboard.azure_key_input.setText("azure-standard-replacement")
+    dashboard.azure_key_input.editingFinished.emit()
+
+    assert standard.voice_catalog_invalidations == [None]
+    assert not standard.voice_catalog_regions
+    assert hd.voice_catalog_invalidations == []
+    assert hd.voice_catalog_regions == {"centralindia", "southeastasia"}
+
+    standard.voice_catalog_regions.update(("eastasia", "westus2"))
+    dashboard.azure_hd_key_input.setText("azure-hd-replacement")
+    dashboard.azure_hd_key_input.editingFinished.emit()
+
+    assert hd.voice_catalog_invalidations == [None]
+    assert not hd.voice_catalog_regions
+    assert standard.voice_catalog_invalidations == [None]
+    assert standard.voice_catalog_regions == {"eastasia", "westus2"}
+
+    with patch.object(
+        QMessageBox,
+        "question",
+        return_value=QMessageBox.Yes,
+    ):
+        dashboard.clear_azure_speech_key()
+
+    assert context.azure_secret_store.load() == ""
+    assert standard.voice_catalog_invalidations == [None, None]
+    assert not standard.voice_catalog_regions
+    assert hd.voice_catalog_invalidations == [None]
+
+    hd.voice_catalog_regions.update(("centralindia", "southeastasia"))
+    with patch.object(
+        QMessageBox,
+        "question",
+        return_value=QMessageBox.Yes,
+    ):
+        dashboard.clear_azure_hd_speech_key()
+
+    assert context.azure_hd_secret_store.load() == ""
+    assert hd.voice_catalog_invalidations == [None, None]
+    assert not hd.voice_catalog_regions
+    assert standard.voice_catalog_invalidations == [None, None]
+
+
 def _assert_cloud_failure_uses_local_tts(
     context: InjectedTestContext,
 ) -> None:
@@ -387,6 +454,7 @@ def run() -> None:
         _assert_azure_failure_uses_local_tts(context)
         _assert_missing_azure_settings_fail_locally(context)
         _assert_secret_fields_save_consistently_and_securely(context)
+        _assert_azure_key_changes_invalidate_isolated_catalogs(context)
         _assert_controls_and_shutdown(context)
     print("DEPENDENCY_INJECTION_OK")
 

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 lazy from PySide6.QtCore import QObject, Signal
 lazy from PySide6.QtWidgets import QApplication, QLineEdit
 
-lazy from app import CompanionWindow
+lazy from app import CompanionWindow, SpeechCredentials
 lazy from db import StudioDB
 lazy from realtime_voice import RealtimeVoiceRequest
 lazy from service_container import CompanionServices
@@ -56,6 +56,10 @@ class FakeRealtime(QObject):
     speaking_changed = Signal(bool)
     viseme_cue = Signal(str, float)
     failed = Signal(str)
+    output_text_started = Signal(int)
+    output_text_delta = Signal(int, str)
+    output_text_done = Signal(int)
+    output_interrupted = Signal(int)
 
     def __init__(self) -> None:
         super().__init__()
@@ -71,9 +75,26 @@ class FakeRealtime(QObject):
         self.start_requests.append(request)
         self.running = True
 
-    def stop(self) -> None:
+    def stop(self) -> int:
         self.running = False
         self.stop_calls += 1
+        return self.stop_calls
+
+    def set_external_playback_active(self, _active: bool) -> None:
+        return
+
+
+def _assert_credential_repr_is_redacted() -> None:
+    secrets = ("openai-secret", "azure-secret", "azure-hd-secret")
+    credentials = SpeechCredentials(
+        openai_api_key=secrets[0],
+        azure_api_key=secrets[1],
+        azure_region="eastasia",
+        azure_hd_api_key=secrets[2],
+        azure_hd_region="westus2",
+    )
+    rendered = repr(credentials)
+    assert all(secret not in rendered for secret in secrets)
 
 
 class FakeListener(QObject):
@@ -316,6 +337,7 @@ def _assert_azure_failure_uses_local_tts(
         "test-key",
         "eastasia",
         "zh-TW-HsiaoChenNeural",
+        "zh-TW",
     )
     context.azure_tts.failed.emit("模擬 Azure 播放失敗")
     context.app.processEvents()
@@ -355,6 +377,7 @@ def _assert_controls_and_shutdown(context: InjectedTestContext) -> None:
 
 
 def run() -> None:
+    _assert_credential_repr_is_redacted()
     with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         context = _create_injected_context(temp_dir)
         _assert_dependencies_are_injected(context)

--- a/tests/test_diagnose_openai_planner_error_safety.py
+++ b/tests/test_diagnose_openai_planner_error_safety.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+lazy import io
+lazy import json
+lazy import sys
+lazy from contextlib import redirect_stdout
+lazy from email.message import Message
+lazy from pathlib import Path
+lazy from unittest.mock import patch
+lazy from urllib.error import HTTPError
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy from tools import diagnose_openai_planner as diagnostic
+
+_FAKE_TOKEN = "NOT-A-REAL-TOKEN-DIAGNOSTIC-BOUNDARY"
+_PRIVATE_PATH = "C:" + "\\Users\\private-user\\AppData\\MoHan\\secret.json"
+_RESPONSE_BODY = json.dumps(
+    {
+        "error": "raw provider failure",
+        "token": _FAKE_TOKEN,
+        "private_path": _PRIVATE_PATH,
+    }
+)
+_UNTRUSTED_DETAIL = (
+    f"response_body={_RESPONSE_BODY}; token={_FAKE_TOKEN}; path={_PRIVATE_PATH}"
+)
+_FORBIDDEN = (
+    _FAKE_TOKEN,
+    _PRIVATE_PATH,
+    _RESPONSE_BODY,
+    "private-user",
+    "raw provider failure",
+    "response_body=",
+)
+
+
+class _SecretStore:
+    def __init__(self, _path: Path) -> None:
+        pass
+
+    def load(self) -> str:
+        return _FAKE_TOKEN
+
+
+class _Cursor:
+    @staticmethod
+    def fetchone() -> tuple[str]:
+        return (json.dumps("gpt-safe-model"),)
+
+
+class _Connection:
+    @staticmethod
+    def execute(_query: str) -> _Cursor:
+        return _Cursor()
+
+    @staticmethod
+    def close() -> None:
+        pass
+
+
+class _Signal:
+    def __init__(self) -> None:
+        self._callback = None
+
+    def connect(self, callback) -> None:
+        self._callback = callback
+
+    def emit(self, value: object) -> None:
+        assert self._callback is not None
+        self._callback(value)
+
+
+class _Signals:
+    def __init__(self) -> None:
+        self.done = _Signal()
+        self.failed = _Signal()
+
+
+class _FailedPlanner:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self.signals = _Signals()
+
+    def run(self) -> None:
+        self.signals.failed.emit(_UNTRUSTED_DETAIL)
+
+
+class _UnreadableBody(io.BytesIO):
+    def read(self, *_args: object, **_kwargs: object) -> bytes:
+        raise AssertionError("HTTP response body must not be read")
+
+
+def _http_error() -> HTTPError:
+    return HTTPError(
+        "https://api.openai.com/private?token=" + _FAKE_TOKEN,
+        503,
+        _UNTRUSTED_DETAIL,
+        Message(),
+        _UnreadableBody(_RESPONSE_BODY.encode("utf-8")),
+    )
+
+
+def _raise(error: BaseException):
+    def raiser(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    return raiser
+
+
+def _run(urlopen_replacement, *, planner=_FailedPlanner) -> tuple[int, str]:
+    output = io.StringIO()
+    with (
+        patch.object(diagnostic, "SecretStore", _SecretStore),
+        patch.object(diagnostic.sqlite3, "connect", return_value=_Connection()),
+        patch.object(diagnostic, "urlopen", urlopen_replacement),
+        patch.object(diagnostic, "ActionPlannerWorker", planner),
+        redirect_stdout(output),
+    ):
+        result = diagnostic.main(_PRIVATE_PATH)
+    return result, output.getvalue()
+
+
+def _assert_private_details_absent(output: str) -> None:
+    lowered = output.casefold()
+    for forbidden in _FORBIDDEN:
+        assert forbidden.casefold() not in lowered, forbidden
+
+
+def test_http_error_exposes_only_finite_metadata() -> None:
+    error = _http_error()
+    result, output = _run(_raise(error))
+
+    assert result == 3
+    assert "MODEL_CHECK=failed" in output
+    assert "type=http_error" in output
+    assert "diagnostic=remote_service_failure" in output
+    assert "http_status=503" in output
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_private_details_absent(output)
+
+
+def test_raw_exception_and_planner_failure_are_sanitized() -> None:
+    error = OSError(_UNTRUSTED_DETAIL)
+    result, output = _run(_raise(error))
+
+    assert result == 4
+    assert "type=operating_system_error" in output
+    assert "diagnostic=local_io_failure" in output
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    _assert_private_details_absent(output)
+
+    response = io.BytesIO(b'{"id":"gpt-safe-model"}')
+    result, output = _run(lambda *_args, **_kwargs: response)
+
+    assert result == 5
+    assert "PLANNER=failed" in output
+    assert "type=unknown_error" in output
+    assert "diagnostic=unknown_failure" in output
+    _assert_private_details_absent(output)
+
+
+def main() -> None:
+    test_http_error_exposes_only_finite_metadata()
+    test_raw_exception_and_planner_failure_are_sanitized()
+    print("DIAGNOSE_OPENAI_PLANNER_ERROR_SAFETY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_duration_localization.py
+++ b/tests/test_duration_localization.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+lazy from db import format_duration
+
+EXPECTED_DURATIONS = frozendict({
+    "zh-TW": (
+        "0 分鐘",
+        "0 分鐘",
+        "0 分鐘",
+        "1 分鐘",
+        "1 分鐘",
+        "59 分鐘",
+        "1 小時 0 分",
+        "1 小時 0 分",
+        "1 小時 0 分",
+        "1 小時 1 分",
+        "1 小時 59 分",
+        "2 小時 0 分",
+    ),
+    "zh-CN": (
+        "0 分钟",
+        "0 分钟",
+        "0 分钟",
+        "1 分钟",
+        "1 分钟",
+        "59 分钟",
+        "1 小时 0 分",
+        "1 小时 0 分",
+        "1 小时 0 分",
+        "1 小时 1 分",
+        "1 小时 59 分",
+        "2 小时 0 分",
+    ),
+    "en": (
+        "0 min",
+        "0 min",
+        "0 min",
+        "1 min",
+        "1 min",
+        "59 min",
+        "1 h 0 min",
+        "1 h 0 min",
+        "1 h 0 min",
+        "1 h 1 min",
+        "1 h 59 min",
+        "2 h 0 min",
+    ),
+    "ja-JP": (
+        "0分",
+        "0分",
+        "0分",
+        "1分",
+        "1分",
+        "59分",
+        "1時間0分",
+        "1時間0分",
+        "1時間0分",
+        "1時間1分",
+        "1時間59分",
+        "2時間0分",
+    ),
+})
+
+BOUNDARY_SECONDS = (
+    -1,
+    0,
+    59,
+    60,
+    61,
+    3599,
+    3600,
+    3601,
+    3659,
+    3660,
+    7199,
+    7200,
+)
+
+
+def assert_all_languages_and_boundaries() -> None:
+    assert tuple(EXPECTED_DURATIONS) == ("zh-TW", "zh-CN", "en", "ja-JP")
+    for language, expected_values in EXPECTED_DURATIONS.items():
+        assert tuple(
+            format_duration(seconds, language)
+            for seconds in BOUNDARY_SECONDS
+        ) == expected_values
+
+
+def assert_language_aliases_and_fallback() -> None:
+    assert format_duration(3660, "zh-Hans") == "1 小时 1 分"
+    assert format_duration(3660, "en-US") == "1 h 1 min"
+    assert format_duration(3660, "ja") == "1時間1分"
+    assert format_duration(3660, "unsupported") == "1 小時 1 分"
+    assert format_duration(3660, "") == "1 小時 1 分"
+
+
+def assert_default_remains_traditional_chinese() -> None:
+    assert format_duration(-1) == "0 分鐘"
+    assert format_duration(3599) == "59 分鐘"
+    assert format_duration(3600) == "1 小時 0 分"
+    assert format_duration(3720) == "1 小時 2 分"
+
+
+def run() -> None:
+    assert_all_languages_and_boundaries()
+    assert_language_aliases_and_fallback()
+    assert_default_remains_traditional_chinese()
+    print("DURATION_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_english_localization.py
+++ b/tests/test_english_localization.py
@@ -153,12 +153,13 @@ def assert_companion_voice_policy() -> list[tuple[str, str]]:
 def assert_empty_voice_selection_fails() -> None:
     # The runtime never lets an empty selection fall through to an arbitrary
     # Windows system default, which could be male.
-    tts = WindowsTTS()
+    tts = WindowsTTS(language="en")
     failures: list[str] = []
     tts.failed.connect(failures.append)
     with patch("speech.windows_voices", return_value=[]):
         tts._run("Hello", "", 0)
-    assert failures and "女性" in failures[-1]
+    assert failures and "female" in failures[-1].casefold()
+    assert "女性" not in failures[-1]
 
 
 def assert_english_wizard(app: QApplication, db: StudioDB) -> None:
@@ -207,6 +208,17 @@ def assert_english_dashboard(
             DashboardDependencies(listener, FakeSecretStore()),
         )
     assert dashboard.tabs.tabText(0) == "Chat"
+    assert dashboard.tabs.tabText(1) == "Today"
+    assert dashboard.todo_input.placeholderText().startswith("Enter a task")
+    assert dashboard.todo_category.itemText(0) == "Comic"
+    assert dashboard.todo_category.itemData(0) == "漫畫"
+    assert dashboard.today_add_button.text() == "＋ Add task"
+    assert dashboard.today_save_idea_button.text() == "✦ Save idea"
+    assert dashboard.today_tasks_heading.text() == "<b>Tasks for today</b>"
+    assert dashboard.creative_ideas_heading.text() == "<b>Creative ideas</b>"
+    assert dashboard.todo_count.text() == "0 open"
+    assert dashboard.idea_count.text() == "0 saved"
+    assert dashboard.work_label.text().startswith("Today ")
     assert dashboard.voice_engine.currentData() == VOICE_ENGINE_WINDOWS
     assert dashboard.windows_voice.currentData() == "OneCore::Microsoft Zira"
     assert dashboard.permission_controls["delete_files"].currentData() == "禁止"

--- a/tests/test_external_error_boundaries.py
+++ b/tests/test_external_error_boundaries.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+lazy import hashlib
+lazy import io
+lazy import os
+lazy import sys
+lazy import tempfile
+lazy import traceback
+lazy from collections.abc import Callable
+lazy from email.message import Message
+lazy from pathlib import Path
+lazy from typing import Self
+lazy from unittest.mock import patch
+lazy from urllib.error import HTTPError
+lazy from urllib.request import Request
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy from tools import sync_wordpress_download_page as wordpress_sync
+lazy from updater import InstallerAsset, UpdateError, UpdateManager
+
+_FAKE_TOKEN = "NOT-A-REAL-TOKEN-EXTERNAL-BOUNDARY"
+_PRIVATE_PATH = "C:" + "\\Users\\private-user\\AppData\\MoHan\\secret.json"
+_RESPONSE_BODY = (
+    '{"token":"'
+    + _FAKE_TOKEN
+    + '","private_path":"'
+    + _PRIVATE_PATH.replace("\\", "\\\\")
+    + '"} trailing-data'
+)
+_API_URL = "https://api.github.com/repos/example/project/releases"
+_INSTALLER_URL = "https://github.com/example/project/releases/download/v1/app.exe"
+_FORBIDDEN = (
+    _FAKE_TOKEN,
+    _PRIVATE_PATH,
+    _RESPONSE_BODY,
+    "private-user",
+    "response_body=",
+)
+
+
+def _untrusted_detail() -> str:
+    return (
+        "response_body="
+        + _RESPONSE_BODY
+        + "; token="
+        + _FAKE_TOKEN
+        + "; path="
+        + _PRIVATE_PATH
+    )
+
+
+def _http_error() -> HTTPError:
+    detail = _untrusted_detail()
+    return HTTPError(
+        _API_URL + "?token=" + _FAKE_TOKEN,
+        503,
+        detail,
+        Message(),
+        io.BytesIO(detail.encode("utf-8")),
+    )
+
+
+def _assert_safe_error(
+    action: Callable[[], object],
+    error_type: type[BaseException],
+    expected_message: str,
+) -> None:
+    try:
+        action()
+    except error_type as error:
+        assert str(error) == expected_message
+        assert error.__cause__ is None
+        assert error.__context__ is None
+        rendered = "\n".join(
+            (
+                str(error),
+                repr(error),
+                "".join(traceback.format_exception(error)),
+            )
+        )
+        lowered = rendered.casefold()
+        for forbidden in _FORBIDDEN:
+            assert forbidden.casefold() not in lowered, forbidden
+        return
+    raise AssertionError(f"expected {error_type.__name__}")
+
+
+class _Response:
+    def __init__(self, url: str, payload: bytes):
+        self._url = url
+        self._payload = payload
+        self._offset = 0
+        self.headers = Message()
+        self.headers["Content-Length"] = str(len(payload))
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._payload) - self._offset
+        chunk = self._payload[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+class _UnreadableManifest:
+    def read_text(self, *, encoding: str) -> str:
+        assert encoding == "utf-8"
+        raise OSError(_untrusted_detail())
+
+
+def _raise_http_error(_request: object, **_kwargs: object) -> object:
+    raise _http_error()
+
+
+def _raise_os_error(_request: object, **_kwargs: object) -> object:
+    raise OSError(_untrusted_detail())
+
+
+def _response_opener(payload: bytes) -> Callable[..., _Response]:
+    def opener(request: Request, **_kwargs: object) -> _Response:
+        return _Response(request.full_url, payload)
+
+    return opener
+
+
+def _raise_progress_error(_received: int, _total: int) -> None:
+    raise RuntimeError(_untrusted_detail())
+
+
+def _wordpress_environment() -> dict[str, str]:
+    return {
+        "WORDPRESS_BASE_URL": "https://wordpress.example.test",
+        "WORDPRESS_USERNAME": _FAKE_TOKEN,
+        "WORDPRESS_APP_PASSWORD": _PRIVATE_PATH,
+    }
+
+
+def test_wordpress_external_errors_are_sanitized() -> None:
+    endpoint = "https://wordpress.example.test/wp-json/wp/v2/pages"
+    with (
+        patch.dict(os.environ, _wordpress_environment(), clear=True),
+        patch.object(wordpress_sync, "urlopen", side_effect=_http_error()),
+    ):
+        _assert_safe_error(
+            lambda: wordpress_sync.request_json(endpoint),
+            RuntimeError,
+            "WordPress API request was rejected",
+        )
+
+    with (
+        patch.dict(os.environ, _wordpress_environment(), clear=True),
+        patch.object(
+            wordpress_sync,
+            "urlopen",
+            side_effect=OSError(_untrusted_detail()),
+        ),
+    ):
+        _assert_safe_error(
+            lambda: wordpress_sync.request_json(endpoint),
+            RuntimeError,
+            "WordPress API is unavailable",
+        )
+
+    with (
+        patch.dict(os.environ, _wordpress_environment(), clear=True),
+        patch.object(
+            wordpress_sync,
+            "urlopen",
+            return_value=_Response(endpoint, _RESPONSE_BODY.encode("utf-8")),
+        ),
+    ):
+        _assert_safe_error(
+            lambda: wordpress_sync.request_json(endpoint),
+            RuntimeError,
+            "WordPress API returned invalid JSON",
+        )
+
+    _assert_safe_error(
+        lambda: wordpress_sync.load_manifest(_UnreadableManifest()),
+        RuntimeError,
+        "Release manifest could not be loaded",
+    )
+
+
+def _manager(
+    download_dir: Path,
+    opener: Callable[..., object],
+) -> UpdateManager:
+    return UpdateManager(
+        "example/project",
+        "1.0.0",
+        download_dir,
+        opener,
+    )
+
+
+def _asset(payload: bytes) -> InstallerAsset:
+    return InstallerAsset(
+        "exe",
+        "app.exe",
+        _INSTALLER_URL,
+        hashlib.sha256(payload).hexdigest(),
+        len(payload),
+    )
+
+
+def test_updater_external_errors_are_sanitized() -> None:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        manager = _manager(root, _raise_http_error)
+        _assert_safe_error(
+            lambda: manager._request_bytes(_API_URL, 1024),
+            UpdateError,
+            "GitHub 更新服務回應錯誤。",
+        )
+
+        manager = _manager(root, _raise_os_error)
+        _assert_safe_error(
+            lambda: manager._request_bytes(_API_URL, 1024),
+            UpdateError,
+            "無法連線至 GitHub 更新服務。",
+        )
+
+        manager = _manager(
+            root,
+            _response_opener(_RESPONSE_BODY.encode("utf-8")),
+        )
+        _assert_safe_error(
+            lambda: manager._request_json(_API_URL),
+            UpdateError,
+            "GitHub 更新資料格式不正確。",
+        )
+
+        malformed_url = "https://[" + _FAKE_TOKEN + "/" + _PRIVATE_PATH
+        _assert_safe_error(
+            lambda: UpdateManager._validate_url(malformed_url),
+            UpdateError,
+            "更新網址不是受信任的 GitHub HTTPS 來源。",
+        )
+
+        payload = b"verified-installer"
+        manager = _manager(root, _response_opener(payload))
+        _assert_safe_error(
+            lambda: manager.download(_asset(payload), _raise_progress_error),
+            UpdateError,
+            "安裝程式下載失敗。",
+        )
+
+        blocked = root / ("private-user-" + _FAKE_TOKEN)
+        blocked.write_text(_RESPONSE_BODY, encoding="utf-8")
+        manager = _manager(blocked, _response_opener(payload))
+        _assert_safe_error(
+            lambda: manager.download(_asset(payload)),
+            UpdateError,
+            "安裝程式下載失敗。",
+        )
+
+
+def main() -> None:
+    test_wordpress_external_errors_are_sanitized()
+    test_updater_external_errors_are_sanitized()
+    print("EXTERNAL_ERROR_BOUNDARIES_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_flagship_localization.py
+++ b/tests/test_flagship_localization.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+lazy import os
+lazy import re
+lazy import sys
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QPushButton,
+    QTabWidget,
+    QTextBrowser,
+    QTextEdit,
+    QWidget,
+)
+
+lazy from db import StudioDB
+lazy from flagship_ui import FlagshipControlCenter, WorkflowEditor
+lazy from flagship_ui_localization import (
+    FLAGSHIP_TRANSLATIONS,
+    FlagshipTranslator,
+    validate_flagship_translations,
+)
+
+HAN_CHARACTER = re.compile(r"[\u3400-\u9fff]")
+ENGLISH_ALLOWED_HAN = frozenset({
+    # User-owned profile data and the character's proper name are content,
+    # not system UI. They are allowed to remain verbatim.
+    "墨寒",
+})
+
+
+def _visible_texts(root: QWidget) -> list[str]:
+    values: list[str] = []
+    if root.windowTitle():
+        values.append(root.windowTitle())
+    for widget in [root, *root.findChildren(QWidget)]:
+        if widget.toolTip():
+            values.append(widget.toolTip())
+        if isinstance(widget, (QLabel, QPushButton, QCheckBox)):
+            values.append(widget.text())
+        if isinstance(widget, (QLineEdit, QTextEdit)):
+            values.append(widget.placeholderText())
+        if isinstance(widget, QComboBox):
+            values.extend(widget.itemText(index) for index in range(widget.count()))
+        if isinstance(widget, QListWidget):
+            values.extend(widget.item(index).text() for index in range(widget.count()))
+        if isinstance(widget, QTextBrowser):
+            values.append(widget.toPlainText())
+        if isinstance(widget, QTabWidget):
+            values.extend(widget.tabText(index) for index in range(widget.count()))
+    return [value for value in values if value]
+
+
+def _unapproved_han(values: list[str]) -> list[str]:
+    offenders: list[str] = []
+    for value in values:
+        cleaned = value
+        for allowed in ENGLISH_ALLOWED_HAN:
+            cleaned = cleaned.replace(allowed, "")
+        if HAN_CHARACTER.search(cleaned):
+            offenders.append(value)
+    return offenders
+
+
+def _assert_canonical_values(center: FlagshipControlCenter) -> None:
+    assert center.remote_host.itemData(0) == "127.0.0.1"
+    assert center.remote_host.itemData(1) == "0.0.0.0"
+    assert center._permission_controls["delete_file"].currentData() == "禁止"
+    assert center._permission_controls["email_send"].currentData() == "每次詢問"
+
+    editor = WorkflowEditor(center, language=center.language)
+    assert [editor.trigger.itemData(index) for index in range(3)] == [
+        "manual",
+        "schedule",
+        "work_start",
+    ]
+    return editor
+
+
+def _assert_english_center(center: FlagshipControlCenter) -> None:
+    assert center.language == "en"
+    assert center.tabs.count() == 7
+    assert [center.tabs.tabText(index) for index in range(7)] == [
+        "Task Center",
+        "Workflows",
+        "Cloud Connectors",
+        "Smart Home",
+        "Remote & Privacy",
+        "Security Permissions",
+        "Audit Log",
+    ]
+    for index in range(center.tabs.count()):
+        center.tabs.setCurrentIndex(index)
+        assert center.tabs.currentWidget() is not None
+
+    editor = _assert_canonical_values(center)
+    try:
+        assert editor.windowTitle() == "Add a Safe Workflow"
+        assert [editor.trigger.itemText(index) for index in range(3)] == [
+            "Run manually",
+            "Daily at a set time",
+            "When work starts",
+        ]
+        assert not _unapproved_han(_visible_texts(center) + _visible_texts(editor))
+    finally:
+        editor.close()
+
+
+def _assert_japanese_center(center: FlagshipControlCenter) -> None:
+    assert center.language == "ja-JP"
+    assert center.tabs.count() == 7
+    assert [center.tabs.tabText(index) for index in range(7)] == [
+        "タスクセンター",
+        "ワークフロー",
+        "クラウド接続",
+        "スマートホーム",
+        "リモートとプライバシー",
+        "セキュリティ権限",
+        "監査ログ",
+    ]
+    for index in range(center.tabs.count()):
+        center.tabs.setCurrentIndex(index)
+        assert center.tabs.currentWidget() is not None
+
+    editor = _assert_canonical_values(center)
+    try:
+        assert editor.windowTitle() == "安全なワークフローを追加"
+        assert [editor.trigger.itemText(index) for index in range(3)] == [
+            "手動で実行",
+            "毎日指定時刻",
+            "作業開始時",
+        ]
+    finally:
+        editor.close()
+
+
+def _assert_user_data_is_preserved(center: FlagshipControlCenter) -> None:
+    user_text = "不要翻譯這段文字 C:\\墨寒\\設定.json"
+    user_url = "https://example.com/繁體路徑"
+    assert (
+        center._t(
+            "[遠端裝置：{device}] {text}",
+            device="我的手機",
+            text=user_text,
+        )
+        == f"[Remote device: 我的手機] {user_text}"
+    )
+    assert center._t("已上傳：{name}", name=user_url) == f"Uploaded: {user_url}"
+    detail = "UnicodeDecodeError: 無法解碼 C:\\舊資料.txt"
+    assert detail in center._t("測試失敗：{error}", error=detail)
+
+
+def run() -> None:
+    validate_flagship_translations()
+    assert all(len(row) == 3 for row in FLAGSHIP_TRANSLATIONS.values())
+    assert FlagshipTranslator("zh-CN").text("任務中心") == "任务中心"
+
+    app = QApplication.instance() or QApplication([])
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        english_db = StudioDB(root / "english.db")
+        japanese_db = StudioDB(root / "japanese.db")
+        english = FlagshipControlCenter(english_db, root, language="en")
+        japanese = FlagshipControlCenter(japanese_db, root, language="ja-JP")
+        try:
+            _assert_english_center(english)
+            _assert_japanese_center(japanese)
+            _assert_user_data_is_preserved(english)
+        finally:
+            english.close_services()
+            japanese.close_services()
+            english_db.close()
+            japanese_db.close()
+            english.deleteLater()
+            japanese.deleteLater()
+            app.processEvents()
+    print("FLAGSHIP_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_full_ui_localization.py
+++ b/tests/test_full_ui_localization.py
@@ -1,0 +1,999 @@
+from __future__ import annotations
+
+lazy import os
+lazy import re
+lazy import subprocess
+lazy import sys
+lazy import webbrowser
+lazy from contextlib import ExitStack, contextmanager
+lazy from dataclasses import dataclass
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+lazy from PySide6.QtCore import QEvent, QModelIndex, QObject, Qt, QTimer, Signal
+lazy from PySide6.QtGui import QAction
+lazy from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QListView,
+    QMenu,
+    QPushButton,
+    QTabWidget,
+    QTextEdit,
+    QWidget,
+)
+
+lazy from app import (
+    ArchivedMemoryDialog,
+    ChatHistoryDialog,
+    Dashboard,
+    DashboardDependencies,
+    MemoryEditorDialog,
+)
+lazy from db import StudioDB
+lazy from platform_contracts import PlatformCapabilities, PlatformPaths
+
+LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]")
+
+LANGUAGE_SELECTOR_NAMES = (
+    "繁體中文（台灣）",
+    "简体中文（中国大陆）",
+    "English",
+    "日本語",
+)
+
+# These are deliberately user-authored, mixed-script values. They are not
+# translations and must survive every storage and rendering path byte for byte.
+USER_SEEDS = {
+    "todo_title": "Todo seed｜繁體原句｜简体原句｜English｜日本語",
+    "idea_title": "Idea seed｜繁體標題｜简体标题｜English｜日本語",
+    "idea_content": "Idea body｜繁體內文｜简体内容｜English｜日本語",
+    "platform_name": "Platform seed｜繁體平台｜简体平台｜English｜日本語",
+    "memory_title": "Memory seed｜繁體標題｜简体标题｜English｜日本語",
+    "memory_content": "Memory body｜繁體內文｜简体内容｜English｜日本語",
+    "chat_content": "Chat seed｜繁體對話｜简体对话｜English｜日本語",
+}
+
+EXPECTED_TABS = {
+    "zh-TW": ("對話", "今日待辦", "工作平台", "長期記憶", "聲音", "電腦權限", "設定"),
+    "zh-CN": ("对话", "今日待办", "工作平台", "长期记忆", "语音", "电脑权限", "设置"),
+    "en": (
+        "Chat",
+        "Today",
+        "Work platforms",
+        "Long-term memory",
+        "Voice",
+        "Computer permissions",
+        "Settings",
+    ),
+    "ja-JP": ("会話", "今日", "仕事プラットフォーム", "長期記憶", "音声", "パソコンの権限", "設定"),
+}
+
+EXPECTED_RUNTIME_PHRASES = {
+    "zh-TW": (
+        "今日卷冊尚空",
+        "尚未建立工作平台",
+        "這個分類目前沒有記憶",
+        "編輯長期記憶",
+        "已封存的長期記憶",
+        "管理／清除對話",
+    ),
+    "zh-CN": (
+        "今日待办尚空",
+        "尚未建立工作平台",
+        "这个分类目前没有记忆",
+        "编辑长期记忆",
+        "已封存的长期记忆",
+        "管理／清除对话",
+    ),
+    "en": (
+        "No tasks yet today",
+        "No work platforms yet",
+        "There are no memories in this category",
+        "Edit long-term memory",
+        "Archived long-term memories",
+        "Manage / clear chats",
+    ),
+    "ja-JP": (
+        "今日の予定はまだありません",
+        "仕事プラットフォームはまだありません",
+        "この分類には記憶がありません",
+        "長期記憶を編集",
+        "保管済みの長期記憶",
+        "会話の管理／消去",
+    ),
+}
+
+# Phrase-level rules avoid the invalid shortcut of banning all Han characters.
+# Shared spellings such as ``新增`` are valid Simplified Chinese too; only
+# orthographically or idiomatically Traditional residues belong in zh-CN.
+FORBIDDEN_PHRASES = {
+    "zh-TW": (
+        "设置",
+        "语音",
+        "对话",
+        "电脑权限",
+        "今日待办",
+        "长期记忆",
+        "删除",
+        "编辑",
+        "选择",
+        "用户",
+        "文件夹",
+    ),
+    "zh-CN": (
+        "設定",
+        "聲音",
+        "語音",
+        "對話",
+        "電腦權限",
+        "今日待辦",
+        "長期記憶",
+        "刪除",
+        "編輯",
+        "選擇",
+        "開啟",
+        "關閉",
+        "儲存",
+        "資料夾",
+        "使用者",
+        "麥克風",
+        "視窗",
+        "顯示",
+        "啟動",
+        "連線",
+        "還原",
+        "靈感",
+    ),
+    "ja-JP": (
+        "今日待辦",
+        "工作平台",
+        "電腦權限",
+        "開始工作",
+        "結束工作",
+        "今日卷冊尚空",
+        "尚未建立",
+        "請先",
+        "刪除勾選",
+        "儲存",
+        "開啟網站",
+        "聲音風格",
+        "語音狀態",
+        "未計時",
+        "分鐘",
+        "使用者",
+        "資料夾",
+        "連線",
+        "啟動",
+        "關閉",
+        "顯示",
+        "選擇",
+        "輸入",
+    ),
+}
+
+REQUIRED_CANONICAL_COMBOS = (
+    "mode_combo",
+    "todo_category",
+    "platform_filter",
+    "memory_category",
+    "memory_filter",
+    "speech_recognition",
+    "voice_engine",
+    "azure_region",
+    "azure_hd_region",
+    "realtime_output_mode",
+    "realtime_noise_reduction",
+    "realtime_turn_detection",
+    "profile_work_type",
+    "profile_ui_language",
+    "platform_status",
+)
+
+# Voice catalogs are intentionally language- and region-dependent. Their
+# current display catalogs are tested elsewhere, so they are not cross-language
+# itemData invariants in this gate.
+DYNAMIC_VOICE_COMBOS = frozenset(
+    {
+        "windows_voice",
+        "tts_voice",
+        "realtime_voice",
+        "azure_voice",
+        "azure_hd_voice",
+    }
+)
+
+WINDOWS_VOICES = (
+    ("OneCore::Microsoft Yating", "zh-TW"),
+    ("OneCore::Microsoft Xiaoxiao", "zh-CN"),
+    ("OneCore::Microsoft Zira", "en-US"),
+    ("OneCore::Microsoft Ayumi", "ja-JP"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedText:
+    source: str
+    kind: str
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class GateIssue:
+    language: str
+    check: str
+    source: str
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageEvidence:
+    language: str
+    tabs: tuple[str, ...]
+    records: tuple[CapturedText, ...]
+    database_values: dict[str, str]
+    canonical_item_data: dict[str, tuple[str, ...]]
+
+
+class FakeSecretStore:
+    def load(self) -> str:
+        return ""
+
+    def save(self, _value: str) -> None:
+        return None
+
+    def clear(self) -> None:
+        return None
+
+
+class FakeListener(QObject):
+    recognized = Signal(str)
+    failed = Signal(str)
+    listening_changed = Signal(bool)
+    recording_changed = Signal(bool)
+    status_changed = Signal(str)
+    diagnostic_changed = Signal(str)
+
+    def toggle_listening(self) -> None:
+        return None
+
+
+class OfflinePlatformServices:
+    capabilities = PlatformCapabilities(
+        platform_id="windows",
+        display_name="Windows",
+        system_local_speech=True,
+        verified_female_voice_catalog=True,
+        offline_speech_recognition=True,
+        secure_secret_storage=True,
+        desktop_autostart=True,
+        native_window_management=True,
+        published_installers=("portable-zip", "exe", "msi"),
+    )
+
+    def __init__(self, root: Path):
+        self.paths = PlatformPaths(
+            data=root / "data",
+            config=root / "config",
+            cache=root / "cache",
+        )
+
+    def set_autostart(
+        self,
+        _enabled: bool,
+        *,
+        application_id: str,
+        command: str,
+    ) -> None:
+        raise AssertionError(
+            f"Offline UI gate attempted autostart: {application_id} {command}"
+        )
+
+    def open_path(self, path: Path) -> None:
+        raise AssertionError(f"Offline UI gate attempted external open: {path}")
+
+
+def fake_secret_store_factory(
+    _path: Path,
+    _description: str = "MoHan protected secret",
+) -> FakeSecretStore:
+    return FakeSecretStore()
+
+
+def deny_network(*args, **kwargs):
+    del kwargs
+    target = args[0] if args else "unknown target"
+    raise AssertionError(f"Offline UI gate attempted network access: {target!r}")
+
+
+def deny_process(*args, **kwargs):
+    del kwargs
+    target = args[0] if args else "unknown command"
+    raise AssertionError(f"Offline UI gate attempted a process: {target!r}")
+
+
+@contextmanager
+def offline_runtime():
+    """Make accidental I/O fail closed while runtime widgets are constructed."""
+    with ExitStack() as stack:
+        for target in (
+            "ai_client.urlopen",
+            "cloud_connectors.urlopen",
+            "home_assistant.urlopen",
+            "speech.urlopen",
+            "updater.urlopen",
+            "socket.create_connection",
+            "websocket.WebSocketApp",
+        ):
+            stack.enter_context(patch(target, side_effect=deny_network))
+        stack.enter_context(patch.object(subprocess, "Popen", side_effect=deny_process))
+        stack.enter_context(patch.object(webbrowser, "open", side_effect=deny_process))
+        # Every UI timer is irrelevant to a static localization traversal. This
+        # also prevents screen capture, scheduled workflows, and polling.
+        stack.enter_context(patch.object(QTimer, "start", return_value=None))
+        yield
+
+
+def clean_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def object_path(root: QWidget, obj: QObject) -> str:
+    parts: list[str] = []
+    current: QObject | None = obj
+    while current is not None:
+        class_name = current.metaObject().className()
+        name = clean_text(current.objectName())
+        segment = f"{class_name}#{name}" if name else class_name
+        parent = current.parent()
+        if not name and parent is not None:
+            siblings = [
+                child
+                for child in parent.children()
+                if child.metaObject().className() == class_name
+            ]
+            if len(siblings) > 1:
+                segment += f"[{siblings.index(current)}]"
+        parts.append(segment)
+        if current is root:
+            break
+        current = parent
+    return "/".join(reversed(parts))
+
+
+def object_aliases(root: QWidget) -> dict[int, str]:
+    aliases: dict[int, str] = {}
+
+    def bind(owner: object, prefix: str = "") -> None:
+        for name, value in vars(owner).items():
+            alias = f"{prefix}{name}"
+            if isinstance(value, QObject):
+                aliases.setdefault(id(value), alias)
+            elif isinstance(value, dict):
+                for key, item in value.items():
+                    if isinstance(item, QObject):
+                        aliases.setdefault(id(item), f"{alias}[{key}]")
+
+    bind(root)
+    flagship = getattr(root, "flagship_center", None)
+    if flagship is not None:
+        bind(flagship, "flagship_center.")
+    return aliases
+
+
+def add_record(
+    records: set[CapturedText],
+    source: str,
+    kind: str,
+    value: object,
+) -> None:
+    text = clean_text(value)
+    if text:
+        records.add(CapturedText(source, kind, text))
+
+
+def widget_content_records(
+    widget: QWidget,
+    source: str,
+) -> set[CapturedText]:
+    records: set[CapturedText] = set()
+    if isinstance(widget, QLabel):
+        add_record(records, source, "text", widget.text())
+    if isinstance(widget, (QPushButton, QCheckBox)):
+        add_record(records, source, "text", widget.text())
+    if isinstance(widget, QGroupBox):
+        add_record(records, source, "title", widget.title())
+    records.update(widget_editor_records(widget, source))
+    records.update(widget_container_records(widget, source))
+    return records
+
+
+def widget_editor_records(
+    widget: QWidget,
+    source: str,
+) -> set[CapturedText]:
+    records: set[CapturedText] = set()
+    if isinstance(widget, QLineEdit):
+        # Secret fields are intentionally never copied into diagnostics.
+        if widget.echoMode() == QLineEdit.Normal:
+            add_record(records, source, "text", widget.text())
+        add_record(records, source, "placeholder", widget.placeholderText())
+    if isinstance(widget, QTextEdit):
+        add_record(records, source, "text", widget.toPlainText())
+        add_record(records, source, "placeholder", widget.placeholderText())
+    if isinstance(widget, QComboBox):
+        add_record(records, source, "text", widget.currentText())
+        for index in range(widget.count()):
+            add_record(records, source, f"combo-item[{index}]", widget.itemText(index))
+            for kind, role in (
+                ("tooltip", Qt.ItemDataRole.ToolTipRole),
+                ("accessibleText", Qt.ItemDataRole.AccessibleTextRole),
+                (
+                    "accessibleDescription",
+                    Qt.ItemDataRole.AccessibleDescriptionRole,
+                ),
+            ):
+                add_record(
+                    records,
+                    source,
+                    f"combo-item-{kind}[{index}]",
+                    widget.itemData(index, role),
+                )
+    return records
+
+
+def widget_container_records(
+    widget: QWidget,
+    source: str,
+) -> set[CapturedText]:
+    records: set[CapturedText] = set()
+    if isinstance(widget, QTabWidget):
+        for index in range(widget.count()):
+            add_record(records, source, f"tabText[{index}]", widget.tabText(index))
+            add_record(
+                records,
+                source,
+                f"tabToolTip[{index}]",
+                widget.tabToolTip(index),
+            )
+            add_record(
+                records,
+                source,
+                f"tabWhatsThis[{index}]",
+                widget.tabWhatsThis(index),
+            )
+            add_record(
+                records,
+                source,
+                f"tabAccessibleName[{index}]",
+                widget.tabBar().accessibleTabName(index),
+            )
+    if isinstance(widget, QMenu):
+        add_record(records, source, "menu-title", widget.title())
+    return records
+
+
+def widget_records(
+    root: QWidget,
+    widget: QWidget,
+    scope: str,
+    aliases: dict[int, str],
+) -> set[CapturedText]:
+    records: set[CapturedText] = set()
+    identity = aliases.get(id(widget), object_path(root, widget))
+    source = f"{scope}/{identity}"
+    for kind, value in (
+        ("windowTitle", widget.windowTitle()),
+        ("tooltip", widget.toolTip()),
+        ("statusTip", widget.statusTip()),
+        ("whatsThis", widget.whatsThis()),
+        ("accessibleName", widget.accessibleName()),
+        ("accessibleDescription", widget.accessibleDescription()),
+    ):
+        add_record(records, source, kind, value)
+    records.update(widget_content_records(widget, source))
+    return records
+
+
+def action_records(
+    root: QWidget,
+    action: QAction,
+    scope: str,
+    aliases: dict[int, str],
+) -> set[CapturedText]:
+    identity = aliases.get(id(action), object_path(root, action))
+    source = f"{scope}/{identity}"
+    records: set[CapturedText] = set()
+    for kind, value in (
+        ("action-text", action.text()),
+        ("action-iconText", action.iconText()),
+        ("action-tooltip", action.toolTip()),
+        ("action-statusTip", action.statusTip()),
+        ("action-whatsThis", action.whatsThis()),
+    ):
+        add_record(records, source, kind, value)
+    return records
+
+
+def has_combo_ancestor(widget: QWidget) -> bool:
+    parent = widget.parentWidget()
+    while parent is not None:
+        if isinstance(parent, QComboBox):
+            return True
+        parent = parent.parentWidget()
+    return False
+
+
+def model_records(
+    root: QWidget,
+    view: QAbstractItemView,
+    scope: str,
+    aliases: dict[int, str],
+) -> set[CapturedText]:
+    model = view.model()
+    combo_views = {
+        id(combo.view())
+        for combo in root.findChildren(QComboBox)
+    }
+    combo_models = {
+        id(combo.model())
+        for combo in root.findChildren(QComboBox)
+    }
+    if (
+        has_combo_ancestor(view)
+        or view.metaObject().className() == "QComboBoxListView"
+        or id(view) in combo_views
+        or (model is not None and id(model) in combo_models)
+    ):
+        return set()
+    identity = aliases.get(id(view), object_path(root, view))
+    source = f"{scope}/{identity}"
+    if model is None:
+        return set()
+    records: set[CapturedText] = set()
+    is_list_view = isinstance(view, QListView)
+    roles = (
+        ("item-text", Qt.ItemDataRole.DisplayRole),
+        ("item-tooltip", Qt.ItemDataRole.ToolTipRole),
+        ("item-accessibleText", Qt.ItemDataRole.AccessibleTextRole),
+        ("item-accessibleDescription", Qt.ItemDataRole.AccessibleDescriptionRole),
+    )
+
+    def visit(parent: QModelIndex | None = None) -> None:
+        parent = QModelIndex() if parent is None else parent
+        for row in range(model.rowCount(parent)):
+            column_count = 1 if is_list_view else model.columnCount(parent)
+            for column in range(column_count):
+                index = model.index(row, column, parent)
+                item_source = f"{source}[{row},{column}]"
+                for kind, role in roles:
+                    add_record(records, item_source, kind, model.data(index, role))
+                if not is_list_view and model.hasChildren(index):
+                    visit(index)
+
+    visit()
+    return records
+
+
+def collect_visible_state(
+    root: QWidget,
+    scope: str,
+    aliases: dict[int, str],
+) -> set[CapturedText]:
+    records: set[CapturedText] = set()
+    widgets = (root, *root.findChildren(QWidget))
+    for widget in widgets:
+        if widget is not root and not widget.isVisibleTo(root):
+            continue
+        records.update(widget_records(root, widget, scope, aliases))
+        if isinstance(widget, QAbstractItemView):
+            records.update(model_records(root, widget, scope, aliases))
+    return records
+
+
+def collect_runtime_text(
+    application: QApplication,
+    root: QWidget,
+    scope: str,
+) -> tuple[CapturedText, ...]:
+    root.show()
+    application.processEvents()
+    aliases = object_aliases(root)
+    records: set[CapturedText] = set()
+    explored: set[tuple[int, int]] = set()
+
+    def visit(container: QWidget) -> None:
+        records.update(collect_visible_state(root, scope, aliases))
+        visible_tabs = [
+            tab
+            for tab in container.findChildren(QTabWidget)
+            if tab.isVisibleTo(root)
+        ]
+        for tab in visible_tabs:
+            original_index = tab.currentIndex()
+            for index in range(tab.count()):
+                marker = (id(tab), index)
+                if marker in explored:
+                    continue
+                explored.add(marker)
+                tab.setCurrentIndex(index)
+                application.processEvents()
+                records.update(collect_visible_state(root, scope, aliases))
+                page = tab.widget(index)
+                if page is not None:
+                    visit(page)
+            tab.setCurrentIndex(original_index)
+            application.processEvents()
+
+    visit(root)
+    # Menus may not be open during a traversal, but already-created menu titles
+    # and actions are runtime UI and must still pass the release gate.
+    for menu in root.findChildren(QMenu):
+        records.update(widget_records(root, menu, scope, aliases))
+    for action in root.findChildren(QAction):
+        records.update(action_records(root, action, scope, aliases))
+    return tuple(sorted(records, key=lambda item: (item.source, item.kind, item.value)))
+
+
+def combo_item_data(combo: QComboBox) -> tuple[str, ...]:
+    return tuple(repr(combo.itemData(index)) for index in range(combo.count()))
+
+
+def canonical_combo_snapshot(dashboard: Dashboard) -> dict[str, tuple[str, ...]]:
+    aliases = object_aliases(dashboard)
+    snapshot: dict[str, tuple[str, ...]] = {}
+    for combo in dashboard.findChildren(QComboBox):
+        identity = aliases.get(id(combo), object_path(dashboard, combo))
+        if identity in DYNAMIC_VOICE_COMBOS:
+            continue
+        values = combo_item_data(combo)
+        if values and any(value != "None" for value in values):
+            snapshot[identity] = values
+    if dashboard.platform_controls:
+        first_controls = next(iter(dashboard.platform_controls.values()))
+        snapshot["platform_status"] = combo_item_data(first_controls.status)
+    return snapshot
+
+
+def stop_and_close(application: QApplication, widget: QWidget) -> None:
+    flagship = getattr(widget, "flagship_center", None)
+    if flagship is not None:
+        flagship.close_services()
+    for timer in widget.findChildren(QTimer):
+        timer.stop()
+    widget.close()
+    widget.deleteLater()
+    application.sendPostedEvents(None, QEvent.DeferredDelete)
+    application.processEvents()
+
+
+def configure_language(db: StudioDB, language: str) -> None:
+    for key, value in (
+        ("onboarding_complete", True),
+        ("assistant_name", "MoHan"),
+        ("user_title", "User"),
+        ("organization_name", ""),
+        ("window_title", "MoHan"),
+        ("work_type", "一般辦公／行政"),
+        ("ui_language", language),
+        ("wake_word", "MoHan"),
+    ):
+        db.set_setting(key, value)
+
+
+def seed_database(db: StudioDB) -> tuple[int, dict[str, str]]:
+    todo_id = db.add_todo(USER_SEEDS["todo_title"])
+    idea_id = db.add_idea(USER_SEEDS["idea_title"], USER_SEEDS["idea_content"])
+    assert db.add_platform(USER_SEEDS["platform_name"])
+    memory_id = db.add_memory(
+        USER_SEEDS["memory_content"],
+        title=USER_SEEDS["memory_title"],
+    )
+    db.log_chat("user", USER_SEEDS["chat_content"])
+
+    todo = next(row for row in db.list_todos(True) if int(row["id"]) == todo_id)
+    idea = db.idea(idea_id)
+    memory = db.memory(memory_id)
+    platform = db.platform_rows()[0]
+    chat = db.chat_history(1)[0]
+    assert idea is not None
+    assert memory is not None
+    return memory_id, {
+        "todo_title": str(todo["title"]),
+        "idea_title": str(idea["title"]),
+        "idea_content": str(idea["content"]),
+        "platform_name": str(platform["platform"]),
+        "memory_title": str(memory["title"]),
+        "memory_content": str(memory["content"]),
+        "chat_content": str(chat["content"]),
+    }
+
+
+def dashboard_dependencies(root: Path) -> DashboardDependencies:
+    return DashboardDependencies(
+        listener=FakeListener(),
+        secret_store=FakeSecretStore(),
+        azure_secret_store=FakeSecretStore(),
+        azure_hd_secret_store=FakeSecretStore(),
+        secret_store_factory=fake_secret_store_factory,
+        platform_services=OfflinePlatformServices(root),
+    )
+
+
+def build_language_evidence(
+    application: QApplication,
+    language: str,
+) -> LanguageEvidence:
+    records: list[CapturedText] = []
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp:
+        root = Path(temp)
+        db = StudioDB(root / f"mohan-{language}.db")
+        try:
+            configure_language(db, language)
+            with (
+                offline_runtime(),
+                patch("app.windows_voices", return_value=WINDOWS_VOICES),
+            ):
+                empty_dashboard = Dashboard(db, dashboard_dependencies(root))
+                empty_tabs = tuple(
+                    empty_dashboard.tabs.tabText(index)
+                    for index in range(empty_dashboard.tabs.count())
+                )
+                records.extend(
+                    collect_runtime_text(
+                        application,
+                        empty_dashboard,
+                        "empty-dashboard",
+                    )
+                )
+                stop_and_close(application, empty_dashboard)
+
+                memory_id, database_values = seed_database(db)
+                seeded_dashboard = Dashboard(db, dashboard_dependencies(root))
+                records.extend(
+                    collect_runtime_text(
+                        application,
+                        seeded_dashboard,
+                        "seeded-dashboard",
+                    )
+                )
+                canonical = canonical_combo_snapshot(seeded_dashboard)
+
+                memory = db.memory(memory_id)
+                assert memory is not None
+                dialogs = (
+                    (
+                        "memory-editor",
+                        MemoryEditorDialog(memory, language=language),
+                    ),
+                    (
+                        "archived-memory",
+                        ArchivedMemoryDialog(db, language=language),
+                    ),
+                    (
+                        "chat-history",
+                        ChatHistoryDialog(db, language=language),
+                    ),
+                )
+                for scope, dialog in dialogs:
+                    records.extend(
+                        collect_runtime_text(application, dialog, scope)
+                    )
+                    stop_and_close(application, dialog)
+                stop_and_close(application, seeded_dashboard)
+        finally:
+            db.close()
+    return LanguageEvidence(
+        language=language,
+        tabs=empty_tabs,
+        records=tuple(
+            sorted(
+                set(records),
+                key=lambda item: (item.source, item.kind, item.value),
+            )
+        ),
+        database_values=database_values,
+        canonical_item_data=canonical,
+    )
+
+
+def scrub_approved_content(record: CapturedText) -> str:
+    value = record.value
+    # User content is an explicit data exception, never a system-translation
+    # exception. A changed seed no longer matches and is therefore reported.
+    for seed in USER_SEEDS.values():
+        value = value.replace(seed, "")
+    # MoHan's source-language character name is an intentional brand spelling.
+    value = value.replace("墨寒", "")
+    # Language names are allowed only as self-names inside the language combo.
+    if "profile_ui_language" in record.source and record.kind.startswith(
+        "combo-item"
+    ):
+        for self_name in LANGUAGE_SELECTOR_NAMES:
+            value = value.replace(self_name, "")
+    return value
+
+
+def issue(
+    issues: set[GateIssue],
+    language: str,
+    check: str,
+    source: str,
+    value: object,
+) -> None:
+    issues.add(GateIssue(language, check, source, clean_text(value)))
+
+
+def validate_expected_ui(
+    evidence: LanguageEvidence,
+    issues: set[GateIssue],
+) -> None:
+    language = evidence.language
+    expected_tabs = EXPECTED_TABS[language]
+    if evidence.tabs != expected_tabs:
+        issue(
+            issues,
+            language,
+            "dashboard tab labels",
+            "Dashboard.tabs",
+            f"expected={expected_tabs!r}; actual={evidence.tabs!r}",
+        )
+
+    visible_values = tuple(record.value for record in evidence.records)
+    for phrase in EXPECTED_RUNTIME_PHRASES[language]:
+        if not any(phrase in value for value in visible_values):
+            issue(
+                issues,
+                language,
+                "missing expected runtime phrase",
+                "runtime traversal",
+                phrase,
+            )
+
+def validate_user_seeds(
+    evidence: LanguageEvidence,
+    issues: set[GateIssue],
+) -> None:
+    language = evidence.language
+    visible_values = tuple(record.value for record in evidence.records)
+    for key, expected in USER_SEEDS.items():
+        actual = evidence.database_values.get(key, "<missing>")
+        if actual != expected:
+            issue(
+                issues,
+                language,
+                "user seed changed in database",
+                f"database.{key}",
+                f"expected={expected!r}; actual={actual!r}",
+            )
+        if not any(expected in value for value in visible_values):
+            issue(
+                issues,
+                language,
+                "user seed missing or changed in UI",
+                f"runtime.{key}",
+                expected,
+            )
+
+
+def validate_script_policy(
+    evidence: LanguageEvidence,
+    issues: set[GateIssue],
+) -> None:
+    language = evidence.language
+    if language == "en":
+        for record in evidence.records:
+            residue = scrub_approved_content(record)
+            match = CJK.search(residue)
+            if match is not None:
+                issue(
+                    issues,
+                    language,
+                    f"unapproved CJK starts with {match.group(0)!r}",
+                    f"{record.source}::{record.kind}",
+                    record.value,
+                )
+        return
+
+    forbidden = FORBIDDEN_PHRASES.get(language, ())
+    for record in evidence.records:
+        residue = scrub_approved_content(record)
+        for phrase in forbidden:
+            if phrase in residue:
+                issue(
+                    issues,
+                    language,
+                    f"forbidden phrase {phrase!r}",
+                    f"{record.source}::{record.kind}",
+                    record.value,
+                )
+
+
+def validate_language(
+    evidence: LanguageEvidence,
+    issues: set[GateIssue],
+) -> None:
+    validate_expected_ui(evidence, issues)
+    validate_user_seeds(evidence, issues)
+    validate_script_policy(evidence, issues)
+
+
+def validate_canonical_item_data(
+    evidence_by_language: dict[str, LanguageEvidence],
+    issues: set[GateIssue],
+) -> None:
+    baseline = evidence_by_language["zh-TW"].canonical_item_data
+    for name in REQUIRED_CANONICAL_COMBOS:
+        values = baseline.get(name)
+        if values is None or not any(value != "None" for value in values):
+            issue(
+                issues,
+                "zh-TW",
+                "missing canonical itemData",
+                name,
+                values,
+            )
+
+    all_names = set().union(
+        *(
+            set(evidence.canonical_item_data)
+            for evidence in evidence_by_language.values()
+        )
+    )
+    for name in sorted(all_names):
+        if name in DYNAMIC_VOICE_COMBOS:
+            continue
+        expected = baseline.get(name)
+        for language in LANGUAGES[1:]:
+            actual = evidence_by_language[language].canonical_item_data.get(name)
+            if actual != expected:
+                issue(
+                    issues,
+                    language,
+                    "canonical itemData changed with UI language",
+                    name,
+                    f"zh-TW={expected!r}; {language}={actual!r}",
+                )
+
+
+def format_issues(issues: set[GateIssue]) -> str:
+    ordered = sorted(
+        issues,
+        key=lambda item: (item.language, item.check, item.source, item.value),
+    )
+    lines = [f"Full UI localization gate found {len(ordered)} issue(s):"]
+    lines.extend(
+        f"- [{item.language}] {item.check} | {item.source} -> {item.value!r}"
+        for item in ordered
+    )
+    return "\n".join(lines)
+
+
+def run() -> None:
+    application = QApplication.instance() or QApplication([])
+    application.setQuitOnLastWindowClosed(False)
+    evidence_by_language = {
+        language: build_language_evidence(application, language)
+        for language in LANGUAGES
+    }
+    issues: set[GateIssue] = set()
+    for evidence in evidence_by_language.values():
+        validate_language(evidence, issues)
+    validate_canonical_item_data(evidence_by_language, issues)
+    assert not issues, format_issues(issues)
+    print("FULL_UI_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -25,6 +25,21 @@ def assert_action_pinned(workflow: str, action: str) -> None:
     )
 
 
+def assert_external_actions_pinned(workflow: str) -> None:
+    references = re.findall(r"(?m)^\s*uses:\s*([^\s#]+)", workflow)
+    assert references, "workflow must use at least one GitHub Action"
+    unpinned = [
+        reference
+        for reference in references
+        if not reference.startswith("./")
+        and not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", reference)
+    ]
+    assert not unpinned, (
+        "external GitHub Actions must be pinned to complete 40-character "
+        f"commit SHAs: {unpinned}"
+    )
+
+
 def test_workspace_workflow_policy() -> None:
     assert "* @hitoshic1982" in read(".github/CODEOWNERS")
     workflow_dir = ROOT / ".github" / "workflows"
@@ -260,6 +275,10 @@ def test_preview_and_windows_workflows() -> None:
     assert "--enable-shared" in read("tools/build_python315_jit_runtime.py")
 
     windows_ci = read(".github/workflows/windows-ci.yml")
+    assert_external_actions_pinned(windows_ci)
+    pinned_quality_install = (
+        "python -m pip install --only-binary=:all: -r requirements-dev.txt"
+    )
     for required in (
         'PYTHONUTF8: "1"',
         'PYTHON_JIT = "0"',
@@ -267,6 +286,7 @@ def test_preview_and_windows_workflows() -> None:
         "tools/benchmark_python315_hotpaths.py",
         "tools/build_python315_jit_runtime.py",
         "tools/profile_mohan_tachyon.py",
+        pinned_quality_install,
         "python -m ruff check .",
         "--target all",
         "--min-samples 100",
@@ -275,8 +295,32 @@ def test_preview_and_windows_workflows() -> None:
         "windows-tachyon-evidence",
     ):
         assert required in windows_ci
-    assert "python -m ruff check ." in read(".github/workflows/release.yml")
+    assert windows_ci.index(pinned_quality_install) < windows_ci.index(
+        "python -m ruff check ."
+    )
     release_workflow = read(".github/workflows/release.yml")
+    assert_external_actions_pinned(release_workflow)
+    assert pinned_quality_install in release_workflow
+    assert release_workflow.index(pinned_quality_install) < release_workflow.index(
+        "python -m ruff check ."
+    )
+    quality_requirements = [
+        line.strip()
+        for line in read("requirements-dev.txt").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    ruff_requirements = [
+        requirement
+        for requirement in quality_requirements
+        if requirement.partition("==")[0].casefold() == "ruff"
+    ]
+    assert len(ruff_requirements) == 1, (
+        "requirements-dev.txt must contain exactly one Ruff requirement"
+    )
+    assert re.fullmatch(
+        r"ruff==[0-9]+(?:\.[0-9]+){2}",
+        ruff_requirements[0],
+    ), "requirements-dev.txt must pin Ruff to one stable version"
     assert release_workflow.index(
         "Require the release tag to still identify the validated commit"
     ) < release_workflow.index("Attest every published artifact")

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -267,6 +267,7 @@ def test_preview_and_windows_workflows() -> None:
         "tools/benchmark_python315_hotpaths.py",
         "tools/build_python315_jit_runtime.py",
         "tools/profile_mohan_tachyon.py",
+        "python -m ruff check .",
         "--target all",
         "--min-samples 100",
         "--max-sample-read-error-percent 15",
@@ -274,6 +275,17 @@ def test_preview_and_windows_workflows() -> None:
         "windows-tachyon-evidence",
     ):
         assert required in windows_ci
+    assert "python -m ruff check ." in read(".github/workflows/release.yml")
+    release_workflow = read(".github/workflows/release.yml")
+    assert release_workflow.index(
+        "Require the release tag to still identify the validated commit"
+    ) < release_workflow.index("Attest every published artifact")
+    for required in (
+        "Existing Release asset size differs",
+        "Existing Release asset content differs",
+        "Accept: application/octet-stream",
+    ):
+        assert required in release_workflow
 
 
 def test_secret_defense_and_community_files() -> None:

--- a/tests/test_memory_management.py
+++ b/tests/test_memory_management.py
@@ -52,9 +52,9 @@ def _assert_memory_update(db: StudioDB, person_id: int) -> None:
         5,
     )
     updated = db.memory(person_id)
-    assert updated["title"] == "主要出版視窗"
+    assert updated["title"] == "主要出版窗口"
     assert updated["category"] == "工作流程"
-    assert updated["content"] == "林小姐是主上的主要出版視窗，週一聯絡。"
+    assert updated["content"] == "林小姐是主上的主要出版窗口，週一聯絡。"
     assert updated["importance"] == 5
     db.add_memory(
         "林小姐是主上的主要出版窗口，週一聯絡。",
@@ -62,7 +62,7 @@ def _assert_memory_update(db: StudioDB, person_id: int) -> None:
         "conversation",
         4,
     )
-    assert db.memory(person_id)["title"] == "主要出版視窗"
+    assert db.memory(person_id)["title"] == "主要出版窗口"
 
 
 def _assert_delete_and_conflict_handling(
@@ -95,8 +95,8 @@ def _assert_editor_and_archive(db: StudioDB, person_id: int) -> None:
     assert editor.category_input.currentText() == "工作流程"
     assert editor.importance_input.value() == 5
     assert editor.values() == (
-        "主要出版視窗",
-        "林小姐是主上的主要出版視窗，週一聯絡。",
+        "主要出版窗口",
+        "林小姐是主上的主要出版窗口，週一聯絡。",
         "工作流程",
         5,
     )

--- a/tests/test_post_speech_motion_continuity.py
+++ b/tests/test_post_speech_motion_continuity.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from itertools import pairwise
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtCore import QAbstractAnimation, QTimer
+lazy from PySide6.QtWidgets import QApplication
+
+lazy from app import CompanionWindow
+lazy from db import StudioDB
+
+
+def _create_window(temp_dir: str) -> tuple[QApplication, CompanionWindow]:
+    os.environ["LOCALAPPDATA"] = temp_dir
+    db_path = Path(temp_dir) / "YanJianStudio" / "MoHan" / "mohan.db"
+    preflight = StudioDB(db_path)
+    preflight.set_setting("tts_enabled", False)
+    preflight.close()
+    app = QApplication([])
+    window = CompanionWindow(startup_speech=False)
+    window.show()
+    app.processEvents()
+    for timer in window.findChildren(QTimer):
+        timer.stop()
+    return app, window
+
+
+def _configure_speech_completion(
+    window: CompanionWindow,
+    final_state: str,
+) -> None:
+    window.state = "speaking"
+    window.speech_playing = True
+    window.audio_driven_mouth = True
+    window.speech_closed_expression = "idle_front"
+    window.speech_mid_expression = "mouth_mid_front"
+    window.speech_open_expression = "speaking_front"
+    window.current_expression = "mouth_o_front"
+    window.after_speech_state = final_state
+    window.after_speech_intensity = 0.8
+    window.ambient_motion_y = 0.75
+    window.ambient_motion_target_y = 0.0
+    window.speech_motion_y = -3.5
+    window.speech_motion_target_y = -3.5
+    window.gesture_motion_y = 0.0
+    window._compose_character_position()
+
+
+def _assert_completion_has_one_motion_owner(
+    window: CompanionWindow,
+) -> None:
+    _configure_speech_completion(window, "happy")
+    window.current_expression = window.speech_closed_expression
+    window._speech_audio_finished()
+
+    assert window.speech_playing
+    assert window.speech_motion_target_y == 0.0
+    assert window.head_motion_y == 0.0
+    positions = [window.character.pos().y()]
+    for _ in range(8):
+        window._motion_tick()
+        positions.append(window.character.pos().y())
+    position_before_handoff = window.character.pos()
+    window._complete_speech_audio_finished()
+
+    assert not window.speech_playing
+    assert window.character.pos() == position_before_handoff
+    assert window.speech_motion_y == 0.0
+    assert max(
+        abs(current - previous)
+        for previous, current in pairwise(positions)
+    ) <= 1
+    animation = getattr(window, "state_animation", None)
+    assert animation is None or animation.state() == QAbstractAnimation.Stopped
+
+
+def _assert_release_is_gradual(window: CompanionWindow) -> None:
+    for scale_percent in (75, 100, 180):
+        window.character_scale_percent = scale_percent
+        window.character_scale = scale_percent / 100.0
+        _configure_speech_completion(window, "idle")
+        window._begin_speech_motion_release()
+        positions = [window.character.pos().y()]
+        for _ in range(12):
+            window._motion_tick()
+            positions.append(window.character.pos().y())
+        deltas = [
+            current - previous
+            for previous, current in pairwise(positions)
+        ]
+        assert all(delta >= 0 for delta in deltas)
+        assert max(deltas, default=0) <= 2
+        assert round(window.speech_motion_y * window.character_scale) == 0
+
+
+def _assert_late_viseme_cannot_restart_motion(
+    window: CompanionWindow,
+) -> None:
+    _configure_speech_completion(window, "idle")
+    window._begin_speech_motion_release()
+    position_before = window.character.pos()
+
+    window._audio_viseme_cue(1.0, "A")
+
+    assert window.character.pos() == position_before
+    assert window.speech_motion_target_y == 0.0
+    assert window.mouth_closing
+
+
+def run() -> None:
+    with TemporaryDirectory() as temp_dir:
+        app, window = _create_window(temp_dir)
+        try:
+            _assert_completion_has_one_motion_owner(window)
+            _assert_release_is_gradual(window)
+            _assert_late_viseme_cannot_restart_motion(window)
+        finally:
+            window.close()
+            app.processEvents()
+    print("POST_SPEECH_MOTION_CONTINUITY_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_post_speech_motion_performance.py
+++ b/tests/test_post_speech_motion_performance.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+lazy import argparse
+lazy import json
+lazy import os
+lazy import statistics
+lazy import subprocess
+lazy import sys
+lazy import time
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy from PySide6.QtCore import QTimer
+lazy from PySide6.QtWidgets import QApplication
+
+lazy from app import (
+    MOTION_FRAME_INTERVAL_MS,
+    SPEECH_MOTION_RELEASE_LIMIT,
+    CompanionWindow,
+)
+lazy from db import StudioDB
+
+VISEME_FRAME_BUDGET_MS = 20.0
+MOTION_FRAME_BUDGET_MS = float(MOTION_FRAME_INTERVAL_MS)
+RELEASE_CYCLE_P95_BUDGET_MS = 8.0
+RELEASE_CYCLE_P99_BUDGET_MS = float(MOTION_FRAME_INTERVAL_MS)
+
+
+class RecordingTimer:
+    """Record requested deadlines without sleeping or pumping Qt events."""
+
+    def __init__(self) -> None:
+        self.intervals_ms: list[int] = []
+
+    def start(self, interval_ms: int) -> None:
+        self.intervals_ms.append(interval_ms)
+
+
+def _percentile(values: list[float], ratio: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, round((len(ordered) - 1) * ratio))
+    return ordered[index]
+
+
+def _timing_summary(values_ms: list[float]) -> dict[str, float]:
+    return {
+        "mean_ms": round(statistics.fmean(values_ms), 6),
+        "p95_ms": round(_percentile(values_ms, 0.95), 6),
+        "p99_ms": round(_percentile(values_ms, 0.99), 6),
+    }
+
+
+def _create_window(
+    temp_dir: str,
+) -> tuple[QApplication, CompanionWindow]:
+    os.environ["LOCALAPPDATA"] = temp_dir
+    db_path = Path(temp_dir) / "YanJianStudio" / "MoHan" / "mohan.db"
+    preflight = StudioDB(db_path)
+    preflight.set_setting("tts_enabled", False)
+    preflight.close()
+    app = QApplication([])
+    window = CompanionWindow(startup_speech=False)
+    window.show()
+    app.processEvents()
+    for timer in window.findChildren(QTimer):
+        timer.stop()
+    return app, window
+
+
+def _configure_audio_speech(window: CompanionWindow) -> None:
+    window.idle_pose = "front"
+    window.state = "speaking"
+    window.speech_playing = True
+    window.speech_pose_suffix = "_front"
+    window.speech_closed_expression = "idle_front"
+    window.speech_mid_expression = "mouth_mid_front"
+    window.speech_open_expression = "speaking_front"
+    window.speech_gesture_expression = None
+    window.speech_motion_y = 0.0
+    window.speech_motion_target_y = 0.0
+    window.ambient_motion_x = 0.0
+    window.ambient_motion_y = 0.0
+    window.gesture_motion_x = 0.0
+    window.gesture_motion_y = 0.0
+    window._start_mouth_animation(audio_driven=True)
+
+
+def _viseme_workload(
+    window: CompanionWindow,
+    iterations: int,
+    *,
+    measure: bool,
+) -> tuple[list[float], dict[str, object]]:
+    vowels = (
+        *("A",) * 4,
+        *("I",) * 4,
+        *("U",) * 4,
+        *("E",) * 4,
+        *("O",) * 4,
+        *("CONSONANT",) * 4,
+    )
+    levels = (0.42, 0.58, 0.72, 0.51)
+    timings_ms: list[float] = []
+    selected_counts: dict[str, int] = {}
+    jaw_checksum = 0
+    motion_checksum = 0
+    position_checksum = 0
+    for index in range(iterations):
+        started = time.perf_counter()
+        window._audio_viseme_cue(
+            levels[index % len(levels)],
+            vowels[index % len(vowels)],
+        )
+        if measure:
+            timings_ms.append((time.perf_counter() - started) * 1000.0)
+        selected = window.viseme_dynamics.current
+        selected_counts[selected] = selected_counts.get(selected, 0) + 1
+        jaw_checksum += round(
+            window.viseme_dynamics.jaw_aperture * 1_000_000
+        )
+        motion_checksum += round(window.speech_motion_y * 1_000_000)
+        position_checksum += window.character.pos().y()
+    return timings_ms, {
+        "iterations": iterations,
+        "selected": dict(sorted(selected_counts.items())),
+        "jaw": jaw_checksum,
+        "motion": motion_checksum,
+        "position": position_checksum,
+    }
+
+
+def _benchmark_visemes(
+    window: CompanionWindow,
+) -> tuple[dict[str, float], dict[str, object]]:
+    _configure_audio_speech(window)
+    _viseme_workload(window, 160, measure=False)
+    _configure_audio_speech(window)
+    timings_ms, checksum = _viseme_workload(window, 480, measure=True)
+    summary = _timing_summary(timings_ms)
+    assert summary["mean_ms"] < VISEME_FRAME_BUDGET_MS / 2, summary
+    assert summary["p95_ms"] < VISEME_FRAME_BUDGET_MS, summary
+    return summary, checksum
+
+
+def _motion_workload(
+    window: CompanionWindow,
+    iterations: int,
+    *,
+    measure: bool,
+) -> tuple[list[float], dict[str, int]]:
+    timings_ms: list[float] = []
+    motion_checksum = 0
+    position_checksum = 0
+    for index in range(iterations):
+        if index % 2:
+            window.speech_motion_y = 0.0
+            window.speech_motion_target_y = -4.0
+        else:
+            window.speech_motion_y = -4.0
+            window.speech_motion_target_y = 0.0
+        started = time.perf_counter()
+        window._motion_tick()
+        if measure:
+            timings_ms.append((time.perf_counter() - started) * 1000.0)
+        motion_checksum += round(window.speech_motion_y * 1_000_000)
+        position_checksum += window.character.pos().y()
+    return timings_ms, {
+        "iterations": iterations,
+        "motion": motion_checksum,
+        "position": position_checksum,
+    }
+
+
+def _benchmark_motion_frames(
+    window: CompanionWindow,
+) -> tuple[dict[str, float], dict[str, int]]:
+    window.state = "speaking"
+    window.ambient_motion_x = 0.0
+    window.ambient_motion_y = 0.0
+    window.gesture_motion_x = 0.0
+    window.gesture_motion_y = 0.0
+    _motion_workload(window, 240, measure=False)
+    timings_ms, checksum = _motion_workload(window, 1_200, measure=True)
+    summary = _timing_summary(timings_ms)
+    assert summary["mean_ms"] < MOTION_FRAME_BUDGET_MS / 4, summary
+    assert summary["p99_ms"] < MOTION_FRAME_BUDGET_MS, summary
+    return summary, checksum
+
+
+def _release_cycle(
+    window: CompanionWindow,
+    attempts_attribute: str,
+    scale: float,
+) -> tuple[int, int, int, int]:
+    timer = RecordingTimer()
+    window.character_scale = scale
+    window.state = "speaking"
+    window.audio_driven_mouth = True
+    window.mouth_closing = False
+    window.ambient_motion_y = 0.0
+    window.speech_motion_y = -4.0
+    window.speech_motion_target_y = -4.0
+    setattr(window, attempts_attribute, 0)
+    window._begin_speech_motion_release()
+    max_attempts = 0
+    motion_ticks = 0
+    for calls in range(1, SPEECH_MOTION_RELEASE_LIMIT + 2):
+        motion_before_wait = window.speech_motion_y
+        ambient_before_wait = window.ambient_motion_y
+        composed_before_wait = ambient_before_wait + motion_before_wait
+        pending = window._wait_for_speech_motion_release(
+            timer,  # type: ignore[arg-type]
+            attempts_attribute,
+        )
+        if pending:
+            assert window.speech_motion_y == motion_before_wait, (
+                "finish wait must not advance the independently timed motion"
+            )
+            assert window.ambient_motion_y == ambient_before_wait
+        else:
+            assert window.speech_motion_y == 0.0
+            assert (
+                window.ambient_motion_y + window.speech_motion_y
+                == composed_before_wait
+            ), "completion must transfer ownership without moving a pixel"
+        max_attempts = max(
+            max_attempts,
+            int(getattr(window, attempts_attribute, 0)),
+        )
+        if not pending:
+            break
+        window._motion_tick()
+        motion_ticks += 1
+    else:
+        raise AssertionError("speech motion release exceeded its hard limit")
+    assert timer.intervals_ms
+    assert all(
+        interval == MOTION_FRAME_INTERVAL_MS
+        for interval in timer.intervals_ms
+    )
+    assert calls <= SPEECH_MOTION_RELEASE_LIMIT
+    assert window.speech_motion_y == 0.0
+    assert getattr(window, attempts_attribute) == 0
+    assert motion_ticks == len(timer.intervals_ms)
+    return calls, max_attempts, len(timer.intervals_ms), motion_ticks
+
+
+def _assert_hard_release_limit(
+    window: CompanionWindow,
+    attempts_attribute: str,
+) -> None:
+    timer = RecordingTimer()
+    window.character_scale = 1.8
+    window.ambient_motion_y = 0.0
+    window.speech_motion_y = -4.0
+    window.speech_motion_target_y = 0.0
+    setattr(window, attempts_attribute, 0)
+    motion_ticks = 0
+    with patch.object(window, "_motion_tick", return_value=None) as motion_tick:
+        for calls in range(1, SPEECH_MOTION_RELEASE_LIMIT + 2):
+            motion_before_wait = window.speech_motion_y
+            ambient_before_wait = window.ambient_motion_y
+            composed_before_wait = ambient_before_wait + motion_before_wait
+            pending = window._wait_for_speech_motion_release(
+                timer,  # type: ignore[arg-type]
+                attempts_attribute,
+            )
+            if not pending:
+                assert window.speech_motion_y == 0.0
+                assert (
+                    window.ambient_motion_y + window.speech_motion_y
+                    == composed_before_wait
+                ), "hard-limit transfer must not move a pixel"
+                break
+            assert window.speech_motion_y == motion_before_wait, (
+                "finish wait must remain a pure observer before the hard limit"
+            )
+            assert window.ambient_motion_y == ambient_before_wait
+            window._motion_tick()
+            motion_ticks += 1
+        else:
+            raise AssertionError(
+                "non-converging speech motion escaped the hard limit"
+            )
+    assert motion_tick.call_count == motion_ticks
+    assert calls == SPEECH_MOTION_RELEASE_LIMIT
+    assert len(timer.intervals_ms) == SPEECH_MOTION_RELEASE_LIMIT - 1
+    assert motion_ticks == SPEECH_MOTION_RELEASE_LIMIT - 1
+    assert all(
+        interval == MOTION_FRAME_INTERVAL_MS
+        for interval in timer.intervals_ms
+    )
+    assert window.speech_motion_y == 0.0
+    assert getattr(window, attempts_attribute) == 0
+
+
+def _benchmark_release_wait(
+    window: CompanionWindow,
+) -> tuple[dict[str, float], dict[str, int]]:
+    attributes = (
+        "speech_motion_release_attempts",
+        "realtime_motion_release_attempts",
+    )
+    scales = (0.75, 1.0, 1.8)
+    assert window.motion_timer.interval() == MOTION_FRAME_INTERVAL_MS
+    timings_ms: list[float] = []
+    calls_checksum = 0
+    timer_starts_checksum = 0
+    motion_ticks_checksum = 0
+    max_calls = 0
+    max_attempts = 0
+    for index in range(180):
+        started = time.perf_counter()
+        calls, attempts, timer_starts, motion_ticks = _release_cycle(
+            window,
+            attributes[index % len(attributes)],
+            scales[index % len(scales)],
+        )
+        timings_ms.append((time.perf_counter() - started) * 1000.0)
+        calls_checksum += calls
+        timer_starts_checksum += timer_starts
+        motion_ticks_checksum += motion_ticks
+        max_calls = max(max_calls, calls)
+        max_attempts = max(max_attempts, attempts)
+
+    for attempts_attribute in attributes:
+        _assert_hard_release_limit(window, attempts_attribute)
+
+    summary = _timing_summary(timings_ms)
+    assert summary["p95_ms"] < RELEASE_CYCLE_P95_BUDGET_MS, summary
+    assert summary["p99_ms"] < RELEASE_CYCLE_P99_BUDGET_MS, summary
+    assert max_calls <= SPEECH_MOTION_RELEASE_LIMIT
+    assert max_attempts < SPEECH_MOTION_RELEASE_LIMIT
+    return summary, {
+        "cycles": len(timings_ms),
+        "calls": calls_checksum,
+        "timer_starts": timer_starts_checksum,
+        "motion_ticks": motion_ticks_checksum,
+        "max_calls": max_calls,
+        "max_attempts": max_attempts,
+        "hard_limit": SPEECH_MOTION_RELEASE_LIMIT,
+        "scheduled_interval_ms": MOTION_FRAME_INTERVAL_MS,
+    }
+
+
+def _worker(expected_jit: bool) -> dict[str, object]:
+    jit = getattr(sys, "_jit", None)
+    if not jit or not jit.is_available():
+        raise RuntimeError("this audit requires a JIT-capable Python 3.15 build")
+    if jit.is_enabled() is not expected_jit:
+        raise RuntimeError(
+            f"PYTHON_JIT was not applied: expected {expected_jit}, "
+            f"observed {jit.is_enabled()}"
+        )
+
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        app, window = _create_window(temp_dir)
+        try:
+            viseme_timing, viseme_checksum = _benchmark_visemes(window)
+            window.mouth_visual_timer.stop()
+            motion_timing, motion_checksum = _benchmark_motion_frames(window)
+            release_timing, release_checksum = _benchmark_release_wait(window)
+        finally:
+            window.close()
+            window.db.close()
+            app.processEvents()
+    return {
+        "jit_enabled": jit.is_enabled(),
+        "timing": {
+            "viseme_50hz": viseme_timing,
+            "motion_16ms": motion_timing,
+            "release_cycle": release_timing,
+        },
+        "checksum": {
+            "viseme_50hz": viseme_checksum,
+            "motion_16ms": motion_checksum,
+            "release_cycle": release_checksum,
+        },
+    }
+
+
+def _run_mode(mode: str) -> dict[str, object]:
+    environment = os.environ.copy()
+    environment["PYTHON_JIT"] = mode
+    environment["QT_QPA_PLATFORM"] = "offscreen"
+    environment.pop("MOHAN_DISABLE_JIT", None)
+    environment.pop("MOHAN_JIT_REEXEC", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--worker",
+            "--expected-jit",
+            mode,
+        ],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            f"PYTHON_JIT={mode} audit failed\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--expected-jit", choices=("0", "1"))
+    arguments = parser.parse_args()
+    if arguments.worker:
+        if arguments.expected_jit is None:
+            parser.error("--worker requires --expected-jit")
+        print(json.dumps(_worker(arguments.expected_jit == "1")))
+        return
+
+    jit = getattr(sys, "_jit", None)
+    if not jit or not jit.is_available():
+        raise RuntimeError("this audit requires a JIT-capable Python 3.15 build")
+    jit_off = _run_mode("0")
+    jit_on = _run_mode("1")
+    assert jit_off["jit_enabled"] is False
+    assert jit_on["jit_enabled"] is True
+    assert jit_off["checksum"] == jit_on["checksum"], (
+        "JIT changed the deterministic post-speech motion result",
+        jit_off["checksum"],
+        jit_on["checksum"],
+    )
+    print(
+        "POST_SPEECH_MOTION_PERFORMANCE_OK "
+        + json.dumps(
+            {
+                "python": sys.version.split()[0],
+                "jit_off": jit_off["timing"],
+                "jit_on": jit_on["timing"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_post_speech_motion_provider_matrix.py
+++ b/tests/test_post_speech_motion_provider_matrix.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from dataclasses import dataclass
+lazy from itertools import pairwise, product
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtCore import QTimer
+lazy from PySide6.QtWidgets import QApplication, QLabel
+
+lazy from app import CompanionWindow, QueuedSpeech
+lazy from db import StudioDB
+
+COMPLETION_PATHS = ("general", "realtime")
+SCALE_PERCENTAGES = (75, 100, 180)
+POSES = ("front", "lean", "cheek")
+FINAL_KINDS = ("idle", "emotion")
+POSE_SUFFIXES = {
+    "front": "_front",
+    "lean": "_lean",
+    "cheek": "",
+}
+IDLE_EXPRESSIONS = {
+    "front": "idle_front",
+    "lean": "idle_lean",
+    "cheek": "idle",
+}
+EMOTIONS = {
+    "front": "protective_front",
+    "lean": "proud_front",
+    "cheek": "happy",
+}
+MAX_RELEASE_TICKS = 16
+MAX_AMBIENT_SETTLE_TICKS = 32
+MAX_FRAME_DELTA_PIXELS = 2
+
+
+@dataclass(frozen=True, slots=True)
+class MotionSample:
+    x: int
+    y: int
+
+
+def _create_window(
+    temp_dir: str,
+) -> tuple[QApplication, CompanionWindow]:
+    os.environ["LOCALAPPDATA"] = temp_dir
+    db_path = Path(temp_dir) / "YanJianStudio" / "MoHan" / "mohan.db"
+    preflight = StudioDB(db_path)
+    preflight.set_setting("tts_enabled", False)
+    preflight.close()
+    app = QApplication([])
+    window = CompanionWindow(startup_speech=False)
+    window.show()
+    app.processEvents()
+    _stop_all_timers(window)
+    return app, window
+
+
+def _stop_all_timers(window: CompanionWindow) -> None:
+    for timer in window.findChildren(QTimer):
+        timer.stop()
+
+
+def _character_layers(window: CompanionWindow) -> tuple[QLabel, ...]:
+    return (
+        window.character,
+        window.expression_overlay,
+        window.sleeve_left_overlay,
+        window.sleeve_right_overlay,
+        window.hair_left_overlay,
+        window.hair_right_overlay,
+        window.physics_overlay,
+        window.face_overlay,
+        window.eye_overlay,
+    )
+
+
+def _sample(window: CompanionWindow) -> MotionSample:
+    layers = _character_layers(window)
+    body_position = window.character.pos()
+    assert all(layer.pos() == body_position for layer in layers), (
+        "every layered character surface must share one composed coordinate"
+    )
+    return MotionSample(body_position.x(), body_position.y())
+
+
+def _reset_scenario(
+    window: CompanionWindow,
+    scale_percent: int,
+    pose: str,
+) -> None:
+    _stop_all_timers(window)
+    window._cancel_expression_transition()
+    window._cancel_pose_transition()
+    window._stop_gesture_animation()
+    window.speech_queue.clear()
+    window.speech_playing = False
+    window.active_speech_text = ""
+    window.realtime_mouth_active = False
+    window.audio_driven_mouth = False
+    window.mouth_closing = False
+    window.speech_gesture_expression = None
+    window.after_speech_state = "idle"
+    window.realtime_after_speech_state = "idle"
+    window.speech_motion_release_attempts = 0
+    window.realtime_motion_release_attempts = 0
+    window.head_motion_y = 0.0
+    window.ambient_motion_x = 0.0
+    window.ambient_motion_y = 0.0
+    window.ambient_motion_target_x = 0.0
+    window.ambient_motion_target_y = 0.0
+    window.speech_motion_y = 0.0
+    window.speech_motion_target_y = 0.0
+    window.gesture_motion_x = 0.0
+    window.gesture_motion_y = 0.0
+    window.gaze_x = 0.0
+    window.gaze_y = 0.0
+    window.gaze_target_x = 0.0
+    window.gaze_target_y = 0.0
+    window.motion_base_x = 0
+    window.motion_base_y = window.character_base_y
+    window.idle_pose = pose
+    idle_expression = IDLE_EXPRESSIONS[pose]
+    window.speech_closed_expression = idle_expression
+    window.speech_mid_expression = f"mouth_mid{POSE_SUFFIXES[pose]}"
+    window.speech_open_expression = f"speaking{POSE_SUFFIXES[pose]}"
+    window._stop_mouth_animation()
+    window.state = "idle"
+    window.expression_arbiter.request("idle", force=True)
+    window._apply_character_scale(scale_percent, preserve_anchor=False)
+    window._set_expression(idle_expression, fade=False)
+    window.last_composed_body_position = None
+    window._compose_character_position()
+    _stop_all_timers(window)
+    assert window.character_scale_percent == scale_percent
+    assert _sample(window).y == window.character_base_y
+
+
+def _begin_general_speech(
+    window: CompanionWindow,
+    final_state: str,
+) -> None:
+    window._begin_speech_presentation(
+        QueuedSpeech("一般語音完成流程", "speaking")
+    )
+    window.after_speech_state = final_state
+    window.after_speech_intensity = 0.8
+    window._start_mouth_animation(audio_driven=True)
+
+
+def _begin_realtime_speech(
+    window: CompanionWindow,
+    final_state: str,
+) -> None:
+    window._realtime_speaking(True)
+    window.realtime_after_speech_state = final_state
+    window.realtime_after_speech_intensity = 0.8
+
+
+def _drive_strong_visemes(window: CompanionWindow) -> None:
+    for _ in range(8):
+        window._audio_viseme_cue(0.95, "A")
+        _sample(window)
+    assert window.state == "speaking"
+    assert window.audio_driven_mouth
+    assert window.speech_motion_y < -2.0
+    assert window.current_expression != window.speech_closed_expression
+
+
+def _completion_is_active(window: CompanionWindow, path: str) -> bool:
+    if path == "general":
+        return window.speech_playing
+    return window.state == "speaking" and window.audio_driven_mouth
+
+
+def _begin_completion(window: CompanionWindow, path: str) -> None:
+    if path == "general":
+        window._speech_audio_finished()
+    else:
+        window._realtime_speaking(False)
+
+
+def _advance_completion(window: CompanionWindow, path: str) -> None:
+    if path == "general":
+        window._complete_speech_audio_finished()
+    else:
+        window._complete_realtime_speaking_stop()
+
+
+def _motion_steps(samples: list[MotionSample]) -> list[int]:
+    return [
+        current.y - previous.y
+        for previous, current in pairwise(samples)
+    ]
+
+
+def _assert_smooth_upward_release(
+    samples: list[MotionSample],
+    context: str,
+) -> None:
+    assert all(sample.x == samples[0].x for sample in samples), (
+        f"{context}: speech completion introduced horizontal movement"
+    )
+    steps = _motion_steps(samples)
+    assert all(step >= 0 for step in steps), (
+        f"{context}: motion reversed during release; trace={samples!r}"
+    )
+    assert max(steps, default=0) <= MAX_FRAME_DELTA_PIXELS, (
+        f"{context}: release snapped by more than "
+        f"{MAX_FRAME_DELTA_PIXELS}px; trace={samples!r}"
+    )
+
+
+def _settle_ambient_motion(
+    window: CompanionWindow,
+    context: str,
+) -> tuple[MotionSample, ...]:
+    samples = [_sample(window)]
+    window.ambient_motion_target_x = 0.0
+    window.ambient_motion_target_y = 0.0
+    for _ in range(MAX_AMBIENT_SETTLE_TICKS):
+        if (
+            window.ambient_motion_x == 0.0
+            and window.ambient_motion_y == 0.0
+        ):
+            break
+        window._motion_tick()
+        samples.append(_sample(window))
+    _assert_smooth_upward_release(samples, f"{context}/ambient")
+    assert samples[-1].y == window.character_base_y, (
+        f"{context}: ambient ownership did not settle at the base line; "
+        f"trace={samples!r}; ambient={window.ambient_motion_y}"
+    )
+    settled = _sample(window)
+    window._motion_tick()
+    assert _sample(window) == settled, (
+        f"{context}: body moved again after ambient motion had settled"
+    )
+    return tuple(samples)
+
+
+def _assert_release_trace(
+    window: CompanionWindow,
+    path: str,
+    final_state: str,
+    context: str,
+) -> tuple[MotionSample, ...]:
+    samples = [_sample(window)]
+    assert samples[0].y < window.character_base_y
+    _begin_completion(window, path)
+    samples.append(_sample(window))
+    assert window.head_motion_y == 0.0
+    assert window.speech_motion_target_y == 0.0
+    assert _completion_is_active(window, path)
+    assert window.state == "speaking"
+
+    for _ in range(MAX_RELEASE_TICKS):
+        if not _completion_is_active(window, path):
+            break
+        window._motion_tick()
+        samples.append(_sample(window))
+        position_before_handoff = samples[-1]
+        _advance_completion(window, path)
+        samples.append(_sample(window))
+        if not _completion_is_active(window, path):
+            assert samples[-1] == position_before_handoff, (
+                f"{context}: state hand-off changed the composed coordinate"
+            )
+        if _completion_is_active(window, path):
+            assert window.state == "speaking", (
+                "state hand-off occurred before speech motion was centred"
+            )
+
+    assert not _completion_is_active(window, path)
+    assert window.state == final_state
+    assert window.speech_motion_y == 0.0
+    assert window.speech_motion_target_y == 0.0
+    assert not window.speech_finish_timer.isActive()
+    assert not window.realtime_finish_timer.isActive()
+    assert not window.mouth_timer.isActive()
+    assert not window.mouth_visual_timer.isActive()
+    assert not window.audio_driven_mouth
+    _assert_smooth_upward_release(samples, f"{context}/speech")
+
+    completed = _sample(window)
+    _begin_completion(window, path)
+    assert _sample(window) == completed, (
+        "a duplicate completion signal changed the body coordinate"
+    )
+    _settle_ambient_motion(window, context)
+    return tuple(samples)
+
+
+def _run_completion_matrix(window: CompanionWindow) -> None:
+    scenarios = product(
+        COMPLETION_PATHS,
+        SCALE_PERCENTAGES,
+        POSES,
+        FINAL_KINDS,
+    )
+    for path, scale_percent, pose, final_kind in scenarios:
+        _reset_scenario(window, scale_percent, pose)
+        final_state = (
+            "idle" if final_kind == "idle" else EMOTIONS[pose]
+        )
+        if path == "general":
+            _begin_general_speech(window, final_state)
+        else:
+            _begin_realtime_speech(window, final_state)
+        assert window.speech_pose_suffix == POSE_SUFFIXES[pose]
+        _drive_strong_visemes(window)
+        _assert_release_trace(
+            window,
+            path,
+            final_state,
+            f"{path}/{scale_percent}/{pose}/{final_kind}",
+        )
+
+
+def _run_queued_speech_matrix(window: CompanionWindow) -> None:
+    for scale_percent, pose in product(SCALE_PERCENTAGES, POSES):
+        _reset_scenario(window, scale_percent, pose)
+        _begin_general_speech(window, "idle")
+        _drive_strong_visemes(window)
+        window.speech_queue.append(
+            QueuedSpeech("排隊中的下一句", "speaking")
+        )
+        _assert_release_trace(
+            window,
+            "general",
+            "idle",
+            f"queued-first/{scale_percent}/{pose}",
+        )
+        assert len(window.speech_queue) == 1
+
+        handoff_position = _sample(window)
+        window._start_next_speech()
+        assert window.speech_playing
+        assert window.active_speech_text == "排隊中的下一句"
+        assert not window.speech_queue
+        assert _sample(window) == handoff_position
+        assert window.speech_motion_y == 0.0
+        window.mouth_timer.stop()
+        window.audio_driven_mouth = True
+        _drive_strong_visemes(window)
+        _assert_release_trace(
+            window,
+            "general",
+            "idle",
+            f"queued-second/{scale_percent}/{pose}",
+        )
+
+
+def run() -> None:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        app, window = _create_window(temp_dir)
+        try:
+            with patch.object(
+                window,
+                "_start_speech_provider",
+                side_effect=AssertionError(
+                    "provider matrix must remain fully offline"
+                ),
+            ):
+                _run_completion_matrix(window)
+                _run_queued_speech_matrix(window)
+        finally:
+            window.speech_queue.clear()
+            window.speech_playing = False
+            window.close()
+            app.processEvents()
+    print("POST_SPEECH_MOTION_PROVIDER_MATRIX_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_profile_transfer.py
+++ b/tests/test_profile_transfer.py
@@ -8,6 +8,7 @@ lazy import zipfile
 lazy from dataclasses import dataclass
 lazy from pathlib import Path
 lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -18,6 +19,13 @@ lazy from profile_transfer import (
     ProfileManifest,
     ProfileTransferError,
 )
+lazy from profile_transfer_ui import localized_profile_failure
+lazy from safe_error_localization import safe_error_message
+
+_BAIT_PATH = r"C:\Users\private-owner\Documents\mohan-private.db"
+_BAIT_TOKEN = "sk-fake-profile-transfer-token"
+_BAIT_DETAIL = f"{_BAIT_PATH}; token={_BAIT_TOKEN}"
+_LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
 
 
 def seed_profile(db: StudioDB, prefix: str) -> None:
@@ -234,7 +242,10 @@ def _assert_atomic_rollback(fixture: TransferFixture) -> None:
     try:
         fixture.target_manager.import_profile(second_bundle)
     except ProfileTransferError as exc:
-        assert "forced rollback" in str(exc)
+        assert "forced rollback" not in str(exc)
+        assert exc.safe_error is not None
+        assert exc.__cause__ is None
+        assert exc.__context__ is None
     else:
         raise AssertionError("forced import failure must be reported")
     assert second_manifest.snapshot_id != previous_snapshot
@@ -246,6 +257,91 @@ def _assert_atomic_rollback(fixture: TransferFixture) -> None:
         "SELECT content FROM chat_log"
     ).fetchone()[0] == previous_chat
     fixture.target_db.conn.execute("DROP TRIGGER reject_portable_todo_delete")
+    fixture.target_db.conn.commit()
+
+
+def _assert_external_failure_is_safe(error: ProfileTransferError) -> None:
+    assert error.safe_error is not None
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    surfaces = [str(error)]
+    surfaces.extend(
+        safe_error_message(language, error.safe_error)
+        for language in _LANGUAGES
+    )
+    for surface in surfaces:
+        assert _BAIT_PATH not in surface
+        assert _BAIT_TOKEN not in surface
+        assert _BAIT_DETAIL not in surface
+    assert all(surface.strip() for surface in surfaces)
+
+
+def _assert_four_language_ui_discards_private_detail() -> None:
+    error = OSError(_BAIT_DETAIL)
+    messages = tuple(
+        localized_profile_failure(language, error)
+        for language in _LANGUAGES
+    )
+    assert len(set(messages)) == len(_LANGUAGES)
+    for message in messages:
+        assert _BAIT_PATH not in message
+        assert _BAIT_TOKEN not in message
+        assert _BAIT_DETAIL not in message
+        assert "diagnostic=local_io_failure" in message
+
+
+def _assert_export_error_discards_private_detail(
+    fixture: TransferFixture,
+) -> None:
+    with patch.object(
+        fixture.source_manager,
+        "_write_archive",
+        side_effect=OSError(_BAIT_DETAIL),
+    ):
+        try:
+            fixture.source_manager.export_profile(
+                fixture.root / "private-export"
+            )
+        except ProfileTransferError as exc:
+            _assert_external_failure_is_safe(exc)
+        else:
+            raise AssertionError("mocked export failure must be reported")
+
+
+def _assert_inspection_error_discards_private_detail(
+    fixture: TransferFixture,
+) -> None:
+    private_source = fixture.root / f"{_BAIT_TOKEN}.mohan-profile"
+    private_source.write_text(_BAIT_DETAIL, encoding="utf-8")
+    try:
+        fixture.target_manager.inspect_profile(private_source)
+    except ProfileTransferError as exc:
+        _assert_external_failure_is_safe(exc)
+    else:
+        raise AssertionError("invalid profile must be rejected")
+
+
+def _assert_sqlite_error_discards_private_detail(
+    fixture: TransferFixture,
+) -> None:
+    fixture.source_db.set_setting("assistant_name", "安全邊界測試")
+    bundle, _manifest = fixture.source_manager.export_profile(
+        fixture.root / "安全邊界測試"
+    )
+    trigger = _BAIT_DETAIL.replace("'", "''")
+    fixture.target_db.conn.execute(
+        "CREATE TRIGGER reject_private_profile_delete "
+        "BEFORE DELETE ON todos BEGIN "
+        f"SELECT RAISE(ABORT,'{trigger}'); END"
+    )
+    fixture.target_db.conn.commit()
+    try:
+        fixture.target_manager.import_profile(bundle)
+    except ProfileTransferError as exc:
+        _assert_external_failure_is_safe(exc)
+    else:
+        raise AssertionError("mocked SQLite failure must be reported")
+    fixture.target_db.conn.execute("DROP TRIGGER reject_private_profile_delete")
     fixture.target_db.conn.commit()
 
 
@@ -270,6 +366,10 @@ def run() -> None:
             _assert_duplicate_snapshot_rejected(fixture)
             _assert_atomic_rollback(fixture)
             _assert_unsafe_archive_rejected(fixture)
+            _assert_export_error_discards_private_detail(fixture)
+            _assert_inspection_error_discards_private_detail(fixture)
+            _assert_sqlite_error_discards_private_detail(fixture)
+            _assert_four_language_ui_discards_private_detail()
         finally:
             fixture.source_db.close()
             fixture.target_db.close()

--- a/tests/test_profile_transfer.py
+++ b/tests/test_profile_transfer.py
@@ -22,8 +22,8 @@ lazy from profile_transfer import (
 lazy from profile_transfer_ui import localized_profile_failure
 lazy from safe_error_localization import safe_error_message
 
-_BAIT_PATH = r"C:\Users\private-owner\Documents\mohan-private.db"
-_BAIT_TOKEN = "sk-fake-profile-transfer-token"
+_BAIT_PATH = r"Z:\private-fixture\owner\mohan-private.db"
+_BAIT_TOKEN = "fixture-profile-private-token"
 _BAIT_DETAIL = f"{_BAIT_PATH}; token={_BAIT_TOKEN}"
 _LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
 

--- a/tests/test_python315_runtime.py
+++ b/tests/test_python315_runtime.py
@@ -5,6 +5,7 @@ lazy import re
 lazy import subprocess
 lazy import sys
 lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -25,6 +26,7 @@ lazy from time_utils import (
     local_wall_time,
     local_wall_time_from_timestamp,
 )
+lazy from tools.migrate_python315_imports import python_files
 
 
 def assert_immutable_mapping(value: object) -> None:
@@ -63,6 +65,15 @@ def main() -> None:
     missing = sentinel("MISSING")
     assert repr(missing) == "MISSING"
     assert missing is not sentinel("MISSING")
+
+    with TemporaryDirectory() as temp_dir:
+        inventory_root = Path(temp_dir)
+        project_source = inventory_root / "project_source.py"
+        project_source.write_text("lazy import json\n", encoding="utf-8")
+        cpython_source = inventory_root / "_python315" / "Lib"
+        cpython_source.mkdir(parents=True)
+        (cpython_source / "test_fixture.py").write_bytes(b"# \xe9\n")
+        assert python_files(inventory_root) == [project_source]
 
     for mapping in (
         DEFAULT_PROFILE,

--- a/tests/test_realtime_localization.py
+++ b/tests/test_realtime_localization.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+lazy import json
+lazy import sys
+lazy from pathlib import Path
+lazy from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy import realtime_voice
+lazy from realtime_voice import (
+    _REALTIME_MESSAGES,
+    MAX_ASSISTANT_RESPONSE_CHARACTERS,
+    RealtimeSessionConfig,
+    RealtimeVoiceClient,
+    RealtimeVoiceRequest,
+    _realtime_message,
+)
+
+EXPECTED_MESSAGES = frozendict({
+    "zh-TW": frozendict({
+        "connecting": "正在連線…",
+        "disconnected": "未連線",
+        "listening": "已連線，妾在聽",
+        "missing_key": "請先儲存 OpenAI API 金鑰",
+        "response_too_long": (
+            "Realtime 回應超過 32,768 字元安全上限，已停止本輪回應。"
+        ),
+        "invalid_key": (
+            "目前儲存的 OpenAI API 金鑰無效或已撤銷。"
+            "請到「設定」頁重新貼上同一 Project 新建立的 API Key。"
+        ),
+        "quota": (
+            "OpenAI API 額度不足或專案預算已達上限。請檢查該 Project 的 "
+            "Billing、Budget 與 Realtime 模型用量限制。"
+        ),
+        "audio_failed": "音訊裝置無法啟動：backend offline",
+        "microphone_prefix": "Windows 無法開啟麥克風。",
+    }),
+    "zh-CN": frozendict({
+        "connecting": "正在连接…",
+        "disconnected": "未连接",
+        "listening": "已连接，妾在听",
+        "missing_key": "请先保存 OpenAI API 密钥",
+        "response_too_long": (
+            "Realtime 回复超过 32,768 字符安全上限，已停止本轮回复。"
+        ),
+        "invalid_key": (
+            "当前保存的 OpenAI API 密钥无效或已撤销。"
+            "请到“设置”页重新粘贴同一 Project 新建立的 API Key。"
+        ),
+        "quota": (
+            "OpenAI API 额度不足或项目预算已达上限。请检查该 Project 的 "
+            "Billing、Budget 与 Realtime 模型用量限制。"
+        ),
+        "audio_failed": "音频设备无法启动：backend offline",
+        "microphone_prefix": "Windows 无法打开麦克风。",
+    }),
+    "en": frozendict({
+        "connecting": "Connecting…",
+        "disconnected": "Disconnected",
+        "listening": "Connected and listening",
+        "missing_key": "Save an OpenAI API key first",
+        "response_too_long": (
+            "The Realtime response exceeded the 32,768-character safety limit; "
+            "this response was stopped."
+        ),
+        "invalid_key": (
+            "The saved OpenAI API key is invalid or revoked. Save a new key from "
+            "the same Project in Settings."
+        ),
+        "quota": (
+            "The OpenAI API quota is insufficient or the project budget limit "
+            "was reached. Check Billing, Budget, and Realtime model usage limits."
+        ),
+        "audio_failed": "The audio device could not start: backend offline",
+        "microphone_prefix": "Windows could not open the microphone.",
+    }),
+    "ja-JP": frozendict({
+        "connecting": "接続中…",
+        "disconnected": "未接続",
+        "listening": "接続済み、聞いています",
+        "missing_key": "先に OpenAI API キーを保存してください",
+        "response_too_long": (
+            "Realtime の応答が 32,768 文字の安全上限を超えたため、"
+            "この応答を停止しました。"
+        ),
+        "invalid_key": (
+            "保存された OpenAI API キーは無効か、取り消されています。"
+            "同じ Project で新しいキーを作成し、設定で保存し直してください。"
+        ),
+        "quota": (
+            "OpenAI API の利用枠が不足しているか、プロジェクトの予算上限に"
+            "達しました。Billing、Budget、Realtime モデルの利用上限を確認してください。"
+        ),
+        "audio_failed": "音声デバイスを開始できませんでした：backend offline",
+        "microphone_prefix": "Windows でマイクを開けませんでした。",
+    }),
+})
+
+
+class _IdleThread:
+    def __init__(self, **_options: object) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+class _WebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.close_calls = 0
+
+    def send(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _request(locale: str, api_key: str = "test-key") -> RealtimeVoiceRequest:
+    return RealtimeVoiceRequest(
+        api_key=api_key,
+        instructions="test",
+        memory_context="",
+        session=RealtimeSessionConfig(locale=locale),
+    )
+
+
+def assert_catalogs_are_complete_and_exact() -> None:
+    expected_keys = set(_REALTIME_MESSAGES["zh-TW"])
+    assert set(_REALTIME_MESSAGES) == set(EXPECTED_MESSAGES)
+    for locale, expected in EXPECTED_MESSAGES.items():
+        assert set(_REALTIME_MESSAGES[locale]) == expected_keys
+        for key in (
+            "connecting",
+            "disconnected",
+            "listening",
+            "missing_key",
+            "response_too_long",
+        ):
+            assert _realtime_message(locale, key) == expected[key]
+
+
+def assert_runtime_status_signals_are_localized() -> None:
+    for locale, expected in EXPECTED_MESSAGES.items():
+        client = RealtimeVoiceClient()
+        statuses: list[str] = []
+        client.status_changed.connect(statuses.append)
+        websocket = _WebSocket()
+
+        with (
+            patch.object(
+                RealtimeVoiceClient,
+                "dependencies_available",
+                return_value=True,
+            ),
+            patch.object(realtime_voice.threading, "Thread", _IdleThread),
+        ):
+            client.start(_request(locale))
+
+        assert statuses == [expected["connecting"]]
+        with patch.object(client, "_open_audio"):
+            client._open_realtime_session(websocket, _request(locale))
+        assert statuses[-1] == expected["listening"]
+        client.stop()
+        assert statuses[-1] == expected["disconnected"]
+        assert websocket.close_calls == 1
+
+
+def assert_missing_key_signal_is_localized() -> None:
+    for locale, expected in EXPECTED_MESSAGES.items():
+        client = RealtimeVoiceClient()
+        failures: list[str] = []
+        client.failed.connect(failures.append)
+        client.start(_request(locale, api_key="  "))
+        assert failures == [expected["missing_key"]]
+        assert not client.running
+
+
+def assert_oversize_failure_is_localized() -> None:
+    oversized = "文" * (MAX_ASSISTANT_RESPONSE_CHARACTERS + 1)
+    traditional = EXPECTED_MESSAGES["zh-TW"]["response_too_long"]
+    for locale, expected in EXPECTED_MESSAGES.items():
+        client = RealtimeVoiceClient()
+        client._reset_session_state(
+            RealtimeVoiceClient._normalized_request(_request(locale))
+        )
+        client.native_audio_output = False
+        failures: list[str] = []
+        client.failed.connect(failures.append)
+        client._handle_assistant_text_delta(
+            {"response_id": "response-1", "delta": oversized}
+        )
+        assert failures == [expected["response_too_long"]]
+        if locale != "zh-TW":
+            assert failures[0] != traditional
+
+
+def assert_security_errors_are_localized() -> None:
+    traditional_invalid = EXPECTED_MESSAGES["zh-TW"]["invalid_key"]
+    traditional_quota = EXPECTED_MESSAGES["zh-TW"]["quota"]
+    for locale, expected in EXPECTED_MESSAGES.items():
+        invalid = RealtimeVoiceClient._friendly_error(
+            "HTTP 401 invalid_api_key",
+            "gpt-realtime-2.1-mini",
+            locale,
+        )
+        quota = RealtimeVoiceClient._friendly_error(
+            "insufficient_quota",
+            "gpt-realtime-2.1-mini",
+            locale,
+        )
+        assert invalid == expected["invalid_key"]
+        assert quota == expected["quota"]
+        if locale != "zh-TW":
+            assert invalid != traditional_invalid
+            assert quota != traditional_quota
+
+
+def assert_audio_errors_are_localized() -> None:
+    traditional_audio = EXPECTED_MESSAGES["zh-TW"]["audio_failed"]
+    for locale, expected in EXPECTED_MESSAGES.items():
+        generic = RealtimeVoiceClient._audio_error_message(
+            RuntimeError("backend offline"),
+            locale,
+        )
+        microphone = RealtimeVoiceClient._audio_error_message(
+            RuntimeError("RawInputStream invalid device"),
+            locale,
+        )
+        assert generic == expected["audio_failed"]
+        assert microphone.startswith(expected["microphone_prefix"])
+        assert "RawInputStream invalid device" in microphone
+        if locale != "zh-TW":
+            assert generic != traditional_audio
+
+
+def assert_unknown_locale_falls_back_safely() -> None:
+    traditional = EXPECTED_MESSAGES["zh-TW"]
+    assert _realtime_message("fr-FR", "connecting") == traditional["connecting"]
+    assert RealtimeVoiceClient._friendly_error(
+        "invalid_api_key",
+        "gpt-realtime-2.1-mini",
+        "fr-FR",
+    ) == traditional["invalid_key"]
+    assert RealtimeVoiceClient._audio_error_message(
+        RuntimeError("backend offline"),
+        "fr-FR",
+    ) == traditional["audio_failed"]
+
+
+def run() -> None:
+    assert_catalogs_are_complete_and_exact()
+    assert_runtime_status_signals_are_localized()
+    assert_missing_key_signal_is_localized()
+    assert_oversize_failure_is_localized()
+    assert_security_errors_are_localized()
+    assert_audio_errors_are_localized()
+    assert_unknown_locale_falls_back_safely()
+    print("REALTIME_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_realtime_localization.py
+++ b/tests/test_realtime_localization.py
@@ -230,9 +230,10 @@ def assert_audio_errors_are_localized() -> None:
             RuntimeError("RawInputStream invalid device"),
             locale,
         )
-        assert generic == expected["audio_failed"]
+        assert generic.startswith(expected["audio_failed"].split("backend offline")[0])
+        assert "backend offline" not in generic
         assert microphone.startswith(expected["microphone_prefix"])
-        assert "RawInputStream invalid device" in microphone
+        assert "RawInputStream invalid device" not in microphone
         if locale != "zh-TW":
             assert generic != traditional_audio
 
@@ -245,10 +246,14 @@ def assert_unknown_locale_falls_back_safely() -> None:
         "gpt-realtime-2.1-mini",
         "fr-FR",
     ) == traditional["invalid_key"]
-    assert RealtimeVoiceClient._audio_error_message(
+    unknown_audio = RealtimeVoiceClient._audio_error_message(
         RuntimeError("backend offline"),
         "fr-FR",
-    ) == traditional["audio_failed"]
+    )
+    assert unknown_audio.startswith(
+        traditional["audio_failed"].split("backend offline")[0]
+    )
+    assert "backend offline" not in unknown_audio
 
 
 def run() -> None:

--- a/tests/test_realtime_speech_output.py
+++ b/tests/test_realtime_speech_output.py
@@ -1,0 +1,845 @@
+from __future__ import annotations
+
+lazy import base64
+lazy import sys
+lazy from collections.abc import Callable
+lazy from dataclasses import fields
+lazy from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from azure_speech import AzureSpeechTTS, _PushAudioReader
+lazy from realtime_speech_output import (
+    REALTIME_OUTPUT_AZURE,
+    REALTIME_OUTPUT_AZURE_HD,
+    REALTIME_OUTPUT_OPENAI,
+    AzureRealtimeVoice,
+    LocalRealtimeVoice,
+    RealtimeSpeechOutput,
+    RealtimeSpeechOutputConfig,
+    RealtimeTextSegmenter,
+)
+lazy from realtime_voice import RealtimeSessionConfig, RealtimeVoiceClient
+
+
+class FakeSignal:
+    def __init__(self) -> None:
+        self._callbacks: list[Callable[..., None]] = []
+
+    def connect(self, callback: Callable[..., None]) -> None:
+        self._callbacks.append(callback)
+
+    def emit(self, *args: object) -> None:
+        for callback in tuple(self._callbacks):
+            callback(*args)
+
+
+class FakeSpeechEngine:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.finished = FakeSignal()
+        self.failed = FakeSignal()
+        self.viseme_cue = FakeSignal()
+        self.synthesis_latency_measured = FakeSignal()
+        self.speak_calls: list[tuple[str, str, str, str]] = []
+        self.locales: list[str] = []
+        self.stop_calls = 0
+        self.volume_calls: list[tuple[int, bool]] = []
+
+    def speak(
+        self,
+        text: str,
+        api_key: str,
+        region: str,
+        voice: str,
+        locale: str = "",
+    ) -> None:
+        self.speak_calls.append((text, api_key, region, voice))
+        self.locales.append(locale)
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def set_volume(self, volume_percent: int, muted: bool = False) -> None:
+        self.volume_calls.append((volume_percent, muted))
+
+
+class FakeOperationSpeechEngine(FakeSpeechEngine):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.operation_started = FakeSignal()
+        self.operation_finished = FakeSignal()
+        self.operation_failed = FakeSignal()
+        self.operation_viseme_cue = FakeSignal()
+        self.operation_synthesis_latency_measured = FakeSignal()
+        self.operation_ids: list[int] = []
+
+    def speak(
+        self,
+        text: str,
+        api_key: str,
+        region: str,
+        voice: str,
+        locale: str = "",
+    ) -> int:
+        self.speak_calls.append((text, api_key, region, voice))
+        self.locales.append(locale)
+        operation_id = len(self.operation_ids) + 1
+        self.operation_ids.append(operation_id)
+        self.operation_started.emit(operation_id)
+        return operation_id
+
+
+class FakeLocalSpeechEngine:
+    def __init__(self) -> None:
+        self.finished = FakeSignal()
+        self.failed = FakeSignal()
+        self.viseme_cue = FakeSignal()
+        self.speak_calls: list[tuple[str, str, int]] = []
+        self.stop_calls = 0
+        self.volume_calls: list[tuple[int, bool]] = []
+
+    def speak(self, text: str, voice_name: str = "", rate: int = -1) -> None:
+        self.speak_calls.append((text, voice_name, rate))
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def set_volume(self, volume_percent: int, muted: bool = False) -> None:
+        self.volume_calls.append((volume_percent, muted))
+
+
+class FakeSynthesizer:
+    def __init__(self) -> None:
+        self.stop_calls = 0
+
+    def stop_speaking_async(self) -> None:
+        self.stop_calls += 1
+
+
+def _voice(prefix: str) -> AzureRealtimeVoice:
+    return AzureRealtimeVoice(
+        api_key=f"{prefix}-test-key",
+        region=f"{prefix}-region",
+        voice=f"{prefix}-female-voice",
+    )
+
+
+def _hybrid_config(
+    mode: str,
+    *,
+    local_available: bool = False,
+) -> RealtimeSpeechOutputConfig:
+    return RealtimeSpeechOutputConfig(
+        mode=mode,
+        azure=_voice("standard"),
+        azure_hd=_voice("hd"),
+        local=LocalRealtimeVoice(
+            available=local_available,
+            voice="local-female-voice",
+            rate=-1,
+        ),
+    )
+
+
+def _create_output() -> tuple[
+    RealtimeSpeechOutput,
+    FakeSpeechEngine,
+    FakeSpeechEngine,
+    FakeLocalSpeechEngine,
+]:
+    standard = FakeSpeechEngine("standard")
+    hd = FakeSpeechEngine("hd")
+    local = FakeLocalSpeechEngine()
+    return RealtimeSpeechOutput(standard, hd, local), standard, hd, local
+
+
+def _create_operation_output() -> tuple[
+    RealtimeSpeechOutput,
+    FakeOperationSpeechEngine,
+    FakeOperationSpeechEngine,
+    FakeLocalSpeechEngine,
+]:
+    standard = FakeOperationSpeechEngine("standard")
+    hd = FakeOperationSpeechEngine("hd")
+    local = FakeLocalSpeechEngine()
+    return RealtimeSpeechOutput(standard, hd, local), standard, hd, local
+
+
+def _assert_session_output_modes_are_exclusive() -> None:
+    native = RealtimeVoiceClient._session_update_event(
+        RealtimeSessionConfig(
+            voice="marin",
+            output_mode=REALTIME_OUTPUT_OPENAI,
+        ),
+        "test",
+    )["session"]
+    assert native["output_modalities"] == ["audio"]
+    assert native["audio"]["output"] == {
+        "format": {"type": "audio/pcm", "rate": 24000},
+        "voice": "marin",
+    }
+
+    for mode in (REALTIME_OUTPUT_AZURE, REALTIME_OUTPUT_AZURE_HD):
+        hybrid = RealtimeVoiceClient._session_update_event(
+            RealtimeSessionConfig(output_mode=mode),
+            "test",
+        )["session"]
+        assert hybrid["output_modalities"] == ["text"]
+        assert "output" not in hybrid["audio"]
+
+
+def _assert_streamed_text_is_segmented_in_order() -> None:
+    segmenter = RealtimeTextSegmenter()
+    assert segmenter.feed("主上，妾已經完整收到您的所有訊息，") == (
+        "主上，妾已經完整收到您的所有訊息，",
+    )
+    assert segmenter.feed("現在開始處理。接著") == ("現在開始處理。",)
+    assert segmenter.feed("會依照順序完成！尾聲") == ("接著會依照順序完成！",)
+    assert segmenter.finish() == ("尾聲",)
+    assert segmenter.finish() == ()
+
+    long_text = "one two three four five six seven eight nine ten eleven"
+    chunks = (*segmenter.feed(long_text), *segmenter.finish())
+    assert "".join(chunks).replace(" ", "") == long_text.replace(" ", "")
+    assert all(len(chunk) <= RealtimeTextSegmenter.MAXIMUM for chunk in chunks)
+
+
+def _assert_secret_repr_is_redacted() -> None:
+    secret = "must-not-appear"
+    voice = AzureRealtimeVoice(secret, "eastasia", "zh-TW-TestNeural")
+    config = RealtimeSpeechOutputConfig(azure=voice)
+
+    assert secret not in repr(voice)
+    assert secret not in repr(config)
+    assert fields(AzureRealtimeVoice)[0].repr is False
+
+
+def _assert_ui_locale_reaches_cross_language_azure_voice() -> None:
+    output, standard, _hd, _local = _create_output()
+    config = _hybrid_config(REALTIME_OUTPUT_AZURE)
+    output.configure(
+        RealtimeSpeechOutputConfig(
+            mode=config.mode,
+            locale="zh-TW",
+            azure=AzureRealtimeVoice(
+                config.azure.api_key,
+                config.azure.region,
+                "zh-CN-XiaoxiaoNeural",
+            ),
+            azure_hd=config.azure_hd,
+            local=config.local,
+        )
+    )
+    output.begin_response(1)
+    output.add_text(1, "跨語系錯誤仍須使用繁體中文。")
+    output.finish_response(1)
+
+    assert standard.locales == ["zh-TW"]
+
+
+def _assert_4096_token_text_remains_bounded() -> None:
+    output, standard, hd, local = _create_operation_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    generation = 1
+    output.begin_response(generation)
+    token_count = 4_096
+    source = "token " * token_count
+    output.add_text(generation, source)
+    output.finish_response(generation)
+
+    assert output._queue.maxlen == 1_024
+    assert len(output._queue) < output._queue.maxlen
+    while output._active_operation_id is not None:
+        standard.operation_finished.emit(output._active_operation_id)
+
+    spoken = "".join(call[0] for call in standard.speak_calls)
+    assert spoken.replace(" ", "") == source.replace(" ", "")
+    assert len(standard.speak_calls) <= 1_024
+    assert hd.speak_calls == []
+    assert local.speak_calls == []
+
+
+def _assert_oversized_response_stays_rejected_until_next_response() -> None:
+    output, standard, hd, local = _create_operation_output()
+    failures: list[str] = []
+    output.failed.connect(failures.append)
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(1)
+    output.add_text(1, "甲" * 32_769)
+
+    assert failures == ["Realtime 回應過長，已安全停止本輪語音。"]
+    assert standard.stop_calls == 0
+    assert standard.speak_calls == []
+
+    output.add_text(1, "這個遲到片段不得重新開啟同一輪。")
+    output.finish_response(1)
+    assert standard.speak_calls == []
+    assert hd.speak_calls == []
+    assert local.speak_calls == []
+
+    output.begin_response(2)
+    output.add_text(2, "下一輪可以安全發聲。")
+    output.finish_response(2)
+    assert [call[0] for call in standard.speak_calls] == ["下一輪可以安全發聲。"]
+
+
+def _assert_segments_wait_for_the_active_engine() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(1)
+    output.add_text(1, "第一句。第二句。")
+    output.finish_response(1)
+
+    assert standard.speak_calls == [
+        (
+            "第一句。",
+            "standard-test-key",
+            "standard-region",
+            "standard-female-voice",
+        )
+    ]
+    assert hd.speak_calls == []
+    assert local.speak_calls == []
+
+    standard.synthesis_latency_measured.emit(120.0)
+    standard.finished.emit()
+    assert [call[0] for call in standard.speak_calls] == ["第一句。", "第二句。"]
+    assert hd.speak_calls == []
+
+    standard.finished.emit()
+    assert [call[0] for call in standard.speak_calls] == ["第一句。", "第二句。"]
+
+
+def _assert_interruption_stops_and_discards_pending_speech() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(1)
+    output.add_text(1, "正在播放。這句不得在插話後播放。")
+    assert len(standard.speak_calls) == 1
+
+    output.cancel(2)
+    assert standard.stop_calls == 1
+    assert hd.stop_calls == 0
+    assert local.stop_calls == 0
+
+    standard.finished.emit()
+    assert len(standard.speak_calls) == 1
+
+
+def _assert_newer_cancel_barrier_blocks_queued_generation() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(3)
+    output.add_text(3, "舊世代已開始。")
+    assert [call[0] for call in standard.speak_calls] == ["舊世代已開始。"]
+
+    output.cancel(4)
+    output.add_text(3, "遲到的舊文字不得重新發聲。")
+    output.finish_response(3)
+    standard.finished.emit()
+
+    assert [call[0] for call in standard.speak_calls] == ["舊世代已開始。"]
+    assert standard.stop_calls == 1
+    assert hd.speak_calls == []
+    assert local.speak_calls == []
+
+    output.begin_response(5)
+    output.add_text(5, "新世代可以安全發聲。")
+    output.finish_response(5)
+
+    assert [call[0] for call in standard.speak_calls] == [
+        "舊世代已開始。",
+        "新世代可以安全發聲。",
+    ]
+
+
+def _assert_stale_same_engine_callbacks_cannot_close_new_operation() -> None:
+    output, standard, _hd, _local = _create_operation_output()
+    failures: list[str] = []
+    visemes: list[tuple[float, str]] = []
+    output.failed.connect(failures.append)
+    output.viseme_cue.connect(lambda level, vowel: visemes.append((level, vowel)))
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(1)
+    output.add_text(1, "舊的一輪。")
+    old_operation = standard.operation_ids[-1]
+
+    output.begin_response(2)
+    output.add_text(2, "新的語音仍應繼續。下一段也必須保留。")
+    output.finish_response(2)
+    new_operation = standard.operation_ids[-1]
+    assert new_operation != old_operation
+
+    standard.operation_synthesis_latency_measured.emit(old_operation, 1.0)
+    standard.operation_viseme_cue.emit(old_operation, 0.9, "A")
+    standard.operation_finished.emit(old_operation)
+    standard.operation_failed.emit(old_operation, "stale failure")
+
+    assert len(standard.speak_calls) == 2
+    assert visemes == []
+    assert failures == []
+    assert output._active_operation_id == new_operation
+
+    standard.operation_synthesis_latency_measured.emit(new_operation, 2.0)
+    standard.operation_viseme_cue.emit(new_operation, 0.5, "I")
+    standard.operation_finished.emit(new_operation)
+
+    assert visemes == [(0.5, "I")]
+    assert len(standard.speak_calls) == 3
+
+
+def _assert_stale_failure_does_not_trigger_fallback() -> None:
+    output, standard, hd, local = _create_operation_output()
+    output.configure(
+        _hybrid_config(
+            REALTIME_OUTPUT_AZURE_HD,
+            local_available=True,
+        )
+    )
+    output.begin_response(1)
+    output.add_text(1, "舊的 Dragon HD。")
+    old_operation = hd.operation_ids[-1]
+
+    output.begin_response(2)
+    output.add_text(2, "新的 Dragon HD。")
+    new_operation = hd.operation_ids[-1]
+    hd.operation_failed.emit(old_operation, "stale failure")
+
+    assert new_operation != old_operation
+    assert len(hd.speak_calls) == 2
+    assert standard.speak_calls == []
+    assert local.speak_calls == []
+    assert output._active_operation_id == new_operation
+
+    hd.operation_failed.emit(new_operation, "current failure")
+    assert [call[0] for call in standard.speak_calls] == ["新的 Dragon HD。"]
+
+
+def _assert_hd_falls_back_to_standard_once() -> None:
+    output, standard, hd, local = _create_output()
+    failures: list[str] = []
+    output.failed.connect(failures.append)
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE_HD))
+    output.begin_response(1)
+    output.add_text(1, "同一段只能各嘗試一次。")
+
+    assert [call[0] for call in hd.speak_calls] == ["同一段只能各嘗試一次。"]
+    assert standard.speak_calls == []
+
+    hd.failed.emit("hd unavailable")
+    assert [call[0] for call in standard.speak_calls] == ["同一段只能各嘗試一次。"]
+    assert local.speak_calls == []
+
+    standard.failed.emit("standard unavailable")
+    assert [call[0] for call in hd.speak_calls] == ["同一段只能各嘗試一次。"]
+    assert [call[0] for call in standard.speak_calls] == ["同一段只能各嘗試一次。"]
+    assert local.speak_calls == []
+    assert failures == ["Realtime 語音輸出失敗：standard unavailable"]
+
+
+def _assert_partial_audio_failure_does_not_repeat_the_clause() -> None:
+    output, standard, hd, local = _create_operation_output()
+    failures: list[str] = []
+    output.failed.connect(failures.append)
+    output.configure(
+        _hybrid_config(REALTIME_OUTPUT_AZURE_HD, local_available=True)
+    )
+    output.begin_response(1)
+    output.add_text(1, "已經播放句首的句子。")
+    operation_id = hd.operation_ids[-1]
+    hd.operation_synthesis_latency_measured.emit(operation_id, 25.0)
+    hd.operation_failed.emit(operation_id, "stream interrupted")
+
+    assert len(hd.speak_calls) == 1
+    assert hd.stop_calls == 1
+    assert standard.speak_calls == []
+    assert local.speak_calls == []
+    assert failures == ["Realtime 語音輸出失敗：stream interrupted"]
+
+    output.add_text(1, "同一輪遲到的片段不得重新啟動發聲。")
+    output.finish_response(1)
+    assert len(hd.speak_calls) == 1
+    assert standard.speak_calls == []
+    assert local.speak_calls == []
+
+    output.begin_response(2)
+    output.add_text(2, "下一輪可以安全重新發聲。")
+    output.finish_response(2)
+    assert [call[0] for call in hd.speak_calls] == [
+        "已經播放句首的句子。",
+        "下一輪可以安全重新發聲。",
+    ]
+
+
+def _assert_fallback_chain_is_one_way_and_isolated() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(
+        _hybrid_config(
+            REALTIME_OUTPUT_AZURE_HD,
+            local_available=True,
+        )
+    )
+    output.begin_response(1)
+    output.add_text(1, "依序備援，不得同時播放。")
+
+    hd.failed.emit("hd unavailable")
+    hd.finished.emit()
+    assert len(standard.speak_calls) == 1
+    assert local.speak_calls == []
+
+    standard.failed.emit("standard unavailable")
+
+    assert [call[0] for call in hd.speak_calls] == ["依序備援，不得同時播放。"]
+    assert [call[0] for call in standard.speak_calls] == ["依序備援，不得同時播放。"]
+    assert local.speak_calls == [("依序備援，不得同時播放。", "local-female-voice", -1)]
+
+    local.finished.emit()
+    assert len(hd.speak_calls) == 1
+    assert len(standard.speak_calls) == 1
+    assert len(local.speak_calls) == 1
+
+
+def _assert_native_mode_never_starts_azure_engines() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_OPENAI))
+    output.begin_response(1)
+    output.add_text(1, "原生 Realtime 應自行發聲。")
+    output.finish_response(1)
+
+    assert not output.active
+    assert standard.speak_calls == []
+    assert hd.speak_calls == []
+    assert local.speak_calls == []
+    assert standard.stop_calls == 0
+    assert hd.stop_calls == 0
+    assert local.stop_calls == 0
+
+
+def _assert_switching_routes_stops_only_the_active_engine() -> None:
+    output, standard, hd, local = _create_output()
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE))
+    output.begin_response(1)
+    output.add_text(1, "一般 Azure 正在播放。")
+
+    output.configure(_hybrid_config(REALTIME_OUTPUT_AZURE_HD))
+    assert standard.stop_calls == 1
+    assert hd.stop_calls == 0
+    assert local.stop_calls == 0
+
+    output.begin_response(2)
+    output.add_text(2, "Dragon HD 接手。")
+    assert [call[0] for call in standard.speak_calls] == ["一般 Azure 正在播放。"]
+    assert [call[0] for call in hd.speak_calls] == ["Dragon HD 接手。"]
+
+
+def _assert_azure_stop_discards_audio_and_isolates_instances() -> None:
+    first = AzureSpeechTTS()
+    second = AzureSpeechTTS()
+    first_reader = _PushAudioReader()
+    second_reader = _PushAudioReader()
+    first_synthesizer = FakeSynthesizer()
+    second_synthesizer = FakeSynthesizer()
+    first_reader.write(memoryview(b"\x01\x00" * 480))
+    second_reader.write(memoryview(b"\x02\x00" * 480))
+    first._active_reader = first_reader
+    first._active_synthesizer = first_synthesizer
+    second._active_reader = second_reader
+    second._active_synthesizer = second_synthesizer
+
+    first.stop()
+
+    assert first_reader.read(bytearray(960)) == 0
+    assert first_synthesizer.stop_calls == 1
+    assert first._active_reader is None
+    assert first._active_synthesizer is None
+    assert second_reader.read(bytearray(960)) == 960
+    assert second_synthesizer.stop_calls == 0
+    assert second._active_reader is second_reader
+    assert second._active_synthesizer is second_synthesizer
+
+
+def _assert_text_mode_rejects_unexpected_openai_audio() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = False
+    speaking: list[bool] = []
+    client.speaking_changed.connect(speaking.append)
+    unexpected_audio = base64.b64encode(b"\x01\x00" * 480).decode("ascii")
+
+    client._handle_server_event({
+        "type": "response.output_audio.delta",
+        "delta": unexpected_audio,
+    })
+
+    assert speaking == []
+    assert not client._assistant_audio_active.is_set()
+    assert client._audio_queue.empty()
+
+
+def _official_text_event(
+    kind: str,
+    response_id: str,
+    **payload: object,
+) -> dict[str, object]:
+    return {
+        "type": kind,
+        "event_id": f"event-{kind}",
+        "response_id": response_id,
+        "item_id": "item-1",
+        "output_index": 0,
+        "content_index": 0,
+        **payload,
+    }
+
+
+def _assert_official_response_lifecycle_commits_only_completed_text() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = False
+    deltas: list[tuple[int, str]] = []
+    transcripts: list[str] = []
+    completed: list[int] = []
+    started: list[int] = []
+    client.output_text_started.connect(started.append)
+    client.output_text_delta.connect(
+        lambda generation, text: deltas.append((generation, text))
+    )
+    client.assistant_transcript.connect(transcripts.append)
+    client.output_text_done.connect(completed.append)
+
+    client._handle_server_event({
+        "type": "response.created",
+        "response": {"id": "response-1", "status": "in_progress"},
+    })
+    assert started == [1]
+    client._handle_server_event(
+        _official_text_event(
+            "response.output_text.delta",
+            "response-1",
+            delta="主上，妾在。",
+        )
+    )
+    client._handle_server_event(
+        _official_text_event(
+            "response.output_text.done",
+            "response-1",
+            text="主上，妾在。",
+        )
+    )
+    assert deltas == [(1, "主上，妾在。")]
+    assert transcripts == []
+    assert completed == []
+
+    completed_event = {
+        "type": "response.done",
+        "response": {"id": "response-1", "status": "completed"},
+    }
+    client._handle_server_event(completed_event)
+    client._handle_server_event(completed_event)
+    client._handle_server_event(
+        _official_text_event(
+            "response.output_text.delta",
+            "response-1",
+            delta="不得重複。",
+        )
+    )
+
+    assert deltas == [(1, "主上，妾在。")]
+    assert transcripts == ["主上，妾在。"]
+    assert completed == [1]
+
+
+def _assert_native_cancel_discards_audio_and_ignores_late_events() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = True
+    speaking: list[bool] = []
+    client.speaking_changed.connect(speaking.append)
+    audio = base64.b64encode(b"\x01\x00" * 480).decode("ascii")
+    client._handle_server_event({
+        "type": "response.created",
+        "response": {"id": "native-old", "status": "in_progress"},
+    })
+    client._handle_server_event(
+        _official_text_event("response.output_audio.delta", "native-old", delta=audio)
+    )
+    assert not client._audio_queue.empty()
+
+    cancelled = {
+        "type": "response.done",
+        "response": {"id": "native-old", "status": "cancelled"},
+    }
+    client._handle_server_event(cancelled)
+    client._handle_server_event(cancelled)
+    assert client._audio_queue.empty()
+    assert speaking == [True, False]
+
+    client._handle_server_event({
+        "type": "response.created",
+        "response": {"id": "native-new", "status": "in_progress"},
+    })
+    client._handle_server_event(
+        _official_text_event("response.output_audio.delta", "native-old", delta=audio)
+    )
+    assert client._audio_queue.empty()
+    client._handle_server_event(
+        _official_text_event("response.output_audio.delta", "native-new", delta=audio)
+    )
+    assert not client._audio_queue.empty()
+
+
+def _assert_aborted_responses_block_late_text_events() -> None:
+    for index, status in enumerate(("cancelled", "failed", "incomplete")):
+        client = RealtimeVoiceClient()
+        client.native_audio_output = False
+        deltas: list[tuple[int, str]] = []
+        transcripts: list[str] = []
+        completed: list[int] = []
+        interrupted: list[int] = []
+        client.output_text_delta.connect(
+            lambda generation, text, deltas=deltas: deltas.append(
+                (generation, text)
+            )
+        )
+        client.assistant_transcript.connect(transcripts.append)
+        client.output_text_done.connect(completed.append)
+        client.output_interrupted.connect(interrupted.append)
+        response_id = f"response-aborted-{index}"
+
+        client._handle_server_event({
+            "type": "response.created",
+            "response": {"id": response_id, "status": "in_progress"},
+        })
+        client._handle_server_event(
+            _official_text_event(
+                "response.output_text.delta",
+                response_id,
+                delta="尚未完成",
+            )
+        )
+        client._handle_server_event({
+            "type": "response.done",
+            "response": {"id": response_id, "status": status},
+        })
+        client._handle_server_event(
+            _official_text_event(
+                "response.output_text.delta",
+                response_id,
+                delta="不得外流",
+            )
+        )
+        client._handle_server_event(
+            _official_text_event(
+                "response.output_text.done",
+                response_id,
+                text="尚未完成不得外流",
+            )
+        )
+        client._handle_server_event({
+            "type": "response.done",
+            "response": {"id": response_id, "status": "completed"},
+        })
+
+        assert deltas == [(1, "尚未完成")]
+        assert transcripts == []
+        assert completed == []
+        assert interrupted == [2]
+
+
+def _assert_missing_response_id_remains_compatible() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = False
+    transcripts: list[str] = []
+    completed: list[int] = []
+    client.assistant_transcript.connect(transcripts.append)
+    client.output_text_done.connect(completed.append)
+
+    client._handle_server_event({
+        "type": "response.output_text.delta",
+        "delta": "相容事件。",
+    })
+    client._handle_server_event({
+        "type": "response.output_text.done",
+        "text": "相容事件。",
+    })
+    client._handle_server_event({
+        "type": "response.done",
+        "response": {"status": "completed"},
+    })
+
+    assert transcripts == ["相容事件。"]
+    assert completed == [1]
+
+
+def _assert_foreign_terminal_event_cannot_cancel_active_response() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = False
+    transcripts: list[str] = []
+    interrupted: list[int] = []
+    client.assistant_transcript.connect(transcripts.append)
+    client.output_interrupted.connect(interrupted.append)
+
+    client._handle_server_event({
+        "type": "response.created",
+        "response": {"id": "response-active", "status": "in_progress"},
+    })
+    client._handle_server_event(
+        _official_text_event(
+            "response.output_text.delta",
+            "response-active",
+            delta="正確回應。",
+        )
+    )
+    client._handle_server_event({
+        "type": "response.done",
+        "response": {"id": "response-stale", "status": "cancelled"},
+    })
+    client._handle_server_event({
+        "type": "response.done",
+        "response": {"id": "response-active", "status": "completed"},
+    })
+
+    assert transcripts == ["正確回應。"]
+    assert interrupted == []
+
+
+def _assert_websocket_close_interrupts_hybrid_output_once() -> None:
+    client = RealtimeVoiceClient()
+    client.native_audio_output = False
+    interrupted: list[int] = []
+    client.output_interrupted.connect(interrupted.append)
+
+    client._close_realtime_session()
+    client._close_realtime_session()
+
+    assert interrupted == [1]
+
+
+def run() -> None:
+    _assert_session_output_modes_are_exclusive()
+    _assert_streamed_text_is_segmented_in_order()
+    _assert_secret_repr_is_redacted()
+    _assert_ui_locale_reaches_cross_language_azure_voice()
+    _assert_4096_token_text_remains_bounded()
+    _assert_oversized_response_stays_rejected_until_next_response()
+    _assert_segments_wait_for_the_active_engine()
+    _assert_interruption_stops_and_discards_pending_speech()
+    _assert_newer_cancel_barrier_blocks_queued_generation()
+    _assert_stale_same_engine_callbacks_cannot_close_new_operation()
+    _assert_stale_failure_does_not_trigger_fallback()
+    _assert_hd_falls_back_to_standard_once()
+    _assert_partial_audio_failure_does_not_repeat_the_clause()
+    _assert_fallback_chain_is_one_way_and_isolated()
+    _assert_native_mode_never_starts_azure_engines()
+    _assert_switching_routes_stops_only_the_active_engine()
+    _assert_azure_stop_discards_audio_and_isolates_instances()
+    _assert_text_mode_rejects_unexpected_openai_audio()
+    _assert_official_response_lifecycle_commits_only_completed_text()
+    _assert_native_cancel_discards_audio_and_ignores_late_events()
+    _assert_aborted_responses_block_late_text_events()
+    _assert_missing_response_id_remains_compatible()
+    _assert_foreign_terminal_event_cannot_cancel_active_response()
+    _assert_websocket_close_interrupts_hybrid_output_once()
+    print("REALTIME_SPEECH_OUTPUT_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_realtime_speech_output.py
+++ b/tests/test_realtime_speech_output.py
@@ -45,6 +45,7 @@ class FakeSpeechEngine:
         self.locales: list[str] = []
         self.stop_calls = 0
         self.volume_calls: list[tuple[int, bool]] = []
+        self.catalog_invalidations: list[str | None] = []
 
     def speak(
         self,
@@ -62,6 +63,9 @@ class FakeSpeechEngine:
 
     def set_volume(self, volume_percent: int, muted: bool = False) -> None:
         self.volume_calls.append((volume_percent, muted))
+
+    def invalidate_voice_catalog(self, region: str | None = None) -> None:
+        self.catalog_invalidations.append(region)
 
 
 class FakeOperationSpeechEngine(FakeSpeechEngine):
@@ -533,6 +537,48 @@ def _assert_switching_routes_stops_only_the_active_engine() -> None:
     assert [call[0] for call in hd.speak_calls] == ["Dragon HD 接手。"]
 
 
+def _assert_changed_realtime_credentials_invalidate_isolated_catalogs() -> None:
+    output, standard, hd, _local = _create_output()
+    initial = _hybrid_config(REALTIME_OUTPUT_AZURE)
+    output.configure(initial)
+    assert standard.catalog_invalidations == [None]
+    assert hd.catalog_invalidations == [None]
+
+    standard.catalog_invalidations.clear()
+    hd.catalog_invalidations.clear()
+    output.configure(initial)
+    assert standard.catalog_invalidations == []
+    assert hd.catalog_invalidations == []
+
+    changed_standard = RealtimeSpeechOutputConfig(
+        mode=REALTIME_OUTPUT_AZURE,
+        azure=AzureRealtimeVoice(
+            "replacement-standard-key",
+            initial.azure.region,
+            initial.azure.voice,
+        ),
+        azure_hd=initial.azure_hd,
+        local=initial.local,
+    )
+    output.configure(changed_standard)
+    assert standard.catalog_invalidations == [None]
+    assert hd.catalog_invalidations == []
+
+    changed_hd = RealtimeSpeechOutputConfig(
+        mode=REALTIME_OUTPUT_AZURE_HD,
+        azure=changed_standard.azure,
+        azure_hd=AzureRealtimeVoice(
+            "replacement-hd-key",
+            initial.azure_hd.region,
+            initial.azure_hd.voice,
+        ),
+        local=initial.local,
+    )
+    output.configure(changed_hd)
+    assert standard.catalog_invalidations == [None]
+    assert hd.catalog_invalidations == [None]
+
+
 def _assert_azure_stop_discards_audio_and_isolates_instances() -> None:
     first = AzureSpeechTTS()
     second = AzureSpeechTTS()
@@ -830,6 +876,7 @@ def run() -> None:
     _assert_fallback_chain_is_one_way_and_isolated()
     _assert_native_mode_never_starts_azure_engines()
     _assert_switching_routes_stops_only_the_active_engine()
+    _assert_changed_realtime_credentials_invalidate_isolated_catalogs()
     _assert_azure_stop_discards_audio_and_isolates_instances()
     _assert_text_mode_rejects_unexpected_openai_audio()
     _assert_official_response_lifecycle_commits_only_completed_text()

--- a/tests/test_realtime_transcription_config.py
+++ b/tests/test_realtime_transcription_config.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 lazy import sys
-lazy from types import SimpleNamespace
+lazy from dataclasses import fields
 lazy from pathlib import Path
+lazy from types import SimpleNamespace
 lazy from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 lazy import realtime_voice
-
 lazy from realtime_voice import (
     RealtimeSessionConfig,
     RealtimeVoiceClient,
@@ -57,8 +59,51 @@ def assert_stale_connection_callbacks_are_ignored() -> None:
     assert client.running
     assert statuses == []
 
+
+def assert_request_locales_are_normalized() -> None:
+    aliases = {
+        "zh-TW": "zh-TW",
+        "zh-CN": "zh-CN",
+        "zh-Hans": "zh-CN",
+        "zh-SG": "zh-CN",
+        "en": "en",
+        "en-US": "en",
+        "en-GB": "en",
+        "ja": "ja-JP",
+        "ja-JP": "ja-JP",
+        "fr-FR": "zh-TW",
+        "": "zh-TW",
+    }
+    assert RealtimeSessionConfig().locale == "zh-TW"
+    for supplied, expected in aliases.items():
+        request = RealtimeVoiceRequest(
+            api_key="  test-key  ",
+            instructions="test",
+            memory_context="",
+            session=RealtimeSessionConfig(locale=supplied),
+        )
+        normalized = RealtimeVoiceClient._normalized_request(request)
+        assert normalized.session.locale == expected
+        assert normalized.api_key == "test-key"
+        assert request.session.locale == supplied
+
+
+def assert_request_secret_repr_is_redacted() -> None:
+    secret = "realtime-secret-must-not-appear"
+    request = RealtimeVoiceRequest(
+        api_key=secret,
+        instructions="test",
+        memory_context="",
+        session=RealtimeSessionConfig(),
+    )
+    assert secret not in repr(request)
+    assert fields(RealtimeVoiceRequest)[0].repr is False
+
+
 def run() -> None:
     assert_stale_connection_callbacks_are_ignored()
+    assert_request_locales_are_normalized()
+    assert_request_secret_repr_is_redacted()
     event = RealtimeVoiceClient._session_update_event(
         RealtimeSessionConfig(
             transcription_prompt="常用詞：墨寒、主上、炎劍文化工作室。",

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -150,7 +150,9 @@ def test_inno_setup_and_artwork_contract() -> None:
     assert '"/MERGETASKS=!desktopicon"' in installer_test
     for required in (
         "MSI $Variant shortcut target escaped the install directory",
-        "MSI $Variant shortcut icon is not the installed MoHan icon",
+        "MSI $Variant shortcut has an invalid Shell Link header",
+        "MSI $Variant shortcut contains an independent icon location",
+        "MSI $Variant shortcut icon escaped the installed MoHan executable",
         "MSI $Variant uninstaller left the Start menu shortcut behind",
     ):
         assert required in installer_test
@@ -250,8 +252,8 @@ def test_wix_source_and_localization_contract() -> None:
     assert_contains(
         wix_source,
         (
-            'Icon="MohanIcon"',
-            'IconIndex="0"',
+            '<Property Id="ARPPRODUCTICON" Value="MohanIcon" />',
+            '<Icon Id="MohanIcon" SourceFile="$(var.IconPath)" />',
             'Key="System.AppUserModel.ID"',
             'Value="FlamebladeStudio.MoHanDesktopAssistant"',
             'Language="$(var.ProductLanguage)"',
@@ -259,6 +261,12 @@ def test_wix_source_and_localization_contract() -> None:
             '<Files Directory="INSTALLFOLDER"',
         ),
     )
+    shortcut = wix_source.split(
+        '<Shortcut Id="ApplicationStartMenuShortcut"',
+        maxsplit=1,
+    )[1].split("</Shortcut>", maxsplit=1)[0]
+    assert 'Icon="' not in shortcut
+    assert 'IconIndex="' not in shortcut
     installer_build = read("installer/build_installers.ps1")
     installer_test = read("installer/test_installers.ps1")
     policy = read("installer/LOCALIZATION.md")

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -335,6 +335,7 @@ def test_packaging_tools_and_public_media() -> None:
             "Get-AuthenticodeSignature",
             "Pyrsys B\\.V\\.",
             'InnoVersion = "7.0.2"',
+            "gh release verify-asset $InnoTag $InnoDownload --repo jrsoftware/issrc",
             'WixVersion = "7.0.0"',
         ),
     )

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -148,6 +148,12 @@ def test_inno_setup_and_artwork_contract() -> None:
     installer_test = read("installer/test_installers.ps1")
     assert 'MOHAN_ALLOW_INSTALLER_MUTATION -ne "1"' in installer_test
     assert '"/MERGETASKS=!desktopicon"' in installer_test
+    for required in (
+        "MSI $Variant shortcut target escaped the install directory",
+        "MSI $Variant shortcut icon is not the installed MoHan icon",
+        "MSI $Variant uninstaller left the Start menu shortcut behind",
+    ):
+        assert required in installer_test
 
     canonical = ROOT / "assets/expressions/idle_front.png"
     assert_image(canonical, (1254, 1254))
@@ -166,7 +172,7 @@ def test_inno_setup_and_artwork_contract() -> None:
     assert 'stroke="#ffffff"' in checkmark.read_text(encoding="utf-8")
 
 
-def test_windows_taskbar_icon_contract() -> None:
+def test_windows_taskbar_icon_contract() -> None:  # noqa: PLR0914 -- one explicit end-to-end icon contract
     canonical = ROOT / "assets/expressions/idle_front.png"
     png_icon = ROOT / "assets/mohan-taskbar-icon.png"
     windows_icon = ROOT / "assets/mohan-halfbody.ico"

--- a/tests/test_remote_tool_error_safety.py
+++ b/tests/test_remote_tool_error_safety.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+lazy import json
+lazy import sys
+lazy from dataclasses import asdict
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+lazy from urllib.error import HTTPError
+lazy from urllib.parse import urlencode
+lazy from urllib.request import Request, urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy import flagship_core
+lazy from db import StudioDB
+lazy from flagship_core import ActionExecutor, ActionPlan, ActionRequest, PolicyEngine
+lazy from remote_control import (
+    REMOTE_FILE_UNAVAILABLE,
+    REMOTE_FILE_UNAVAILABLE_MESSAGES,
+    RemoteControlServer,
+    RemoteRequestHandler,
+    RemoteServerConfig,
+    RemoteServerServices,
+    TokenRegistry,
+    remote_file_unavailable,
+)
+lazy from safe_error import sanitize_error as canonical_sanitize_error
+
+_BAIT_MARKER = "NOT" + "-A-REAL-SECRET-42"
+_PRIVATE_PATH = "C:" + "\\Users\\private-user\\AppData\\secret.txt"
+_FORBIDDEN = (_BAIT_MARKER, _PRIVATE_PATH, "private-user", "api_key=")
+
+
+class _UnavailableRemoteFile:
+    name = "unavailable.txt"
+    suffix = ".txt"
+
+    def open(self, _mode: str) -> None:
+        try:
+            raise OSError(_PRIVATE_PATH)
+        except OSError as source:
+            raise PermissionError("api_key=" + _BAIT_MARKER) from source
+
+
+def _authorized_request(url: str, token: str) -> Request:
+    return Request(url, headers={"Authorization": f"Bearer {token}"})
+
+
+def _read_fixed_file_error(request: Request) -> dict[str, str]:
+    try:
+        urlopen(request, timeout=3)
+    except HTTPError as exc:
+        assert exc.code == 403
+        payload = json.load(exc)
+    else:
+        raise AssertionError("unavailable remote files must fail closed")
+    assert payload == {"error": REMOTE_FILE_UNAVAILABLE}
+    serialized = json.dumps(payload, ensure_ascii=False)
+    for forbidden in _FORBIDDEN:
+        assert forbidden.casefold() not in serialized.casefold()
+    return payload
+
+
+def _assert_remote_file_boundary(root: Path) -> None:
+    database = StudioDB(root / "remote-safety.db")
+    shared_file = root / "shared.txt"
+    shared_content = b"safe remote content"
+    shared_file.write_bytes(shared_content)
+    registry = TokenRegistry(database)
+    token = registry.pair("安全測試裝置", ["files"])
+    server = RemoteControlServer(
+        RemoteServerConfig(
+            host="127.0.0.1",
+            port=0,
+            enabled=True,
+            allow_commands=False,
+            allow_files=True,
+        ),
+        registry,
+        RemoteServerServices(
+            status_provider=lambda: {"ok": True},
+            command_handler=lambda _text, _device: {"accepted": False},
+            allowed_folders=(str(root),),
+        ),
+    )
+    server.start()
+    try:
+        port = server._server.server_port
+        endpoint = f"http://127.0.0.1:{port}/api/v1/file"
+        query = urlencode({"path": str(shared_file)})
+        with urlopen(
+            _authorized_request(f"{endpoint}?{query}", token),
+            timeout=3,
+        ) as response:
+            assert response.status == 200
+            assert response.read() == shared_content
+            disposition = response.headers["Content-Disposition"]
+        assert shared_file.name not in disposition
+        assert "mohan-" in disposition
+
+        outside_path = root.parent / "private-user" / "secret.txt"
+        outside_query = urlencode({"path": str(outside_path)})
+        _read_fixed_file_error(
+            _authorized_request(f"{endpoint}?{outside_query}", token)
+        )
+
+        original_json = RemoteRequestHandler._json
+
+        def checked_json(
+            handler: RemoteRequestHandler,
+            status: int,
+            payload: dict[str, object],
+        ) -> None:
+            if payload == {"error": REMOTE_FILE_UNAVAILABLE}:
+                assert sys.exception() is None
+            original_json(handler, status, payload)
+
+        with (
+            patch.object(
+                server,
+                "_allowed_file",
+                return_value=_UnavailableRemoteFile(),
+            ),
+            patch.object(RemoteRequestHandler, "_json", checked_json),
+        ):
+            _read_fixed_file_error(
+                _authorized_request(f"{endpoint}?{query}", token)
+            )
+    finally:
+        server.stop()
+        database.close()
+
+
+def _assert_tool_error_boundary() -> None:
+    audit: list[tuple[str, dict[str, object]]] = []
+    executor = ActionExecutor(
+        PolicyEngine({"read_status": "允許"}),
+        audit=lambda event, payload: audit.append((event, payload)),
+    )
+
+    def failing_handler(_request: ActionRequest):
+        try:
+            raise OSError(_PRIVATE_PATH)
+        except OSError as source:
+            raise RuntimeError("api_key=" + _BAIT_MARKER) from source
+
+    def checked_sanitizer(error: BaseException):
+        assert sys.exception() is None
+        assert error.__cause__ is not None
+        assert error.__context__ is not None
+        return canonical_sanitize_error(error)
+
+    executor.register("read_status", failing_handler)
+    request = ActionRequest("read_status", "讀取安全測試狀態")
+    with patch.object(
+        flagship_core,
+        "sanitize_error",
+        side_effect=checked_sanitizer,
+    ):
+        result, = executor.execute(ActionPlan("安全錯誤測試", [request]))
+
+    assert not result.success
+    assert "type=runtime_error" in result.message
+    assert "diagnostic=internal_failure" in result.message
+    surface = json.dumps(
+        {"result": asdict(result), "audit": audit},
+        ensure_ascii=False,
+        default=str,
+    )
+    for forbidden in _FORBIDDEN:
+        assert forbidden.casefold() not in surface.casefold()
+    assert any(event == "action_result" for event, _payload in audit)
+
+
+def run() -> None:
+    assert tuple(REMOTE_FILE_UNAVAILABLE_MESSAGES) == (
+        "zh-TW",
+        "zh-CN",
+        "en-US",
+        "ja-JP",
+    )
+    assert remote_file_unavailable("zh-TW") == "檔案目前無法提供"
+    assert remote_file_unavailable("zh-CN") == "文件目前无法提供"
+    assert remote_file_unavailable("en") == "The file is currently unavailable."
+    assert remote_file_unavailable("ja-JP") == "現在このファイルを提供できません。"
+    with TemporaryDirectory(dir=Path.cwd()) as temporary:
+        _assert_remote_file_boundary(Path(temporary).resolve())
+    _assert_tool_error_boundary()
+    print("REMOTE_TOOL_ERROR_SAFETY_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_safe_error.py
+++ b/tests/test_safe_error.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+lazy import io
+lazy import sys
+lazy from pathlib import Path
+lazy from urllib.error import HTTPError, URLError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from safe_error import (
+    SafeDiagnostic,
+    SafeErrorType,
+    sanitize_error,
+)
+
+
+class _Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class _ResponseError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.response = _Response(status_code)
+
+
+class _BrokenStatusError(Exception):
+    @property
+    def status(self) -> int:
+        raise RuntimeError("property contains a secret")
+
+    def __str__(self) -> str:
+        raise RuntimeError("string conversion contains a secret")
+
+
+class _IntSubclass(int):
+    pass
+
+
+def _bait_details() -> tuple[str, ...]:
+    marker = "NOT" + "-A-REAL-SECRET-42"
+    return (
+        "api" + f"_key={marker}",
+        "tok" + f"en={marker}",
+        "pass" + f"word={marker}",
+        "Author" + "ization: " + "Bearer " + marker,
+        "Coo" + "kie: session=" + marker,
+        "Server=db.example.test;User Id=user;Pass" + "word=" + marker,
+        "maintainer" + "@example.test",
+        "C:" + "\\Users\\private-user\\AppData\\secret.txt",
+        "/home/" + "private-user/.config/secret.json",
+        "/Users/" + "private-user/Library/secret.json",
+        "\\\\server\\Users\\private-user\\secret.txt",
+        "密" + "碼＝" + marker,
+        "トー" + "クン＝" + marker,
+        "🔐 " + marker,
+    )
+
+
+def _surfaces(error) -> str:
+    return "\n".join((str(error), repr(error)))
+
+
+def _assert_bait_secrets_are_discarded() -> None:
+    baits = _bait_details()
+    combined = " | ".join(baits)
+    errors = (
+        RuntimeError(combined),
+        _ResponseError(combined, 503),
+        HTTPError(
+            "https://example.test/private",
+            401,
+            combined,
+            None,
+            io.BytesIO(combined.encode("utf-8")),
+        ),
+        _BrokenStatusError(combined),
+        combined,
+    )
+
+    for error in errors:
+        surface = _surfaces(sanitize_error(error))
+        for bait in baits:
+            assert bait not in surface
+        for private_fragment in (
+            "NOT-A-REAL-SECRET",
+            "private-user",
+            "example.test",
+            "Bearer",
+            "session=",
+        ):
+            assert private_fragment not in surface
+
+
+def _assert_http_status_is_preserved_safely() -> None:
+    cases = {
+        401: SafeDiagnostic.AUTHENTICATION_REQUIRED,
+        403: SafeDiagnostic.ACCESS_DENIED,
+        404: SafeDiagnostic.RESOURCE_NOT_FOUND,
+        408: SafeDiagnostic.REQUEST_TIMEOUT,
+        409: SafeDiagnostic.CONFLICT,
+        429: SafeDiagnostic.RATE_LIMITED,
+        503: SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+    }
+    for status, diagnostic in cases.items():
+        safe = sanitize_error(RuntimeError("opaque"), http_status=status)
+        assert safe.error_type is SafeErrorType.HTTP_ERROR
+        assert safe.diagnostic is diagnostic
+        assert safe.http_status == status
+        assert str(status) in str(safe)
+
+    response_error = sanitize_error(_ResponseError("opaque", 502))
+    assert response_error.http_status == 502
+    assert response_error.diagnostic is SafeDiagnostic.REMOTE_SERVICE_FAILURE
+
+    parsed = sanitize_error("HTTP/1.1 429 followed by untrusted Unicode 🔐")
+    assert parsed.http_status == 429
+    assert parsed.diagnostic is SafeDiagnostic.RATE_LIMITED
+
+    exception_text = sanitize_error(RuntimeError("HTTP 504", *_bait_details()))
+    assert exception_text.http_status == 504
+    assert exception_text.diagnostic is SafeDiagnostic.REQUEST_TIMEOUT
+    assert "NOT-A-REAL-SECRET" not in _surfaces(exception_text)
+
+    explicit_wins = sanitize_error("HTTP 401", http_status=503)
+    assert explicit_wins.http_status == 503
+    assert explicit_wins.diagnostic is SafeDiagnostic.REMOTE_SERVICE_FAILURE
+
+
+def _assert_invalid_status_is_not_exposed() -> None:
+    for invalid in (True, 0, 99, 600, 9_999, _IntSubclass(503)):
+        safe = sanitize_error(RuntimeError("opaque"), http_status=invalid)
+        assert safe.http_status is None
+        assert "http_status=" not in str(safe)
+
+
+def _assert_approved_error_types() -> None:
+    decoding_error = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
+    cases = (
+        (
+            TimeoutError("opaque"),
+            SafeErrorType.TIMEOUT_ERROR,
+            SafeDiagnostic.REQUEST_TIMEOUT,
+        ),
+        (
+            ConnectionError("opaque"),
+            SafeErrorType.CONNECTION_ERROR,
+            SafeDiagnostic.NETWORK_UNAVAILABLE,
+        ),
+        (
+            URLError("opaque"),
+            SafeErrorType.CONNECTION_ERROR,
+            SafeDiagnostic.NETWORK_UNAVAILABLE,
+        ),
+        (
+            PermissionError("opaque"),
+            SafeErrorType.AUTHORIZATION_ERROR,
+            SafeDiagnostic.ACCESS_DENIED,
+        ),
+        (
+            FileNotFoundError("opaque"),
+            SafeErrorType.NOT_FOUND_ERROR,
+            SafeDiagnostic.RESOURCE_NOT_FOUND,
+        ),
+        (
+            decoding_error,
+            SafeErrorType.DECODING_ERROR,
+            SafeDiagnostic.INVALID_RESPONSE,
+        ),
+        (
+            ValueError("opaque"),
+            SafeErrorType.VALIDATION_ERROR,
+            SafeDiagnostic.INVALID_INPUT,
+        ),
+        (
+            OSError("opaque"),
+            SafeErrorType.OPERATING_SYSTEM_ERROR,
+            SafeDiagnostic.LOCAL_IO_FAILURE,
+        ),
+        (
+            RuntimeError("opaque"),
+            SafeErrorType.RUNTIME_ERROR,
+            SafeDiagnostic.INTERNAL_FAILURE,
+        ),
+        (
+            Exception("opaque"),
+            SafeErrorType.UNKNOWN_ERROR,
+            SafeDiagnostic.UNKNOWN_FAILURE,
+        ),
+    )
+    for error, error_type, diagnostic in cases:
+        safe = sanitize_error(error)
+        assert safe.error_type is error_type
+        assert safe.diagnostic is diagnostic
+        assert safe.http_status is None
+
+
+def _assert_limited_text_diagnostics() -> None:
+    cases = {
+        "rate limit reached": SafeDiagnostic.RATE_LIMITED,
+        "authentication failed": SafeDiagnostic.AUTHENTICATION_REQUIRED,
+        "access denied": SafeDiagnostic.ACCESS_DENIED,
+        "operation timed out": SafeDiagnostic.REQUEST_TIMEOUT,
+        "network unreachable": SafeDiagnostic.NETWORK_UNAVAILABLE,
+        "resource not found": SafeDiagnostic.RESOURCE_NOT_FOUND,
+        "operation cancelled": SafeDiagnostic.OPERATION_CANCELLED,
+    }
+    for raw, diagnostic in cases.items():
+        safe = sanitize_error(raw + " — 機密詳細資料 🔐")
+        assert safe.diagnostic is diagnostic
+        assert raw not in _surfaces(safe)
+        assert "機密詳細資料" not in _surfaces(safe)
+
+
+def _assert_unicode_is_opaque() -> None:
+    raw = "認証失敗：密碼不可公開；路徑不可公開。🔐\n第二行"
+    safe = sanitize_error(RuntimeError(raw))
+    assert safe.error_type is SafeErrorType.RUNTIME_ERROR
+    assert safe.diagnostic is SafeDiagnostic.INTERNAL_FAILURE
+    surface = _surfaces(safe)
+    assert raw not in surface
+    assert "認証" not in surface
+    assert "密碼" not in surface
+    assert "🔐" not in surface
+    assert str(safe) == "type=runtime_error; diagnostic=internal_failure"
+
+
+def run() -> None:
+    _assert_bait_secrets_are_discarded()
+    _assert_http_status_is_preserved_safely()
+    _assert_invalid_status_is_not_exposed()
+    _assert_approved_error_types()
+    _assert_limited_text_diagnostics()
+    _assert_unicode_is_opaque()
+    print("SAFE_ERROR_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_safe_error_integration.py
+++ b/tests/test_safe_error_integration.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+lazy import io
+lazy import os
+lazy import sys
+lazy import traceback
+lazy from pathlib import Path
+lazy from types import SimpleNamespace
+lazy from unittest.mock import patch
+lazy from urllib.error import HTTPError
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy import ai_client
+lazy import app
+lazy import camera_presence
+lazy import flagship_ui
+lazy import speech
+lazy from ai_client import ActionPlannerWorker, AIWorker, AIWorkerRequest
+lazy from app import CompanionWindow
+lazy from camera_presence import CameraPresenceController
+lazy from flagship_ui import OAuthWorker
+lazy from realtime_voice import RealtimeVoiceClient
+lazy from safe_error import SafeDiagnostic, SafeErrorType
+lazy from service_status_localization import ServiceStatus, service_status
+
+_BAIT_MARKER = "NOT" + "-A-REAL-SECRET-42"
+_PRIVATE_WINDOWS_PATH = "C:" + "\\Users\\private-user\\AppData\\secret.txt"
+_PRIVATE_POSIX_PATH = "/home/" + "private-user/.config/secret.json"
+
+
+def _bait_detail(*, http_status: int | None = None) -> str:
+    status = f"HTTP {http_status}; " if http_status is not None else ""
+    return (
+        status
+        + "api_key="
+        + _BAIT_MARKER
+        + "; token="
+        + _BAIT_MARKER
+        + "; password="
+        + _BAIT_MARKER
+        + "; Authorization: Bearer "
+        + _BAIT_MARKER
+        + "; maintainer"
+        + "@example.test; "
+        + _PRIVATE_WINDOWS_PATH
+        + "; "
+        + _PRIVATE_POSIX_PATH
+    )
+
+
+_FORBIDDEN_FRAGMENTS = (
+    _BAIT_MARKER,
+    "api_key=",
+    "token=",
+    "password=",
+    "bearer",
+    "maintainer@example.test",
+    "private-user",
+    "appdata",
+    ".config/secret",
+)
+
+
+def _assert_sanitized(
+    surface: object,
+    *,
+    error_type: SafeErrorType | None = None,
+    diagnostic: SafeDiagnostic | None = None,
+    http_status: int | None = None,
+) -> str:
+    if isinstance(surface, BaseException):
+        assert surface.__cause__ is None
+        assert surface.__context__ is None
+        text = "\n".join(
+            (
+                str(surface),
+                repr(surface),
+                "".join(traceback.format_exception_only(type(surface), surface)),
+            )
+        )
+    else:
+        text = str(surface)
+    lowered = text.casefold()
+    for forbidden in _FORBIDDEN_FRAGMENTS:
+        assert forbidden.casefold() not in lowered, (
+            f"untrusted error detail escaped into the UI: {forbidden!r}"
+        )
+    if error_type is not None:
+        assert error_type.value in lowered
+    if diagnostic is not None:
+        assert diagnostic.value in lowered
+    if http_status is not None:
+        assert str(http_status) in text
+    return text
+
+
+class _SignalRecorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def __call__(self, *values: object) -> None:
+        self.calls.append(values)
+
+    def single(self) -> tuple[object, ...]:
+        assert len(self.calls) == 1
+        return self.calls[0]
+
+
+def _http_error(status: int) -> HTTPError:
+    detail = _bait_detail(http_status=status)
+    return HTTPError(
+        "https://example.test/private?token=" + _BAIT_MARKER,
+        status,
+        detail,
+        None,
+        io.BytesIO(detail.encode("utf-8")),
+    )
+
+
+def _assert_openai_transcription_http_error() -> None:
+    cases = (
+        (418, SafeDiagnostic.INVALID_INPUT),
+        (422, SafeDiagnostic.INVALID_INPUT),
+        (599, SafeDiagnostic.REMOTE_SERVICE_FAILURE),
+    )
+    for status, diagnostic in cases:
+        error = _http_error(status)
+        reported: RuntimeError | None = None
+        with patch.object(speech, "urlopen", side_effect=error):
+            try:
+                speech.transcribe_wav_bytes(
+                    b"RIFF",
+                    _BAIT_MARKER,
+                    "gpt-4o-mini-transcribe",
+                    speech.SpeechTranscriptionLocale(
+                        provider_language="zh",
+                        ui_language="en",
+                    ),
+                )
+            except RuntimeError as exc:
+                reported = exc
+            else:
+                raise AssertionError("the mocked HTTP failure must be reported")
+        assert reported is not None
+        surface = _assert_sanitized(
+            reported,
+            error_type=SafeErrorType.HTTP_ERROR,
+            diagnostic=diagnostic,
+            http_status=status,
+        )
+        assert "OpenAI" in surface
+
+
+def _assert_realtime_error_boundaries() -> None:
+    detail = _bait_detail(http_status=502)
+    friendly = RealtimeVoiceClient._friendly_error(
+        detail,
+        "gpt-realtime-2.1-mini",
+        "en",
+    )
+    _assert_sanitized(
+        friendly,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+        http_status=502,
+    )
+
+    audio = RealtimeVoiceClient._audio_error_message(
+        RuntimeError("RawInputStream failed; " + detail),
+        "en",
+    )
+    _assert_sanitized(
+        audio,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+        http_status=502,
+    )
+
+
+class _FailingOAuthFlow:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def authorize(self) -> dict[str, object]:
+        raise RuntimeError(_bait_detail(http_status=401))
+
+
+def _assert_oauth_worker_boundary() -> None:
+    worker = OAuthWorker(
+        "google",
+        "client-id",
+        "client-secret",
+        ["openid"],
+    )
+    failed = _SignalRecorder()
+    worker.signals.failed.connect(failed)
+    with patch.object(flagship_ui, "OAuthPKCEFlow", _FailingOAuthFlow):
+        worker.run()
+    provider_id, message = failed.single()
+    assert provider_id == "google"
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.AUTHENTICATION_REQUIRED,
+        http_status=401,
+    )
+
+
+class _FakeSignal:
+    def __init__(self) -> None:
+        self._callback = None
+
+    def connect(self, callback) -> None:
+        self._callback = callback
+
+    def emit(self, *values: object) -> None:
+        assert self._callback is not None
+        self._callback(*values)
+
+
+class _FakeCamera:
+    def __init__(self, _device: object) -> None:
+        self.errorOccurred = _FakeSignal()
+
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class _FakeCaptureSession:
+    def setCamera(self, _camera: object) -> None:
+        return None
+
+    def setVideoSink(self, _sink: object) -> None:
+        return None
+
+
+class _FakeVideoSink:
+    def __init__(self) -> None:
+        self.videoFrameChanged = _FakeSignal()
+
+
+class _FakeDevice:
+    def description(self) -> str:
+        return "USB Camera"
+
+
+class _FakeMediaDevices:
+    @staticmethod
+    def videoInputs() -> list[_FakeDevice]:
+        return [_FakeDevice()]
+
+
+def _assert_camera_error_boundary() -> None:
+    with (
+        patch.object(camera_presence, "QCamera", _FakeCamera),
+        patch.object(
+            camera_presence,
+            "QMediaCaptureSession",
+            _FakeCaptureSession,
+        ),
+        patch.object(camera_presence, "QVideoSink", _FakeVideoSink),
+        patch.object(
+            camera_presence,
+            "QMediaDevices",
+            _FakeMediaDevices,
+        ),
+    ):
+        controller = CameraPresenceController(language="en")
+        status = _SignalRecorder()
+        controller.status_changed.connect(status)
+        controller.start()
+        controller.camera.errorOccurred.emit(0, _bait_detail())
+        message = status.calls[-1][0]
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.UNKNOWN_ERROR,
+        diagnostic=SafeDiagnostic.UNKNOWN_FAILURE,
+    )
+
+
+def _assert_ai_worker_boundaries() -> None:
+    request = AIWorkerRequest(
+        user_text="hello",
+        mode="companion",
+        api_key=_BAIT_MARKER,
+        response_language="en",
+    )
+    worker = AIWorker(request)
+    failed = _SignalRecorder()
+    worker.signals.failed.connect(failed)
+    with patch.object(ai_client, "urlopen", side_effect=_http_error(503)):
+        worker.run()
+    message, = failed.single()
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+        http_status=503,
+    )
+
+    planner = ActionPlannerWorker(
+        "open the dashboard",
+        api_key=_BAIT_MARKER,
+        model="gpt-test",
+        available_targets="dashboard",
+        language="en",
+    )
+    planner_failed = _SignalRecorder()
+    planner.signals.failed.connect(planner_failed)
+    with patch.object(ai_client, "urlopen", side_effect=_http_error(403)):
+        planner.run()
+    planner_message, = planner_failed.single()
+    _assert_sanitized(
+        planner_message,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.ACCESS_DENIED,
+        http_status=403,
+    )
+
+
+class _FakeDashboard:
+    def __init__(self) -> None:
+        self.api_statuses: list[str] = []
+        self.realtime_statuses: list[tuple[str, bool | None]] = []
+
+    def set_api_status(self, status: str) -> None:
+        self.api_statuses.append(status)
+
+    def set_realtime_status(
+        self,
+        status: str,
+        active: bool | None = None,
+    ) -> None:
+        self.realtime_statuses.append((status, active))
+
+
+def _assert_dashboard_and_online_voice_boundaries() -> None:
+    dashboard = _FakeDashboard()
+    credentials = SimpleNamespace(
+        azure_region="eastasia",
+    )
+    platform = SimpleNamespace(
+        capabilities=SimpleNamespace(display_name="Windows")
+    )
+    fake = SimpleNamespace(
+        dashboard=dashboard,
+        db=SimpleNamespace(setting=lambda _key, default=None: default),
+        platform_services=platform,
+        speech_fallback_attempts=set(),
+        speech_playing=False,
+        active_speech_engine="",
+        active_speech_text="",
+        cloud_fallback_active=False,
+        _speech_credentials=lambda: credentials,
+        _configured_speech_providers=lambda _credentials: (),
+        _speech_audio_finished=lambda: None,
+    )
+    CompanionWindow._online_voice_failed(
+        fake,
+        "openai-speech",
+        "OpenAI voice",
+        _bait_detail(http_status=429),
+    )
+    assert len(dashboard.api_statuses) == 1
+    _assert_sanitized(
+        dashboard.api_statuses[0],
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.RATE_LIMITED,
+        http_status=429,
+    )
+
+    realtime_fake = SimpleNamespace(
+        dashboard=dashboard,
+        db=SimpleNamespace(setting=lambda _key, default=None: default),
+        realtime=SimpleNamespace(running=False),
+        _stop_realtime_output=lambda: None,
+    )
+    warning = _SignalRecorder()
+    with patch.object(
+        app,
+        "QMessageBox",
+        SimpleNamespace(warning=warning),
+    ):
+        CompanionWindow._realtime_failed(
+            realtime_fake,
+            _bait_detail(http_status=504),
+        )
+    assert len(dashboard.realtime_statuses) == 1
+    realtime_status, active = dashboard.realtime_statuses[0]
+    assert active is False
+    _assert_sanitized(
+        realtime_status,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.REQUEST_TIMEOUT,
+        http_status=504,
+    )
+    _parent, _title, warning_message = warning.single()
+    _assert_sanitized(
+        warning_message,
+        error_type=SafeErrorType.HTTP_ERROR,
+        diagnostic=SafeDiagnostic.REQUEST_TIMEOUT,
+        http_status=504,
+    )
+
+
+def _assert_generic_service_status_boundary() -> None:
+    camera = service_status(
+        "en",
+        ServiceStatus.CAMERA_ERROR,
+        detail=_bait_detail(),
+    )
+    _assert_sanitized(
+        camera,
+        error_type=SafeErrorType.UNKNOWN_ERROR,
+        diagnostic=SafeDiagnostic.UNKNOWN_FAILURE,
+    )
+
+    connection = service_status(
+        "en",
+        ServiceStatus.SPEECH_OPENAI_CONNECTION_ERROR,
+        detail=_bait_detail(),
+    )
+    _assert_sanitized(
+        connection,
+        error_type=SafeErrorType.UNKNOWN_ERROR,
+        diagnostic=SafeDiagnostic.UNKNOWN_FAILURE,
+    )
+
+
+def run() -> None:
+    _assert_openai_transcription_http_error()
+    _assert_realtime_error_boundaries()
+    _assert_oauth_worker_boundary()
+    _assert_camera_error_boundary()
+    _assert_ai_worker_boundaries()
+    _assert_dashboard_and_online_voice_boundaries()
+    _assert_generic_service_status_boundary()
+    print("SAFE_ERROR_INTEGRATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_safe_error_integration.py
+++ b/tests/test_safe_error_integration.py
@@ -18,7 +18,7 @@ lazy import camera_presence
 lazy import flagship_ui
 lazy import speech
 lazy from ai_client import ActionPlannerWorker, AIWorker, AIWorkerRequest
-lazy from app import CompanionWindow
+lazy from app import AZURE_SECRET_POLICY, CompanionWindow, Dashboard
 lazy from camera_presence import CameraPresenceController
 lazy from flagship_ui import OAuthWorker
 lazy from realtime_voice import RealtimeVoiceClient
@@ -432,6 +432,93 @@ def _assert_generic_service_status_boundary() -> None:
     )
 
 
+def _assert_settings_error_boundaries() -> None:
+    class FailingSecretStore:
+        def save(self, _value: str) -> None:
+            raise OSError(_bait_detail())
+
+    key_input = SimpleNamespace(text=lambda: _BAIT_MARKER)
+    fake = SimpleNamespace(
+        ui_language="en",
+        _t=lambda _key, fallback, **values: fallback.format(**values),
+    )
+    warning = _SignalRecorder()
+    with patch.object(
+        app,
+        "QMessageBox",
+        SimpleNamespace(warning=warning),
+    ):
+        saved = Dashboard._persist_secret_input(
+            fake,
+            key_input,
+            FailingSecretStore(),
+            AZURE_SECRET_POLICY,
+            silent=False,
+        )
+    assert saved is False
+    _parent, _title, message = warning.single()
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.OPERATING_SYSTEM_ERROR,
+        diagnostic=SafeDiagnostic.LOCAL_IO_FAILURE,
+    )
+
+
+def _assert_workflow_validation_boundaries() -> None:
+    warning = _SignalRecorder()
+    center = SimpleNamespace(
+        language="en",
+        _t=lambda source, **_values: source,
+    )
+    invalid_workflow = SimpleNamespace(
+        require_preview=False,
+        to_plan=lambda: (_ for _ in ()).throw(
+            ValueError(_bait_detail())
+        ),
+    )
+    with patch.object(
+        flagship_ui,
+        "QMessageBox",
+        SimpleNamespace(warning=warning),
+    ):
+        flagship_ui.FlagshipControlCenter.run_workflow(
+            center,
+            invalid_workflow,
+        )
+    _parent, _title, message = warning.single()
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.VALIDATION_ERROR,
+        diagnostic=SafeDiagnostic.INVALID_INPUT,
+    )
+
+    warning = _SignalRecorder()
+    fake = SimpleNamespace(
+        ui_language="en",
+        autostart=SimpleNamespace(isChecked=lambda: True),
+        platform_services=SimpleNamespace(
+            capabilities=SimpleNamespace(desktop_autostart=True)
+        ),
+        db=SimpleNamespace(set_setting=lambda *_args: None),
+        _settings_text=lambda _key, **values: values.get("reason", "title"),
+    )
+    with (
+        patch.object(app, "set_autostart", side_effect=OSError(_bait_detail())),
+        patch.object(
+            app,
+            "QMessageBox",
+            SimpleNamespace(warning=warning),
+        ),
+    ):
+        Dashboard._save_autostart_setting(fake)
+    _parent, _title, message = warning.single()
+    _assert_sanitized(
+        message,
+        error_type=SafeErrorType.OPERATING_SYSTEM_ERROR,
+        diagnostic=SafeDiagnostic.LOCAL_IO_FAILURE,
+    )
+
+
 def run() -> None:
     _assert_openai_transcription_http_error()
     _assert_realtime_error_boundaries()
@@ -440,6 +527,8 @@ def run() -> None:
     _assert_ai_worker_boundaries()
     _assert_dashboard_and_online_voice_boundaries()
     _assert_generic_service_status_boundary()
+    _assert_settings_error_boundaries()
+    _assert_workflow_validation_boundaries()
     print("SAFE_ERROR_INTEGRATION_OK")
 
 

--- a/tests/test_safe_error_localization.py
+++ b/tests/test_safe_error_localization.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy import safe_error_localization as localization
+lazy from safe_error import SafeDiagnostic, SafeError, SafeErrorType
+lazy from safe_error_localization import safe_error_message
+
+SUPPORTED_LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+
+ERROR_DIAGNOSTICS = {
+    SafeErrorType.HTTP_ERROR: SafeDiagnostic.UNEXPECTED_RESPONSE,
+    SafeErrorType.TIMEOUT_ERROR: SafeDiagnostic.REQUEST_TIMEOUT,
+    SafeErrorType.CONNECTION_ERROR: SafeDiagnostic.NETWORK_UNAVAILABLE,
+    SafeErrorType.AUTHENTICATION_ERROR: SafeDiagnostic.AUTHENTICATION_REQUIRED,
+    SafeErrorType.AUTHORIZATION_ERROR: SafeDiagnostic.ACCESS_DENIED,
+    SafeErrorType.RATE_LIMIT_ERROR: SafeDiagnostic.RATE_LIMITED,
+    SafeErrorType.NOT_FOUND_ERROR: SafeDiagnostic.RESOURCE_NOT_FOUND,
+    SafeErrorType.CANCELLED_ERROR: SafeDiagnostic.OPERATION_CANCELLED,
+    SafeErrorType.DECODING_ERROR: SafeDiagnostic.INVALID_RESPONSE,
+    SafeErrorType.VALIDATION_ERROR: SafeDiagnostic.INVALID_INPUT,
+    SafeErrorType.OPERATING_SYSTEM_ERROR: SafeDiagnostic.LOCAL_IO_FAILURE,
+    SafeErrorType.RUNTIME_ERROR: SafeDiagnostic.INTERNAL_FAILURE,
+    SafeErrorType.UNKNOWN_ERROR: SafeDiagnostic.UNKNOWN_FAILURE,
+}
+
+HTTP_DIAGNOSTICS = {
+    100: SafeDiagnostic.UNEXPECTED_RESPONSE,
+    200: SafeDiagnostic.UNEXPECTED_RESPONSE,
+    302: SafeDiagnostic.UNEXPECTED_RESPONSE,
+    400: SafeDiagnostic.INVALID_INPUT,
+    401: SafeDiagnostic.AUTHENTICATION_REQUIRED,
+    403: SafeDiagnostic.ACCESS_DENIED,
+    404: SafeDiagnostic.RESOURCE_NOT_FOUND,
+    408: SafeDiagnostic.REQUEST_TIMEOUT,
+    409: SafeDiagnostic.CONFLICT,
+    418: SafeDiagnostic.INVALID_INPUT,
+    429: SafeDiagnostic.RATE_LIMITED,
+    451: SafeDiagnostic.ACCESS_DENIED,
+    500: SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+    503: SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+    504: SafeDiagnostic.REQUEST_TIMEOUT,
+    599: SafeDiagnostic.REMOTE_SERVICE_FAILURE,
+}
+
+
+def _bait_details() -> tuple[str, ...]:
+    marker = "NOT" + "-A-REAL-SECRET-LOCALIZATION-42"
+    return (
+        "api" + f"_key={marker}",
+        "tok" + f"en={marker}",
+        "pass" + f"word={marker}",
+        "Coo" + "kie: session=" + marker,
+        "Author" + "ization: " + "Bearer " + marker,
+        "maintainer" + "@example.test",
+        "C:" + "\\Users\\private-user\\AppData\\secret.txt",
+        "/home/" + "private-user/.config/secret.json",
+        "/Users/" + "private-user/Library/secret.json",
+        "\\\\server\\Users\\private-user\\secret.txt",
+        "密" + "碼＝" + marker,
+        "トー" + "クン＝" + marker,
+        "🔐 " + marker,
+    )
+
+
+def _assert_catalog_order_and_completeness() -> None:
+    assert tuple(localization._MESSAGES) == tuple(SafeDiagnostic)
+    for diagnostic, translations in localization._MESSAGES.items():
+        assert tuple(translations) == SUPPORTED_LANGUAGES, diagnostic
+        assert all(message.strip() for message in translations.values()), diagnostic
+
+
+def _assert_every_error_type_renders() -> None:
+    assert set(ERROR_DIAGNOSTICS) == set(SafeErrorType)
+    for error_type, diagnostic in ERROR_DIAGNOSTICS.items():
+        status = 502 if error_type is SafeErrorType.HTTP_ERROR else None
+        safe = SafeError(error_type, diagnostic, status)
+        for language in SUPPORTED_LANGUAGES:
+            expected = localization._MESSAGES[diagnostic][language]
+            metadata = (
+                f"type={error_type.value}; diagnostic={diagnostic.value}"
+            )
+            if status is not None:
+                expected = f"{expected} [{metadata}; HTTP {status}]"
+            else:
+                expected = f"{expected} [{metadata}]"
+            assert safe_error_message(language, safe) == expected
+
+
+def _assert_http_statuses_render_safely() -> None:
+    for status, diagnostic in HTTP_DIAGNOSTICS.items():
+        for language in SUPPORTED_LANGUAGES:
+            expected = localization._MESSAGES[diagnostic][language]
+            expected = (
+                f"{expected} [type=http_error; "
+                f"diagnostic={diagnostic.value}; HTTP {status}]"
+            )
+            rendered = safe_error_message(
+                language,
+                RuntimeError("opaque provider failure"),
+                http_status=status,
+            )
+            assert rendered == expected, (language, status, rendered)
+
+
+def _assert_sensitive_details_never_render() -> None:
+    baits = _bait_details()
+    combined = " | ".join(baits)
+    inputs: tuple[BaseException | str, ...] = (
+        combined,
+        RuntimeError(combined),
+        ValueError(combined),
+        ConnectionError(combined),
+    )
+    for language in SUPPORTED_LANGUAGES:
+        for error in inputs:
+            rendered = safe_error_message(language, error)
+            for bait in baits:
+                assert bait not in rendered
+            for private_fragment in (
+                "NOT-A-REAL-SECRET",
+                "private-user",
+                "example.test",
+                "Bearer",
+                "session=",
+                "🔐",
+            ):
+                assert private_fragment not in rendered
+
+
+def _assert_serialized_safe_error_keeps_diagnostic() -> None:
+    for diagnostic in SafeDiagnostic:
+        safe = SafeError(SafeErrorType.UNKNOWN_ERROR, diagnostic)
+        serialized = str(safe)
+        for language in SUPPORTED_LANGUAGES:
+            assert safe_error_message(language, serialized) == safe_error_message(
+                language,
+                safe,
+            )
+
+    safe_http = SafeError(
+        SafeErrorType.HTTP_ERROR,
+        SafeDiagnostic.CONFLICT,
+        409,
+    )
+    for language in SUPPORTED_LANGUAGES:
+        assert safe_error_message(language, str(safe_http)) == safe_error_message(
+            language,
+            safe_http,
+        )
+
+
+def run() -> None:
+    _assert_catalog_order_and_completeness()
+    _assert_every_error_type_renders()
+    _assert_http_statuses_render_safely()
+    _assert_sensitive_details_never_render()
+    _assert_serialized_safe_error_keeps_diagnostic()
+    print("SAFE_ERROR_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_service_language_wiring.py
+++ b/tests/test_service_language_wiring.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+PROJECT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT))
+
+lazy from db import StudioDB
+lazy from platform_contracts import PlatformCapabilities, PlatformPaths
+lazy from service_container import create_default_services
+
+UI_LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+TEST_SECRETS = (
+    "openai-service-language-test-key",
+    "azure-service-language-test-key",
+    "azure-hd-service-language-test-key",
+)
+
+
+class _WindowsPlatformProbe:
+    capabilities = PlatformCapabilities(
+        platform_id="windows-test",
+        display_name="Windows Test",
+        system_local_speech=True,
+        verified_female_voice_catalog=True,
+        offline_speech_recognition=True,
+        secure_secret_storage=True,
+        desktop_autostart=False,
+        native_window_management=False,
+        published_installers=(),
+    )
+
+    def __init__(self, root: Path) -> None:
+        self.paths = PlatformPaths(root, root, root / "cache")
+
+    def set_autostart(
+        self,
+        enabled: bool,
+        *,
+        application_id: str,
+        command: str,
+    ) -> None:
+        del enabled, application_id, command
+
+    def open_path(self, path: Path) -> None:
+        del path
+
+
+class _SecretStoreProbe:
+    def __init__(self, path: Path, value: str) -> None:
+        self.path = path
+        self.value = value
+
+    def load(self) -> str:
+        return self.value
+
+    def save(self, value: str) -> None:
+        self.value = value
+
+    def clear(self) -> None:
+        self.value = ""
+
+    def __repr__(self) -> str:
+        return f"_SecretStoreProbe(value={self.value!r})"
+
+
+class _SecretStoreFactoryProbe:
+    def __init__(self) -> None:
+        self.created: list[_SecretStoreProbe] = []
+
+    def __call__(
+        self,
+        path: Path,
+        description: str = "MoHan protected secret",
+    ) -> _SecretStoreProbe:
+        del description
+        value = TEST_SECRETS[len(self.created)]
+        store = _SecretStoreProbe(path, value)
+        self.created.append(store)
+        return store
+
+    def __repr__(self) -> str:
+        return f"_SecretStoreFactoryProbe(secrets={TEST_SECRETS!r})"
+
+
+class _BackupManagerProbe:
+    def __init__(self, _db, _backup_dir: Path) -> None:
+        return None
+
+    def automatic_if_due(self) -> None:
+        return None
+
+
+def _assert_language_wiring(
+    root: Path,
+    language: str | None,
+    expected: str,
+    *,
+    saved_language: str | None = None,
+) -> None:
+    if language is not None and saved_language is not None:
+        case_name = f"saved-{saved_language}-explicit-{language}"
+    elif language is not None:
+        case_name = f"explicit-{language}"
+    elif saved_language is not None:
+        case_name = f"saved-{saved_language}"
+    else:
+        case_name = "default"
+    data_path = root / case_name
+    if saved_language is not None:
+        db = StudioDB(data_path / "mohan.db")
+        db.set_setting("ui_language", saved_language)
+        db.close()
+    factory = _SecretStoreFactoryProbe()
+    kwargs = {} if language is None else {"ui_language": language}
+    opened_databases: list[StudioDB] = []
+
+    def open_database(path: Path) -> StudioDB:
+        db = StudioDB(path)
+        opened_databases.append(db)
+        return db
+
+    with (
+        patch("service_container.StudioDB", side_effect=open_database),
+        patch(
+            "service_container.platform_secret_store_factory",
+            return_value=factory,
+        ),
+        patch("service_container.BackupManager", _BackupManagerProbe),
+    ):
+        services = create_default_services(
+            data_path,
+            PROJECT / "voice_listener.ps1",
+            platform_services=_WindowsPlatformProbe(root),
+            **kwargs,
+        )
+
+    assert opened_databases == [services.db]
+    assert services.local_tts.language == expected
+    assert services.cloud_tts.language == expected
+    assert services.listener.language == expected
+    assert services.realtime_speech_output is not None
+    assert services.realtime_speech_output._local_speech.language == expected
+
+    rendered = repr(services)
+    assert all(secret not in rendered for secret in TEST_SECRETS)
+    for path in data_path.rglob("*"):
+        if path.is_file():
+            content = path.read_bytes()
+            assert all(
+                secret.encode("utf-8") not in content
+                for secret in TEST_SECRETS
+            )
+    services.db.close()
+
+
+def run() -> None:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp:
+        root = Path(temp)
+        _assert_language_wiring(root, None, "zh-TW")
+        for language in UI_LANGUAGES:
+            _assert_language_wiring(root, language, language)
+        _assert_language_wiring(root, "en-US", "en")
+        _assert_language_wiring(
+            root,
+            None,
+            "ja-JP",
+            saved_language="ja-JP",
+        )
+        _assert_language_wiring(
+            root,
+            None,
+            "en",
+            saved_language="en",
+        )
+        _assert_language_wiring(
+            root,
+            "en",
+            "en",
+            saved_language="ja-JP",
+        )
+    print("SERVICE_LANGUAGE_WIRING_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_service_status_localization.py
+++ b/tests/test_service_status_localization.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+lazy import io
+lazy import json
+lazy import os
+lazy import re
+lazy import sys
+lazy import tempfile
+lazy from pathlib import Path
+lazy from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy import camera_presence
+lazy from ai_client import ActionPlannerWorker
+lazy from camera_presence import CameraPresenceController
+lazy from service_status_localization import (
+    SUPPORTED_SERVICE_LANGUAGES,
+    ServiceStatus,
+    service_status,
+)
+lazy from speech import SpeechListener, SpeechListenerProviders
+
+HAN_TEXT = re.compile(r"[\u3400-\u9fff]")
+FORMAT_VALUES = {
+    "detail": "Driver 42",
+    "device": "USB Camera",
+    "model": "gpt-test",
+    "status": 503,
+    "voice": "Zira",
+}
+
+
+class _CapturedThread:
+    def __init__(self, target, args, daemon):
+        assert daemon
+        self.target = target
+        self.args = args
+
+    def start(self) -> None:
+        return None
+
+
+class _FakeSignal:
+    def __init__(self) -> None:
+        self.callback = None
+
+    def connect(self, callback) -> None:
+        self.callback = callback
+
+    def emit(self, *args) -> None:
+        assert self.callback is not None
+        self.callback(*args)
+
+
+class _FakeDevice:
+    def description(self) -> str:
+        return "USB Camera"
+
+
+class _FakeCamera:
+    def __init__(self, _device) -> None:
+        self.errorOccurred = _FakeSignal()
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+
+class _FakeCaptureSession:
+    def setCamera(self, _camera) -> None:
+        return None
+
+    def setVideoSink(self, _sink) -> None:
+        return None
+
+
+class _FakeVideoSink:
+    def __init__(self) -> None:
+        self.videoFrameChanged = _FakeSignal()
+
+
+class _FakeMediaDevices:
+    @staticmethod
+    def videoInputs() -> list[_FakeDevice]:
+        return [_FakeDevice()]
+
+
+def _assert_catalog_contract() -> None:
+    for language in SUPPORTED_SERVICE_LANGUAGES:
+        for key in ServiceStatus:
+            rendered = service_status(
+                language,
+                key,
+                **FORMAT_VALUES,
+            )
+            assert rendered.strip(), (language, key)
+            if language == "en":
+                assert not HAN_TEXT.search(rendered), (key, rendered)
+
+    assert service_status(
+        "en-US",
+        ServiceStatus.CAMERA_CLOSED,
+    ) == service_status("en", ServiceStatus.CAMERA_CLOSED)
+    assert service_status(
+        "unknown",
+        ServiceStatus.CAMERA_CLOSED,
+    ) == "攝影機已關閉"
+    camera_error = service_status(
+        "en",
+        ServiceStatus.CAMERA_ERROR,
+        detail="供應器原始錯誤 42",
+    )
+    assert camera_error.startswith("Camera error: type=unknown_error")
+    assert "diagnostic=unknown_failure" in camera_error
+    assert "供應器原始錯誤 42" not in camera_error
+
+
+def _assert_speech_states() -> None:
+    statuses: list[str] = []
+    diagnostics: list[str] = []
+    failures: list[str] = []
+    recognized: list[str] = []
+    listener = SpeechListener(
+        Path("voice_listener.ps1"),
+        SpeechListenerProviders(
+            api_key=lambda: "sk-test",
+            recognition_mode=lambda: "OpenAI",
+            windows_fallback=lambda: False,
+        ),
+        language="en",
+    )
+    listener.status_changed.connect(statuses.append)
+    listener.diagnostic_changed.connect(diagnostics.append)
+    listener.failed.connect(failures.append)
+    listener.recognized.connect(recognized.append)
+
+    with patch("speech.threading.Thread", _CapturedThread):
+        listener.listen_once()
+    assert statuses[-1].startswith("Listening")
+
+    listener._busy.clear()
+    listener._recording_active.clear()
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as stream:
+        audio_path = Path(stream.name)
+        stream.write(b"RIFF-test")
+    with (
+        patch.object(listener, "_record_wav", return_value=audio_path),
+        patch.object(listener, "_transcribe", return_value="Provider result"),
+    ):
+        listener._busy.set()
+        listener._listen_with_openai(
+            "sk-test",
+            "gpt-test",
+            "en",
+            "prompt",
+            False,
+        )
+    assert recognized[-1] == "Provider result"
+    assert statuses[-1] == "Recognizing…"
+    assert diagnostics[-1] == "OpenAI transcription succeeded: gpt-test"
+
+    no_key = SpeechListener(
+        Path("voice_listener.ps1"),
+        SpeechListenerProviders(
+            api_key=lambda: "",
+            recognition_mode=lambda: "OpenAI",
+            windows_fallback=lambda: False,
+        ),
+        language="en",
+    )
+    no_key.failed.connect(failures.append)
+    no_key.listen_once()
+    assert failures[-1] == (
+        "The OpenAI API key has not been configured."
+        " Windows fallback recognition is currently disabled."
+    )
+    assert not HAN_TEXT.search(failures[-1])
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as stream:
+        failed_audio = Path(stream.name)
+        stream.write(b"RIFF-test")
+    with (
+        patch.object(listener, "_record_wav", return_value=failed_audio),
+        patch.object(
+            listener,
+            "_transcribe",
+            side_effect=RuntimeError("Provider 503"),
+        ),
+    ):
+        listener._busy.set()
+        listener._listen_with_openai(
+            "sk-test",
+            "gpt-test",
+            "en",
+            "prompt",
+            False,
+        )
+    assert failures[-1].endswith(
+        "Windows fallback recognition is currently disabled."
+    )
+
+
+def _assert_camera_states() -> None:
+    statuses: list[str] = []
+    with (
+        patch.object(camera_presence, "QCamera", _FakeCamera),
+        patch.object(
+            camera_presence,
+            "QMediaCaptureSession",
+            _FakeCaptureSession,
+        ),
+        patch.object(camera_presence, "QVideoSink", _FakeVideoSink),
+        patch.object(camera_presence, "QMediaDevices", _FakeMediaDevices),
+    ):
+        controller = CameraPresenceController(language="en")
+        controller.status_changed.connect(statuses.append)
+        controller.start()
+        assert statuses[:2] == [
+            "Starting camera…",
+            "Camera active: USB Camera (local presence detection only)",
+        ]
+        controller.camera.errorOccurred.emit(0, "Driver 42")
+        assert statuses[-1].startswith("Camera error: type=unknown_error")
+        assert "diagnostic=unknown_failure" in statuses[-1]
+        assert "Driver 42" not in statuses[-1]
+        controller.stop()
+        assert statuses[-1] == "Camera closed"
+
+    with patch.object(camera_presence, "QCamera", None):
+        unavailable = CameraPresenceController(language="en")
+        try:
+            unavailable.start()
+        except RuntimeError as exc:
+            assert str(exc).startswith("This package does not include")
+            assert not HAN_TEXT.search(str(exc))
+        else:
+            raise AssertionError("missing camera component must fail closed")
+
+
+def _planner_response() -> io.BytesIO:
+    return io.BytesIO(
+        json.dumps(
+            {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "propose_action_plan",
+                        "arguments": json.dumps(
+                            {
+                                "title": "Open project",
+                                "steps": [],
+                            }
+                        ),
+                    }
+                ]
+            }
+        ).encode("utf-8")
+    )
+
+
+def _assert_ai_states() -> None:
+    completed: list[object] = []
+    worker = ActionPlannerWorker(
+        "Open the project",
+        api_key="sk-test",
+        model="gpt-test",
+        available_targets="project",
+        language="en",
+    )
+    assert worker.waiting_status == "Planning…"
+    worker.signals.done.connect(completed.append)
+    with patch("ai_client.urlopen", return_value=_planner_response()):
+        worker.run()
+    assert completed == [{"title": "Open project", "steps": []}]
+
+    failures: list[str] = []
+    missing_key = ActionPlannerWorker(
+        "Open the project",
+        api_key="",
+        model="gpt-test",
+        available_targets="project",
+        language="en",
+    )
+    missing_key.signals.failed.connect(failures.append)
+    with patch.dict(os.environ, {"OPENAI_API_KEY": ""}):
+        missing_key.run()
+    assert failures[-1].startswith("The OpenAI API key is not configured")
+    assert not HAN_TEXT.search(failures[-1])
+
+
+def run() -> None:
+    _assert_catalog_contract()
+    _assert_speech_states()
+    _assert_camera_states()
+    _assert_ai_states()
+    print("SERVICE_STATUS_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_settings_ui_localization.py
+++ b/tests/test_settings_ui_localization.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+lazy import re
+lazy import sys
+lazy from pathlib import Path
+lazy from string import Formatter
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+lazy from settings_ui_localization import (
+    LANGUAGE_ORDER,
+    PHYSICS_TEXT_KEYS,
+    PROACTIVE_MODE_KEYS,
+    TOPMOST_MODE_KEYS,
+    TRANSLATIONS,
+    SettingsText,
+    settings_text,
+)
+
+CJK = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]")
+TRADITIONAL_PHRASES = (
+    "設定",
+    "資料夾",
+    "程式",
+    "開啟",
+    "啟用",
+    "關閉",
+    "顯示",
+    "瀏覽",
+    "實機驗證",
+    "請先",
+    "髮飾",
+    "滑鼠",
+)
+
+
+def format_fields(template: str) -> tuple[str, ...]:
+    return tuple(
+        field_name
+        for _literal, field_name, _format_spec, _conversion in Formatter().parse(
+            template
+        )
+        if field_name is not None
+    )
+
+
+def assert_complete_translation_contract() -> None:
+    expected_keys = frozenset(SettingsText)
+    assert LANGUAGE_ORDER == ("zh-TW", "zh-CN", "en", "ja-JP")
+    assert tuple(TRANSLATIONS) == LANGUAGE_ORDER
+    for language in LANGUAGE_ORDER:
+        assert frozenset(TRANSLATIONS[language]) == expected_keys
+        assert all(TRANSLATIONS[language].values())
+    for key in SettingsText:
+        expected_fields = format_fields(TRANSLATIONS["zh-TW"][key])
+        assert all(
+            format_fields(TRANSLATIONS[language][key]) == expected_fields
+            for language in LANGUAGE_ORDER
+        ), key
+        values = {field: f"<{field}>" for field in expected_fields}
+        for language in LANGUAGE_ORDER:
+            TRANSLATIONS[language][key].format(**values)
+
+
+def assert_ordered_integration_contracts() -> None:
+    assert TOPMOST_MODE_KEYS == (
+        SettingsText.TOPMOST_SMART,
+        SettingsText.TOPMOST_ALWAYS,
+        SettingsText.TOPMOST_NEVER,
+    )
+    assert PROACTIVE_MODE_KEYS == (
+        SettingsText.PROACTIVE_QUIET,
+        SettingsText.PROACTIVE_BALANCED,
+        SettingsText.PROACTIVE_ACTIVE,
+    )
+    assert tuple(PHYSICS_TEXT_KEYS) == (
+        "physics_sleeves",
+        "physics_hair",
+        "physics_ornament",
+        "physics_eye_tracking",
+        "physics_face_parallax",
+    )
+    assert all(
+        name_key.name.endswith("_NAME")
+        and description_key.name.endswith("_DESCRIPTION")
+        for name_key, description_key in PHYSICS_TEXT_KEYS.values()
+    )
+
+
+def assert_english_contains_no_cjk() -> None:
+    english = "\n".join(TRANSLATIONS["en"].values())
+    assert not CJK.search(english), english
+    assert settings_text("en", SettingsText.TOPMOST_ALWAYS) == "Always on top"
+    assert settings_text("en", SettingsText.WORK_FOLDER_OPEN) == (
+        "Open work folder"
+    )
+
+
+def assert_simplified_chinese_contains_no_traditional_phrases() -> None:
+    simplified = "\n".join(TRANSLATIONS["zh-CN"].values())
+    for phrase in TRADITIONAL_PHRASES:
+        assert phrase not in simplified, phrase
+    assert settings_text("zh-CN", SettingsText.TOPMOST_SMART) == (
+        "智能置顶（推荐）"
+    )
+    assert settings_text("zh-CN", SettingsText.WORK_FOLDER_BROWSE) == (
+        "浏览…"
+    )
+
+
+def assert_natural_japanese_key_items() -> None:
+    assert settings_text("ja-JP", SettingsText.AUTOSTART_WINDOWS) == (
+        "Windows サインイン後に自動起動"
+    )
+    assert settings_text("ja-JP", SettingsText.PROACTIVE_BALANCED) == (
+        "バランス（推奨）"
+    )
+    assert settings_text("ja-JP", SettingsText.PHYSICS_EYE_TRACKING_NAME) == (
+        "視線のマウス追従"
+    )
+    assert settings_text("ja-JP", SettingsText.WORK_FOLDER_OPEN) == (
+        "作業フォルダーを開く"
+    )
+    assert settings_text("ja-JP", SettingsText.AI_CORE_LABEL) == "AI コア"
+    assert "入力してください" in settings_text(
+        "ja-JP",
+        SettingsText.PROFILE_REQUIRED_MESSAGE,
+    )
+
+
+def assert_formatting_aliases_and_fallback() -> None:
+    assert settings_text(
+        "en-US",
+        SettingsText.AUTOSTART_UNAVAILABLE,
+        platform="Linux",
+    ) == "Autostart on Linux has not been verified on a physical device"
+    assert settings_text(
+        "zh-Hans",
+        SettingsText.CHARACTER_SCALE_LABEL,
+        assistant="墨寒",
+    ) == "桌面墨寒显示大小"
+    assert settings_text(
+        "ja",
+        SettingsText.AUTOSTART_ERROR,
+        reason="権限不足",
+    ) == "自動起動を更新できませんでした：権限不足"
+    assert settings_text(
+        "unsupported",
+        SettingsText.CHARACTER_SCALE_RESET_TOOLTIP,
+        assistant="墨寒",
+    ) == "將桌面墨寒恢復為原始顯示大小"
+
+
+def run() -> None:
+    assert_complete_translation_contract()
+    assert_ordered_integration_contracts()
+    assert_english_contains_no_cjk()
+    assert_simplified_chinese_contains_no_traditional_phrases()
+    assert_natural_japanese_key_items()
+    assert_formatting_aliases_and_fallback()
+    print("SETTINGS_UI_LOCALIZATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_speech_completion_timer_contract.py
+++ b/tests/test_speech_completion_timer_contract.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from collections.abc import Callable
+lazy from itertools import pairwise
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+lazy from unittest.mock import MagicMock, patch
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtCore import QAbstractAnimation, QPoint, QTimer
+lazy from PySide6.QtWidgets import QApplication, QLabel
+
+lazy from app import CompanionWindow, QueuedSpeech
+lazy from db import StudioDB
+
+FINAL_STATE = "proud_front"
+FINAL_STATE_SOURCE = "ai_tag"
+MAX_COMPLETION_CYCLES = 20
+MAX_VISIBLE_FRAME_DELTA_PIXELS = 2
+TIMER_ORDERS = {
+    "mouth-motion-finish": ("mouth", "motion", "finish"),
+    "finish-motion-mouth": ("finish", "motion", "mouth"),
+    "motion-duplicate-finish": (
+        "motion",
+        "finish",
+        "finish",
+        "mouth",
+    ),
+}
+
+
+def _create_window(
+    temp_dir: str,
+) -> tuple[QApplication, CompanionWindow]:
+    os.environ["LOCALAPPDATA"] = temp_dir
+    db_path = Path(temp_dir) / "YanJianStudio" / "MoHan" / "mohan.db"
+    preflight = StudioDB(db_path)
+    preflight.set_setting("tts_enabled", False)
+    preflight.close()
+    app = QApplication([])
+    window = CompanionWindow(startup_speech=False)
+    window.show()
+    app.processEvents()
+    _stop_timers(window)
+    return app, window
+
+
+def _stop_timers(window: CompanionWindow) -> None:
+    for timer in window.findChildren(QTimer):
+        timer.stop()
+
+
+def _character_layers(window: CompanionWindow) -> tuple[QLabel, ...]:
+    return (
+        window.character,
+        window.expression_overlay,
+        window.sleeve_left_overlay,
+        window.sleeve_right_overlay,
+        window.hair_left_overlay,
+        window.hair_right_overlay,
+        window.physics_overlay,
+        window.face_overlay,
+        window.eye_overlay,
+    )
+
+
+def _sample_position(window: CompanionWindow) -> QPoint:
+    body_position = window.character.pos()
+    assert all(
+        layer.pos() == body_position for layer in _character_layers(window)
+    ), "speech completion split the layered character coordinates"
+    return QPoint(body_position)
+
+
+def _reset_window(window: CompanionWindow) -> None:
+    _stop_timers(window)
+    window._cancel_expression_transition()
+    window._cancel_pose_transition()
+    window._stop_gesture_animation()
+    window.speech_queue.clear()
+    window.speech_playing = False
+    window.active_speech_text = ""
+    window.realtime_mouth_active = False
+    window.audio_driven_mouth = False
+    window.mouth_closing = False
+    window.speech_gesture_expression = None
+    window.speech_motion_release_attempts = 0
+    window.realtime_motion_release_attempts = 0
+    window.head_motion_y = 0.0
+    window.ambient_motion_x = 0.0
+    window.ambient_motion_y = 0.0
+    window.ambient_motion_target_x = 0.0
+    window.ambient_motion_target_y = 0.0
+    window.speech_motion_y = 0.0
+    window.speech_motion_target_y = 0.0
+    window.gesture_motion_x = 0.0
+    window.gesture_motion_y = 0.0
+    window.gaze_x = 0.0
+    window.gaze_y = 0.0
+    window.idle_pose = "front"
+    window.speech_closed_expression = "idle_front"
+    window.speech_mid_expression = "mouth_mid_front"
+    window.speech_open_expression = "speaking_front"
+    window.after_speech_state = "idle"
+    window.realtime_after_speech_state = "idle"
+    window.state = "idle"
+    window.expression_arbiter.request("idle", force=True)
+    window._stop_mouth_animation()
+    window._set_expression("idle_front", fade=False)
+    window.last_composed_body_position = None
+    window._compose_character_position()
+    _stop_timers(window)
+    assert _sample_position(window).y() == window.character_base_y
+
+
+def _begin_speech(window: CompanionWindow, path: str) -> None:
+    if path == "general":
+        window._begin_speech_presentation(
+            QueuedSpeech(
+                "計時器完成契約",
+                FINAL_STATE,
+                0.8,
+                FINAL_STATE_SOURCE,
+            )
+        )
+        window.after_speech_state = FINAL_STATE
+        window.after_speech_intensity = 0.8
+        window._start_mouth_animation(audio_driven=True)
+        assert window.after_speech_state == FINAL_STATE
+    else:
+        window._realtime_speaking(True)
+        window.realtime_after_speech_state = FINAL_STATE
+        window.realtime_after_speech_intensity = 0.8
+        assert window.realtime_after_speech_state == FINAL_STATE
+    for vowel in ("A", "A", "A", "O", "O", "O", "E", "E"):
+        window._audio_viseme_cue(0.95, vowel)
+    assert window.state == "speaking"
+    assert window.audio_driven_mouth
+    assert window.speech_motion_y < -1.0
+    assert window.current_expression != window.speech_closed_expression
+
+
+def _completion_is_active(window: CompanionWindow, path: str) -> bool:
+    if path == "general":
+        return window.speech_playing
+    return (
+        window.state == "speaking"
+        and window.audio_driven_mouth
+        and not window.speech_playing
+    )
+
+
+def _completion_timer(window: CompanionWindow, path: str) -> QTimer:
+    return (
+        window.speech_finish_timer
+        if path == "general"
+        else window.realtime_finish_timer
+    )
+
+
+def _completion_callback(
+    window: CompanionWindow,
+    path: str,
+) -> Callable[[], None]:
+    return (
+        window._complete_speech_audio_finished
+        if path == "general"
+        else window._complete_realtime_speaking_stop
+    )
+
+
+def _signal_audio_finished(window: CompanionWindow, path: str) -> None:
+    if path == "general":
+        window._speech_audio_finished()
+    else:
+        window._realtime_speaking(False)
+
+
+def _final_state_calls(set_state: MagicMock) -> list:
+    return [
+        call
+        for call in set_state.call_args_list
+        if call.args and call.args[0] == FINAL_STATE
+    ]
+
+
+def _run_timer_action(
+    window: CompanionWindow,
+    callback: Callable[[], None],
+    action: str,
+    context: str,
+) -> None:
+    before = _sample_position(window)
+    if action == "mouth":
+        window._render_audio_mouth_transition()
+    elif action == "motion":
+        window._motion_tick()
+    else:
+        callback()
+    after = _sample_position(window)
+    if action in {"mouth", "finish"}:
+        assert after == before, (
+            f"{context}: {action} callback changed the visible pixel"
+        )
+        return
+    assert abs(after.y() - before.y()) <= MAX_VISIBLE_FRAME_DELTA_PIXELS, (
+        f"{context}: motion timer jumped from {before.y()} to {after.y()}"
+    )
+
+
+def _assert_timer_order_contract(
+    window: CompanionWindow,
+    path: str,
+    order_name: str,
+) -> None:
+    _reset_window(window)
+    _begin_speech(window, path)
+    callback = _completion_callback(window, path)
+    timer = _completion_timer(window, path)
+    with patch.object(
+        window,
+        "set_state",
+        wraps=window.set_state,
+    ) as set_state:
+        _signal_audio_finished(window, path)
+        _signal_audio_finished(window, path)
+        assert timer.isActive(), (
+            f"{path}/{order_name}: duplicate end signal lost the timer"
+        )
+        assert window.mouth_closing
+        assert window.speech_motion_target_y == 0.0
+
+        position_before_late_viseme = _sample_position(window)
+        window._audio_viseme_cue(1.0, "A")
+        assert _sample_position(window) == position_before_late_viseme
+        assert window.speech_motion_target_y == 0.0
+
+        for cycle in range(MAX_COMPLETION_CYCLES):
+            if not _completion_is_active(window, path):
+                break
+            context = f"{path}/{order_name}/cycle-{cycle}"
+            for action in TIMER_ORDERS[order_name]:
+                _run_timer_action(window, callback, action, context)
+
+        assert not _completion_is_active(window, path), (
+            f"{path}/{order_name}: completion did not converge"
+        )
+        assert not timer.isActive()
+        assert window.state == FINAL_STATE, (
+            f"{path}/{order_name}: final state was {window.state!r}"
+        )
+        handoff_calls = _final_state_calls(set_state)
+        assert len(handoff_calls) == 1, (
+            f"{path}/{order_name}: state handoff count was "
+            f"{len(handoff_calls)}"
+        )
+        assert handoff_calls[0].kwargs["animate_gesture"] is False
+        animation = getattr(window, "state_animation", None)
+        assert animation is None or (
+            animation.state() == QAbstractAnimation.Stopped
+        ), f"{path}/{order_name}: post-speech gesture replayed"
+        assert window.gesture_motion_x == 0.0
+        assert window.gesture_motion_y == 0.0
+
+        completed_position = _sample_position(window)
+        completed_state = window.state
+        completed_call_count = len(set_state.call_args_list)
+        callback()
+        callback()
+        _signal_audio_finished(window, path)
+        window._audio_viseme_cue(1.0, "O")
+        assert _sample_position(window) == completed_position
+        assert window.state == completed_state
+        assert len(set_state.call_args_list) == completed_call_count
+        assert len(_final_state_calls(set_state)) == 1
+
+        release_positions = [_sample_position(window)]
+        for _ in range(MAX_COMPLETION_CYCLES):
+            window._motion_tick()
+            release_positions.append(_sample_position(window))
+            if release_positions[-1].y() == window.character_base_y:
+                break
+        assert release_positions[-1].y() == window.character_base_y
+        assert max(
+            (
+                abs(current.y() - previous.y())
+                for previous, current in pairwise(release_positions)
+            ),
+            default=0,
+        ) <= MAX_VISIBLE_FRAME_DELTA_PIXELS
+
+
+def run() -> None:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        app, window = _create_window(temp_dir)
+        try:
+            for path in ("general", "realtime"):
+                for order_name in TIMER_ORDERS:
+                    _assert_timer_order_contract(
+                        window,
+                        path,
+                        order_name,
+                    )
+        finally:
+            window.speech_queue.clear()
+            window.speech_playing = False
+            window.close()
+            app.processEvents()
+    print("SPEECH_COMPLETION_TIMER_CONTRACT_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_speech_provider_registry.py
+++ b/tests/test_speech_provider_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 lazy import sys
+lazy from dataclasses import fields
 lazy from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -126,6 +127,8 @@ def run() -> None:
         api_key="not-a-real-key",
         instructions="calm",
     )
+    assert "not-a-real-key" not in repr(request)
+    assert fields(SpeechRequest)[3].repr is False
     registry.provider(WINDOWS_LOCAL_PROVIDER).speak(request)
     registry.provider(OPENAI_SPEECH_PROVIDER).speak(request)
     registry.provider(AZURE_SPEECH_PROVIDER).speak(
@@ -133,7 +136,7 @@ def run() -> None:
             text=request.text,
             voice="zh-TW-HsiaoChenNeural",
             api_key=request.api_key,
-            options={"region": "eastasia"},
+            options={"region": "eastasia", "locale": "zh-CN"},
         )
     )
     assert local.calls == [("主上，妾在。", "female-test", -2)]
@@ -146,6 +149,7 @@ def run() -> None:
             "not-a-real-key",
             "eastasia",
             "zh-TW-HsiaoChenNeural",
+            "zh-CN",
         )
     ]
 

--- a/tests/test_transcription_control.py
+++ b/tests/test_transcription_control.py
@@ -82,7 +82,7 @@ def run() -> None:
         temp.write(b"RIFF-test")
     diagnostics: list[str] = []
     failures: list[str] = []
-    worker = SpeechListener(Path("voice_listener.ps1"))
+    worker = SpeechListener(Path("voice_listener.ps1"), language="en")
     worker._busy.set()
     worker.diagnostic_changed.connect(diagnostics.append)
     worker.failed.connect(failures.append)
@@ -103,8 +103,9 @@ def run() -> None:
             "繁中詞庫",
             False,
         )
-    assert diagnostics and "成功連線" in diagnostics[-1]
-    assert failures and "備援目前已關閉" in failures[-1]
+    assert diagnostics and "internal_failure" in diagnostics[-1]
+    assert "成功連線" not in diagnostics[-1]
+    assert failures and "fallback recognition is currently disabled" in failures[-1]
     assert not audio_path.exists()
     assert not worker.is_busy
     print("TRANSCRIPTION_CONTROL_OK")

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -931,9 +931,8 @@ def _assert_realtime_text_contract(app: QApplication, window: CompanionWindow) -
     window._realtime_assistant_text("妾会保持专注，好好陪着你。")
     app.processEvents()
     chat_text = window.dashboard.chat.toPlainText()
-    assert "你還記得自己的故事嗎？" in chat_text
-    assert "妾會保持專注，好好陪著你。" in chat_text
-    assert "你还记得" not in chat_text
+    assert "你还记得自己的故事吗？" in chat_text
+    assert "妾会保持专注，好好陪着你。" in chat_text
 
 
 def _assert_chat_history_contract(window: CompanionWindow) -> None:
@@ -981,8 +980,8 @@ def _assert_idea_contract(app: QApplication, window: CompanionWindow) -> None:
     window.dashboard.idea_list.item(0).setCheckState(Qt.Unchecked)
     editor = IdeaEditorDialog("剑魂故事", "她听见主上的声音。")
     assert editor.values() == (
-        "劍魂故事",
-        "她聽見主上的聲音。",
+        "剑魂故事",
+        "她听见主上的声音。",
     )
     editor.close()
 
@@ -994,7 +993,7 @@ def _assert_memory_contract(app: QApplication, window: CompanionWindow) -> None:
     app.processEvents()
     memories = window.db.list_memories(category="人物")
     assert len(memories) == 1
-    assert memories[0]["title"] == "林小姐是我的出版視窗"
+    assert memories[0]["title"] == "林小姐是我的出版窗口"
     assert window.dashboard.memory_count.text() == "1 則"
     assert "【人物】" in window.dashboard.memory_list.item(0).text()
     assert window.dashboard.memory_filter.itemText(0) == "全部記憶（1）"
@@ -1012,7 +1011,7 @@ def _assert_memory_contract(app: QApplication, window: CompanionWindow) -> None:
     memory_editor.content_input.setPlainText("林小姐每週一聯絡")
     memory_editor.category_input.setCurrentText("工作流程")
     assert memory_editor.values() == (
-        "主要出版視窗",
+        "主要出版窗口",
         "林小姐每週一聯絡",
         "工作流程",
         4,

--- a/tests/test_user_content_preservation.py
+++ b/tests/test_user_content_preservation.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+lazy import json
+lazy import sys
+lazy from dataclasses import dataclass
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from db import PlatformProgressUpdate, StudioDB
+
+UI_LANGUAGES = ("zh-TW", "zh-CN", "en", "ja-JP")
+
+
+@dataclass(frozen=True, slots=True)
+class StoredCase:
+    todo_id: int
+    idea_id: int
+    memory_id: int
+    platform_name: str
+    workflow_id: int
+    connector_id: str
+    allowed_target_id: int
+    paired_device_id: int
+
+
+def user_text(language: str, field: str) -> str:
+    return (
+        f"{language}｜{field}｜简体剑魂不转换｜繁體墨寒不改寫｜"
+        "English e\u0301 stays EXACT｜日本語かなカナ｜emoji 👩🏻‍💻🗡️"
+    )
+
+
+def row_with_id(rows: list, row_id: int):
+    return next(row for row in rows if int(row["id"]) == row_id)
+
+
+def write_case(db: StudioDB, language: str) -> StoredCase:
+    db.set_setting("ui_language", language)
+
+    todo_id = db.add_todo(user_text(language, "todo-title"), "其他")
+
+    idea_id = db.add_idea(
+        user_text(language, "idea-add-title"),
+        user_text(language, "idea-add-content"),
+    )
+    added_idea = db.idea(idea_id)
+    assert added_idea is not None
+    assert added_idea["title"] == user_text(language, "idea-add-title")
+    assert added_idea["content"] == user_text(language, "idea-add-content")
+    db.update_idea(
+        idea_id,
+        user_text(language, "idea-update-title"),
+        user_text(language, "idea-update-content"),
+    )
+
+    memory_id = db.add_memory(
+        user_text(language, "memory-add-content"),
+        "偏好",
+        "manual",
+        3,
+        user_text(language, "memory-add-title"),
+    )
+    added_memory = db.memory(memory_id)
+    assert added_memory is not None
+    assert added_memory["title"] == user_text(language, "memory-add-title")
+    assert added_memory["content"] == user_text(language, "memory-add-content")
+    assert db.update_memory(
+        memory_id,
+        user_text(language, "memory-update-title"),
+        user_text(language, "memory-update-content"),
+        "偏好",
+        4,
+    )
+
+    db.log_chat("user", user_text(language, "chat-content"))
+
+    platform_name = user_text(language, "custom-platform-name")
+    platform_url = f"https://example.invalid/{language}/preservation"
+    assert db.add_platform(platform_name, platform_url)
+    db.update_platform(
+        PlatformProgressUpdate(
+            platform=platform_name,
+            status="進行中",
+            missing=user_text(language, "platform-missing"),
+            item_name=user_text(language, "platform-item-name"),
+            next_action=user_text(language, "platform-next-action"),
+            notes=user_text(language, "platform-notes"),
+            url=platform_url,
+        )
+    )
+
+    workflow_definition = json.dumps(
+        {"description": user_text(language, "workflow-definition")},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    workflow_id = db.save_workflow(
+        user_text(language, "workflow-name"),
+        workflow_definition,
+    )
+
+    connector_id = f"preservation-{language.lower()}"
+    db.save_connector(
+        connector_id,
+        user_text(language, "connector-display-name"),
+        True,
+        {"note": user_text(language, "connector-configuration")},
+    )
+
+    allowed_target_id = db.add_allowed_target(
+        "folder",
+        user_text(language, "allowed-target-display-name"),
+        f"virtual://preservation/{language}",
+        "read",
+    )
+    paired_device_id = db.add_paired_device(
+        user_text(language, "paired-device-name"),
+        f"test-only-token-hash-{language}",
+        ["status"],
+    )
+    return StoredCase(
+        todo_id=todo_id,
+        idea_id=idea_id,
+        memory_id=memory_id,
+        platform_name=platform_name,
+        workflow_id=workflow_id,
+        connector_id=connector_id,
+        allowed_target_id=allowed_target_id,
+        paired_device_id=paired_device_id,
+    )
+
+
+def assert_reopened_case(db: StudioDB, language: str, stored: StoredCase) -> None:
+    assert db.setting("ui_language") == language
+
+    todo = row_with_id(db.list_todos(include_done=True), stored.todo_id)
+    assert todo["title"] == user_text(language, "todo-title")
+    assert todo["category"] == "其他"
+    assert todo["status"] == "待辦"
+
+    idea = db.idea(stored.idea_id)
+    assert idea is not None
+    assert idea["text"] == user_text(language, "idea-update-title")
+    assert idea["title"] == user_text(language, "idea-update-title")
+    assert idea["content"] == user_text(language, "idea-update-content")
+
+    memory = db.memory(stored.memory_id)
+    assert memory is not None
+    assert memory["title"] == user_text(language, "memory-update-title")
+    assert memory["content"] == user_text(language, "memory-update-content")
+    assert memory["category"] == "偏好"
+
+    chat = db.recent_chat(1)[0]
+    assert chat["role"] == "user"
+    assert chat["content"] == user_text(language, "chat-content")
+
+    platform = next(
+        row
+        for row in db.platform_rows()
+        if row["platform"] == stored.platform_name
+    )
+    assert platform["status"] == "進行中"
+    assert platform["missing"] == user_text(language, "platform-missing")
+    assert platform["item_name"] == user_text(language, "platform-item-name")
+    assert platform["next_action"] == user_text(language, "platform-next-action")
+    assert platform["notes"] == user_text(language, "platform-notes")
+    assert platform["url"] == f"https://example.invalid/{language}/preservation"
+
+    workflow = db.workflow(stored.workflow_id)
+    assert workflow is not None
+    assert workflow["name"] == user_text(language, "workflow-name")
+    assert json.loads(workflow["definition"]) == {
+        "description": user_text(language, "workflow-definition")
+    }
+
+    connector = db.connector(stored.connector_id)
+    assert connector is not None
+    assert connector["display_name"] == user_text(
+        language,
+        "connector-display-name",
+    )
+    assert json.loads(connector["configuration"]) == {
+        "note": user_text(language, "connector-configuration")
+    }
+
+    allowed_target = row_with_id(db.allowed_targets(), stored.allowed_target_id)
+    assert allowed_target["display_name"] == user_text(
+        language,
+        "allowed-target-display-name",
+    )
+
+    paired_device = row_with_id(db.paired_devices(), stored.paired_device_id)
+    assert paired_device["device_name"] == user_text(
+        language,
+        "paired-device-name",
+    )
+
+
+def test_studio_db_preserves_user_content() -> None:
+    with TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        for language in UI_LANGUAGES:
+            database_path = root / f"user-content-{language}.db"
+            database = StudioDB(database_path)
+            try:
+                stored = write_case(database, language)
+            finally:
+                database.close()
+
+            reopened_database = StudioDB(database_path)
+            try:
+                assert_reopened_case(reopened_database, language, stored)
+            finally:
+                reopened_database.close()
+
+
+def main() -> None:
+    test_studio_db_preserves_user_content()
+    print("USER_CONTENT_PRESERVATION_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_v312_release_consistency.py
+++ b/tests/test_v312_release_consistency.py
@@ -13,6 +13,7 @@ lazy from version_info import APP_VERSION, FALLBACK_VERSION
 
 VERSION = "3.1.2"
 TAG = f"v{VERSION}"
+RELEASE_DATE = "2026-08-13"
 PYTHON_VERSION = "3.15.0-rc.1"
 LANGUAGE_HEADINGS = (
     "## 繁體中文",
@@ -66,6 +67,7 @@ def test_runtime_and_package_versions() -> None:
 
     citation = read("CITATION.cff")
     assert f'version: "{VERSION}"' in citation
+    assert f'date-released: "{RELEASE_DATE}"' in citation
 
 
 def test_readme_uses_one_dynamic_release_badge_per_language() -> None:
@@ -123,7 +125,7 @@ def test_four_language_release_sources_are_complete_and_permanent() -> None:
     language_sections(readme, "README.md")
     language_sections(changelog, "CHANGELOG.md")
     note_sections = language_sections(notes, f"docs/releases/{TAG}.md")
-    assert changelog.count(f"### {TAG} — 2026-08-13") == 4
+    assert changelog.count(f"### {TAG} — {RELEASE_DATE}") == 4
     assert notes.startswith(
         "# 墨寒桌面助理 v3.1.2／墨寒桌面助手 v3.1.2／"
         "MoHan Desktop Assistant v3.1.2／"

--- a/tests/test_v312_release_consistency.py
+++ b/tests/test_v312_release_consistency.py
@@ -55,38 +55,6 @@ def language_sections(document: str, source: str) -> tuple[str, ...]:
     )
 
 
-def assert_no_premature_publication(
-    document: str,
-    source: str,
-) -> None:
-    publication_terms = (
-        "已發布",
-        "已发布",
-        "has been published",
-        "is published",
-        "公開完了",
-        "公開済み",
-    )
-    preparation_terms = (
-        "尚未",
-        "不代表",
-        "並不代表",
-        "并不代表",
-        "not published",
-        "does not mean",
-        "未公開",
-        "示しません",
-    )
-    for line in document.splitlines():
-        if VERSION not in line:
-            continue
-        if not any(term in line for term in publication_terms):
-            continue
-        assert any(term in line for term in preparation_terms), (
-            f"{source} prematurely describes {TAG} as published: {line}"
-        )
-
-
 def test_runtime_and_package_versions() -> None:
     assert APP_VERSION == VERSION
     assert FALLBACK_VERSION == VERSION
@@ -103,16 +71,16 @@ def test_runtime_and_package_versions() -> None:
 def test_readme_uses_one_dynamic_release_badge_per_language() -> None:
     readme = read("README.md")
     sections = language_sections(readme, "README.md")
-    prepared_descriptions = (
+    release_gate_descriptions = (
         "實際產物仍須通過本版最終發布門檻",
         "实际产物仍须通过本版本最终发布关卡",
         "actual artifacts must still pass this release's final publication gates",
         "実際の成果物は本版の最終公開ゲートに合格する必要があります",
     )
 
-    for section, prepared_description in zip(
+    for section, release_gate_description in zip(
         sections,
-        prepared_descriptions,
+        release_gate_descriptions,
         strict=True,
     ):
         badge_block = section.split("</p>", maxsplit=1)[0]
@@ -131,41 +99,59 @@ def test_readme_uses_one_dynamic_release_badge_per_language() -> None:
             "version that may later be Stable or RC"
         )
 
-        assert prepared_description in section
-
-    assert_no_premature_publication(readme, "README.md")
+        assert release_gate_description in section
 
 
-def test_four_language_release_sources_are_prepared_not_published() -> None:
+def assert_no_stale_release_status(document: str, source: str) -> None:
+    stale_status_patterns = (
+        r"v3\.1\.2[^\n]*(?:尚未發布|預定)",
+        r"v3\.1\.2[^\n]*(?:尚未发布|计划)",
+        r"v3\.1\.2[^\n]*(?:not published|is planned)",
+        r"v3\.1\.2[^\n]*(?:未公開|予定)",
+    )
+    for pattern in stale_status_patterns:
+        assert re.search(pattern, document, flags=re.IGNORECASE) is None, (
+            f"{source} contains stale v3.1.2 publication wording: {pattern}"
+        )
+
+
+def test_four_language_release_sources_are_complete_and_permanent() -> None:
+    readme = read("README.md")
     changelog = read("CHANGELOG.md")
     notes = read(f"docs/releases/{TAG}.md")
 
+    language_sections(readme, "README.md")
     language_sections(changelog, "CHANGELOG.md")
-    language_sections(notes, f"docs/releases/{TAG}.md")
-    assert changelog.count(f"### {TAG} — 2026-08-12") == 4
+    note_sections = language_sections(notes, f"docs/releases/{TAG}.md")
+    assert changelog.count(f"### {TAG} — 2026-08-13") == 4
     assert notes.startswith(
         "# 墨寒桌面助理 v3.1.2／墨寒桌面助手 v3.1.2／"
         "MoHan Desktop Assistant v3.1.2／"
         "墨寒デスクトップアシスタント v3.1.2\n"
     )
 
-    for marker in (
-        "v3.1.2 尚未發布",
-        "v3.1.2 尚未发布",
-        "v3.1.2 is not published",
-        "v3.1.2 は未公開",
+    permanent_descriptions = (
+        "本版完整提供繁體中文、簡體中文、英文與日文介面",
+        "本版本完整提供繁体中文、简体中文、英文与日文界面",
+        (
+            "This release provides complete Traditional Chinese, Simplified "
+            + "Chinese, English, and Japanese interfaces"
+        ),
+        "本版は繁体字中国語、簡体字中国語、英語、日本語の完全な画面を提供します",
+    )
+    for section, description in zip(
+        note_sections,
+        permanent_descriptions,
+        strict=True,
     ):
-        assert marker in changelog, marker
-    for marker in (
-        "不代表 CI 已全綠或 v3.1.2 已發布",
-        "并不代表 CI 已全部通过或 v3.1.2 已发布",
-        "does not mean CI is all green or v3.1.2 has been published",
-        "CI の全成功や v3.1.2 の公開完了を示しません",
-    ):
-        assert marker in notes, marker
+        assert description in section, description
 
-    assert_no_premature_publication(changelog, "CHANGELOG.md")
-    assert_no_premature_publication(notes, f"docs/releases/{TAG}.md")
+    for source, document in (
+        ("README.md", readme),
+        ("CHANGELOG.md", changelog),
+        (f"docs/releases/{TAG}.md", notes),
+    ):
+        assert_no_stale_release_status(document, source)
 
 
 def test_release_workflow_derives_and_validates_the_exact_tag() -> None:
@@ -242,7 +228,7 @@ def test_python315_node24_and_jit_release_contract() -> None:
 def main() -> None:
     test_runtime_and_package_versions()
     test_readme_uses_one_dynamic_release_badge_per_language()
-    test_four_language_release_sources_are_prepared_not_published()
+    test_four_language_release_sources_are_complete_and_permanent()
     test_release_workflow_derives_and_validates_the_exact_tag()
     test_python315_node24_and_jit_release_contract()
     print("V312_RELEASE_CONSISTENCY_OK")

--- a/tests/test_v312_release_consistency.py
+++ b/tests/test_v312_release_consistency.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+lazy import re
+lazy import sys
+lazy import tomllib
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy from version_info import APP_VERSION, FALLBACK_VERSION
+
+VERSION = "3.1.2"
+TAG = f"v{VERSION}"
+PYTHON_VERSION = "3.15.0-rc.1"
+LANGUAGE_HEADINGS = (
+    "## 繁體中文",
+    "## 简体中文",
+    "## English",
+    "## 日本語",
+)
+
+
+def read(relative: str) -> str:
+    path = ROOT / relative
+    assert path.is_file(), f"missing v3.1.2 release input: {relative}"
+    return path.read_text(encoding="utf-8")
+
+
+def project_metadata(relative: str) -> dict[str, object]:
+    document = tomllib.loads(
+        (ROOT / relative).read_text(encoding="utf-8")
+    )
+    return document["project"]
+
+
+def language_sections(document: str, source: str) -> tuple[str, ...]:
+    matches = tuple(
+        tuple(re.finditer(rf"(?m)^{re.escape(heading)}\s*$", document))
+        for heading in LANGUAGE_HEADINGS
+    )
+    assert all(len(heading_matches) == 1 for heading_matches in matches), (
+        f"{source} must contain exactly one of each four-language section"
+    )
+    positions = tuple(heading_matches[0].start() for heading_matches in matches)
+    assert positions == tuple(sorted(positions)), (
+        f"{source} language order must be Traditional Chinese, Simplified "
+        "Chinese, English, then Japanese"
+    )
+    ends = (*positions[1:], len(document))
+    return tuple(
+        document[start:end]
+        for start, end in zip(positions, ends, strict=True)
+    )
+
+
+def assert_no_premature_publication(
+    document: str,
+    source: str,
+) -> None:
+    publication_terms = (
+        "已發布",
+        "已发布",
+        "has been published",
+        "is published",
+        "公開完了",
+        "公開済み",
+    )
+    preparation_terms = (
+        "尚未",
+        "不代表",
+        "並不代表",
+        "并不代表",
+        "not published",
+        "does not mean",
+        "未公開",
+        "示しません",
+    )
+    for line in document.splitlines():
+        if VERSION not in line:
+            continue
+        if not any(term in line for term in publication_terms):
+            continue
+        assert any(term in line for term in preparation_terms), (
+            f"{source} prematurely describes {TAG} as published: {line}"
+        )
+
+
+def test_runtime_and_package_versions() -> None:
+    assert APP_VERSION == VERSION
+    assert FALLBACK_VERSION == VERSION
+
+    for metadata_path in ("pyproject.toml", "sbom/preview.pyproject.toml"):
+        metadata = project_metadata(metadata_path)
+        assert metadata["version"] == VERSION, metadata_path
+        assert metadata["requires-python"] == ">=3.15,<3.16", metadata_path
+
+    citation = read("CITATION.cff")
+    assert f'version: "{VERSION}"' in citation
+
+
+def test_readme_uses_one_dynamic_release_badge_per_language() -> None:
+    readme = read("README.md")
+    sections = language_sections(readme, "README.md")
+    prepared_descriptions = (
+        "實際產物仍須通過本版最終發布門檻",
+        "实际产物仍须通过本版本最终发布关卡",
+        "actual artifacts must still pass this release's final publication gates",
+        "実際の成果物は本版の最終公開ゲートに合格する必要があります",
+    )
+
+    for section, prepared_description in zip(
+        sections,
+        prepared_descriptions,
+        strict=True,
+    ):
+        badge_block = section.split("</p>", maxsplit=1)[0]
+        assert badge_block.count("img.shields.io/github/v/release/") == 1
+        assert "label=published" in badge_block
+        assert VERSION not in badge_block, (
+            "the published-Release badge must stay dynamic rather than repeat "
+            "the prepared source version"
+        )
+
+        creator_start = section.index("<strong>")
+        creator_end = section.index("</p>", creator_start)
+        creator_block = section[creator_start:creator_end]
+        assert VERSION not in creator_block, (
+            "the creator summary must link to Releases without repeating a "
+            "version that may later be Stable or RC"
+        )
+
+        assert prepared_description in section
+
+    assert_no_premature_publication(readme, "README.md")
+
+
+def test_four_language_release_sources_are_prepared_not_published() -> None:
+    changelog = read("CHANGELOG.md")
+    notes = read(f"docs/releases/{TAG}.md")
+
+    language_sections(changelog, "CHANGELOG.md")
+    language_sections(notes, f"docs/releases/{TAG}.md")
+    assert changelog.count(f"### {TAG} — 2026-08-12") == 4
+    assert notes.startswith(
+        "# 墨寒桌面助理 v3.1.2／墨寒桌面助手 v3.1.2／"
+        "MoHan Desktop Assistant v3.1.2／"
+        "墨寒デスクトップアシスタント v3.1.2\n"
+    )
+
+    for marker in (
+        "v3.1.2 尚未發布",
+        "v3.1.2 尚未发布",
+        "v3.1.2 is not published",
+        "v3.1.2 は未公開",
+    ):
+        assert marker in changelog, marker
+    for marker in (
+        "不代表 CI 已全綠或 v3.1.2 已發布",
+        "并不代表 CI 已全部通过或 v3.1.2 已发布",
+        "does not mean CI is all green or v3.1.2 has been published",
+        "CI の全成功や v3.1.2 の公開完了を示しません",
+    ):
+        assert marker in notes, marker
+
+    assert_no_premature_publication(changelog, "CHANGELOG.md")
+    assert_no_premature_publication(notes, f"docs/releases/{TAG}.md")
+
+
+def test_release_workflow_derives_and_validates_the_exact_tag() -> None:
+    workflow = read(".github/workflows/release.yml")
+    assert re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", TAG)
+    for required in (
+        'if [[ "$tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+-rc\\.[1-9][0-9]*$ ]]',
+        'elif [[ "$tag" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+$ ]]',
+        'echo "version=${tag#v}" >> "$GITHUB_OUTPUT"',
+        "Expected exactly one literal FALLBACK_VERSION",
+        'if [[ "$source_version" != "$RELEASE_VERSION" ]]',
+        'notes="docs/releases/$RELEASE_TAG.md"',
+        '--notes-file "docs/releases/$tag.md"',
+    ):
+        assert required in workflow, required
+    assert (ROOT / "docs" / "releases" / f"{TAG}.md").is_file()
+
+
+def test_python315_node24_and_jit_release_contract() -> None:
+    release = read(".github/workflows/release.yml")
+    windows = read(".github/workflows/windows-ci.yml")
+
+    workflow_dir = ROOT / ".github" / "workflows"
+    for workflow_path in sorted(workflow_dir.glob("*.yml")):
+        workflow = workflow_path.read_text(encoding="utf-8")
+        assert 'FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"' in workflow, (
+            f"{workflow_path.name} must force the Node 24 action runtime"
+        )
+        assert "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION" not in workflow
+
+    windows_python_versions = set(
+        re.findall(r'python-version:\s*"([^"]+)"', windows)
+    )
+    assert windows_python_versions == {PYTHON_VERSION}
+    release_python_versions = re.findall(
+        r'python-version:\s*"([^"]+)"',
+        release,
+    )
+    assert PYTHON_VERSION in release_python_versions
+    assert set(release_python_versions) == {PYTHON_VERSION, "3.14.7"}
+    assert release_python_versions.count("3.14.7") == 1, (
+        "Python 3.14 must remain isolated to third-party SBOM tooling"
+    )
+
+    for required in (
+        'PYTHON_JIT = "0"',
+        'PYTHON_JIT = "1"',
+        "sys._jit.is_available()",
+        "sys._jit.is_enabled()",
+        "tools/benchmark_python315_hotpaths.py",
+    ):
+        assert required in windows, required
+    for required in (
+        "Build and verify JIT-default Python 3.15 runtime",
+        "PACKAGED_JIT_DEFAULT_OK",
+        "$env:PYTHON_JIT = $null",
+        "$env:MOHAN_DISABLE_JIT = $null",
+    ):
+        assert required in release, required
+    assert "--enable-experimental-jit=yes" in read(
+        "tools/build_python315_jit_runtime.py"
+    )
+
+    readme = read("README.md")
+    for statement in (
+        "JIT 預設啟用",
+        "JIT 默认启用",
+        "JIT is on by default",
+        "JIT は既定で有効",
+    ):
+        assert statement in readme, statement
+
+
+def main() -> None:
+    test_runtime_and_package_versions()
+    test_readme_uses_one_dynamic_release_badge_per_language()
+    test_four_language_release_sources_are_prepared_not_published()
+    test_release_workflow_derives_and_validates_the_exact_tag()
+    test_python315_node24_and_jit_release_contract()
+    print("V312_RELEASE_CONSISTENCY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_windows_tts_cancellation.py
+++ b/tests/test_windows_tts_cancellation.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+lazy import io
+lazy import math
+lazy import struct
+lazy import sys
+lazy import threading
+lazy import time
+lazy import wave
+lazy from pathlib import Path
+lazy from typing import ClassVar
+lazy from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtCore import QCoreApplication
+
+lazy from contracts import LocalSpeechEnginePort
+lazy from speech import UnavailableSystemTTS, WindowsTTS
+
+
+def _test_wave(duration: float = 0.20, rate: int = 24_000) -> bytes:
+    output = io.BytesIO()
+    with wave.open(output, "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(2)
+        target.setframerate(rate)
+        target.writeframes(
+            b"".join(
+                struct.pack(
+                    "<h",
+                    round(
+                        math.sin(index * math.tau * 440.0 / rate)
+                        * 7_200
+                    ),
+                )
+                for index in range(round(duration * rate))
+            )
+        )
+    return output.getvalue()
+
+
+def _wait_until(
+    app: QCoreApplication,
+    condition,
+    timeout: float = 2.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not condition():
+        app.processEvents()
+        if time.monotonic() >= deadline:
+            raise AssertionError("timed out waiting for Windows TTS worker")
+        time.sleep(0.005)
+    app.processEvents()
+
+
+class BlockingPowerShell:
+    instances: ClassVar[list[BlockingPowerShell]] = []
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        self.returncode: int | None = None
+        self.communicating = threading.Event()
+        self.terminated = threading.Event()
+        self.__class__.instances.append(self)
+
+    def communicate(self, timeout: float | None = None):
+        del timeout
+        self.communicating.set()
+        if not self.terminated.wait(timeout=2.0):
+            raise AssertionError("PowerShell cancellation was not delivered")
+        return b"", b"cancelled"
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -1
+        self.terminated.set()
+
+
+class BlockingRawOutputStream:
+    instances: ClassVar[list[BlockingRawOutputStream]] = []
+
+    def __init__(self, **_kwargs) -> None:
+        self.started = threading.Event()
+        self.writing = threading.Event()
+        self.aborted = threading.Event()
+        self.closed = threading.Event()
+        self.__class__.instances.append(self)
+
+    def start(self) -> None:
+        self.started.set()
+
+    def write(self, _chunk: bytes) -> None:
+        self.writing.set()
+        if not self.aborted.wait(timeout=2.0):
+            raise AssertionError("audio playback cancellation was not delivered")
+
+    def stop(self) -> None:
+        raise AssertionError("cancelled playback must not drain to completion")
+
+    def abort(self) -> None:
+        self.aborted.set()
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class CompletingRawOutputStream:
+    instances: ClassVar[list[CompletingRawOutputStream]] = []
+
+    def __init__(self, **_kwargs) -> None:
+        self.writes: list[bytes] = []
+        self.stopped = False
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    def start(self) -> None:
+        return
+
+    def write(self, chunk: bytes) -> None:
+        self.writes.append(chunk)
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def abort(self) -> None:
+        raise AssertionError("completed playback must not be aborted")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _signals(tts: WindowsTTS):
+    events: list[tuple[str, object]] = []
+    tts.viseme_cue.connect(
+        lambda level, vowel: events.append(("viseme", (level, vowel)))
+    )
+    tts.failed.connect(lambda message: events.append(("failed", message)))
+    tts.finished.connect(lambda: events.append(("finished", None)))
+    return events
+
+
+def _assert_contract() -> None:
+    assert "stop" in LocalSpeechEnginePort.__dict__
+    assert callable(WindowsTTS.stop)
+    unavailable = UnavailableSystemTTS("unavailable")
+    unavailable_events: list[str] = []
+    unavailable.finished.connect(lambda: unavailable_events.append("finished"))
+    unavailable.stop()
+    assert unavailable_events == []
+
+
+def _assert_synthesis_is_cancellable(app: QCoreApplication) -> None:
+    BlockingPowerShell.instances.clear()
+    tts = WindowsTTS()
+    events = _signals(tts)
+    with (
+        patch("speech.windows_voices", return_value=[("Hanhan", "zh-TW")]),
+        patch("subprocess.Popen", BlockingPowerShell),
+    ):
+        tts.speak("合成期間取消", "Hanhan")
+        _wait_until(app, lambda: bool(BlockingPowerShell.instances))
+        process = BlockingPowerShell.instances[0]
+        _wait_until(app, process.communicating.is_set)
+        tts.stop()
+        _wait_until(app, process.terminated.is_set)
+        time.sleep(0.03)
+        app.processEvents()
+    assert events == []
+
+
+def _assert_playback_is_cancellable(app: QCoreApplication) -> None:
+    BlockingRawOutputStream.instances.clear()
+    tts = WindowsTTS()
+    events = _signals(tts)
+    audio = _test_wave()
+
+    def play_synthesized(
+        _text: str,
+        _voice_name: str,
+        _rate: int,
+        generation: int,
+    ) -> None:
+        tts._play_wave_bytes(audio, generation)
+
+    with (
+        patch("speech.windows_voices", return_value=[("Hanhan", "zh-TW")]),
+        patch.object(tts, "_run_sapi", side_effect=play_synthesized),
+        patch("sounddevice.RawOutputStream", BlockingRawOutputStream),
+    ):
+        tts.speak("播放期間取消", "Hanhan")
+        _wait_until(app, lambda: bool(BlockingRawOutputStream.instances))
+        stream = BlockingRawOutputStream.instances[0]
+        _wait_until(app, stream.writing.is_set)
+        tts.stop()
+        event_count_at_stop = len(events)
+        _wait_until(app, stream.closed.is_set)
+        time.sleep(0.03)
+        app.processEvents()
+    assert stream.aborted.is_set()
+    assert len(events) == event_count_at_stop
+    assert all(name not in {"failed", "finished"} for name, _ in events)
+
+
+def _assert_new_speech_invalidates_old_generation(
+    app: QCoreApplication,
+) -> None:
+    tts = WindowsTTS()
+    events = _signals(tts)
+    first_started = threading.Event()
+    release_first = threading.Event()
+
+    def controlled_synthesis(
+        text: str,
+        _voice_name: str,
+        _rate: int,
+        generation: int,
+    ) -> None:
+        if text == "第一句":
+            first_started.set()
+            release_first.wait(timeout=2.0)
+            tts._emit_viseme(generation, 0.8, "A")
+
+    with (
+        patch("speech.windows_voices", return_value=[("Hanhan", "zh-TW")]),
+        patch.object(tts, "_run_sapi", side_effect=controlled_synthesis),
+    ):
+        tts.speak("第一句", "Hanhan")
+        _wait_until(app, first_started.is_set)
+        tts.speak("第二句", "Hanhan")
+        _wait_until(
+            app,
+            lambda: any(name == "finished" for name, _ in events),
+        )
+        release_first.set()
+        time.sleep(0.03)
+        app.processEvents()
+    assert events == [("finished", None)]
+
+
+def _assert_normal_speech_still_completes(app: QCoreApplication) -> None:
+    CompletingRawOutputStream.instances.clear()
+    tts = WindowsTTS()
+    events = _signals(tts)
+    audio = _test_wave(0.06)
+
+    def play_synthesized(
+        _text: str,
+        _voice_name: str,
+        _rate: int,
+        generation: int,
+    ) -> None:
+        tts._play_wave_bytes(audio, generation)
+
+    with (
+        patch("speech.windows_voices", return_value=[("Hanhan", "zh-TW")]),
+        patch.object(tts, "_run_sapi", side_effect=play_synthesized),
+        patch("sounddevice.RawOutputStream", CompletingRawOutputStream),
+    ):
+        tts.speak("正常朗讀", "Hanhan")
+        _wait_until(
+            app,
+            lambda: any(name == "finished" for name, _ in events),
+        )
+    stream = CompletingRawOutputStream.instances[0]
+    assert stream.writes
+    assert stream.stopped
+    assert stream.closed
+    assert events[-2:] == [
+        ("viseme", (0.0, "CLOSED")),
+        ("finished", None),
+    ]
+    assert all(name != "failed" for name, _ in events)
+
+
+def run() -> None:
+    app = QCoreApplication.instance() or QCoreApplication([])
+    _assert_contract()
+    _assert_synthesis_is_cancellable(app)
+    _assert_playback_is_cancellable(app)
+    _assert_new_speech_invalidates_old_generation(app)
+    _assert_normal_speech_still_completes(app)
+    print("WINDOWS_TTS_CANCELLATION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/audit_python315_compatibility.py
+++ b/tools/audit_python315_compatibility.py
@@ -146,7 +146,7 @@ class CompatibilityAudit(ast.NodeVisitor):
             if alias.name in removed_names:
                 self.issue(node, f"REMOVED_API {node.module}.{alias.name}")
 
-    def visit_Call(self, node: ast.Call) -> None:
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: C901, PLR0912 -- one explicit compatibility rule table
         name = call_name(node.func)
         if name in REMOVED_CALLS or (
             isinstance(node.func, ast.Attribute)

--- a/tools/diagnose_openai_planner.py
+++ b/tools/diagnose_openai_planner.py
@@ -11,6 +11,7 @@ lazy from urllib.request import Request, urlopen
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 lazy from ai_client import ActionPlannerWorker
+lazy from safe_error import sanitize_error
 lazy from secret_store import SecretStore
 
 
@@ -48,15 +49,16 @@ def main(data_path_text: str) -> int:
             f"elapsed={time.monotonic() - started:.2f}s"
         )
     except HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")[:800]
+        error = sanitize_error(exc, http_status=exc.code)
         print(
-            f"MODEL_CHECK=http_{exc.code},"
-            f"elapsed={time.monotonic() - started:.2f}s,detail={detail}"
+            f"MODEL_CHECK=failed,{error},"
+            f"elapsed={time.monotonic() - started:.2f}s"
         )
         return 3
-    except Exception as exc:  # noqa: BLE001 -- diagnostic prints the terminal cause
+    except Exception as exc:  # noqa: BLE001 -- external errors become finite metadata
+        error = sanitize_error(exc)
         print(
-            f"MODEL_CHECK={type(exc).__name__}:{exc},"
+            f"MODEL_CHECK=failed,{error},"
             f"elapsed={time.monotonic() - started:.2f}s"
         )
         return 4
@@ -76,7 +78,8 @@ def main(data_path_text: str) -> int:
     worker.run()
     elapsed = time.monotonic() - started
     if errors:
-        print(f"PLANNER=failed,elapsed={elapsed:.2f}s,error={errors[0]}")
+        error = sanitize_error(errors[0])
+        print(f"PLANNER=failed,{error},elapsed={elapsed:.2f}s")
         return 5
     if not plans:
         print(f"PLANNER=no_signal,elapsed={elapsed:.2f}s")

--- a/tools/install_windows_packaging_tools.ps1
+++ b/tools/install_windows_packaging_tools.ps1
@@ -24,7 +24,7 @@ gh release download $InnoTag `
     --clobber
 if ($LASTEXITCODE -ne 0) { throw "Official Inno Setup download failed" }
 
-gh release verify-asset $InnoDownload --repo jrsoftware/issrc
+gh release verify-asset $InnoTag $InnoDownload --repo jrsoftware/issrc
 if ($LASTEXITCODE -ne 0) {
     throw "Official Inno Setup release attestation verification failed"
 }

--- a/tools/migrate_python315_imports.py
+++ b/tools/migrate_python315_imports.py
@@ -10,6 +10,7 @@ EXCLUDED_PARTS = frozenset({
     ".ruff_cache",
     ".venv",
     ".venv315",
+    "_python315",
     "__pycache__",
     "build",
     "build-temp",
@@ -69,7 +70,10 @@ def python_files(root: Path = ROOT) -> list[Path]:
     return sorted(
         path
         for path in root.rglob("*.py")
-        if not any(part in EXCLUDED_PARTS for part in path.parts)
+        if not any(
+            part in EXCLUDED_PARTS
+            for part in path.relative_to(root).parts
+        )
     )
 
 

--- a/tools/sync_wordpress_download_page.py
+++ b/tools/sync_wordpress_download_page.py
@@ -6,7 +6,7 @@ lazy import html
 lazy import json
 lazy import os
 lazy from pathlib import Path
-lazy from urllib.error import HTTPError
+lazy from urllib.error import HTTPError, URLError
 lazy from urllib.parse import urlencode, urlparse
 lazy from urllib.request import Request, urlopen
 
@@ -33,46 +33,103 @@ DOWNLOAD_LABELS = {
 }
 
 
+def _wordpress_credentials(url: str) -> tuple[str, str]:
+    configuration_failed = False
+    base_url = ""
+    username = ""
+    password = ""
+    try:
+        base_url = os.environ["WORDPRESS_BASE_URL"].rstrip("/")
+        username = os.environ["WORDPRESS_USERNAME"]
+        password = os.environ["WORDPRESS_APP_PASSWORD"].replace(" ", "")
+        parsed_base = urlparse(base_url)
+        parsed_url = urlparse(url)
+        same_host = parsed_url.hostname == parsed_base.hostname
+    except (KeyError, TypeError, ValueError):
+        configuration_failed = True
+        same_host = False
+    if configuration_failed:
+        raise RuntimeError("WordPress API configuration is invalid")
+    if parsed_base.scheme != "https" or parsed_url.scheme != "https" or not same_host:
+        raise RuntimeError("WordPress API must use the configured HTTPS host")
+    return username, password
+
+
+def _wordpress_request(
+    url: str,
+    method: str,
+    payload: dict | None,
+) -> Request:
+    username, password = _wordpress_credentials(url)
+    request_failed = False
+    request: Request | None = None
+    try:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        data = None
+        headers = {
+            "Authorization": f"Basic {token}",
+            "Accept": "application/json",
+            "User-Agent": "MoHan-GitHub-Release-Sync",
+        }
+        if payload is not None:
+            data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            headers["Content-Type"] = "application/json; charset=utf-8"
+        request = Request(
+            url,
+            data=data,
+            headers=headers,
+            method=method,
+        )
+    except (RecursionError, TypeError, ValueError, UnicodeError):
+        request_failed = True
+    if request_failed or request is None:
+        raise RuntimeError("WordPress API request could not be prepared")
+    return request
+
+
+def _read_wordpress_json(request: Request) -> object:
+    response_failure: str | None = None
+    result: object | None = None
+    try:
+        with urlopen(request, timeout=30) as response:
+            result = json.load(response)
+    except HTTPError:
+        response_failure = "WordPress API request was rejected"
+    except (URLError, TimeoutError, OSError):
+        response_failure = "WordPress API is unavailable"
+    except (
+        AttributeError,
+        UnicodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+    ):
+        response_failure = "WordPress API returned invalid JSON"
+    if response_failure is not None:
+        raise RuntimeError(response_failure)
+    return result
+
+
 def request_json(
     url: str,
     method: str = "GET",
     payload: dict | None = None,
 ) -> object:
-    base_url = os.environ["WORDPRESS_BASE_URL"].rstrip("/")
-    parsed_base = urlparse(base_url)
-    parsed_url = urlparse(url)
-    if (
-        parsed_base.scheme != "https"
-        or parsed_url.scheme != "https"
-        or parsed_url.hostname != parsed_base.hostname
-    ):
-        raise RuntimeError("WordPress API must use the configured HTTPS host")
-    username = os.environ["WORDPRESS_USERNAME"]
-    password = os.environ["WORDPRESS_APP_PASSWORD"].replace(" ", "")
-    token = base64.b64encode(f"{username}:{password}".encode()).decode()
-    data = None
-    headers = {
-        "Authorization": f"Basic {token}",
-        "Accept": "application/json",
-        "User-Agent": "MoHan-GitHub-Release-Sync",
-    }
-    if payload is not None:
-        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-        headers["Content-Type"] = "application/json; charset=utf-8"
-    request = Request(
-        url,
-        data=data,
-        headers=headers,
-        method=method,
-    )
+    return _read_wordpress_json(_wordpress_request(url, method, payload))
+
+
+def load_manifest(path: Path) -> dict:
+    manifest_failed = False
+    manifest: object | None = None
     try:
-        with urlopen(request, timeout=30) as response:
-            return json.load(response)
-    except HTTPError as exc:
-        detail = exc.read(2048).decode("utf-8", "replace")
-        raise RuntimeError(
-            f"WordPress API returned {exc.code}: {detail}"
-        ) from exc
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError, RecursionError):
+        manifest_failed = True
+    if manifest_failed or not isinstance(manifest, dict):
+        raise RuntimeError("Release manifest could not be loaded")
+    return manifest
 
 
 def release_block(manifest: dict, release_url: str) -> str:
@@ -194,7 +251,7 @@ def main() -> int:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--release-url", required=True)
     args = parser.parse_args()
-    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    manifest = load_manifest(args.manifest)
     base = os.environ["WORDPRESS_BASE_URL"].rstrip("/")
     api = f"{base}/wp-json/wp/v2/pages"
     page_id = os.environ.get("WORDPRESS_DOWNLOAD_PAGE_ID", "").strip()

--- a/ui_localization.py
+++ b/ui_localization.py
@@ -8,6 +8,7 @@ lazy from ui_localization_ja import JAPANESE_UI
 
 _ENGLISH: Mapping[str, str] = deep_freeze({
     "first_run_title": "First-run setup",
+    "first_run_brand": "MoHan",
     "first_run_heading": "<b>Welcome to MoHan Desktop Assistant</b>",
     "first_run_hero_tagline": (
         "A thousand-year-old Northern Song sword spirit who listens, "
@@ -50,6 +51,311 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
     "tab_voice": "Voice",
     "tab_permissions": "Computer permissions",
     "tab_settings": "Settings",
+    "today_input_placeholder": (
+        "Enter a task, for example: Finish the storyboard for chapter 3"
+    ),
+    "todo_category_comic": "Comic",
+    "todo_category_article": "Article",
+    "todo_category_music": "Music",
+    "todo_category_stickers": "Stickers",
+    "todo_category_publishing": "Publishing",
+    "todo_category_administration": "Administration",
+    "todo_category_other": "Other",
+    "add_todo": "＋ Add task",
+    "save_as_idea": "✦ Save idea",
+    "today_tasks_heading": "<b>Tasks for today</b>",
+    "creative_ideas_heading": "<b>Creative ideas</b>",
+    "edit_selected_idea": "Edit selected idea",
+    "edit_selected_idea_tooltip": (
+        "You can also double-click an idea below"
+    ),
+    "delete_checked_ideas": "Delete checked ideas",
+    "delete_checked_ideas_tooltip": (
+        "Deletes only checked ideas and asks for confirmation first"
+    ),
+    "todo_complete_tooltip": "Mark as completed",
+    "todo_category_suffix": "Task for today",
+    "delete": "Delete",
+    "delete_todo_tooltip": "Delete this task",
+    "idea_editor_title": "Edit creative idea",
+    "idea_title": "<b>Idea title</b>",
+    "idea_title_placeholder": "Give this idea a clear title",
+    "idea_content": "<b>Idea details</b>",
+    "idea_content_placeholder": (
+        "Record the scene, dialogue, music direction, or next action…"
+    ),
+    "cancel": "Cancel",
+    "save_idea": "Save idea",
+    "idea_title_required_title": "Title required",
+    "idea_title_required": "Enter an idea title first.",
+    "todo_count": "{count} open",
+    "todo_empty": (
+        "No tasks yet today.\nWrite down the one thing that matters most."
+    ),
+    "idea_count": "{count} saved",
+    "idea_empty": (
+        "No ideas saved yet. Enter text above and choose “Save idea”."
+    ),
+    "idea_edit_tooltip": "Double-click to edit the title and details",
+    "today_time": "Today {total} | {state}",
+    "timing_active": "Timing",
+    "timing_inactive": "Not timing",
+    "todo_title_required": "Enter a task title first.",
+    "todo_added": "✓ Task added: {text}",
+    "todo_added_speech": "Added to today's tasks.",
+    "idea_capture_required": "Enter an idea to save first.",
+    "idea_added": "✓ Idea saved: {text}",
+    "idea_added_speech": "I saved that idea before it slipped away.",
+    "idea_select_edit": "Select an idea to edit first.",
+    "idea_not_found": (
+        "That idea could not be found. Refresh and try again."
+    ),
+    "idea_updated": "✓ Idea updated: {title}",
+    "idea_select_delete": "Check one or more ideas to delete first.",
+    "idea_delete_title": "Delete creative ideas",
+    "idea_delete_confirm": "Permanently delete the {count} checked ideas?",
+    "idea_deleted": "✓ Deleted {count} ideas.",
+    "platform_name_placeholder": (
+        "Platform, system, or tool name, for example: ERP, Notion, client portal"
+    ),
+    "platform_url_placeholder": "URL (optional, for example: https://example.com)",
+    "add_platform": "Add work platform",
+    "platform_filter_all": "All platforms",
+    "platform_filter_active": "In progress",
+    "platform_filter_blocked": "Missing information / blocked",
+    "platform_filter_finished": "Completed / published",
+    "platform_filter_not_started": "Not started",
+    "save_all_platforms": "Save all now",
+    "show": "Show",
+    "platform_empty": (
+        "No work platforms yet.\nAdd a company system, collaboration tool, "
+        "client portal, or any platform you use above."
+    ),
+    "platform_intro": (
+        "Manage the platforms, systems, client portals, and collaboration "
+        "tools you use. Each user creates their own list; no industry is assumed."
+    ),
+    "platform_auto_save_note": (
+        "Changes save automatically. You can also use each card's Save button."
+    ),
+    "platform_item_placeholder": "Current task, project, or case",
+    "platform_missing_placeholder": (
+        "Missing information, pending replies, or blockers; leave blank if none"
+    ),
+    "platform_next_placeholder": "Next concrete action and deadline",
+    "platform_notes_placeholder": "Notes, rules, contacts, or other details",
+    "platform_url_card_placeholder": "https://… (optional)",
+    "platform_not_saved": "Not saved",
+    "save_platform": "Save platform",
+    "platform_field_item": "Task / project",
+    "platform_field_missing": "Missing / blocked",
+    "platform_field_next": "Next action",
+    "platform_field_notes": "Notes",
+    "platform_field_url": "URL",
+    "open_platform": "Open website / tool",
+    "delete_platform": "Delete platform",
+    "platform_updated": "Updated: {updated}",
+    "platform_updated_unknown": "Update time unknown",
+    "save_changes": "Save changes",
+    "platform_waiting_auto_save": "{platform} changed; waiting to auto-save…",
+    "platform_validation_finished_blocked": (
+        "This work is completed but still lists missing information or blockers."
+    ),
+    "platform_validation_revision_details": (
+        "Describe the needed revision under Missing, Next action, or Notes."
+    ),
+    "platform_validation_not_started_data": (
+        "This card already has work details. Consider changing its status to "
+        "Preparing materials."
+    ),
+    "platform_validation_item_name": (
+        "Add a task, project, or case name so it is easy to identify later."
+    ),
+    "platform_summary_unsaved": " | Unsaved {count}",
+    "platform_summary": (
+        "{total} platforms | Completed {finished} | In progress {active} | "
+        "Not started {not_started} | Missing / blocked {blocked}{unsaved}"
+    ),
+    "platform_saved": "{platform} saved.",
+    "platform_saved_automatic": "{platform} saved automatically.",
+    "all_platforms_saved": (
+        "All work platforms saved; {count} still list missing information or blockers."
+    ),
+    "all_platforms_saved_speech": (
+        "Work platforms saved. {count} still have missing information or blockers."
+    ),
+    "memory_intro": (
+        "MoHan stores only people, preferences, goals, workflows, and important "
+        "dates that you allow. Memories stay on this computer and can be "
+        "browsed by category, edited individually, or deleted."
+    ),
+    "memory_input_placeholder": (
+        "For example: Finish the comic before administrative work"
+    ),
+    "remember": "Remember this",
+    "memory_filter_label": "Browse by category",
+    "all_memories": "All memories",
+    "edit_selected_memory": "Edit selected memory",
+    "edit_memory_tooltip": "You can also double-click a memory below",
+    "delete_checked_memories": "Delete checked memories",
+    "delete_checked_memories_tooltip": (
+        "Deletes only checked memories and asks for confirmation first"
+    ),
+    "clear_all_memories": "Clear all memories",
+    "optimize_memories": "Safely organize memories",
+    "optimize_memories_tooltip": (
+        "Merges low-importance duplicates and archives older overflow first"
+    ),
+    "view_archived_memories": "View archived memories",
+    "auto_memory": (
+        "Create memories from explicit phrases such as “remember this”, "
+        "“I like”, or “I usually”"
+    ),
+    "memory_count": "{count} saved",
+    "memory_empty": "There are no memories in this category.",
+    "memory_source_manual_short": "Manual",
+    "memory_source_conversation_short": "Conversation",
+    "memory_untitled": "Untitled memory",
+    "memory_item": (
+        "[{category}] {title}  Importance {importance}/5\n{content}\n"
+        "Source: {source}  Updated: {updated}"
+    ),
+    "memory_added_speech": (
+        "I saved that. You can review or change it individually later."
+    ),
+    "memory_select_edit_title": "No memory selected",
+    "memory_select_edit": "Select a memory to edit first.",
+    "memory_not_found_title": "Memory not found",
+    "memory_not_found": (
+        "That memory no longer exists. The list will be refreshed."
+    ),
+    "memory_save_failed_title": "Memory could not be saved",
+    "memory_save_failed": (
+        "An identical memory may already exist. Existing data was not changed."
+    ),
+    "memory_select_delete_title": "No memories checked",
+    "memory_select_delete": "Check one or more memories to delete first.",
+    "memory_delete_title": "Delete long-term memories",
+    "memory_delete_confirm": (
+        "Permanently delete the {count} checked memories?"
+    ),
+    "memory_clear_title": "Clear long-term memory",
+    "memory_clear_confirm": (
+        "Delete every long-term memory stored by MoHan? This cannot be undone."
+    ),
+    "memory_optimize_title": "Memory organization complete",
+    "memory_optimize_result": (
+        "Merged {deduplicated} similar memories and archived {pruned} older, "
+        "low-importance memories.\nActive: {active}; archived and restorable: "
+        "{archived}."
+    ),
+    "memory_editor_title": "Edit long-term memory",
+    "memory_title_label": "<b>Memory title</b>",
+    "memory_title_placeholder": "Use a short title to identify this memory",
+    "memory_category_label": "<b>Category</b>",
+    "memory_importance_label": "<b>Importance</b>",
+    "memory_content_label": "<b>Memory details</b>",
+    "memory_content_placeholder": (
+        "Record the person, preference, goal, workflow, or important date…"
+    ),
+    "memory_source_manual": "Created manually",
+    "memory_source_conversation": "Explicitly remembered from a conversation",
+    "memory_metadata": (
+        "Source: {source}  Created: {created}  Updated: {updated}"
+    ),
+    "save_memory": "Save memory",
+    "memory_title_required_title": "Title required",
+    "memory_title_required": "Enter a memory title first.",
+    "memory_content_required_title": "Details required",
+    "memory_content_required": "Enter the memory details first.",
+    "archived_memory_title": "Archived long-term memories",
+    "archived_memory_intro": (
+        "Automatic organization only archives older, low-importance "
+        "conversation memories; it does not destroy them. Check any item here "
+        "to restore it."
+    ),
+    "restore_checked_memories": "Restore checked memories",
+    "close": "Close",
+    "archived_memory_item": (
+        "[{category}] {title}\n{content}\nArchive reason: {reason}  "
+        "Archived: {archived}"
+    ),
+    "archived_memory_count": "{count} memories can be restored",
+    "archived_memory_select_title": "No memories checked",
+    "archived_memory_select": "Check one or more memories to restore first.",
+    "archived_memory_restored": "Restored {count} memories.",
+    "chat_history_title": "Manage / clear chats",
+    "chat_history_intro": (
+        "Chats stay on this computer and are not deleted automatically. Check "
+        "only the entries you are certain you want to delete permanently."
+    ),
+    "delete_checked_chats": "Delete checked chats",
+    "chat_history_item": "{created} | {speaker}\n{content}",
+    "chat_history_truncated_suffix": (
+        " (This window shows only the 500 most recent entries.)"
+    ),
+    "chat_history_status": "{count} chats are stored on this computer.{suffix}",
+    "chat_select_delete_title": "No chats checked",
+    "chat_select_delete": "Check one or more chats to delete first.",
+    "chat_delete_title": "Permanently delete chats",
+    "chat_delete_confirm": "Permanently delete the {count} checked chats?",
+    "load_older_chat_tooltip": "Load 50 earlier chats from this computer",
+    "manage_chat_tooltip": (
+        "Select and delete specific chats without affecting the others"
+    ),
+    "chat_zoom_out_tooltip": "Make chat text smaller (Ctrl + wheel down)",
+    "chat_zoom_in_tooltip": "Make chat text larger (Ctrl + wheel up)",
+    "chat_retention_status": (
+        "{total} chats stored locally; showing the most recent {shown}"
+    ),
+    "platform_name_required": "Enter a platform, system, or tool name first.",
+    "platform_duplicate": "“{platform}” already exists. Use a different name.",
+    "platform_added": "Work platform added: {platform}",
+    "platform_delete_title": "Delete work platform",
+    "platform_delete_confirm": (
+        "Delete “{platform}” and its work progress? This cannot be undone."
+    ),
+    "platform_not_found": "Work platform not found: {platform}",
+    "platform_deleted": "Work platform deleted: {platform}",
+    "platform_url_missing_title": "URL not set",
+    "platform_url_missing": (
+        "Enter the website or tool URL on the “{platform}” card first."
+    ),
+    "platform_url_unsupported_title": "Unsupported URL format",
+    "platform_url_unsupported": "Only http:// or https:// URLs can be opened.",
+    "permission_open_platform": "open the {platform} website",
+    "echo_guard_tooltip": (
+        "Pauses microphone upload while MoHan speaks and resumes after playback; "
+        "you cannot interrupt while this option is enabled."
+    ),
+    "hybrid_transcript_tooltip": (
+        "Realtime keeps native audio understanding. After each utterance, the "
+        "screen text uses a high-accuracy OpenAI transcription of the complete "
+        "recording, and MoHan replies only after it succeeds."
+    ),
+    "flagship_heading": "<b>Flagship control center</b>",
+    "increase": "Increase",
+    "decrease": "Decrease",
+    "voice_section": "Voice",
+    "profile_required_title": "Required profile details missing",
+    "profile_required": (
+        "Assistant name and how the assistant addresses you cannot be blank."
+    ),
+    "send_chat_required_title": "No message entered",
+    "send_chat_required": (
+        "Enter text on the left and choose Send; you can also use the microphone."
+    ),
+    "thinking_status": "{assistant} is thinking…",
+    "answering_status": "Answering…",
+    "api_connection_failed": "OpenAI API: connection failed ({error})",
+    "voice_ready_short": "Ready",
+    "microphone_idle": "🎙 Microphone",
+    "microphone_send_now": "⏹ Send now",
+    "microphone_recognizing": "Recognizing…",
+    "voice_status_format": "Voice status: {phase}",
+    "bubble_full_content": "…\n(See the Chat page for the complete message.)",
+    "tray_open_today": "Open Today",
+    "tray_quit": "Quit MoHan",
     "chat_retention": "Chats stay on this computer and are not auto-deleted",
     "load_older_chat": "Load older chats",
     "manage_chat": "Manage / clear chats",
@@ -308,6 +614,7 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
 
 _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
     "first_run_title": "首次启动设置",
+    "first_run_brand": "墨寒  MoHan",
     "first_run_heading": "<b>欢迎使用墨寒桌面助手</b>",
     "first_run_hero_tagline": (
         "来自北宋的千年女剑魂，陪您说话、记忆，也陪您把工作做好。"
@@ -345,6 +652,237 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
     "tab_voice": "语音",
     "tab_permissions": "电脑权限",
     "tab_settings": "设置",
+    "today_input_placeholder": (
+        "输入待办标题，例如：完成漫画第 3 话分镜"
+    ),
+    "todo_category_comic": "漫画",
+    "todo_category_article": "文章",
+    "todo_category_music": "音乐",
+    "todo_category_stickers": "贴图",
+    "todo_category_publishing": "出版",
+    "todo_category_administration": "行政",
+    "todo_category_other": "其他",
+    "add_todo": "＋ 添加待办",
+    "save_as_idea": "✦ 保存灵感",
+    "today_tasks_heading": "<b>今天要做</b>",
+    "creative_ideas_heading": "<b>创作灵感</b>",
+    "edit_selected_idea": "编辑选中灵感",
+    "edit_selected_idea_tooltip": "也可以双击下方任一灵感",
+    "delete_checked_ideas": "删除勾选灵感",
+    "delete_checked_ideas_tooltip": "只删除已勾选的灵感，执行前会再次确认",
+    "todo_complete_tooltip": "标记为已完成",
+    "todo_category_suffix": "今日待办",
+    "delete": "删除",
+    "delete_todo_tooltip": "删除这项待办",
+    "idea_editor_title": "编辑创作灵感",
+    "idea_title": "<b>灵感标题</b>",
+    "idea_title_placeholder": "为这则灵感填写清楚的标题",
+    "idea_content": "<b>灵感内容</b>",
+    "idea_content_placeholder": (
+        "记录情节、画面、对白、音乐方向或后续可执行的想法……"
+    ),
+    "cancel": "取消",
+    "save_idea": "保存灵感",
+    "idea_title_required_title": "缺少标题",
+    "idea_title_required": "请先填写灵感标题。",
+    "todo_count": "{count} 项未完成",
+    "todo_empty": "今日待办尚空。\n请先写下一件真正重要的事。",
+    "idea_count": "{count} 则",
+    "idea_empty": (
+        "尚无灵感记录；输入上方文字后点击“保存灵感”。"
+    ),
+    "idea_edit_tooltip": "双击打开并编辑标题与内容",
+    "today_time": "今日 {total}｜{state}",
+    "timing_active": "计时中",
+    "timing_inactive": "未计时",
+    "todo_title_required": "请先输入待办标题。",
+    "todo_added": "✓ 已添加待办：{text}",
+    "todo_added_speech": "已收入今日待办。",
+    "idea_capture_required": "请先输入要保存的灵感。",
+    "idea_added": "✓ 已保存灵感：{text}",
+    "idea_added_speech": "灵感稍纵即逝，妾已替您收好。",
+    "idea_select_edit": "请先选择一则要编辑的灵感。",
+    "idea_not_found": "找不到这则灵感，请刷新后再试。",
+    "idea_updated": "✓ 已更新灵感：{title}",
+    "idea_select_delete": "请先勾选要删除的灵感。",
+    "idea_delete_title": "删除创作灵感",
+    "idea_delete_confirm": "确定永久删除勾选的 {count} 则灵感吗？",
+    "idea_deleted": "✓ 已删除 {count} 则灵感。",
+    "platform_name_placeholder": "平台、系统或工具名称，例如：公司 ERP、Notion、客户后台",
+    "platform_url_placeholder": "网址（可留空，例如：https://example.com）",
+    "add_platform": "添加工作平台",
+    "platform_filter_all": "全部平台",
+    "platform_filter_active": "进行中",
+    "platform_filter_blocked": "待补资料／受阻",
+    "platform_filter_finished": "已完成／已发布",
+    "platform_filter_not_started": "尚未开始",
+    "save_all_platforms": "立即保存全部",
+    "show": "显示",
+    "platform_empty": (
+        "尚未建立工作平台。\n请在上方输入公司系统、协作工具、客户后台或任何工作平台。"
+    ),
+    "platform_intro": (
+        "集中管理工作中使用的平台、系统、客户入口或协作工具。"
+        "每位用户都可以建立自己的工作平台，不预设绑定任何行业。"
+    ),
+    "platform_auto_save_note": "修改后会自动保存；也可以使用每张卡片的保存按钮。",
+    "platform_item_placeholder": "当前负责的工作事项、项目或案件",
+    "platform_missing_placeholder": "待补资料、等待他人回复或其他阻碍；没有可留空",
+    "platform_next_placeholder": "下一个具体动作与期限",
+    "platform_notes_placeholder": "备注、规则、联系窗口或其他补充",
+    "platform_url_card_placeholder": "https://…（可留空）",
+    "platform_not_saved": "尚未保存",
+    "save_platform": "保存此平台",
+    "platform_field_item": "工作事项／项目",
+    "platform_field_missing": "待补资料／阻碍",
+    "platform_field_next": "下一步",
+    "platform_field_notes": "备注",
+    "platform_field_url": "网址",
+    "open_platform": "打开网站／工具",
+    "delete_platform": "删除平台",
+    "platform_updated": "更新：{updated}",
+    "platform_updated_unknown": "更新时间未知",
+    "save_changes": "保存修改",
+    "platform_waiting_auto_save": "{platform} 有修改，正在等待自动保存……",
+    "platform_validation_finished_blocked": "注意：工作已完成，但仍列有待补资料或阻碍。",
+    "platform_validation_revision_details": "请在待补资料／阻碍、下一步或备注中写明需修改的内容。",
+    "platform_validation_not_started_data": "已有工作资料，请确认状态是否应改为“准备资料”。",
+    "platform_validation_item_name": "建议填写工作事项、项目或案件名称，日后较容易辨认。",
+    "platform_summary_unsaved": "｜未保存 {count}",
+    "platform_summary": (
+        "{total} 个平台｜已完成 {finished}｜进行中 {active}｜"
+        "尚未开始 {not_started}｜待补／阻碍 {blocked}{unsaved}"
+    ),
+    "platform_saved": "{platform} 已保存。",
+    "platform_saved_automatic": "{platform} 已自动保存。",
+    "all_platforms_saved": "全部工作平台已保存；{count} 个平台仍列有待补资料或阻碍。",
+    "all_platforms_saved_speech": "工作平台已保存。仍有 {count} 个平台标有待补资料或阻碍。",
+    "memory_intro": (
+        "墨寒只保存您允许留下的人物、偏好、目标、工作流程与重要日期。"
+        "记忆保存在本机，可按分类浏览、逐项编辑或删除。"
+    ),
+    "memory_input_placeholder": "例如：先完成漫画，再处理行政工作",
+    "remember": "让墨寒记住",
+    "memory_filter_label": "分类浏览",
+    "all_memories": "全部记忆",
+    "edit_selected_memory": "编辑选中记忆",
+    "edit_memory_tooltip": "也可以双击下方任一记忆",
+    "delete_checked_memories": "删除勾选记忆",
+    "delete_checked_memories_tooltip": "只删除已勾选的记忆，执行前会再次确认",
+    "clear_all_memories": "清除全部记忆",
+    "optimize_memories": "安全整理记忆",
+    "optimize_memories_tooltip": "合并低重要度重复内容，超量旧记忆只会先封存",
+    "view_archived_memories": "查看已封存记忆",
+    "auto_memory": "从“请记住／我喜欢／我习惯”等明确说法自动建立记忆",
+    "memory_count": "{count} 则",
+    "memory_empty": "这个分类目前没有记忆。",
+    "memory_source_manual_short": "手动",
+    "memory_source_conversation_short": "对话",
+    "memory_untitled": "未命名记忆",
+    "memory_item": (
+        "【{category}】{title}　重要度 {importance}／5\n{content}\n"
+        "来源：{source}　更新：{updated}"
+    ),
+    "memory_added_speech": "妾已记下。您日后若要更改，也可逐项整理。",
+    "memory_select_edit_title": "尚未选中",
+    "memory_select_edit": "请先选择一则要编辑的记忆。",
+    "memory_not_found_title": "找不到记忆",
+    "memory_not_found": "这则记忆已不存在，列表将重新整理。",
+    "memory_save_failed_title": "无法保存记忆",
+    "memory_save_failed": "可能已有内容完全相同的记忆。原有数据未被更改。",
+    "memory_select_delete_title": "尚未勾选",
+    "memory_select_delete": "请先勾选要删除的记忆。",
+    "memory_delete_title": "删除长期记忆",
+    "memory_delete_confirm": "确定永久删除勾选的 {count} 则记忆吗？",
+    "memory_clear_title": "清除长期记忆",
+    "memory_clear_confirm": "确定删除墨寒保存的全部长期记忆吗？此操作无法恢复。",
+    "memory_optimize_title": "记忆整理完成",
+    "memory_optimize_result": (
+        "合并 {deduplicated} 则近似记忆，封存 {pruned} 则较旧低重要度记忆。\n"
+        "目前使用中 {active} 则；可恢复封存 {archived} 则。"
+    ),
+    "memory_editor_title": "编辑长期记忆",
+    "memory_title_label": "<b>记忆标题</b>",
+    "memory_title_placeholder": "用一句短标题识别这则记忆",
+    "memory_category_label": "<b>分类</b>",
+    "memory_importance_label": "<b>重要度</b>",
+    "memory_content_label": "<b>记忆内容</b>",
+    "memory_content_placeholder": "完整记录人物背景、偏好、目标、工作流程或重要日期……",
+    "memory_source_manual": "手动建立",
+    "memory_source_conversation": "由对话明确记住",
+    "memory_metadata": "来源：{source}　建立：{created}　更新：{updated}",
+    "save_memory": "保存记忆",
+    "memory_title_required_title": "尚无标题",
+    "memory_title_required": "请先填写记忆标题。",
+    "memory_content_required_title": "尚无内容",
+    "memory_content_required": "请先填写记忆内容。",
+    "archived_memory_title": "已封存的长期记忆",
+    "archived_memory_intro": (
+        "自动整理只会封存较旧、低重要度的对话记忆，不会直接销毁。"
+        "您可以在这里随时勾选恢复。"
+    ),
+    "restore_checked_memories": "恢复勾选记忆",
+    "close": "关闭",
+    "archived_memory_item": (
+        "【{category}】{title}\n{content}\n封存原因：{reason}　时间：{archived}"
+    ),
+    "archived_memory_count": "目前共有 {count} 则可恢复记忆",
+    "archived_memory_select_title": "尚未选中",
+    "archived_memory_select": "请先勾选要恢复的记忆。",
+    "archived_memory_restored": "已恢复 {count} 则记忆。",
+    "chat_history_title": "管理／清除对话",
+    "chat_history_intro": (
+        "对话平时保存在本机，不会自动删除。请只勾选确定要永久删除的记录。"
+    ),
+    "delete_checked_chats": "删除勾选对话",
+    "chat_history_item": "{created}｜{speaker}\n{content}",
+    "chat_history_truncated_suffix": "（管理窗口最多显示最近 500 则）",
+    "chat_history_status": "本机共保存 {count} 则对话。{suffix}",
+    "chat_select_delete_title": "尚未勾选",
+    "chat_select_delete": "请先勾选要删除的对话。",
+    "chat_delete_title": "永久删除对话",
+    "chat_delete_confirm": "确定永久删除勾选的 {count} 则对话吗？",
+    "load_older_chat_tooltip": "每次向前加载 50 则本机对话",
+    "manage_chat_tooltip": "勾选并删除指定对话，其他内容不受影响",
+    "chat_zoom_out_tooltip": "缩小对话文字（Ctrl＋鼠标滚轮向下）",
+    "chat_zoom_in_tooltip": "放大对话文字（Ctrl＋鼠标滚轮向上）",
+    "chat_retention_status": "本机保存 {total} 则对话，目前显示最近 {shown} 则",
+    "platform_name_required": "请先输入平台、系统或工具名称。",
+    "platform_duplicate": "“{platform}”已存在，请使用不同名称。",
+    "platform_added": "已添加工作平台：{platform}",
+    "platform_delete_title": "删除工作平台",
+    "platform_delete_confirm": "确定删除“{platform}”及其工作进度吗？此操作无法恢复。",
+    "platform_not_found": "找不到工作平台：{platform}",
+    "platform_deleted": "已删除工作平台：{platform}",
+    "platform_url_missing_title": "尚未设置网址",
+    "platform_url_missing": "请先在“{platform}”卡片填写网站或工具网址。",
+    "platform_url_unsupported_title": "网址格式不支持",
+    "platform_url_unsupported": "只允许打开 http:// 或 https:// 网址。",
+    "permission_open_platform": "打开 {platform} 网站",
+    "echo_guard_tooltip": "墨寒说话时暂停上传麦克风，播放结束后再恢复；启用时无法在她说话途中插话。",
+    "hybrid_transcript_tooltip": (
+        "Realtime 保留原生音频理解；每句说完后，界面文字改用完整录音的 "
+        "OpenAI 高精度转录。成功后才允许墨寒回答。"
+    ),
+    "flagship_heading": "<b>旗舰控制中心</b>",
+    "increase": "增加",
+    "decrease": "减少",
+    "voice_section": "语音",
+    "profile_required_title": "尚缺必要资料",
+    "profile_required": "助手名称与助手对您的称呼不可留空。",
+    "send_chat_required_title": "尚未输入内容",
+    "send_chat_required": "请先在左侧输入文字，再点击“发送”；也可以直接使用麦克风。",
+    "thinking_status": "{assistant}思考中……",
+    "answering_status": "回答中……",
+    "api_connection_failed": "OpenAI API：连接失败（{error}）",
+    "voice_ready_short": "准备就绪",
+    "microphone_idle": "🎙 麦克风",
+    "microphone_send_now": "⏹ 立即发送",
+    "microphone_recognizing": "识别中……",
+    "voice_status_format": "语音状态：{phase}",
+    "bubble_full_content": "……\n（完整内容请见对话页）",
+    "tray_open_today": "打开今日待办",
+    "tray_quit": "退出墨寒",
     "chat_retention": "对话保存在本机，不会自动删除",
     "load_older_chat": "加载更早对话",
     "manage_chat": "管理／清除对话",
@@ -592,6 +1130,29 @@ WORK_TYPE_LABELS: Mapping[str, str] = frozendict({
     "其他（可自行輸入）": "Other (enter your own)",
 })
 
+PLATFORM_STATUS_LABELS: Mapping[str, str] = frozendict({
+    "尚未開始": "Not started",
+    "準備資料": "Preparing materials",
+    "進行中": "In progress",
+    "待送出": "Ready to submit",
+    "等待回覆": "Waiting for response",
+    "審核中": "Under review",
+    "需修正": "Needs revision",
+    "已排程": "Scheduled",
+    "已完成": "Completed",
+    "已上架": "Published",
+    "暫停": "Paused",
+})
+
+MEMORY_CATEGORY_LABELS: Mapping[str, str] = frozendict({
+    "人物": "People",
+    "偏好": "Preferences",
+    "目標": "Goals",
+    "工作流程": "Workflows",
+    "重要日期": "Important dates",
+    "其他": "Other",
+})
+
 SIMPLIFIED_MODE_LABELS: Mapping[str, str] = frozendict({
     "工作": "工作",
     "陪伴": "陪伴",
@@ -610,6 +1171,29 @@ SIMPLIFIED_WORK_TYPE_LABELS: Mapping[str, str] = frozendict({
     "教育／研究": "教育／研究",
     "銷售／客戶服務": "销售／客户服务",
     "其他（可自行輸入）": "其他（可自行输入）",
+})
+
+SIMPLIFIED_PLATFORM_STATUS_LABELS: Mapping[str, str] = frozendict({
+    "尚未開始": "尚未开始",
+    "準備資料": "准备资料",
+    "進行中": "进行中",
+    "待送出": "待提交",
+    "等待回覆": "等待回复",
+    "審核中": "审核中",
+    "需修正": "需修改",
+    "已排程": "已排期",
+    "已完成": "已完成",
+    "已上架": "已发布",
+    "暫停": "暂停",
+})
+
+SIMPLIFIED_MEMORY_CATEGORY_LABELS: Mapping[str, str] = frozendict({
+    "人物": "人物",
+    "偏好": "偏好",
+    "目標": "目标",
+    "工作流程": "工作流程",
+    "重要日期": "重要日期",
+    "其他": "其他",
 })
 
 

--- a/ui_localization.py
+++ b/ui_localization.py
@@ -74,7 +74,29 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
         "{platform} local voice has not completed device verification"
     ),
     "tts_voice": "OpenAI text-to-speech voice",
-    "realtime_voice": "Realtime conversation voice",
+    "realtime_output_source": "Realtime response voice source",
+    "realtime_output_openai": (
+        "Native OpenAI Realtime voice (lowest latency, existing default)"
+    ),
+    "realtime_output_azure": "Azure Speech female voice (gentle streaming)",
+    "realtime_output_azure_hd": (
+        "Azure Dragon HD female voice (requires S0)"
+    ),
+    "realtime_output_note_openai": (
+        "Uses the OpenAI Realtime native voice below. This is the lowest-"
+        "latency option and preserves native OpenAI Realtime speech output."
+    ),
+    "realtime_output_note_azure": (
+        "Uses the Azure Speech female voice, region, and key configured above. "
+        "OpenAI Realtime handles live understanding while Azure streams the "
+        "spoken response."
+    ),
+    "realtime_output_note_azure_hd": (
+        "Uses the Dragon HD female voice, S0 region, and separate key "
+        "configured above. OpenAI Realtime handles live understanding while "
+        "Dragon HD streams the spoken response."
+    ),
+    "realtime_voice": "Native OpenAI Realtime voice",
     "realtime_model": "Realtime model",
     "realtime_transcription_model": "Realtime transcription model",
     "realtime_noise": "Realtime microphone noise reduction",
@@ -161,6 +183,14 @@ _ENGLISH: Mapping[str, str] = deep_freeze({
     "no_transcription_error": "No transcription errors recorded",
     "preview_voice": "Preview: Commander, I am here.",
     "realtime_disconnected": "Realtime: Disconnected",
+    "realtime_status_format": "Realtime: {status}",
+    "realtime_disconnected_status": "Disconnected",
+    "realtime_error_status": "Error: {error}",
+    "realtime_voice_title": "Realtime voice",
+    "realtime_output_unavailable": (
+        "Realtime Azure speech output is unavailable, so the live "
+        "conversation was not started."
+    ),
     "start_realtime": "Start Realtime conversation",
     "stop_realtime": "Stop Realtime conversation",
     "near_field": "Close microphone (recommended)",
@@ -339,7 +369,27 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
         "{platform} 本机语音尚未完成设备实测"
     ),
     "tts_voice": "OpenAI 文字转语音声音",
-    "realtime_voice": "Realtime 对话声音",
+    "realtime_output_source": "Realtime 回复声音来源",
+    "realtime_output_openai": (
+        "OpenAI Realtime 原生语音（最低延迟，现有默认）"
+    ),
+    "realtime_output_azure": "Azure Speech 女性声线（柔和流式播放）",
+    "realtime_output_azure_hd": (
+        "Azure Dragon HD 女性声线（需 S0）"
+    ),
+    "realtime_output_note_openai": (
+        "使用下方“OpenAI Realtime 原生声线”；延迟最低，完整保留 "
+        "OpenAI Realtime 的原生实时语音输出。"
+    ),
+    "realtime_output_note_azure": (
+        "沿用上方“Azure Speech 女性声线”、区域与密钥。OpenAI Realtime "
+        "负责实时理解，Azure 以流式方式发声。"
+    ),
+    "realtime_output_note_azure_hd": (
+        "沿用上方“Dragon HD 女性声线”、S0 区域与独立密钥。OpenAI "
+        "Realtime 负责实时理解，Dragon HD 以流式方式发声。"
+    ),
+    "realtime_voice": "OpenAI Realtime 原生声线",
     "realtime_model": "Realtime 模型",
     "realtime_transcription_model": "Realtime 转录模型",
     "realtime_noise": "Realtime 麦克风降噪",
@@ -416,6 +466,13 @@ _SIMPLIFIED_CHINESE: Mapping[str, str] = deep_freeze({
     "no_transcription_error": "没有转录错误记录",
     "preview_voice": "试听：主上，妾在。",
     "realtime_disconnected": "Realtime：未连接",
+    "realtime_status_format": "Realtime：{status}",
+    "realtime_disconnected_status": "未连接",
+    "realtime_error_status": "错误：{error}",
+    "realtime_voice_title": "Realtime 语音",
+    "realtime_output_unavailable": (
+        "Realtime Azure 语音输出服务尚未建立，未启动实时对话。"
+    ),
     "start_realtime": "启动 Realtime 自然对话",
     "stop_realtime": "停止 Realtime 自然对话",
     "near_field": "近距离麦克风（推荐）",

--- a/ui_localization_ja.py
+++ b/ui_localization_ja.py
@@ -6,6 +6,7 @@ lazy from immutable_config import deep_freeze
 
 JAPANESE_UI: Mapping[str, str] = deep_freeze({
     "first_run_title": "初回セットアップ",
+    "first_run_brand": "墨寒  MoHan",
     "first_run_heading": "<b>墨寒デスクトップアシスタントへようこそ</b>",
     "first_run_hero_tagline": (
         "北宋から来た千年の女剣魂。話を聴き、記憶し、仕事を整えるあなたの伴侶です。"
@@ -43,6 +44,252 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
     "tab_voice": "音声",
     "tab_permissions": "パソコンの権限",
     "tab_settings": "設定",
+    "today_input_placeholder": "予定を入力（例：漫画第3話の絵コンテを完成）",
+    "todo_category_comic": "漫画",
+    "todo_category_article": "文章",
+    "todo_category_music": "音楽",
+    "todo_category_stickers": "スタンプ",
+    "todo_category_publishing": "出版",
+    "todo_category_administration": "管理",
+    "todo_category_other": "その他",
+    "add_todo": "＋ 予定を追加",
+    "save_as_idea": "✦ アイデアに保存",
+    "today_tasks_heading": "<b>今日の予定</b>",
+    "creative_ideas_heading": "<b>創作アイデア</b>",
+    "edit_selected_idea": "選択したアイデアを編集",
+    "edit_selected_idea_tooltip": (
+        "下のアイデアをダブルクリックしても編集できます"
+    ),
+    "delete_checked_ideas": "チェックしたアイデアを削除",
+    "delete_checked_ideas_tooltip": (
+        "チェックしたアイデアだけを確認後に削除します"
+    ),
+    "todo_complete_tooltip": "完了としてマーク",
+    "todo_category_suffix": "今日の予定",
+    "delete": "削除",
+    "delete_todo_tooltip": "この予定を削除",
+    "idea_editor_title": "創作アイデアを編集",
+    "idea_title": "<b>アイデアのタイトル</b>",
+    "idea_title_placeholder": "分かりやすいタイトルを付けてください",
+    "idea_content": "<b>アイデアの内容</b>",
+    "idea_content_placeholder": (
+        "場面、台詞、音楽の方向性、次の行動などを記録…"
+    ),
+    "cancel": "キャンセル",
+    "save_idea": "アイデアを保存",
+    "idea_title_required_title": "タイトルが必要です",
+    "idea_title_required": "先にアイデアのタイトルを入力してください。",
+    "todo_count": "未完了 {count} 件",
+    "todo_empty": (
+        "今日の予定はまだありません。\n最も大切なことを一つ書きましょう。"
+    ),
+    "idea_count": "{count} 件",
+    "idea_empty": (
+        "アイデアはまだありません。上に入力して"
+        "「アイデアに保存」を選んでください。"
+    ),
+    "idea_edit_tooltip": "ダブルクリックしてタイトルと内容を編集",
+    "today_time": "今日 {total}｜{state}",
+    "timing_active": "計測中",
+    "timing_inactive": "未計測",
+    "todo_title_required": "先に予定のタイトルを入力してください。",
+    "todo_added": "✓ 予定を追加：{text}",
+    "todo_added_speech": "今日の予定に追加しました。",
+    "idea_capture_required": "先に保存するアイデアを入力してください。",
+    "idea_added": "✓ アイデアを保存：{text}",
+    "idea_added_speech": "消えてしまう前に、そのアイデアを保存しました。",
+    "idea_select_edit": "先に編集するアイデアを選択してください。",
+    "idea_not_found": (
+        "そのアイデアが見つかりません。更新してもう一度お試しください。"
+    ),
+    "idea_updated": "✓ アイデアを更新：{title}",
+    "idea_select_delete": "先に削除するアイデアをチェックしてください。",
+    "idea_delete_title": "創作アイデアを削除",
+    "idea_delete_confirm": (
+        "チェックした {count} 件のアイデアを完全に削除しますか？"
+    ),
+    "idea_deleted": "✓ {count} 件のアイデアを削除しました。",
+    "platform_name_placeholder": "プラットフォーム／システム名（例：ERP、Notion）",
+    "platform_url_placeholder": "URL（任意、例：https://example.com）",
+    "add_platform": "仕事プラットフォームを追加",
+    "platform_filter_all": "すべて",
+    "platform_filter_active": "進行中",
+    "platform_filter_blocked": "情報不足／停止中",
+    "platform_filter_finished": "完了／公開済み",
+    "platform_filter_not_started": "未着手",
+    "save_all_platforms": "すべて今すぐ保存",
+    "show": "表示",
+    "platform_empty": (
+        "仕事プラットフォームはまだありません。\n会社のシステム、共同作業ツール、"
+        "顧客ポータルなどを上に追加してください。"
+    ),
+    "platform_intro": (
+        "仕事で使うプラットフォーム、システム、顧客ポータル、共同作業ツールを"
+        "管理します。業種を決めつけず、利用者ごとに作成できます。"
+    ),
+    "platform_auto_save_note": "変更は自動保存され、各カードの保存ボタンも使えます。",
+    "platform_item_placeholder": "現在の仕事、プロジェクト、案件",
+    "platform_missing_placeholder": "不足資料、返信待ち、障害（なければ空欄）",
+    "platform_next_placeholder": "次の具体的な行動と期限",
+    "platform_notes_placeholder": "メモ、規則、連絡先など",
+    "platform_url_card_placeholder": "https://…（任意）",
+    "platform_not_saved": "未保存",
+    "save_platform": "このプラットフォームを保存",
+    "platform_field_item": "仕事／プロジェクト",
+    "platform_field_missing": "不足／障害",
+    "platform_field_next": "次の行動",
+    "platform_field_notes": "メモ",
+    "platform_field_url": "URL",
+    "open_platform": "ウェブサイト／ツールを開く",
+    "delete_platform": "プラットフォームを削除",
+    "platform_updated": "更新：{updated}",
+    "platform_updated_unknown": "更新時刻は不明です",
+    "save_changes": "変更を保存",
+    "platform_waiting_auto_save": "{platform} の変更を自動保存します…",
+    "platform_validation_finished_blocked": "完了済みですが、不足情報または障害が残っています。",
+    "platform_validation_revision_details": "不足／障害、次の行動、またはメモに修正内容を書いてください。",
+    "platform_validation_not_started_data": "仕事の情報があります。状態を「資料準備」に変更するか確認してください。",
+    "platform_validation_item_name": "後で識別しやすいよう、仕事やプロジェクト名を入力してください。",
+    "platform_summary_unsaved": "｜未保存 {count}",
+    "platform_summary": (
+        "{total} 件｜完了 {finished}｜進行中 {active}｜未着手 {not_started}｜"
+        "不足／障害 {blocked}{unsaved}"
+    ),
+    "platform_saved": "{platform} を保存しました。",
+    "platform_saved_automatic": "{platform} を自動保存しました。",
+    "all_platforms_saved": "すべて保存しました。{count} 件に不足情報または障害があります。",
+    "all_platforms_saved_speech": "仕事プラットフォームを保存しました。{count} 件に不足情報または障害があります。",
+    "memory_intro": (
+        "墨寒は許可された人物、好み、目標、ワークフロー、重要な日付だけを"
+        "保存します。記憶はこのパソコンに保存され、分類別の閲覧、個別編集、"
+        "削除ができます。"
+    ),
+    "memory_input_placeholder": "例：漫画を終えてから管理作業を行う",
+    "remember": "記憶する",
+    "memory_filter_label": "分類別に表示",
+    "all_memories": "すべての記憶",
+    "edit_selected_memory": "選択した記憶を編集",
+    "edit_memory_tooltip": "下の記憶をダブルクリックしても編集できます",
+    "delete_checked_memories": "チェックした記憶を削除",
+    "delete_checked_memories_tooltip": "チェックした記憶だけを確認後に削除します",
+    "clear_all_memories": "すべての記憶を消去",
+    "optimize_memories": "安全に記憶を整理",
+    "optimize_memories_tooltip": "重要度の低い重複を統合し、古い超過分は先に保管します",
+    "view_archived_memories": "保管済み記憶を表示",
+    "auto_memory": "「覚えて」「好き」「いつも」など明確な表現から記憶を作成",
+    "memory_count": "{count} 件",
+    "memory_empty": "この分類には記憶がありません。",
+    "memory_source_manual_short": "手動",
+    "memory_source_conversation_short": "会話",
+    "memory_untitled": "無題の記憶",
+    "memory_item": (
+        "【{category}】{title}　重要度 {importance}／5\n{content}\n"
+        "出典：{source}　更新：{updated}"
+    ),
+    "memory_added_speech": "記憶しました。後から一件ずつ確認や変更ができます。",
+    "memory_select_edit_title": "記憶が選択されていません",
+    "memory_select_edit": "先に編集する記憶を選択してください。",
+    "memory_not_found_title": "記憶が見つかりません",
+    "memory_not_found": "この記憶は存在しません。一覧を更新します。",
+    "memory_save_failed_title": "記憶を保存できません",
+    "memory_save_failed": "同じ内容の記憶が既にある可能性があります。既存データは変更されません。",
+    "memory_select_delete_title": "記憶がチェックされていません",
+    "memory_select_delete": "先に削除する記憶をチェックしてください。",
+    "memory_delete_title": "長期記憶を削除",
+    "memory_delete_confirm": "チェックした {count} 件の記憶を完全に削除しますか？",
+    "memory_clear_title": "長期記憶を消去",
+    "memory_clear_confirm": "墨寒が保存した長期記憶をすべて削除しますか？元に戻せません。",
+    "memory_optimize_title": "記憶の整理が完了しました",
+    "memory_optimize_result": (
+        "類似した記憶を {deduplicated} 件統合し、古く重要度の低い記憶を "
+        "{pruned} 件保管しました。\n使用中：{active} 件、復元可能：{archived} 件。"
+    ),
+    "memory_editor_title": "長期記憶を編集",
+    "memory_title_label": "<b>記憶のタイトル</b>",
+    "memory_title_placeholder": "短いタイトルでこの記憶を識別",
+    "memory_category_label": "<b>分類</b>",
+    "memory_importance_label": "<b>重要度</b>",
+    "memory_content_label": "<b>記憶の内容</b>",
+    "memory_content_placeholder": "人物、好み、目標、ワークフロー、重要な日付を記録…",
+    "memory_source_manual": "手動で作成",
+    "memory_source_conversation": "会話で明示的に記憶",
+    "memory_metadata": "出典：{source}　作成：{created}　更新：{updated}",
+    "save_memory": "記憶を保存",
+    "memory_title_required_title": "タイトルが必要です",
+    "memory_title_required": "先に記憶のタイトルを入力してください。",
+    "memory_content_required_title": "内容が必要です",
+    "memory_content_required": "先に記憶の内容を入力してください。",
+    "archived_memory_title": "保管済みの長期記憶",
+    "archived_memory_intro": (
+        "自動整理は古く重要度の低い会話記憶を保管するだけで、削除はしません。"
+        "ここでチェックすればいつでも復元できます。"
+    ),
+    "restore_checked_memories": "チェックした記憶を復元",
+    "close": "閉じる",
+    "archived_memory_item": (
+        "【{category}】{title}\n{content}\n保管理由：{reason}　保管日時：{archived}"
+    ),
+    "archived_memory_count": "復元可能な記憶：{count} 件",
+    "archived_memory_select_title": "記憶がチェックされていません",
+    "archived_memory_select": "先に復元する記憶をチェックしてください。",
+    "archived_memory_restored": "{count} 件の記憶を復元しました。",
+    "chat_history_title": "会話の管理／消去",
+    "chat_history_intro": (
+        "会話はこのパソコンに保存され、自動削除されません。完全に削除して"
+        "よい記録だけをチェックしてください。"
+    ),
+    "delete_checked_chats": "チェックした会話を削除",
+    "chat_history_item": "{created}｜{speaker}\n{content}",
+    "chat_history_truncated_suffix": "（この画面には最近の 500 件だけを表示）",
+    "chat_history_status": "このパソコンに {count} 件の会話を保存中。{suffix}",
+    "chat_select_delete_title": "会話がチェックされていません",
+    "chat_select_delete": "先に削除する会話をチェックしてください。",
+    "chat_delete_title": "会話を完全に削除",
+    "chat_delete_confirm": "チェックした {count} 件の会話を完全に削除しますか？",
+    "load_older_chat_tooltip": "このパソコンから過去の会話を 50 件ずつ読み込み",
+    "manage_chat_tooltip": "選択した会話だけを削除し、他の内容には影響しません",
+    "chat_zoom_out_tooltip": "会話の文字を縮小（Ctrl＋ホイール下）",
+    "chat_zoom_in_tooltip": "会話の文字を拡大（Ctrl＋ホイール上）",
+    "chat_retention_status": "このパソコンに {total} 件を保存中。最近の {shown} 件を表示",
+    "platform_name_required": "先にプラットフォーム、システム、またはツール名を入力してください。",
+    "platform_duplicate": "「{platform}」は既にあります。別の名前を使用してください。",
+    "platform_added": "仕事プラットフォームを追加：{platform}",
+    "platform_delete_title": "仕事プラットフォームを削除",
+    "platform_delete_confirm": "「{platform}」と作業状況を削除しますか？元に戻せません。",
+    "platform_not_found": "仕事プラットフォームが見つかりません：{platform}",
+    "platform_deleted": "仕事プラットフォームを削除：{platform}",
+    "platform_url_missing_title": "URL が未設定です",
+    "platform_url_missing": "先に「{platform}」カードへウェブサイトまたはツールの URL を入力してください。",
+    "platform_url_unsupported_title": "対応していない URL 形式です",
+    "platform_url_unsupported": "http:// または https:// の URL だけを開けます。",
+    "permission_open_platform": "{platform} のウェブサイトを開く",
+    "echo_guard_tooltip": (
+        "墨寒の発話中はマイクの送信を停止し、再生後に再開します。"
+        "有効時は発話の途中で割り込めません。"
+    ),
+    "hybrid_transcript_tooltip": (
+        "Realtime 本来の音声理解を保ち、発話後の画面文字には録音全体の "
+        "OpenAI 高精度文字起こしを使用します。成功後に墨寒が返答します。"
+    ),
+    "flagship_heading": "<b>フラッグシップ操作センター</b>",
+    "increase": "増やす",
+    "decrease": "減らす",
+    "voice_section": "音声",
+    "profile_required_title": "必須情報がありません",
+    "profile_required": "アシスタント名と、あなたへの呼び方は空欄にできません。",
+    "send_chat_required_title": "メッセージが入力されていません",
+    "send_chat_required": "左側に文字を入力して送信してください。マイクから話すこともできます。",
+    "thinking_status": "{assistant}が考えています…",
+    "answering_status": "回答中…",
+    "api_connection_failed": "OpenAI API：接続失敗（{error}）",
+    "voice_ready_short": "準備完了",
+    "microphone_idle": "🎙 マイク",
+    "microphone_send_now": "⏹ 今すぐ送信",
+    "microphone_recognizing": "認識中…",
+    "voice_status_format": "音声状態：{phase}",
+    "bubble_full_content": "…\n（全文は会話ページで確認できます）",
+    "tray_open_today": "今日を開く",
+    "tray_quit": "墨寒を終了",
     "chat_retention": "会話はこのパソコンに保存され、自動削除されません",
     "load_older_chat": "過去の会話を読み込む",
     "manage_chat": "会話の管理／消去",
@@ -298,4 +545,29 @@ JAPANESE_WORK_TYPE_LABELS: Mapping[str, str] = frozendict({
     "教育／研究": "教育／研究",
     "銷售／客戶服務": "営業／カスタマーサービス",
     "其他（可自行輸入）": "その他（自由入力）",
+})
+
+
+JAPANESE_PLATFORM_STATUS_LABELS: Mapping[str, str] = frozendict({
+    "尚未開始": "未着手",
+    "準備資料": "資料準備",
+    "進行中": "進行中",
+    "待送出": "提出待ち",
+    "等待回覆": "返信待ち",
+    "審核中": "審査中",
+    "需修正": "修正が必要",
+    "已排程": "予定済み",
+    "已完成": "完了",
+    "已上架": "公開済み",
+    "暫停": "一時停止",
+})
+
+
+JAPANESE_MEMORY_CATEGORY_LABELS: Mapping[str, str] = frozendict({
+    "人物": "人物",
+    "偏好": "好み",
+    "目標": "目標",
+    "工作流程": "ワークフロー",
+    "重要日期": "重要な日付",
+    "其他": "その他",
 })

--- a/ui_localization_ja.py
+++ b/ui_localization_ja.py
@@ -67,7 +67,29 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
         "{platform} 本機音声は実機検証が完了していません"
     ),
     "tts_voice": "OpenAI 読み上げ音声",
-    "realtime_voice": "Realtime 会話音声",
+    "realtime_output_source": "Realtime 応答音声の出力元",
+    "realtime_output_openai": (
+        "OpenAI Realtime ネイティブ音声（最小遅延、従来の初期設定）"
+    ),
+    "realtime_output_azure": "Azure Speech 女性音声（穏やかなストリーミング）",
+    "realtime_output_azure_hd": (
+        "Azure Dragon HD 女性音声（S0 必須）"
+    ),
+    "realtime_output_note_openai": (
+        "下の「OpenAI Realtime ネイティブ音声」を使用します。遅延が最も"
+        "小さく、OpenAI Realtime 本来のリアルタイム音声出力を維持します。"
+    ),
+    "realtime_output_note_azure": (
+        "上で設定した Azure Speech 女性音声、リージョン、キーを使用します。"
+        "リアルタイムの理解は OpenAI Realtime、音声のストリーミング再生は "
+        "Azure が担当します。"
+    ),
+    "realtime_output_note_azure_hd": (
+        "上で設定した Dragon HD 女性音声、S0 リージョン、専用キーを使用します。"
+        "リアルタイムの理解は OpenAI Realtime、音声のストリーミング再生は "
+        "Dragon HD が担当します。"
+    ),
+    "realtime_voice": "OpenAI Realtime ネイティブ音声",
     "realtime_model": "Realtime モデル",
     "realtime_transcription_model": "Realtime 文字起こしモデル",
     "realtime_noise": "Realtime マイクノイズ低減",
@@ -146,6 +168,14 @@ JAPANESE_UI: Mapping[str, str] = deep_freeze({
     "no_transcription_error": "文字起こしエラーはありません",
     "preview_voice": "試聴：主様、妾はここにおります。",
     "realtime_disconnected": "Realtime：未接続",
+    "realtime_status_format": "Realtime：{status}",
+    "realtime_disconnected_status": "未接続",
+    "realtime_error_status": "エラー：{error}",
+    "realtime_voice_title": "Realtime 音声",
+    "realtime_output_unavailable": (
+        "Realtime の Azure 音声出力を利用できないため、"
+        "リアルタイム会話を開始しませんでした。"
+    ),
     "start_realtime": "Realtime 会話を開始",
     "stop_realtime": "Realtime 会話を停止",
     "near_field": "近距離マイク（推奨）",

--- a/updater.py
+++ b/updater.py
@@ -107,23 +107,34 @@ class UpdateManager:
 
     @staticmethod
     def _validate_url(url: str) -> None:
-        parsed = urlparse(url)
-        if parsed.scheme != "https" or parsed.hostname not in ALLOWED_DOWNLOAD_HOSTS:
+        parsed = None
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname
+        except (AttributeError, TypeError, ValueError):
+            hostname = None
+        if (
+            parsed is None
+            or parsed.scheme != "https"
+            or hostname not in ALLOWED_DOWNLOAD_HOSTS
+        ):
             raise UpdateError("更新網址不是受信任的 GitHub HTTPS 來源。")
         if parsed.username or parsed.password:
             raise UpdateError("更新網址不得包含登入憑證。")
 
     def _request_bytes(self, url: str, limit: int) -> bytes:
         self._validate_url(url)
-        request = Request(
-            url,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "User-Agent": "MoHan-Desktop-Assistant-Updater",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-        )
+        failure: str | None = None
+        data: bytes | None = None
         try:
+            request = Request(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "MoHan-Desktop-Assistant-Updater",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
             with self._opener(
                 request,
                 timeout=20,
@@ -133,23 +144,39 @@ class UpdateManager:
                 self._validate_url(final_url)
                 announced = response.headers.get("Content-Length")
                 if announced and int(announced) > limit:
-                    raise UpdateError("更新資料超過安全大小限制。")
-                data = response.read(limit + 1)
+                    failure = "更新資料超過安全大小限制。"
+                else:
+                    data = response.read(limit + 1)
+        except UpdateError:
+            failure = "GitHub 更新服務回應格式不正確。"
         except HTTPError as exc:
-            if exc.code == 404:
-                raise UpdateError("目前沒有符合更新頻道的已發布版本。") from exc
-            raise UpdateError(f"GitHub 更新服務回應錯誤（{exc.code}）。") from exc
-        except (URLError, TimeoutError, OSError) as exc:
-            raise UpdateError("無法連線至 GitHub 更新服務。") from exc
+            failure = (
+                "目前沒有符合更新頻道的已發布版本。"
+                if exc.code == 404
+                else "GitHub 更新服務回應錯誤。"
+            )
+        except (URLError, TimeoutError, OSError):
+            failure = "無法連線至 GitHub 更新服務。"
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            failure = "GitHub 更新服務回應格式不正確。"
+        if failure is not None:
+            raise UpdateError(failure)
+        if data is None:
+            raise UpdateError("GitHub 更新服務沒有回傳資料。")
         if len(data) > limit:
             raise UpdateError("更新資料超過安全大小限制。")
         return data
 
     def _request_json(self, url: str, limit: int = MAX_MANIFEST_BYTES) -> Any:
+        invalid_json = False
+        result: Any = None
         try:
-            return json.loads(self._request_bytes(url, limit).decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise UpdateError("GitHub 更新資料格式不正確。") from exc
+            result = json.loads(self._request_bytes(url, limit).decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+            invalid_json = True
+        if invalid_json:
+            raise UpdateError("GitHub 更新資料格式不正確。")
+        return result
 
     def _release_candidates(self, channel: str) -> list[dict[str, Any]]:
         endpoint = f"https://api.github.com/repos/{self.repository}/releases"
@@ -252,7 +279,13 @@ class UpdateManager:
         name = str(item.get("name", ""))
         url = str(item.get("url", ""))
         digest = str(item.get("sha256", "")).lower()
-        size = int(item.get("size", 0))
+        invalid_size = False
+        try:
+            size = int(item.get("size", 0))
+        except (TypeError, ValueError, OverflowError):
+            invalid_size = True
+        if invalid_size:
+            raise UpdateError("安裝程式大小格式錯誤。")
         if Path(name).name != name or not re.fullmatch(
             r"[A-Za-z0-9_.-]+",
             name,
@@ -271,16 +304,42 @@ class UpdateManager:
         progress: Callable[[int, int], None] | None = None,
     ) -> Path:
         self._validate_url(asset.url)
-        self.download_dir.mkdir(parents=True, exist_ok=True)
         target = self.download_dir / asset.name
         partial = target.with_suffix(target.suffix + ".part")
-        request = Request(
-            asset.url,
-            headers={"User-Agent": "MoHan-Desktop-Assistant-Updater"},
+        received, actual_digest, failure = self._download_to_partial(
+            asset,
+            partial,
+            progress,
         )
+        if failure is not None:
+            self._discard_partial(partial)
+            raise UpdateError(failure)
+        if received != asset.size:
+            self._discard_partial(partial)
+            raise UpdateError("安裝程式下載不完整。")
+        if actual_digest != asset.sha256:
+            self._discard_partial(partial)
+            raise UpdateError("安裝程式 SHA256 驗證失敗，已拒絕執行。")
+        if not self._replace_partial(partial, target):
+            self._discard_partial(partial)
+            raise UpdateError("安裝程式無法安全儲存。")
+        return target
+
+    def _download_to_partial(
+        self,
+        asset: InstallerAsset,
+        partial: Path,
+        progress: Callable[[int, int], None] | None,
+    ) -> tuple[int, str, str | None]:
         digest = hashlib.sha256()
         received = 0
+        failure: str | None = None
         try:
+            request = Request(
+                asset.url,
+                headers={"User-Agent": "MoHan-Desktop-Assistant-Updater"},
+            )
+            self.download_dir.mkdir(parents=True, exist_ok=True)
             with self._opener(
                 request,
                 timeout=30,
@@ -293,20 +352,39 @@ class UpdateManager:
                         break
                     received += len(chunk)
                     if received > asset.size or received > MAX_INSTALLER_BYTES:
-                        raise UpdateError("安裝程式下載大小與清單不符。")
+                        failure = "安裝程式下載大小與清單不符。"
+                        break
                     digest.update(chunk)
                     handle.write(chunk)
                     if progress:
                         progress(received, asset.size)
-            if received != asset.size:
-                raise UpdateError("安裝程式下載不完整。")
-            if digest.hexdigest().lower() != asset.sha256:
-                raise UpdateError("安裝程式 SHA256 驗證失敗，已拒絕執行。")
-            os.replace(partial, target)
-            return target
         except UpdateError:
-            partial.unlink(missing_ok=True)
-            raise
-        except (URLError, TimeoutError, OSError) as exc:
-            partial.unlink(missing_ok=True)
-            raise UpdateError("安裝程式下載失敗。") from exc
+            failure = "安裝程式下載失敗。"
+        except (
+            AttributeError,
+            HTTPError,
+            OSError,
+            RuntimeError,
+            TimeoutError,
+            TypeError,
+            URLError,
+            ValueError,
+        ):
+            failure = "安裝程式下載失敗。"
+        return received, digest.hexdigest().lower(), failure
+
+    @staticmethod
+    def _replace_partial(partial: Path, target: Path) -> bool:
+        try:
+            os.replace(partial, target)
+        except (OSError, TypeError, ValueError):
+            return False
+        return True
+
+    @staticmethod
+    def _discard_partial(path: Path) -> None:
+        try:
+            path.unlink(missing_ok=True)
+        except (OSError, TypeError, ValueError):
+            # The original safe failure must not be replaced by a private path.
+            return

--- a/updater_ui.py
+++ b/updater_ui.py
@@ -18,6 +18,12 @@ lazy from PySide6.QtWidgets import (
     QWidget,
 )
 
+lazy from auxiliary_ui_localization import (
+    AuxiliaryOperation,
+    AuxiliaryText,
+    auxiliary_text,
+    localized_operation_error,
+)
 lazy from updater import ReleaseInfo, UpdateError, UpdateManager
 lazy from version_info import APP_VERSION, PROJECT_REPOSITORY
 
@@ -44,9 +50,16 @@ class _Worker(QRunnable):
 
 
 class UpdatePanel(QWidget):
-    def __init__(self, db, data_dir: Path, parent=None):
+    def __init__(
+        self,
+        db,
+        data_dir: Path,
+        parent=None,
+        language: str = "zh-TW",
+    ):
         super().__init__(parent)
         self.db = db
+        self.language = language
         self.manager = UpdateManager(
             PROJECT_REPOSITORY,
             APP_VERSION,
@@ -57,37 +70,44 @@ class UpdatePanel(QWidget):
         self.silent_check = False
 
         layout = QVBoxLayout(self)
-        title = QLabel("<b>軟體更新</b>")
-        self.current = QLabel(f"目前版本：{APP_VERSION}")
+        self.title = QLabel(self._t(AuxiliaryText.UPDATE_TITLE))
+        self.current = QLabel(
+            self._t(AuxiliaryText.CURRENT_VERSION, version=APP_VERSION)
+        )
         row = QHBoxLayout()
         self.channel = QComboBox()
-        self.channel.addItem("穩定版（建議）", "stable")
-        self.channel.addItem("預覽版／RC", "preview")
+        self.channel.addItem(self._t(AuxiliaryText.CHANNEL_STABLE), "stable")
+        self.channel.addItem(self._t(AuxiliaryText.CHANNEL_PREVIEW), "preview")
         saved_channel = str(db.setting("update_channel", "stable"))
         self.channel.setCurrentIndex(
             max(0, self.channel.findData(saved_channel))
         )
-        self.automatic = QCheckBox("啟動後自動檢查更新")
+        self.automatic = QCheckBox(self._t(AuxiliaryText.AUTO_CHECK))
         self.automatic.setChecked(
             bool(db.setting("automatic_update_check", True))
         )
-        self.check_button = QPushButton("立即檢查更新")
-        self.download_button = QPushButton("下載並安裝")
+        self.check_button = QPushButton(self._t(AuxiliaryText.CHECK_NOW))
+        self.download_button = QPushButton(
+            self._t(AuxiliaryText.DOWNLOAD_INSTALL)
+        )
         self.download_button.setEnabled(False)
-        row.addWidget(QLabel("更新頻道"))
+        self.channel_label = QLabel(self._t(AuxiliaryText.CHANNEL_LABEL))
+        row.addWidget(self.channel_label)
         row.addWidget(self.channel)
         row.addWidget(self.automatic)
         row.addStretch()
         row.addWidget(self.check_button)
         row.addWidget(self.download_button)
-        self.status = QLabel("尚未檢查")
+        self.status = QLabel(self._t(AuxiliaryText.NOT_CHECKED))
         self.status.setWordWrap(True)
         self.progress = QProgressBar()
         self.progress.setVisible(False)
         self.notes = QTextBrowser()
-        self.notes.setPlaceholderText("有新版本時會在此顯示 Release Notes。")
+        self.notes.setPlaceholderText(
+            self._t(AuxiliaryText.NOTES_PLACEHOLDER)
+        )
         self.notes.setMaximumHeight(150)
-        layout.addWidget(title)
+        layout.addWidget(self.title)
         layout.addWidget(self.current)
         layout.addLayout(row)
         layout.addWidget(self.status)
@@ -99,6 +119,9 @@ class UpdatePanel(QWidget):
         self.check_button.clicked.connect(self.check_updates)
         self.download_button.clicked.connect(self.download_update)
         self._automatic_check_started = False
+
+    def _t(self, key: AuxiliaryText, **values: object) -> str:
+        return auxiliary_text(self.language, key, **values)
 
     def start_automatic_check(self) -> None:
         if self._automatic_check_started or not self.automatic.isChecked():
@@ -121,7 +144,7 @@ class UpdatePanel(QWidget):
         self.silent_check = silent
         self.release = None
         self._set_busy(True)
-        self.status.setText("正在安全地檢查 GitHub Release……")
+        self.status.setText(self._t(AuxiliaryText.CHECKING))
         worker = _Worker(
             lambda _progress: self.manager.check(
                 str(self.channel.currentData())
@@ -135,19 +158,27 @@ class UpdatePanel(QWidget):
         self.release = result if isinstance(result, ReleaseInfo) else None
         self._set_busy(False)
         if self.release is None:
-            self.status.setText("目前已是此更新頻道的最新版本。")
+            self.status.setText(self._t(AuxiliaryText.UP_TO_DATE))
             self.notes.clear()
             return
         self.status.setText(
-            f"發現新版本 {self.release.version}；安裝前會驗證 SHA256。"
+            self._t(
+                AuxiliaryText.NEW_VERSION,
+                version=self.release.version,
+            )
         )
-        self.notes.setMarkdown(self.release.notes or "此版本未提供說明。")
+        self.notes.setMarkdown(
+            self.release.notes or self._t(AuxiliaryText.NO_RELEASE_NOTES)
+        )
         self.download_button.setEnabled(True)
         if not self.silent_check:
             QMessageBox.information(
                 self,
-                "發現墨寒新版本",
-                f"新版本 {self.release.version} 已可下載。",
+                self._t(AuxiliaryText.NEW_VERSION_TITLE),
+                self._t(
+                    AuxiliaryText.NEW_VERSION_AVAILABLE,
+                    version=self.release.version,
+                ),
             )
 
     def download_update(self) -> None:
@@ -156,9 +187,12 @@ class UpdatePanel(QWidget):
         asset = self.release.preferred_installer()
         answer = QMessageBox.question(
             self,
-            "下載官方更新",
-            "將從官方 GitHub Release 下載安裝程式，完成 SHA256 驗證後再啟動。\n\n"
-            f"版本：{self.release.version}\n檔案：{asset.name}\n\n是否繼續？",
+            self._t(AuxiliaryText.DOWNLOAD_TITLE),
+            self._t(
+                AuxiliaryText.DOWNLOAD_PROMPT,
+                version=self.release.version,
+                filename=asset.name,
+            ),
         )
         if answer != QMessageBox.Yes:
             return
@@ -166,7 +200,7 @@ class UpdatePanel(QWidget):
         self.progress.setVisible(True)
         self.progress.setRange(0, 100)
         self.progress.setValue(0)
-        self.status.setText("正在下載並核對安裝程式……")
+        self.status.setText(self._t(AuxiliaryText.DOWNLOADING))
 
         def download(progress):
             return self.manager.download(
@@ -188,27 +222,48 @@ class UpdatePanel(QWidget):
         path = Path(result)
         answer = QMessageBox.question(
             self,
-            "驗證完成",
-            "SHA256 驗證通過。現在將關閉墨寒並開啟安裝程式。\n"
-            "您的對話、記憶、待辦與設定仍保留在本機資料目錄。\n\n"
-            "是否立即升級？",
+            self._t(AuxiliaryText.VERIFIED_TITLE),
+            self._t(AuxiliaryText.VERIFIED_PROMPT),
         )
         if answer != QMessageBox.Yes:
-            self.status.setText(f"已安全下載：{path}")
+            self.status.setText(
+                self._t(AuxiliaryText.SAFE_DOWNLOADED, path=path)
+            )
             return
         try:
             if path.suffix.lower() == ".msi":
                 subprocess.Popen(["msiexec.exe", "/i", str(path)])
             else:
                 subprocess.Popen([str(path)])
-        except OSError as exc:
-            self._operation_failed(f"無法啟動安裝程式：{exc}")
+        except OSError:
+            self._operation_failed(
+                "",
+                key=AuxiliaryText.INSTALLER_LAUNCH_FAILED,
+            )
             return
         QTimer.singleShot(250, QApplication.quit)
 
-    def _operation_failed(self, message: str) -> None:
+    def _operation_failed(
+        self,
+        message: str,
+        *,
+        key: AuxiliaryText | None = None,
+    ) -> None:
         self._set_busy(False)
         self.progress.setVisible(False)
-        self.status.setText(message)
+        localized_message = (
+            self._t(key)
+            if key is not None
+            else localized_operation_error(
+                self.language,
+                message,
+                operation=AuxiliaryOperation.UPDATE,
+            )
+        )
+        self.status.setText(localized_message)
         if not self.silent_check:
-            QMessageBox.warning(self, "墨寒更新", message)
+            QMessageBox.warning(
+                self,
+                self._t(AuxiliaryText.UPDATE_DIALOG_TITLE),
+                localized_message,
+            )

--- a/version_info.py
+++ b/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "3.1.1"
+FALLBACK_VERSION = "3.1.2"
 
 
 def _build_info_path() -> Path:


### PR DESCRIPTION
## 繁體中文
### 摘要
本 PR 準備墨寒 v3.1.2，新增可選的「OpenAI Realtime 即時理解＋Azure 串流發聲」模式，並修正語音切換、發話結束動作交接、嘴型同步、Windows MSI 開始功能表圖示及安全邊界。既有 OpenAI Realtime 原生聲音完整保留並維持預設。
### 主要變更
- 一般 Azure Speech 與 Dragon HD 使用各自獨立的區域、加密金鑰及動態女性聲線。
- 切換 Realtime 回覆聲音來源後立即儲存；三種模式彼此隔離、不混音、不污染設定。
- 24 kHz PCM16 串流接入既有 50 Hz 本機嘴型分析；取消、失敗、斷線或舊回應不會繼續發聲。
- 修正發話結束後身體短暫回彈／抖動；動作平滑返回中央後才交接狀態。
- 維持正面、朝左與托腮姿勢的分層嘴型及嘴角一致性，並以 75%、100%、180% 顯示倍率回歸。
- 修正 WiX MSI 開始功能表捷徑，使其沿用目標 EXE 內嵌墨寒半身圖示；已安裝應用程式圖示仍保留。
- 強化敏感資料、外部錯誤、設定匯出與公開發行內容稽核；金鑰不得進入 SQLite、錯誤、log、Git 或安裝包。
- 完整提供繁中、簡中、英文、日文介面與文件。
### 門檻
本機已通過 95／95 回歸、Ruff、編譯、公開內容安全稽核及四語 MSI 資料庫驗證。合併與發版只採信同一最終遠端 HEAD SHA 上全部 GitHub Actions 綠燈。Windows CI 必須實際驗證繁中基底 MSI＋簡中／英文／日文 MST 的安裝、圖示、啟動與解除安裝。使用者實機動作觀察仍如實列為待驗收，不以自動化冒充實機結果。
---
## 简体中文
### 摘要
本 PR 准备墨寒 v3.1.2，新增可选的“OpenAI Realtime 即时理解＋Azure 流式发声”模式，并修复语音切换、说话结束动作交接、嘴形同步、Windows MSI 开始菜单图标及安全边界。现有 OpenAI Realtime 原生声音完整保留并继续作为默认选项。
### 主要变更
- 一般 Azure Speech 与 Dragon HD 使用各自独立的区域、加密密钥及动态女性声音。
- 切换 Realtime 回复声音来源后立即保存；三种模式相互隔离、不混音、不污染设置。
- 24 kHz PCM16 流接入现有 50 Hz 本地嘴形分析；取消、失败、断线或旧回复不会继续发声。
- 修复说话结束后身体短暂回弹／抖动；动作平滑返回中央后才交接状态。
- 保持正面、朝左及托腮姿势的分层嘴形与嘴角一致性，并以 75%、100%、180% 显示倍率回归。
- 修复 WiX MSI 开始菜单快捷方式，使其沿用目标 EXE 内嵌的墨寒半身图标；已安装应用图标仍保留。
- 加强敏感数据、外部错误、设置导出及公开发布内容审计；密钥不得进入 SQLite、错误、日志、Git 或安装包。
- 完整提供繁中、简中、英文、日文界面与文档。
### 关卡
本地已通过 95／95 回归、Ruff、编译、公开内容安全审计及四语 MSI 数据库验证。合并与发布只采用同一最终远程 HEAD SHA 上全部 GitHub Actions 绿灯。Windows CI 必须实际验证繁中基础 MSI＋简中／英文／日文 MST 的安装、图标、启动与卸载。用户真机动作观察仍如实列为待验收，不以自动化冒充真机结果。
---
## English
### Summary
This PR prepares MoHan v3.1.2 with optional “OpenAI Realtime understanding + Azure streaming speech” modes and fixes voice switching, post-speech motion hand-off, lip synchronization, the Windows MSI Start menu icon, and security boundaries. Native OpenAI Realtime voices remain intact and stay the default.
### Main changes
- Standard Azure Speech and Dragon HD use independent regions, encrypted keys, and dynamically discovered female voices.
- Realtime response-voice changes save immediately; all three modes remain isolated and never mix audio or overwrite settings.
- 24 kHz PCM16 streaming feeds the existing local 50 Hz lip analysis; cancelled, failed, disconnected, or stale responses cannot continue speaking.
- Fixes the brief body rebound or shake after speech by handing off state only after motion returns smoothly to centre.
- Preserves layered visemes and mouth corners across front, left-facing, and chin-rest poses with 75%, 100%, and 180% scale regressions.
- Fixes the WiX MSI Start menu shortcut so it inherits MoHan’s embedded half-body EXE icon while retaining the Installed Apps icon.
- Strengthens sensitive-data, external-error, profile-export, and public-release audits; keys must never enter SQLite, errors, logs, Git, or installers.
- Provides complete Traditional Chinese, Simplified Chinese, English, and Japanese interfaces and documentation.
### Gates
Local preflight passed all 95 regressions, Ruff, compilation, public-release security audit, and four-locale MSI database validation. Merge and release decisions use only a complete green GitHub Actions run on one final remote HEAD SHA. Windows CI must perform real install, icon, launch, and uninstall validation with the Traditional Chinese base MSI plus Simplified Chinese, English, and Japanese MSTs. Owner real-device motion observation remains honestly pending and is not replaced by automation.
---
## 日本語
### 概要
この PR は墨寒 v3.1.2 を準備し、任意の「OpenAI Realtime 即時理解＋Azure ストリーミング発話」モードを追加するとともに、音声切替、発話終了時の動作引継ぎ、口形同期、Windows MSI スタートメニューアイコン、安全境界を修正します。OpenAI Realtime のネイティブ音声は維持され、引き続き既定値です。
### 主な変更
- 通常 Azure Speech と Dragon HD は、独立したリージョン、暗号化キー、動的に取得した女性音声を使用します。
- Realtime 応答音声の切替を即時保存し、三モードを分離して混音や設定汚染を防ぎます。
- 24 kHz PCM16 ストリームを既存の本機 50 Hz 口形解析へ渡し、取消・失敗・切断・古い応答の発話継続を防ぎます。
- 発話終了後の短い身体の跳ね戻り／揺れを修正し、動作が中央へ滑らかに戻ってから状態を引き継ぎます。
- 正面、左向き、頬杖姿勢の階層口形と口角を維持し、75%、100%、180% の表示倍率で回帰検証します。
- WiX MSI のスタートメニューショートカットを修正し、対象 EXE 内蔵の墨寒半身アイコンを継承させ、インストール済みアプリのアイコンも維持します。
- 機密情報、外部エラー、設定エクスポート、公開リリース監査を強化し、キーを SQLite、エラー、ログ、Git、インストーラーへ入れません。
- 繁体字中国語、簡体字中国語、英語、日本語の完全な画面と文書を提供します。
### ゲート
ローカル事前検証では 95／95 回帰、Ruff、コンパイル、公開内容セキュリティ監査、四言語 MSI データベース検証に合格しました。マージと公開は、一つの最終リモート HEAD SHA 上ですべての GitHub Actions が成功した場合に限ります。Windows CI は繁体字中国語基礎 MSI＋簡体字中国語／英語／日本語 MST の実インストール、アイコン、起動、アンインストールを検証します。所有者による実機動作観察は未完了として正直に記録し、自動化で代替しません。