### PR TITLE
修正 Windows 發行原生測試順序／修正 Windows 发布原生测试顺序／Fix Windows release native test ordering／Windows リリースのネイティブテスト順序を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,16 @@ jobs:
         run: >-
           python -m pip install --only-binary=:all: -r requirements-dev.txt
 
+      - name: Build native acceleration for full Windows regression
+        shell: pwsh
+        run: |
+          rustup toolchain install 1.97.1 --profile minimal --component clippy,rustfmt
+          python -m pip install --only-binary=:all: maturin==1.14.1
+          python tools/build_native_acceleration.py `
+            --output-dir native-wheels `
+            --evidence native-wheels/build-evidence.json `
+            --install
+
       - name: Install pinned Windows installer toolchains
         env:
           GH_TOKEN: ${{ github.token }}
@@ -233,10 +243,9 @@ jobs:
           & $env:MOHAN_JIT_PYTHON tools/install_python315_dependencies.py
           --qt-compat-wheelhouse qt315-wheelhouse
 
-      - name: Install pinned Rust native build toolchain
+      - name: Install native build dependencies into JIT-default Python
         shell: pwsh
         run: |
-          rustup toolchain install 1.97.1 --profile minimal --component clippy,rustfmt
           & $env:MOHAN_JIT_PYTHON -m pip install --only-binary=:all: -r requirements-dev.txt
           & $env:MOHAN_JIT_PYTHON -m pip install --only-binary=:all: maturin==1.14.1
 


### PR DESCRIPTION
## 繁體中文

修正正式 Windows 發行流程的測試順序：在完整回歸前，以固定版 Rust 1.97.1 與 Maturin 1.14.1 建置並安裝第一方 `_mohan_accel`，使 `test_native_concurrency.py` 檢驗真正的原生並行實作。

JIT 預設 Python 3.15 的相依安裝維持原位置；正式封裝與原生證據流程不變。

本機已通過 `tests/test_github_governance.py`；完整原生回歸由此 PR 的 Windows CI 驗證。

- 安全與隱私：未新增金鑰、個資、網路權限或資料收集。
- 相容性：不改變使用者設定、資料、封裝格式或平台範圍。

## 简体中文

修正 Windows 正式发布流程的测试顺序：完整回归前以固定版 Rust 1.97.1 与 Maturin 1.14.1 构建并安装第一方 `_mohan_accel`，使 `test_native_concurrency.py` 验证真实的原生并发实现。

JIT 默认 Python 3.15 的依赖安装保留在原位置；正式打包与原生证据流程不变。

本机已通过 `tests/test_github_governance.py`；完整原生回归由此 PR 的 Windows CI 验证。

- 安全与隐私：未新增密钥、个人资料、网络权限或数据收集。
- 兼容性：不改变用户设置、数据、打包格式或平台范围。

## English

Fix the formal Windows release ordering: before full regression, build and install the pinned Rust 1.97.1 and Maturin 1.14.1 first-party `_mohan_accel` module so `test_native_concurrency.py` verifies the real native-concurrency implementation.

JIT-default Python 3.15 dependency installation remains in its existing position; the formal packaging and native-evidence path remain unchanged.

Local `tests/test_github_governance.py` passes; this PR's Windows CI verifies the complete native regression.

- Safety and privacy: no keys, personal data, network permissions, or data collection were added.
- Compatibility: user settings, data, package format, and platform scope remain unchanged.

## 日本語

Windows 正式リリースのテスト順序を修正します。完全回帰の前に固定版 Rust 1.97.1 と Maturin 1.14.1 で第一者 `_mohan_accel` をビルド・導入し、`test_native_concurrency.py` が実際のネイティブ並行実装を検証します。

JIT 既定 Python 3.15 の依存関係導入は既存位置を維持し、正式パッケージとネイティブ証跡の手順も不変です。

ローカルの `tests/test_github_governance.py` は成功しており、完全なネイティブ回帰はこの PR の Windows CI が検証します。

- 安全性とプライバシー：キー、個人情報、ネットワーク権限、データ収集を追加していません。
- 互換性：利用者設定、データ、パッケージ形式、プラットフォーム範囲は変更しません。