### PR TITLE
修正 macOS PoseAtlas Preview 封裝驗證／修复 macOS PoseAtlas Preview 封装验证／Fix macOS PoseAtlas Preview packaging verification／macOS PoseAtlas Preview パッケージ検証を修正

### DIFF
--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -34,6 +34,7 @@ lazy from tools.build_preview_package import (
     _validate_version,
 )
 lazy from tools.check_layered_imports import inspect_layered_imports
+lazy from tools.smoke_preview_package import _require_pose_atlas
 
 
 def read(relative: str) -> str:
@@ -338,6 +339,19 @@ def test_four_language_release_notes_and_boundaries() -> None:
     for forbidden_claim in ("feature parity achieved", "完整支援 macOS"):
         assert forbidden_claim not in guide
 
+
+
+def test_pose_atlas_smoke_accepts_complete_duplicate_bundle_roots(tmp_path: Path) -> None:
+    for duplicate in ("Contents/Resources", "Contents/Frameworks"):
+        atlas = tmp_path / duplicate / "assets" / "pose-atlas" / "v4"
+        atlas.mkdir(parents=True)
+        for index in range(24):
+            stem = f"yaw{index:03}-pitch+00"
+            (atlas / f"{stem}.png").write_bytes(b"png")
+            (atlas / f"{stem}.landmarks.json").write_text("{}", encoding="utf-8")
+            (atlas / f"{stem}.hands.json").write_text("{}", encoding="utf-8")
+
+    _require_pose_atlas(tmp_path)
 
 def main() -> None:
     test_preview_ui_contract()

--- a/tools/smoke_preview_package.py
+++ b/tools/smoke_preview_package.py
@@ -19,16 +19,16 @@ def _require_license(path: Path) -> None:
 
 def _require_pose_atlas(root: Path) -> None:
     atlas_roots = tuple(path for path in root.rglob("v4") if path.is_dir() and path.parent.name == "pose-atlas")
-    if len(atlas_roots) != 1:
+    if not atlas_roots:
         raise RuntimeError("Preview package omitted PoseAtlas v4 assets")
-    atlas_root = atlas_roots[0]
-    views = tuple(atlas_root.glob("yaw*-pitch+00.png"))
-    if len(views) != 24:
-        raise RuntimeError("Preview package PoseAtlas v4 view count is incomplete")
-    for view in views:
-        for suffix in (".landmarks.json", ".hands.json"):
-            if not (atlas_root / f"{view.stem}{suffix}").is_file():
-                raise RuntimeError(f"Preview package PoseAtlas v4 sidecar missing: {view.stem}{suffix}")
+    for atlas_root in atlas_roots:
+        views = tuple(atlas_root.glob("yaw*-pitch+00.png"))
+        if len(views) != 24:
+            raise RuntimeError("Preview package PoseAtlas v4 view count is incomplete")
+        for view in views:
+            for suffix in (".landmarks.json", ".hands.json"):
+                if not (atlas_root / f"{view.stem}{suffix}").is_file():
+                    raise RuntimeError(f"Preview package PoseAtlas v4 sidecar missing: {view.stem}{suffix}")
 
 
 def _run(


### PR DESCRIPTION
## 繁體中文

修正 macOS Preview 封裝中有效的 PoseAtlas v4 重複資產根目錄被煙霧檢查錯誤拒絕的問題。檢查現在會驗證每一個找到的資產根目錄皆含完整 24 視角與 landmarks／hands sidecars，仍不接受遺漏或不完整資產。

- 未新增秘密、個資、權限或資料庫變更。
- 已通過 Preview 封裝測試與靜態品質檢查。
- 此修正僅影響 macOS 封裝驗證，不改變 Windows 正式支援與其他平台 Preview 邊界。

## 简体中文

修正 macOS Preview 封装中有效的 PoseAtlas v4 重复资产根目录被烟雾检查错误拒绝的问题。检查现在会验证每一个找到的资产根目录都含完整 24 视角与 landmarks／hands sidecars，仍不接受缺失或不完整资产。

- 未新增秘密、个人资料、权限或数据库变更。
- 已通过 Preview 封装测试与静态质量检查。
- 此修正仅影响 macOS 封装验证，不改变 Windows 正式支持与其他平台 Preview 边界。

## English

Fix the macOS Preview smoke check falsely rejecting valid duplicate PoseAtlas v4 asset roots. Every discovered asset root must now independently contain all 24 views and landmarks/hands sidecars; omitted or incomplete assets still fail.

- No secrets, personal data, permissions, or database changes.
- Preview packaging tests and static quality checks pass.
- This affects only macOS package verification and does not change the Windows stable or other-platform Preview boundaries.

## 日本語

macOS Preview の smoke 検査が、有効な PoseAtlas v4 資産ルートの重複を誤って拒否する問題を修正します。見つかった各資産ルートに 24 視角と landmarks／hands sidecar がすべてそろっていることを検証し、欠落または不完全な資産は引き続き失敗します。

- 秘密情報、個人データ、権限、データベースの変更はありません。
- Preview パッケージングテストと静的品質検査に合格しています。
- この修正は macOS パッケージ検証だけに影響し、Windows 正式版および他プラットフォーム Preview の境界を変更しません。