### PR TITLE
墨寒 v4.0.1 維護發行準備／墨寒 v4.0.1 维护发布准备／MoHan v4.0.1 maintenance release preparation／墨寒 v4.0.1 メンテナンスリリース準備

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 > **歷史紀錄（v3.1.2 跨平台進度）：** Windows 仍是唯一完成既有公開版本實機、完整回歸、安裝與發布驗證的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已納入安全平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI；實際產物仍須通過本版最終發布門檻，CI 也不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
-> **目前發行目標：** 原始碼與套件中繼資料已同步至 `v4.0.0`，Windows 正式發行路徑已具備；macOS／Linux 仍是功能受限 Preview，最新公開版本仍以頁首的動態 Published Release 徽章與 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 為準。
+> **目前發行目標：** 原始碼與套件中繼資料已同步至 `v4.0.1`，Windows 正式發行路徑已具備；macOS／Linux 仍是功能受限 Preview，最新公開版本仍以頁首的動態 Published Release 徽章與 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 為準。
 
-> **目前開發版本：** `4.0.0`；這是尚未發布的開發草稿。Windows 建置命令：`.\build.ps1 -Version "4.0.0"`。
+> **目前開發版本：** `4.0.1`；這是尚未發布的開發草稿。Windows 建置命令：`.\build.ps1 -Version "4.0.1"`。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -436,9 +436,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **历史记录（v3.1.2 跨平台进度）：** Windows 仍是唯一完成现有公开版本真机、完整回归、安装与发布验证的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已纳入安全平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI；实际产物仍须通过本版本最终发布关卡，CI 也不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
-> **当前发布目标：** 源代码与软件包元数据已同步至 `v4.0.0`，Windows 正式发布路径已经具备；macOS／Linux 仍是功能受限 Preview，最新公开版本仍以页首的动态 Published Release 徽章与 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 为准。
+> **当前发布目标：** 源代码与软件包元数据已同步至 `v4.0.1`，Windows 正式发布路径已经具备；macOS／Linux 仍是功能受限 Preview，最新公开版本仍以页首的动态 Published Release 徽章与 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 为准。
 
-> **当前开发版本：** `4.0.0`；这是尚未发布的开发草稿。Windows 构建命令：`.\build.ps1 -Version "4.0.0"`。
+> **当前开发版本：** `4.0.1`；这是尚未发布的开发草稿。Windows 构建命令：`.\build.ps1 -Version "4.0.1"`。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -854,9 +854,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **Historical record (v3.1.2 cross-platform status):** Windows remains the only platform whose existing public releases have completed real-device use, the full regression suite, installation, and publication validation. The limited v3.1.2 macOS/Linux DMG/AppImage Previews include safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen; the actual artifacts must still pass this release's final publication gates. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
-> **Current release target:** Source and package metadata are synchronized at `v4.0.0`; the Windows formal-release path is ready, while macOS/Linux remain limited Previews. The dynamic Published Release badge above and [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) remain authoritative for the latest public version.
+> **Current release target:** Source and package metadata are synchronized at `v4.0.1`; the Windows formal-release path is ready, while macOS/Linux remain limited Previews. The dynamic Published Release badge above and [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) remain authoritative for the latest public version.
 
-> **Current development version:** `4.0.0`; this is an unreleased development draft. Windows build command: `.\build.ps1 -Version "4.0.0"`.
+> **Current development version:** `4.0.1`; this is an unreleased development draft. Windows build command: `.\build.ps1 -Version "4.0.1"`.
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -1272,9 +1272,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **履歴（v3.1.2 クロスプラットフォーム状況）：** 既存の公開版について、実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.2 の macOS／Linux 機能限定 DMG／AppImage Preview には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI を導入していますが、実際の成果物は本版の最終公開ゲートに合格する必要があります。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
-> **現在の公開目標：** ソースとパッケージのメタデータは `v4.0.0` に同期済みです。Windows の正式公開経路は準備済みで、macOS/Linux は機能限定 Preview のままです。最新の公開版は、ページ上部の動的な Published Release バッジと [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) を正とします。
+> **現在の公開目標：** ソースとパッケージのメタデータは `v4.0.1` に同期済みです。Windows の正式公開経路は準備済みで、macOS/Linux は機能限定 Preview のままです。最新の公開版は、ページ上部の動的な Published Release バッジと [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) を正とします。
 
-> **現在の開発版：** `4.0.0`。これは未公開の開発草案です。Windows のビルドコマンド：`.\build.ps1 -Version "4.0.0"`。
+> **現在の開発版：** `4.0.1`。これは未公開の開発草案です。Windows のビルドコマンド：`.\build.ps1 -Version "4.0.1"`。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -77,7 +77,7 @@ The next maintainer should read this document, the workflows, and the evidence f
 
 ## 日本語
 
-> これは v4.0.1 の正式な Release 説明です。Windows は正式サポートプラットフォームです。macOS と Linux は機能制限付き Preview のみで、開発者の実機認証や Windows と同等の機能を主張するものではありません。
+> これは v4.0.1 の正式な Release 説明です。Windows は正式サポートプラットフォームです。macOS と Linux は機能限定 Preview のみで、開発者の実機認証や Windows と同等の機能を主張するものではありません。
 
 ### 本リリースのポイント
 

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -1,0 +1,101 @@
+# 墨寒桌面助理 v4.0.1 發行說明／墨寒桌面助手 v4.0.1 发布说明／MoHan Desktop Assistant v4.0.1 Release Notes／墨寒デスクトップアシスタント v4.0.1 リリースノート
+
+## 繁體中文
+
+> 這是 v4.0.1 的正式 Release 說明。Windows 為正式支援平台；macOS 與 Linux 僅提供功能受限 Preview，不宣稱開發者實機認證或 Windows 功能同等。
+
+### 本版重點
+
+- 控制台新增桌面夥伴狀態卡 `desktop_companion_status.py`，以即時且可本地化的狀態取代原有控制台人像，完整反映手勢與語音活動。
+- 手勢與揮手互動維持獨立且具韌性 `gesture_runtime.py`，狀態更新不會阻斷或干擾正在進行的語音回應。
+- 重新整理 v4 README 四語摘要 `v4.0.1`，並收尾 Windows GUI 回歸測試的清理程序，確保乾淨環境可重複執行。
+
+### 相容性與平台邊界
+
+- 本版僅修正 v4.0.0 之後的維護問題，不變更既有功能邊界；Windows 為正式支援，macOS Arm／x86 與 Linux 維持功能受限 Preview。
+- 不新增外部相依套件，不改變任何授權、隱私或可回退驗證原則。
+
+### 維護交接
+
+本節作為 v4.0.1 後續維護的交接基線；每次變更均應更新可重現證據、四語文件與本 Release 說明。
+
+- 發行來源：分支、合併後的 main、版本、標籤與 GitHub Release 必須指向同一不可變提交。
+- 平台邊界：Windows 正式支援；macOS 與 Linux 維持 Preview，維持同版號、四語及封裝 smoke 驗證。
+- 發行證據：維持完整回歸、安裝／升級、SBOM、SHA-256、秘密防護、四語治理與原生證據的可重現檢查。
+
+下一位維護者應先閱讀本說明、工作流程與證據檔，再修改版本、封裝或發布程序。
+
+## 简体中文
+
+> 这是 v4.0.1 的正式 Release 说明。Windows 是正式支持平台；macOS 与 Linux 仅提供功能受限 Preview，不声明开发者实机认证或 Windows 功能同等。
+
+### 本版重点
+
+- 控制台新增桌面伙伴状态卡 `desktop_companion_status.py`，以即时且可本地化的状态取代原有控制台人像，完整反映手势与语音活动。
+- 手势与挥手互动保持独立且具韧性 `gesture_runtime.py`，状态更新不会阻断或干扰正在进行的语音回应。
+- 重新整理 v4 README 四语摘要 `v4.0.1`，并收尾 Windows GUI 回归测试的清理流程，确保干净环境可重复执行。
+
+### 兼容性与平台边界
+
+- 本版仅修正 v4.0.0 之后的维护问题，不改变既有功能边界；Windows 为正式支持，macOS Arm／x86 与 Linux 保持功能受限 Preview。
+- 不新增外部依赖包，不改变任何授权、隐私或可回退验证原则。
+
+### 维护交接
+
+本节作为 v4.0.1 后续维护的交接基线；每次变更均应更新可重现证据、四语文档与本 Release 说明。
+
+- 发行来源：分支、合并后的 main、版本、标签与 GitHub Release 必须指向同一不可变提交。
+- 平台边界：Windows 正式支持；macOS 与 Linux 保持 Preview，保持同版本号、四语及封装 smoke 验证。
+- 发行证据：保持完整回归、安装／升级、SBOM、SHA-256、秘密防护、四语治理与原生证据的可重现检查。
+
+下一位维护者应先阅读本说明、工作流程与证据文件，再修改版本、封装或发布程序。
+
+## English
+
+> These are the formal v4.0.1 Release Notes. Windows is the formally supported platform; macOS and Linux are limited Previews, with no claim of developer physical certification or Windows feature parity.
+
+### Highlights
+
+- The console adds a desktop companion status card `desktop_companion_status.py`, replacing the former console portrait with a live, localizable status that fully reflects gesture and speech activity.
+- Gesture and wave interaction remain independent and resilient `gesture_runtime.py`, and status updates never block or disturb an in-progress speech response.
+- The v4 README four-language summaries are refreshed `v4.0.1`, and the Windows GUI regression teardown is finalized so clean environments run repeatedly.
+
+### Compatibility and platform boundaries
+
+- This release only fixes maintenance issues found after v4.0.0 and does not change existing feature boundaries; Windows remains formally supported, while macOS Arm/x86 and Linux remain limited Previews.
+- No new external dependency is added, and no authorization, privacy, or fallback verification principle is changed.
+
+### Maintenance handoff
+
+This section is the v4.0.1 handoff baseline for future maintenance; every change must update reproducible evidence, four-language documentation, and these Release Notes.
+
+- Release source: the branch, merged main, version, tag, and GitHub Release must point to the same immutable commit.
+- Platform boundaries: Windows is formally supported; macOS and Linux remain Previews with the same version number, four languages, and package smoke verification.
+- Release evidence: maintain reproducible checks for full regression, install/upgrade, SBOM, SHA-256, secret isolation, four-language governance, and native evidence.
+
+The next maintainer should read this document, the workflows, and the evidence files before changing versions, packaging, or the publication process.
+
+## 日本語
+
+> これは v4.0.1 の正式な Release 説明です。Windows は正式サポートプラットフォームです。macOS と Linux は機能制限付き Preview のみで、開発者の実機認証や Windows と同等の機能を主張するものではありません。
+
+### 本リリースのポイント
+
+- コンソールにデスクトップコンパニオンのステータスカード `desktop_companion_status.py` を追加し、従来のコンソールポートレートを、ジェスチャーと音声活動を完全に反映するライブでローカライズ可能なステータスに置き換えました。
+- ジェスチャーと手を振る操作は独立かつ回復力を持つ `gesture_runtime.py` を維持し、ステータス更新が進行中の音声応答をブロックしたり妨げたりしません。
+- v4 README の4言語サマリー `v4.0.1` を更新し、Windows GUI 回帰テストの後処理を完了して、クリーンな環境で繰り返し実行できるようにしました。
+
+### 互換性とプラットフォーム境界
+
+- 本リリースは v4.0.0 以降に見つかったメンテナンス問題のみを修正し、既存の機能境界は変更しません。Windows は正式サポート、macOS Arm／x86 と Linux は機能制限付き Preview のままです。
+- 新しい外部依存パッケージは追加せず、認可、プライバシー、フォールバック検証の原則は変更しません。
+
+### メンテナンス引き継ぎ
+
+このセクションは v4.0.1 の今後のメンテナンスのための引き継ぎベースラインです。すべての変更は、再現可能な証拠、4言語ドキュメント、本 Release 説明を更新する必要があります。
+
+- リリースソース：ブランチ、マージ後の main、バージョン、タグ、GitHub Release は同じ不変コミットを指す必要があります。
+- プラットフォーム境界：Windows は正式サポート。macOS と Linux は Preview のままで、同じバージョン番号、4言語、パッケージ smoke 検証を維持します。
+- リリース証拠：完全な回帰、インストール／アップグレード、SBOM、SHA-256、秘密の分離、4言語ガバナンス、ネイティブ証拠の再現可能なチェックを維持します。
+
+次のメンテナは、バージョン、パッケージング、公開プロセスを変更する前に、本説明、ワークフロー、証拠ファイルを読む必要があります。

--- a/domain/version_info.py
+++ b/domain/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "4.0.0"
+FALLBACK_VERSION = "4.0.1"
 
 
 def _build_info_path() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "4.0.0"
+version = "4.0.1"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "4.0.0"
+version = "4.0.1"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/tests/test_v4_development_version_consistency.py
+++ b/tests/test_v4_development_version_consistency.py
@@ -6,7 +6,7 @@ lazy import tomllib
 lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-DEVELOPMENT_VERSION = "4.0.0"
+DEVELOPMENT_VERSION = "4.0.1"
 VERSION_AUTHORITY = "domain/version_info.py"
 LANGUAGE_HEADINGS = (
     "## 繁體中文",


### PR DESCRIPTION
## 繁體中文

- 將版本中繼資料自 v4.0.0 同步至 v4.0.1：`domain/version_info.py`（FALLBACK_VERSION）、`pyproject.toml`、`sbom/preview.pyproject.toml`。
- 同步 `tests/test_v4_development_version_consistency.py` 的 DEVELOPMENT_VERSION 為 v4.0.1。
- 更新四語 README 的「目前發行目標／目前開發版本」區塊為 v4.0.1（含 Windows 建置命令）。
- 新增 `docs/releases/v4.0.1.md` 四語發行註記，並通過 `tools/check_four_language_docs.py` 結構驗證。
- 已驗證：`git diff --check`、四語文件檢查與版本一致性測試全數通過。

## 简体中文

- 将版本元数据自 v4.0.0 同步至 v4.0.1：`domain/version_info.py`（FALLBACK_VERSION）、`pyproject.toml`、`sbom/preview.pyproject.toml`。
- 同步 `tests/test_v4_development_version_consistency.py` 的 DEVELOPMENT_VERSION 为 v4.0.1。
- 更新四语 README 的「当前发布目标／当前开发版本」区块为 v4.0.1（含 Windows 构建命令）。
- 新增 `docs/releases/v4.0.1.md` 四语发行注记，并通过 `tools/check_four_language_docs.py` 结构验证。
- 已验证：`git diff --check`、四语文档检查与版本一致性测试全部通过。

## English

- Synchronize version metadata from v4.0.0 to v4.0.1: `domain/version_info.py` (FALLBACK_VERSION), `pyproject.toml`, and `sbom/preview.pyproject.toml`.
- Update DEVELOPMENT_VERSION to v4.0.1 in `tests/test_v4_development_version_consistency.py`.
- Refresh the four-language README "current release target / current development version" blocks to v4.0.1 (including the Windows build command).
- Add the four-language release notes `docs/releases/v4.0.1.md`, validated by `tools/check_four_language_docs.py`.
- Verified: `git diff --check`, the four-language document checks, and the version-consistency tests all pass.

## 日本語

- バージョンメタデータを v4.0.0 から v4.0.1 へ同期：`domain/version_info.py`（FALLBACK_VERSION）、`pyproject.toml`、`sbom/preview.pyproject.toml`。
- `tests/test_v4_development_version_consistency.py` の DEVELOPMENT_VERSION を v4.0.1 に更新。
- 四言語 README の「現在の公開目標／現在の開発版」ブロックを v4.0.1（Windows ビルドコマンド含む）に更新。
- 四言語リリースノート `docs/releases/v4.0.1.md` を追加し、`tools/check_four_language_docs.py` による構造検証に合格。
- 検証済み：`git diff --check`、四言語ドキュメント検査、バージョン整合性テストがすべて合格。
