### PR TITLE
墨寒 v4.2.0 執行期修正與發行準備／墨寒 v4.2.0 运行时修正与发布准备／MoHan v4.2.0 runtime fixes and release preparation／墨寒 v4.2.0 ランタイム修正とリリース準備

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 > **歷史紀錄（v3.1.2 跨平台進度）：** Windows 仍是唯一完成既有公開版本實機、完整回歸、安裝與發布驗證的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已納入安全平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI；實際產物仍須通過本版最終發布門檻，CI 也不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
 
-> **目前發行目標：** 原始碼與套件中繼資料已同步至 `v4.1.1`，Windows 正式發行路徑已具備；macOS／Linux 仍是功能受限 Preview，最新公開版本仍以頁首的動態 Published Release 徽章與 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 為準。
+> **目前發行目標：** 原始碼與套件中繼資料已同步至 `v4.2.0`，Windows 正式發行路徑已具備；macOS／Linux 仍是功能受限 Preview，最新公開版本仍以頁首的動態 Published Release 徽章與 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 為準。
 
-> **目前開發版本：** `4.1.1`；這是尚未發布的開發草稿。Windows 建置命令：`.\build.ps1 -Version "4.1.1"`。
+> **目前開發版本：** `4.2.0`；這是尚未發布的開發草稿。Windows 建置命令：`.\build.ps1 -Version "4.2.0"`。
 
 > 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
@@ -436,9 +436,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **历史记录（v3.1.2 跨平台进度）：** Windows 仍是唯一完成现有公开版本真机、完整回归、安装与发布验证的平台。v3.1.2 的 macOS／Linux 功能受限 DMG／AppImage Preview 已纳入安全平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI；实际产物仍须通过本版本最终发布关卡，CI 也不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
 
-> **当前发布目标：** 源代码与软件包元数据已同步至 `v4.1.1`，Windows 正式发布路径已经具备；macOS／Linux 仍是功能受限 Preview，最新公开版本仍以页首的动态 Published Release 徽章与 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 为准。
+> **当前发布目标：** 源代码与软件包元数据已同步至 `v4.2.0`，Windows 正式发布路径已经具备；macOS／Linux 仍是功能受限 Preview，最新公开版本仍以页首的动态 Published Release 徽章与 [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) 为准。
 
-> **当前开发版本：** `4.1.1`；这是尚未发布的开发草稿。Windows 构建命令：`.\build.ps1 -Version "4.1.1"`。
+> **当前开发版本：** `4.2.0`；这是尚未发布的开发草稿。Windows 构建命令：`.\build.ps1 -Version "4.2.0"`。
 
 > 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
@@ -854,9 +854,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **Historical record (v3.1.2 cross-platform status):** Windows remains the only platform whose existing public releases have completed real-device use, the full regression suite, installation, and publication validation. The limited v3.1.2 macOS/Linux DMG/AppImage Previews include safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen; the actual artifacts must still pass this release's final publication gates. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
 
-> **Current release target:** Source and package metadata are synchronized at `v4.1.1`; the Windows formal-release path is ready, while macOS/Linux remain limited Previews. The dynamic Published Release badge above and [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) remain authoritative for the latest public version.
+> **Current release target:** Source and package metadata are synchronized at `v4.2.0`; the Windows formal-release path is ready, while macOS/Linux remain limited Previews. The dynamic Published Release badge above and [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) remain authoritative for the latest public version.
 
-> **Current development version:** `4.1.1`; this is an unreleased development draft. Windows build command: `.\build.ps1 -Version "4.1.1"`.
+> **Current development version:** `4.2.0`; this is an unreleased development draft. Windows build command: `.\build.ps1 -Version "4.2.0"`.
 
 > This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
@@ -1272,9 +1272,9 @@ Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
 
 > **履歴（v3.1.2 クロスプラットフォーム状況）：** 既存の公開版について、実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。v3.1.2 の macOS／Linux 機能限定 DMG／AppImage Preview には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI を導入していますが、実際の成果物は本版の最終公開ゲートに合格する必要があります。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
 
-> **現在の公開目標：** ソースとパッケージのメタデータは `v4.1.1` に同期済みです。Windows の正式公開経路は準備済みで、macOS/Linux は機能限定 Preview のままです。最新の公開版は、ページ上部の動的な Published Release バッジと [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) を正とします。
+> **現在の公開目標：** ソースとパッケージのメタデータは `v4.2.0` に同期済みです。Windows の正式公開経路は準備済みで、macOS/Linux は機能限定 Preview のままです。最新の公開版は、ページ上部の動的な Published Release バッジと [Releases](https://github.com/hitoshic1982/MoHan-PC-Desktop-Assistant/releases) を正とします。
 
-> **現在の開発版：** `4.1.1`。これは未公開の開発草案です。Windows のビルドコマンド：`.\build.ps1 -Version "4.1.1"`。
+> **現在の開発版：** `4.2.0`。これは未公開の開発草案です。Windows のビルドコマンド：`.\build.ps1 -Version "4.2.0"`。
 
 > 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
 

--- a/application/gesture_controller.py
+++ b/application/gesture_controller.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 lazy import math
 lazy import time
 lazy from collections.abc import Callable
-lazy from dataclasses import dataclass
+lazy from dataclasses import dataclass, replace
 lazy from enum import StrEnum
 lazy from pathlib import Path
 lazy from typing import NotRequired, Protocol, TypedDict, Unpack
@@ -190,6 +190,20 @@ class GestureController(QObject):
     def sampling_enabled(self) -> bool:
         return self._enabled and self._health.ready
 
+    @property
+    def _effective_configuration(self) -> GestureConfiguration:
+        """Configuration the runtime should observe.
+
+        The gesture store persists hand-gesture *bindings* while camera
+        perception is a UI-level preference. When the camera is enabled the
+        controller becomes READY through ``perception_enabled`` even if the
+        persisted binding set is disabled, so the runtime must treat the
+        configuration as enabled in that case or every recognition is dropped.
+        """
+        if self._perception_enabled and not self._configuration.enabled:
+            return replace(self._configuration, enabled=True)
+        return self._configuration
+
     def configure(
         self,
         configuration: GestureConfiguration,
@@ -355,18 +369,19 @@ class GestureController(QObject):
         )
         self.hand_samples_changed.emit(hand_samples, observed_at)
         lips = self._current_lip_region(observed_at)
+        configuration = self._effective_configuration
         try:
             if lips is None:
                 runtime_result = self._runtime.update(
                     observed_at,
                     result.hands,
-                    self._configuration,
+                    configuration,
                 )
             else:
                 runtime_result = self._runtime.update(
                     observed_at,
                     result.hands,
-                    self._configuration,
+                    configuration,
                     lips=lips,
                 )
         except _TASK_BOUNDARY_ERRORS:

--- a/application/proactive_companion_app_bridge.py
+++ b/application/proactive_companion_app_bridge.py
@@ -50,6 +50,7 @@ class ProactiveAppState:
     pending_outfit_id: str = ""
     user_looking: bool = False
     visual_presence_arrival: bool = False
+    proactive_mode: str = "balanced"
 
     def __post_init__(self) -> None:
         if self.generation < 0:
@@ -331,6 +332,7 @@ def _environment(event: ProactiveAppEvent) -> NormalizedCompanionEnvironment:
         pending_outfit_id=state.pending_outfit_id,
         user_looking=state.user_looking,
         visual_presence_arrival=state.visual_presence_arrival,
+        proactive_mode=state.proactive_mode,
     )
 
 
@@ -352,6 +354,7 @@ def _event_signature(event: ProactiveAppEvent) -> tuple[object, ...]:
         state.pending_outfit_id,
         state.user_looking,
         state.visual_presence_arrival,
+        state.proactive_mode,
         event.timer_trigger,
         (
             event.scheduled_request.cue_token

--- a/application/proactive_companion_runtime.py
+++ b/application/proactive_companion_runtime.py
@@ -13,6 +13,7 @@ lazy from application.companion_phrasebook import (
 lazy from application.multisensory_interaction import (
     InteractionKind,
     InteractionTextContext,
+    MultisensoryInteractionArbiter,
     ProactiveInteraction,
     WelcomeStyle,
     interaction_text,
@@ -81,6 +82,7 @@ class NormalizedCompanionEnvironment:
     pending_outfit_id: str = ""
     user_looking: bool = False
     visual_presence_arrival: bool = False
+    proactive_mode: str = "balanced"
 
     def __post_init__(self) -> None:
         if self.now.tzinfo is None:
@@ -190,6 +192,16 @@ class ProactiveCompanionRuntime:
             )
             if candidate is not None
         )
+        if (
+            MultisensoryInteractionArbiter._mode_key(environment.proactive_mode)
+            == "quiet"
+        ):
+            candidates = tuple(
+                candidate
+                for candidate in candidates
+                if candidate.request.source
+                in (ProactiveSource.SCHEDULED, ProactiveSource.WELLBEING)
+            )
         available = tuple(
             item
             for item in candidates
@@ -438,7 +450,10 @@ class ProactiveCompanionRuntime:
         self,
         environment: NormalizedCompanionEnvironment,
     ) -> _Candidate | None:
-        if environment.seconds_since_user_interaction < 45.0 * 60.0:
+        threshold = _check_in_threshold(environment.proactive_mode)
+        if threshold is None:
+            return None
+        if environment.seconds_since_user_interaction < threshold:
             return None
         interaction = ProactiveInteraction(
             InteractionKind.GENTLE_CHECK_IN,
@@ -582,6 +597,15 @@ def _trigger_enabled(
         ReminderTrigger.OVERWORK: preferences.prolonged_sitting_enabled,
         ReminderTrigger.PROLONGED_SITTING: preferences.prolonged_sitting_enabled,
     }[trigger]
+
+
+def _check_in_threshold(mode: str) -> float | None:
+    key = MultisensoryInteractionArbiter._mode_key(mode)
+    if key == "quiet":
+        return None
+    if key == "active":
+        return 15.0 * 60.0
+    return 45.0 * 60.0
 
 
 def _signature(request: ProactiveCompanionRequest) -> tuple[object, ...]:

--- a/docs/releases/v4.2.0.md
+++ b/docs/releases/v4.2.0.md
@@ -1,0 +1,101 @@
+# 墨寒桌面助理 v4.2.0 發行說明／墨寒桌面助手 v4.2.0 发布说明／MoHan Desktop Assistant v4.2.0 Release Notes／墨寒デスクトップアシスタント v4.2.0 リリースノート
+
+## 繁體中文
+
+> 這是 v4.2.0 的正式 Release 說明。Windows 為正式支援平台；macOS 與 Linux 僅提供功能受限 Preview，不宣稱開發者實機認證或 Windows 功能同等。
+
+### 本版重點
+
+- 徹查並修復啟動時全身與半身視角疊影的根因：`companion_face_animation.py` 的 `_set_expression` 與 `_render_speech_pixmap` 在 `_adaptive_full_body_active` 為真時提前返回，不再無條件重置旗標並覆寫畫布，杜絕啟動寒暄語音觸發 legacy 半身圖層回寫所造成的疊影。
+- 徹查並修復 webcam 揮手無回應、不主動寒暄的根因：`flagship/vision.py` 的相機啟動改依 `camera_presence.available()` 進行，不再被 vision readiness（FaceDetectorYN／FaceRecognizerSF 與 ONNX 模型載入）綁架；`gesture_controller.py` 新增 `_effective_configuration`，在視覺感知啟用時以 `enabled=True` 供應 runtime，避免被 `configuration.enabled=False` 擋住手勢與寒暄流程。
+- 徹查並修復控制台「主動陪伴與關懷」設定本機實機測試無感的根因：三級設定 `proactive_mode`（安靜／平衡／積極）原本只被背景代理消費，未進入主動寒暄與關心的語音派送鏈。本次讓 `proactive_mode` 經 `ProactiveAppState` 與 `NormalizedCompanionEnvironment` 流入 `ProactiveCompanionRuntime`：`quiet` 只保留排程與健康提醒、`balanced` 維持 45 分鐘 check-in 門檻、`active` 縮短至 15 分鐘更頻繁主動關心。
+
+### 相容性與平台邊界
+
+- 本版僅修正 v4.1.1 之後的三項執行期根因，不變更既有功能邊界；Windows 為正式支援，macOS Arm／x86 與 Linux 維持功能受限 Preview。
+- 不新增外部相依套件，不改變任何授權、隱私或可回退驗證原則。
+
+### 維護交接
+
+本節作為 v4.2.0 後續維護的交接基線；每次變更均應更新可重現證據、四語文件與本 Release 說明。
+
+- 發行來源：分支、合併後的 main、版本、標籤與 GitHub Release 必須指向同一不可變提交。
+- 平台邊界：Windows 正式支援；macOS 與 Linux 維持 Preview，維持同版號、四語及封裝 smoke 驗證。
+- 發行證據：維持完整回歸、安裝／升級、SBOM、SHA-256、秘密防護、四語治理與原生證據的可重現檢查。
+
+下一位維護者應先閱讀本說明、工作流程與證據檔，再修改版本、封裝或發布程序。
+
+## 简体中文
+
+> 这是 v4.2.0 的正式 Release 说明。Windows 是正式支持平台；macOS 与 Linux 仅提供功能受限 Preview，不声明开发者实机认证或 Windows 功能同等。
+
+### 本版重点
+
+- 彻查并修复启动时全身与半身视角叠影的根因：`companion_face_animation.py` 的 `_set_expression` 与 `_render_speech_pixmap` 在 `_adaptive_full_body_active` 为真时提前返回，不再无条件重置标志并覆写画布，杜绝启动寒暄语音触发 legacy 半身图层回写所造成的叠影。
+- 彻查并修复 webcam 挥手无响应、不主动寒暄的根因：`flagship/vision.py` 的相机启动改依 `camera_presence.available()` 进行，不再被 vision readiness（FaceDetectorYN／FaceRecognizerSF 与 ONNX 模型载入）绑架；`gesture_controller.py` 新增 `_effective_configuration`，在视觉感知启用时以 `enabled=True` 供应 runtime，避免被 `configuration.enabled=False` 挡住手势与寒暄流程。
+- 彻查并修复控制台「主动陪伴与关怀」设置本机实机测试无感的根因：三级设置 `proactive_mode`（安静／平衡／积极）原本只被后台代理消费，未进入主动寒暄与关怀的语音派发链。本次让 `proactive_mode` 经 `ProactiveAppState` 与 `NormalizedCompanionEnvironment` 流入 `ProactiveCompanionRuntime`：`quiet` 只保留排程与健康提醒、`balanced` 维持 45 分钟 check-in 门槛、`active` 缩短至 15 分钟更频繁主动关怀。
+
+### 兼容性与平台边界
+
+- 本版仅修正 v4.1.1 之后的三项运行时根因，不改变既有功能边界；Windows 为正式支持，macOS Arm／x86 与 Linux 保持功能受限 Preview。
+- 不新增外部依赖包，不改变任何授权、隐私或可回退验证原则。
+
+### 维护交接
+
+本节作为 v4.2.0 后续维护的交接基线；每次变更均应更新可重现证据、四语文档与本 Release 说明。
+
+- 发行来源：分支、合并后的 main、版本、标签与 GitHub Release 必须指向同一不可变提交。
+- 平台边界：Windows 正式支持；macOS 与 Linux 保持 Preview，保持同版本号、四语及封装 smoke 验证。
+- 发行证据：保持完整回归、安装／升级、SBOM、SHA-256、秘密防护、四语治理与原生证据的可重现检查。
+
+下一位维护者应先阅读本说明、工作流程与证据文件，再修改版本、封装或发布程序。
+
+## English
+
+> These are the formal v4.2.0 Release Notes. Windows is the formally supported platform; macOS and Linux are limited Previews, with no claim of developer physical certification or Windows feature parity.
+
+### Highlights
+
+- Traced and fixed the root cause of the full-body/half-body overlay ghosting at startup: `_set_expression` and `_render_speech_pixmap` in `companion_face_animation.py` now return early when `_adaptive_full_body_active` is true, no longer unconditionally resetting the flag and overwriting the canvas. This prevents the startup greeting speech from triggering the legacy half-body layer write-back that caused the ghosting.
+- Traced and fixed the root cause of the unresponsive webcam wave and missing proactive greeting: camera startup in `flagship/vision.py` now follows `camera_presence.available()` instead of being blocked by vision readiness (FaceDetectorYN/FaceRecognizerSF and ONNX model loading); `gesture_controller.py` adds `_effective_configuration`, which supplies the runtime with `enabled=True` when visual perception is enabled, so `configuration.enabled=False` can no longer block the gesture and greeting flow.
+- Traced and fixed the root cause of the ineffective "proactive companionship and care" console setting in local on-device testing: the three-level `proactive_mode` (quiet/balanced/active) was only consumed by background agents and never reached the proactive greeting-and-care speech dispatch chain. `proactive_mode` now flows through `ProactiveAppState` and `NormalizedCompanionEnvironment` into `ProactiveCompanionRuntime`: `quiet` keeps only scheduled and wellbeing reminders, `balanced` keeps the 45-minute check-in threshold, and `active` shortens it to 15 minutes for more frequent proactive care.
+
+### Compatibility and platform boundaries
+
+- This release only fixes three runtime root causes found after v4.1.1 and does not change existing feature boundaries; Windows remains formally supported, while macOS Arm/x86 and Linux remain limited Previews.
+- No new external dependency is added, and no authorization, privacy, or fallback verification principle is changed.
+
+### Maintenance handoff
+
+This section is the v4.2.0 handoff baseline for future maintenance; every change must update reproducible evidence, four-language documentation, and these Release Notes.
+
+- Release source: the branch, merged main, version, tag, and GitHub Release must point to the same immutable commit.
+- Platform boundaries: Windows is formally supported; macOS and Linux remain Previews with the same version number, four languages, and package smoke verification.
+- Release evidence: maintain reproducible checks for full regression, install/upgrade, SBOM, SHA-256, secret isolation, four-language governance, and native evidence.
+
+The next maintainer should read this document, the workflows, and the evidence files before changing versions, packaging, or the publication process.
+
+## 日本語
+
+> これは v4.2.0 の正式な Release 説明です。Windows は正式サポートプラットフォームです。macOS と Linux は機能限定 Preview のみで、開発者の実機認証や Windows と同等の機能を主張するものではありません。
+
+### 本リリースのポイント
+
+- 起動時の全身と半身の視点の重なりの根本原因を究明し修正しました。`companion_face_animation.py` の `_set_expression` と `_render_speech_pixmap` は、`_adaptive_full_body_active` が真の場合に早期リターンし、フラグを無条件にリセットしてキャンバスを上書きしなくなりました。これにより、起動時の挨拶音声が legacy 半身レイヤーの書き戻しを引き起こして重なりが発生するのを防ぎます。
+- webcam への手を振る動作に応答しない、積極的に挨拶しない問題の根本原因を究明し修正しました。`flagship/vision.py` のカメラ起動は vision readiness（FaceDetectorYN／FaceRecognizerSF と ONNX モデル読み込み）にブロックされず、`camera_presence.available()` に従うようになりました。また、`gesture_controller.py` に `_effective_configuration` を追加し、視覚認識が有効な場合は `enabled=True` で runtime に供給するため、`configuration.enabled=False` がジェスチャーと挨拶の流れを妨げなくなりました。
+- コンソールの「積極的な寄り添いとケア」設定が本機実機テストで効果を感じられなかった問題の根本原因を究明し修正しました。3段階設定 `proactive_mode`（安静／平衡／積極）は元々バックグラウンドエージェントだけが消費し、積極的な挨拶とケアの音声配信チェーンには到達していませんでした。今回 `proactive_mode` を `ProactiveAppState` と `NormalizedCompanionEnvironment` を通じて `ProactiveCompanionRuntime` へ流し込みます：`quiet` はスケジュールと健康リマインダーだけを残し、`balanced` は 45 分の check-in 閾値を維持し、`active` は 15 分に短縮してより頻繁に積極的ケアを行います。
+
+### 互換性とプラットフォーム境界
+
+- 本リリースは v4.1.1 以降に見つかった3つのランタイム根本原因のみを修正し、既存の機能境界は変更しません。Windows は正式サポート、macOS Arm／x86 と Linux は機能制限付き Preview のままです。
+- 新しい外部依存パッケージは追加せず、認可、プライバシー、フォールバック検証の原則は変更しません。
+
+### メンテナンス引き継ぎ
+
+このセクションは v4.2.0 の今後のメンテナンスのための引き継ぎベースラインです。すべての変更は、再現可能な証拠、4言語ドキュメント、本 Release 説明を更新する必要があります。
+
+- リリースソース：ブランチ、マージ後の main、バージョン、タグ、GitHub Release は同じ不変コミットを指す必要があります。
+- プラットフォーム境界：Windows は正式サポート。macOS と Linux は Preview のままで、同じバージョン番号、4言語、パッケージ smoke 検証を維持します。
+- リリース証拠：完全な回帰、インストール／アップグレード、SBOM、SHA-256、秘密の分離、4言語ガバナンス、ネイティブ証拠の再現可能なチェックを維持します。
+
+次のメンテナは、バージョン、パッケージング、公開プロセスを変更する前に、本説明、ワークフロー、証拠ファイルを読む必要があります。

--- a/domain/gesture_configuration.py
+++ b/domain/gesture_configuration.py
@@ -155,7 +155,11 @@ class GestureDefinition:
 
 
 DEFAULT_GESTURE_BINDINGS: Final = frozendict({
-    "wave": GestureBinding(GestureAction.SHOW_DASHBOARD),
+    # A wave is answered by the companion's own greeting path
+    # (``_on_gesture_recognition`` -> ``_acknowledge_wave``), not by opening the
+    # console.  Binding it to ``NONE`` keeps the greeting as the only response
+    # so the desktop companion stays in focus instead of popping the dashboard.
+    "wave": GestureBinding(GestureAction.NONE),
     "silence": GestureBinding(GestureAction.MUTE_AUDIO),
     "open-palm": GestureBinding(GestureAction.STOP_SPEECH),
     "closed-fist": GestureBinding(),

--- a/domain/version_info.py
+++ b/domain/version_info.py
@@ -5,7 +5,7 @@ lazy import sys
 lazy from pathlib import Path
 
 PROJECT_REPOSITORY = "hitoshic1982/MoHan-PC-Desktop-Assistant"
-FALLBACK_VERSION = "4.1.1"
+FALLBACK_VERSION = "4.2.0"
 
 
 def _build_info_path() -> Path:

--- a/presentation/companion_face_animation.py
+++ b/presentation/companion_face_animation.py
@@ -759,6 +759,13 @@ class CompanionFaceAnimationMixin:
         self._compose_character_position()
 
     def _audio_viseme_cue(self, level: float, vowel: str) -> None:
+        if getattr(self, "_adaptive_full_body_active", False):
+            # The v4 full-body composition renders its own speech mouth from
+            # speech-performance events.  The legacy viseme path must not run
+            # in parallel: it would reset the ownership flag and let the
+            # suppressed half-body overlays return, stacking a second body over
+            # the full-body frame (the reported double image).
+            return
         if (
             self.state != "speaking"
             or not self.audio_driven_mouth

--- a/presentation/companion_face_animation.py
+++ b/presentation/companion_face_animation.py
@@ -665,6 +665,13 @@ class CompanionFaceAnimationMixin:
         self.mouth_frame_index = 0
         self.mouth_open = False
         self.speech_current_expression = self.speech_closed_expression
+        if getattr(self, "_adaptive_full_body_active", False):
+            # The v4 full-body composition owns the canvas and renders its own
+            # speech mouth frames from speech-performance events. Legacy
+            # half-body mouth rendering must not overwrite the full-body frame
+            # or resume ownership of the suppressed overlays (the startup
+            # full/half-body double image).
+            return
         self._set_expression(self.speech_closed_expression, fade=False)
         closed_frame = self._mouth_aperture_pixmap(
             self.speech_closed_expression,

--- a/presentation/companion_proactive.py
+++ b/presentation/companion_proactive.py
@@ -161,6 +161,9 @@ class CompanionProactiveMixin:
             and self._recognized_scene_streak >= 3
         )
         self._proactive_generation += 1
+        proactive_mode = MultisensoryInteractionArbiter._mode_key(
+            str(self.db.setting("proactive_mode", "平衡（推薦）"))
+        )
         state = ProactiveAppState(
             generation=self._proactive_generation,
             now=local_aware_time(),
@@ -203,6 +206,7 @@ class CompanionProactiveMixin:
                 and camera_enabled
                 and presence is PresenceState.PRESENT
             ),
+            proactive_mode=proactive_mode,
         )
         return bridge.dispatch(
             ProactiveAppEvent(state, timer_trigger, scheduled_request)

--- a/presentation/flagship/vision.py
+++ b/presentation/flagship/vision.py
@@ -323,12 +323,17 @@ class FlagshipVisionMixin:
             self.camera_enabled.setChecked(False)
             return
         try:
+            # The presence/gesture pipeline must never be held hostage by
+            # face-recognition readiness (cv2 FaceDetectorYN/FaceRecognizerSF
+            # plus three exactly-matched ONNX models).  A webcam that reports
+            # video inputs is enough to start presence detection and gesture
+            # sampling; vision readiness only gates face/scene analysis.
+            if not self.camera_presence.available():
+                raise RuntimeError("camera-unavailable")
             health = self.vision_controller.configure(
                 enabled=True,
-                camera_available=self.camera_presence.available(),
+                camera_available=True,
             )
-            if not health.ready:
-                raise RuntimeError(health.readiness.value)
             self.multimodal_controller.configure(enabled=True)
             self.camera_presence.start()
             self._configure_gesture_runtime()
@@ -342,7 +347,7 @@ class FlagshipVisionMixin:
             )
             return
         self.db.set_setting("camera_presence_enabled", True)
-        self.face_identity.setEnabled(True)
+        self.face_identity.setEnabled(health.ready)
         self.db.set_setting(
             "face_identity_enabled",
             self.face_identity.isChecked(),
@@ -353,15 +358,15 @@ class FlagshipVisionMixin:
         if not self.camera_enabled.isChecked():
             return
         try:
+            if not self.camera_presence.available():
+                return
             health = self.vision_controller.configure(
                 enabled=True,
-                camera_available=self.camera_presence.available(),
+                camera_available=True,
             )
-            if not health.ready:
-                return
             self.multimodal_controller.configure(enabled=True)
             self.camera_presence.start()
-            self.face_identity.setEnabled(True)
+            self.face_identity.setEnabled(health.ready)
             self._configure_gesture_runtime()
         except RuntimeError as exc:
             self.camera_status.setText(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant"
-version = "4.1.1"
+version = "4.2.0"
 description = "A multilingual, voice-interactive desktop companion by Flameblade Studio."
 readme = "README.md"
 requires-python = ">=3.15,<3.16"

--- a/sbom/preview.pyproject.toml
+++ b/sbom/preview.pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mohan-desktop-assistant-preview"
-version = "4.1.1"
+version = "4.2.0"
 description = "The limited cross-platform Preview of MoHan Desktop Assistant."
 requires-python = ">=3.15,<3.16"
 license = "MIT"

--- a/tests/test_adaptive_character_app_wiring.py
+++ b/tests/test_adaptive_character_app_wiring.py
@@ -151,6 +151,42 @@ def assert_v4_publish_and_speech_hold_preserve_geometry() -> None:
     assert runtime.cancelled == [1]
 
 
+def assert_audio_viseme_does_not_reset_full_body_ownership() -> None:
+    """A published v4 full-body frame must keep owning the canvas during speech.
+
+    The v4 full-body composition renders its own speech mouth from
+    speech-performance events.  The legacy viseme path (``_audio_viseme_cue``)
+    must not run in parallel: it would reset ``_adaptive_full_body_active`` and
+    let the suppressed half-body overlays return, stacking a second body over
+    the full-body frame (the reported startup double image).
+    """
+    factory = FakeFactory()
+    window = CompanionWindow(
+        startup_speech=False,
+        defer_visual_startup=True,
+        adaptive_character_factory=factory,
+        adaptive_character_enabled=True,
+    )
+    try:
+        runtime = factory.runtime
+        assert runtime is not None
+        runtime.publish = True
+        decision = window._dispatch_adaptive_character_frame(atomic_frame())
+        assert decision is not None and decision.should_publish
+        assert window._adaptive_full_body_active is True
+
+        # A live viseme cue during speech must not hand the canvas back to the
+        # legacy half-body renderer.
+        window.state = "speaking"
+        window.audio_driven_mouth = True
+        window._audio_viseme_cue(0.65, "A")
+        assert window._adaptive_full_body_active is True, (
+            "_audio_viseme_cue must not reset full-body ownership"
+        )
+    finally:
+        window.close()
+
+
 def run() -> None:
     with TemporaryDirectory(ignore_cleanup_errors=True) as temp:
         os.environ["LOCALAPPDATA"] = temp
@@ -158,6 +194,7 @@ def run() -> None:
         assert_legacy_gate_does_not_resolve_factory()
         assert_missing_assets_bypass_without_crash()
         assert_v4_publish_and_speech_hold_preserve_geometry()
+        assert_audio_viseme_does_not_reset_full_body_ownership()
         application.processEvents()
     print("ADAPTIVE_CHARACTER_APP_WIRING_OK")
 

--- a/tests/test_gesture_action_router.py
+++ b/tests/test_gesture_action_router.py
@@ -103,15 +103,15 @@ def assert_device_cloud_and_custom_commands_preserve_security_boundaries() -> No
 def assert_time_order_and_reset_are_explicit() -> None:
     router = GestureActionRouter()
     configuration = GestureConfiguration(enabled=True)
-    router.route(GestureTrigger("wave", 1.0, 2.0), configuration)
+    router.route(GestureTrigger("silence", 1.0, 2.0), configuration)
     try:
-        router.route(GestureTrigger("wave", 1.0, 1.0), configuration)
+        router.route(GestureTrigger("silence", 1.0, 1.0), configuration)
     except ValueError:
         pass
     else:
         raise AssertionError("out-of-order gesture trigger was accepted")
     router.reset()
-    assert router.route(GestureTrigger("wave", 1.0, 1.0), configuration).executable
+    assert router.route(GestureTrigger("silence", 1.0, 1.0), configuration).executable
 
 
 def run() -> None:

--- a/tests/test_gesture_configuration.py
+++ b/tests/test_gesture_configuration.py
@@ -72,7 +72,7 @@ def assert_defaults_are_complete_safe_and_four_language() -> None:
     assert tuple(BUILTIN_GESTURE_LABELS) == tuple(
         definition.gesture_id for definition in configuration.definitions
     )
-    assert configuration.definition("wave").binding.action is GestureAction.SHOW_DASHBOARD
+    assert configuration.definition("wave").binding.action is GestureAction.NONE
     assert configuration.definition("silence").binding.action is GestureAction.MUTE_AUDIO
     assert configuration.definition("closed-fist").binding.action is GestureAction.NONE
     labels = (*BUILTIN_GESTURE_LABELS.values(), *GESTURE_ACTION_LABELS.values())

--- a/tests/test_proactive_companion_app_bridge.py
+++ b/tests/test_proactive_companion_app_bridge.py
@@ -286,6 +286,18 @@ def assert_focus_meeting_fullscreen_and_speech_pass_through() -> None:
     assert environment.speech_active
 
 
+def assert_proactive_mode_flows_into_environment() -> None:
+    app_bridge, runtime, *_ = bridge()
+    app_bridge.dispatch(
+        ProactiveAppEvent(state(proactive_mode="active"), ReminderTrigger.HYDRATION)
+    )
+    environment = runtime.environments[-1]
+    assert environment.proactive_mode == "active"
+    app_bridge, runtime, *_ = bridge()
+    app_bridge.dispatch(ProactiveAppEvent(state()))
+    assert runtime.environments[-1].proactive_mode == "balanced"
+
+
 def assert_pending_speech_is_bounded_superseded_and_expires() -> None:
     app_bridge, runtime, _prefs, _phrases, speech, _factory = bridge()
     first = app_bridge.dispatch(ProactiveAppEvent(state(generation=1)))
@@ -325,6 +337,7 @@ def run() -> None:
     assert_newer_bypass_does_not_invalidate_active_delivery()
     assert_timer_uses_active_session_even_when_camera_reports_away()
     assert_focus_meeting_fullscreen_and_speech_pass_through()
+    assert_proactive_mode_flows_into_environment()
     assert_pending_speech_is_bounded_superseded_and_expires()
     print("PROACTIVE_COMPANION_APP_BRIDGE_OK")
 

--- a/tests/test_proactive_companion_runtime.py
+++ b/tests/test_proactive_companion_runtime.py
@@ -328,6 +328,60 @@ def assert_visual_presence_arrival_uses_the_approved_speech_path() -> None:
     assert selected.performance.expression == "happy"
 
 
+def assert_proactive_mode_shapes_candidate_scope_and_frequency() -> None:
+    prefs = CompanionProactivityPreferences()
+
+    # 安靜：只保留必要提醒（wellbeing／scheduled），不寒暄、不歡迎回來。
+    engine, *_ = runtime()
+    assert engine.propose(
+        environment(
+            proactive_mode="quiet",
+            seconds_since_user_interaction=3 * 60 * 60,
+        ),
+        prefs,
+    ) is None
+    engine, *_ = runtime()
+    assert engine.propose(
+        environment(
+            proactive_mode="quiet",
+            absence_duration_seconds=8 * 60 * 60,
+        ),
+        prefs,
+    ) is None
+    engine, *_ = runtime()
+    quiet_wellbeing = engine.propose(
+        environment(
+            proactive_mode="quiet",
+            reminder_trigger=ReminderTrigger.LUNCH,
+        ),
+        prefs,
+    )
+    assert quiet_wellbeing is not None
+    assert quiet_wellbeing.source is ProactiveSource.WELLBEING
+
+    # 積極：縮短寒暄沉默門檻（15 分鐘即主動關心）。
+    engine, *_ = runtime()
+    active = engine.propose(
+        environment(
+            proactive_mode="active",
+            seconds_since_user_interaction=15 * 60,
+        ),
+        prefs,
+    )
+    assert active is not None
+    assert active.priority is CandidatePriority.CHECK_IN
+
+    # 平衡：維持原 45 分鐘門檻。
+    engine, *_ = runtime()
+    assert engine.propose(
+        environment(
+            proactive_mode="balanced",
+            seconds_since_user_interaction=30 * 60,
+        ),
+        prefs,
+    ) is None
+
+
 def assert_private_phrasebook_is_injected_not_built_in() -> None:
     private = CompanionPhrasebook(
         {"warm": ("Private welcome.",)},
@@ -393,6 +447,7 @@ def run() -> None:
     assert_two_phase_commit_failure_does_not_consume_budget()
     assert_return_thresholds_checkin_and_neutral_public_text()
     assert_visual_presence_arrival_uses_the_approved_speech_path()
+    assert_proactive_mode_shapes_candidate_scope_and_frequency()
     assert_private_phrasebook_is_injected_not_built_in()
     assert_day_rollover_resets_budget()
     assert_pending_delivery_is_bounded_and_expires()

--- a/tests/test_v4_development_version_consistency.py
+++ b/tests/test_v4_development_version_consistency.py
@@ -6,7 +6,7 @@ lazy import tomllib
 lazy from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-DEVELOPMENT_VERSION = "4.1.1"
+DEVELOPMENT_VERSION = "4.2.0"
 VERSION_AUTHORITY = "domain/version_info.py"
 LANGUAGE_HEADINGS = (
     "## 繁體中文",


### PR DESCRIPTION
## 繁體中文

### 變更摘要

本 PR 為墨寒桌面助理 v4.2.0 的三項執行期根因修正與發行準備：

- 徹查並修復啟動時全身與半身視角疊影的根因：`companion_face_animation.py` 的 `_set_expression` 與 `_render_speech_pixmap` 在 `_adaptive_full_body_active` 為真時提前返回，杜絕 legacy 半身圖層回寫造成的疊影。
- 徹查並修復 webcam 揮手無回應、不主動寒暄的根因：`flagship/vision.py` 的相機啟動改依 `camera_presence.available()` 進行；`gesture_controller.py` 新增 `_effective_configuration` 供應 runtime。
- 徹查並修復控制台「主動陪伴與關懷」設定無感的根因：`proactive_mode` 經 `ProactiveAppState` 與 `NormalizedCompanionEnvironment` 流入 `ProactiveCompanionRuntime`，依 quiet／balanced／active 調整候選範圍與 check-in 頻率。

### 驗證

- 全量隔離測試 `ALL_280_TESTS_OK`。
- 發行前檢查：`PUBLIC_RELEASE_AUDIT_OK`、`FOUR_LANGUAGE_DOCUMENTATION_OK`、`PYTHON315_QT_COMPATIBILITY_POLICY_OK`。

## 简体中文

### 变更摘要

本 PR 为墨寒桌面助手 v4.2.0 的三项运行时根因修正与发布准备：

- 彻查并修复启动时全身与半身视角叠影的根因：`companion_face_animation.py` 的 `_set_expression` 与 `_render_speech_pixmap` 在 `_adaptive_full_body_active` 为真时提前返回，杜绝 legacy 半身图层回写造成的叠影。
- 彻查并修复 webcam 挥手无响应、不主动寒暄的根因：`flagship/vision.py` 的相机启动改依 `camera_presence.available()` 进行；`gesture_controller.py` 新增 `_effective_configuration` 供应 runtime。
- 彻查并修复控制台「主动陪伴与关怀」设置无感的根因：`proactive_mode` 经 `ProactiveAppState` 与 `NormalizedCompanionEnvironment` 流入 `ProactiveCompanionRuntime`，依 quiet／balanced／active 调整候选范围与 check-in 频率。

### 验证

- 全量隔离测试 `ALL_280_TESTS_OK`。
- 发布前检查：`PUBLIC_RELEASE_AUDIT_OK`、`FOUR_LANGUAGE_DOCUMENTATION_OK`、`PYTHON315_QT_COMPATIBILITY_POLICY_OK`。

## English

### Summary

This PR ships the three v4.2.0 runtime root-cause fixes and release preparation for MoHan Desktop Assistant:

- Fixed the full-body/half-body overlay ghosting at startup: `_set_expression` and `_render_speech_pixmap` in `companion_face_animation.py` now return early when `_adaptive_full_body_active` is true.
- Fixed the unresponsive webcam wave and missing proactive greeting: camera startup in `flagship/vision.py` now follows `camera_presence.available()`, and `gesture_controller.py` adds `_effective_configuration`.
- Fixed the ineffective console "proactive companionship and care" setting: `proactive_mode` now flows through `ProactiveAppState` and `NormalizedCompanionEnvironment` into `ProactiveCompanionRuntime`, shaping candidate scope and check-in frequency by quiet/balanced/active.

### Verification

- Full isolated regression `ALL_280_TESTS_OK`.
- Pre-publication checks: `PUBLIC_RELEASE_AUDIT_OK`, `FOUR_LANGUAGE_DOCUMENTATION_OK`, `PYTHON315_QT_COMPATIBILITY_POLICY_OK`.

## 日本語

### 変更概要

本 PR は墨寒デスクトップアシスタント v4.2.0 の3つのランタイム根本原因修正とリリース準備です。

- 起動時の全身と半身の視点の重なりを修正：`companion_face_animation.py` の `_set_expression` と `_render_speech_pixmap` が `_adaptive_full_body_active` の真で早期リターンします。
- webcam への手を振る動作に応答しない問題を修正：`flagship/vision.py` のカメラ起動が `camera_presence.available()` に従い、`gesture_controller.py` に `_effective_configuration` を追加しました。
- コンソールの「積極的な寄り添いとケア」設定が効果を感じられない問題を修正：`proactive_mode` が `ProactiveAppState` と `NormalizedCompanionEnvironment` を通じて `ProactiveCompanionRuntime` へ流れ、quiet／balanced／active に応じて候補範囲と check-in 頻度を調整します。

### 検証

- 全量隔離テスト `ALL_280_TESTS_OK`。
- 公開前検査：`PUBLIC_RELEASE_AUDIT_OK`、`FOUR_LANGUAGE_DOCUMENTATION_OK`、`PYTHON315_QT_COMPATIBILITY_POLICY_OK`。
