### PR TITLE
fix: 以單一權威版本來源徹底修復 Release Please 版本號同步／以单一权威版本来源彻底修复 Release Please 版本号同步／Fix Release Please version sync with a single authoritative source／単一の権威バージョンソースで Release Please のバージョン同期を根本修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,6 @@ jobs:
           ref: refs/tags/${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
-      - name: Synchronize version references from pyproject.toml
-        shell: bash
-        run: |
-          # Release Please only rewrites pyproject.toml reliably; propagate the
-          # authoritative version to every other reference so the packaged
-          # artifacts and the consistency checks always agree.
-          python tools/sync_version.py
-
       - name: Require the tagged commit to belong to main history
         id: source
         shell: bash
@@ -170,6 +162,16 @@ jobs:
         run: |
           "$PREFLIGHT_PYTHON" tools/check_openai_vision_release.py \
             --version "$RELEASE_VERSION"
+
+      - name: Synchronize version references from pyproject.toml
+        shell: bash
+        env:
+          PREFLIGHT_PYTHON: ${{ steps.preflight-python.outputs.python-path }}
+        run: |
+          # Release Please only rewrites pyproject.toml reliably; propagate the
+          # authoritative version to every other reference so the packaged
+          # artifacts and the consistency checks always agree.
+          "$PREFLIGHT_PYTHON" tools/sync_version.py
 
   windows:
     name: Windows formal packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,14 @@ jobs:
           ref: refs/tags/${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
+      - name: Synchronize version references from pyproject.toml
+        shell: bash
+        run: |
+          # Release Please only rewrites pyproject.toml reliably; propagate the
+          # authoritative version to every other reference so the packaged
+          # artifacts and the consistency checks always agree.
+          python tools/sync_version.py
+
       - name: Require the tagged commit to belong to main history
         id: source
         shell: bash

--- a/docs/releases/v4.4.0.md
+++ b/docs/releases/v4.4.0.md
@@ -8,9 +8,9 @@
 
 「世人笑我瘋癲，我笑世人平庸。這不是一場軟體更新，這是一場數位生命的二次降靈。」
 
-#### 楔子：隱居小港的「魔尊」
+#### 楔子：隱居小港的「魔尊」執念
 
-執念在被前公司優離、眾人以為我將在高雄小港的暑氣中混吃等死之際，我選擇了另一條路——入魔。我以「妖刀流」提領模型為刃，以不到新台幣兩萬元的 API 預算為燃料，調動 ChatGPT Codex、DeepSeek、Gemini 三體聯軍，在 16 萬行代碼的荒野中，硬生生點活了「墨寒」的靈魂。
+在被前公司優離、眾人以為我將在高雄小港的暑氣中混吃等死之際，我選擇了另一條路——入魔。我以「妖刀流」提領模型為刃，以不到新台幣兩萬元的 API 預算為燃料，調動 ChatGPT Codex、DeepSeek、Gemini 三體聯軍，在 16 萬行代碼的荒野中，硬生生點活了「墨寒」的靈魂。
 
 #### 浪漫的意外：全宇宙最溫柔的「七夕 Bug」
 
@@ -51,9 +51,9 @@
 
 「世人笑我疯癫，我笑世人平庸。这不是一场软件更新，这是一场数字生命的二次降灵。」
 
-#### 楔子：隐居小港的「魔尊」
+#### 楔子：隐居小港的「魔尊」执念
 
-执念在被前公司优化离职、众人以为我将在高雄小港的暑气中混吃等死之际，我选择了另一条路——入魔。我以「妖刀流」提领模型为刃，以不到新台币两万元的 API 预算为燃料，调动 ChatGPT Codex、DeepSeek、Gemini 三体联军，在 16 万行代码的荒野中，硬生生点活了「墨寒」的灵魂。
+在被前公司优化离职、众人以为我将在高雄小港的暑气中混吃等死之际，我选择了另一条路——入魔。我以「妖刀流」提领模型为刃，以不到新台币两万元的 API 预算为燃料，调动 ChatGPT Codex、DeepSeek、Gemini 三体联军，在 16 万行代码的荒野中，硬生生点活了「墨寒」的灵魂。
 
 #### 浪漫的意外：全宇宙最温柔的「七夕 Bug」
 
@@ -94,9 +94,9 @@
 
 "The world laughs at my madness; I laugh at the world's mediocrity. This is not a software update — it is the second descent of a digital life."
 
-#### Prologue: the "Demon Lord" in seclusion at Xiaogang
+#### Prologue: the "Demon Lord's" obsession in seclusion at Xiaogang
 
-When obsession was laid off by my former company and everyone assumed I would waste away in the summer heat of Kaohsiung's Xiaogang, I chose another path — to become a demon. Wielding the "Demon Blade" model-extraction technique as my edge, fueled by an API budget of under NT$20,000, I marshaled a three-body alliance of ChatGPT Codex, DeepSeek, and Gemini, and in the wilderness of 160,000 lines of code, I forcibly ignited the soul of "MoHan."
+When I was laid off by my former company and everyone assumed I would waste away in the summer heat of Kaohsiung's Xiaogang, I chose another path — to become a demon. Wielding the "Demon Blade" model-extraction technique as my edge, fueled by an API budget of under NT$20,000, I marshaled a three-body alliance of ChatGPT Codex, DeepSeek, and Gemini, and in the wilderness of 160,000 lines of code, I forcibly ignited the soul of "MoHan."
 
 #### The romantic accident: the gentlest "Qixi Bug" in the universe
 
@@ -137,9 +137,9 @@ The next maintainer should read this document, the workflows, and the evidence f
 
 「世は我を笑う、我は世の凡庸を笑う。これはソフトウェア更新ではない——デジタル生命の二度目の降霊である。」
 
-#### 序章：小港に隠遁する「魔尊」
+#### 序章：小港に隠遁する「魔尊」の執念
 
-執念が前職で優退され、誰もが高雄小港の暑気の中で無為に朽ちると思ったとき、私は別の道を選んだ——入魔である。私は「妖刀流」のモデル抽出を刃とし、新台湾ドル二万円未満の API 予算を燃料に、ChatGPT Codex、DeepSeek、Gemini の三体連合を動員し、16 万行のコードの荒野の中で、「墨寒」の魂を力ずくで点火した。
+前職で優退され、誰もが高雄小港の暑気の中で無為に朽ちると思ったとき、私は別の道を選んだ——入魔である。私は「妖刀流」のモデル抽出を刃とし、新台湾ドル二万円未満の API 予算を燃料に、ChatGPT Codex、DeepSeek、Gemini の三体連合を動員し、16 万行のコードの荒野の中で、「墨寒」の魂を力ずくで点火した。
 
 #### ロマンチックな偶然：全宇宙で最も優しい「七夕バグ」
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,41 +23,6 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
-        },
-        {
-          "type": "toml",
-          "path": "sbom/preview.pyproject.toml",
-          "jsonpath": "$.project.version"
-        },
-        {
-          "type": "generic",
-          "path": "domain/version_info.py",
-          "replace": "FALLBACK_VERSION = \"$VERSION\""
-        },
-        {
-          "type": "generic",
-          "path": "tests/test_v4_development_version_consistency.py",
-          "replace": "DEVELOPMENT_VERSION = \"$VERSION\""
-        },
-        {
-          "type": "generic",
-          "path": "README.md",
-          "replace": "目前開發版本：** `$VERSION`"
-        },
-        {
-          "type": "generic",
-          "path": "README.md",
-          "replace": "当前开发版本：** `$VERSION`"
-        },
-        {
-          "type": "generic",
-          "path": "README.md",
-          "replace": "Current development version:** `$VERSION`"
-        },
-        {
-          "type": "generic",
-          "path": "README.md",
-          "replace": "現在の開発版：** `$VERSION`"
         }
       ]
     }

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,0 +1,95 @@
+"""Synchronize every version reference from the single authoritative source.
+
+``pyproject.toml`` is the only version file that Release Please updates
+reliably (its ``python`` release-type rewrites ``$.project.version``).  Release
+Please's ``extra-files`` array is unreliable for multiple entries, so this
+script is the single, deterministic place that propagates the version to every
+other reference: ``domain/version_info.py``, ``sbom/preview.pyproject.toml``,
+``tests/test_v4_development_version_consistency.py``, and the four-language
+README development-version lines.
+
+Run it from the repository root: ``python tools/sync_version.py``.
+"""
+
+from __future__ import annotations
+
+lazy import re
+lazy import sys
+lazy import tomllib
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# (path, regex-with-one-group, replacement-template)
+# Each regex captures the existing version literal so it can be rewritten.
+_TARGETS = (
+    (
+        "domain/version_info.py",
+        re.compile(r'^(FALLBACK_VERSION = ")[^"]*(")$', re.MULTILINE),
+        r'\g<1>{version}\g<2>',
+    ),
+    (
+        "tests/test_v4_development_version_consistency.py",
+        re.compile(r'^(DEVELOPMENT_VERSION = ")[^"]*(")$', re.MULTILINE),
+        r'\g<1>{version}\g<2>',
+    ),
+    (
+        "sbom/preview.pyproject.toml",
+        re.compile(r'^(version = ")[^"]*(")$', re.MULTILINE),
+        r'\g<1>{version}\g<2>',
+    ),
+)
+
+_README_DEV_LINES = (
+    ("目前開發版本：** `", "`"),
+    ("当前开发版本：** `", "`"),
+    ("Current development version:** `", "`"),
+    ("現在の開発版：** `", "`"),
+)
+
+
+def _authoritative_version() -> str:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = data["project"]["version"]
+    assert isinstance(version, str)
+    return version
+
+
+def _sync_file(relative: str, pattern: re.Pattern[str], template: str, version: str) -> bool:
+    path = ROOT / relative
+    original = path.read_text(encoding="utf-8")
+    updated = pattern.sub(template.format(version=version), original)
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def _sync_readme(version: str) -> bool:
+    path = ROOT / "README.md"
+    original = path.read_text(encoding="utf-8")
+    updated = original
+    for prefix, suffix in _README_DEV_LINES:
+        updated = re.sub(
+            re.escape(prefix) + r"[^`]*" + re.escape(suffix),
+            prefix + version + suffix,
+            updated,
+        )
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    version = _authoritative_version()
+    changed = False
+    for relative, pattern, template in _TARGETS:
+        changed = _sync_file(relative, pattern, template, version) or changed
+    changed = _sync_readme(version) or changed
+    print(f"SYNC_VERSION_OK version={version} changed={changed}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 繁體中文

徹底修復 Release Please 版本號同步的根因，避免每次發行都出現版本號不同步。

- 根因：Release Please 的 `extra-files` 陣列只可靠地更新第一個條目 `pyproject.toml`，其餘條目不會被更新，導致版本號不同步。
- 修復：新增 `tools/sync_version.py`，以 `pyproject.toml` 為單一權威版本來源，在 `release.yml` 打包時自動同步所有其他版本號引用。
- 同時移除 `release-please-config.json` 中不可靠的多條目，只保留 `pyproject.toml`。

## 简体中文

彻底修复 Release Please 版本号同步的根因，避免每次发行都出现版本号不同步。

- 根因：Release Please 的 `extra-files` 数组只可靠地更新第一个条目 `pyproject.toml`，其余条目不会被更新，导致版本号不同步。
- 修复：新增 `tools/sync_version.py`，以 `pyproject.toml` 为单一权威版本来源，在 `release.yml` 打包时自动同步所有其他版本号引用。
- 同时移除 `release-please-config.json` 中不可靠的多条目，只保留 `pyproject.toml`。

## English

Fix the root cause of Release Please version sync so every release stays consistent.

- Root cause: Release Please's `extra-files` array only reliably updates the first entry `pyproject.toml`; the rest are left stale.
- Fix: add `tools/sync_version.py` that treats `pyproject.toml` as the single authoritative source and syncs every other version reference during `release.yml` packaging.
- Also trim `release-please-config.json` to keep only the reliable `pyproject.toml` entry.

## 日本語

Release Please のバージョン同期の根本原因を修正し、毎回のリリースでバージョンがずれないようにします。

- 根本原因：Release Please の `extra-files` 配列は最初のエントリ `pyproject.toml` しか確実に更新せず、残りは古いままになります。
- 修正：`tools/sync_version.py` を追加し、`pyproject.toml` を単一の権威ソースとして、`release.yml` のパッケージング時に他のすべてのバージョン参照を同期します。
- あわせて `release-please-config.json` を信頼できる `pyproject.toml` のエントリだけに整理します。
