### PR TITLE
chore: 讓 release-please 發布後自動觸發打包與資產上傳／让 release-please 发布后自动触发打包与资产上传／Auto-trigger packaging and asset upload after release-please publishes a release／release-please 公開後にパッケージングとアセットアップロードを自動実行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -118,6 +120,20 @@ jobs:
               echo "Existing Release maturity does not match its tag: $RELEASE_TAG" >&2
               exit 7
             }
+          elif [[ "$EVENT_NAME" == "release" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # release-please 透過 API 建立 tag/release（不觸發 push 事件）。
+            # release 事件或明確的 workflow_dispatch 都允許在 release 已存在時
+            # 上傳資產（而非重建），以補齊 release-please 建立的空 release。
+            if [[ -n "$release_id" ]]; then
+              release_mode_matches="$(
+                gh api "$releases_api/$release_id" \
+                  --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE"
+              )"
+              [[ "$release_mode_matches" == true ]] || {
+                echo "Existing Release maturity does not match its tag: $RELEASE_TAG" >&2
+                exit 7
+              }
+            fi
           elif [[ -n "$release_id" ]]; then
             echo "Release already exists; refusing to rebuild it: $RELEASE_TAG" >&2
             exit 7
@@ -779,7 +795,7 @@ jobs:
           fi
 
       - name: Attest every published artifact
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' || inputs.publish }}
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: release-artifacts/*
@@ -824,8 +840,8 @@ jobs:
           done < <(find release-artifacts -maxdepth 1 -type f | sort)
           echo "Release $tag is unchanged and matches the verified artifact set."
 
-      - name: Publish one GitHub release
-        if: ${{ github.event_name == 'push' || inputs.publish }}
+      - name: Publish or upload one GitHub release
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' || inputs.publish }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -837,45 +853,51 @@ jobs:
           tag="${{ needs.resolve-release.outputs.tag }}"
           release_title="墨寒桌面助理 $tag／墨寒桌面助手 $tag／MoHan Desktop Assistant $tag／墨寒デスクトップアシスタント $tag"
           readonly release_title
+          mapfile -d '' assets < <(find release-artifacts -maxdepth 1 -type f -print0 | sort -z)
           existing_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\") | .id" | head -n 1)"
           if [[ -n "$existing_id" ]]; then
-            echo "Release $tag already exists; refusing to overwrite it." >&2
-            exit 7
-          fi
-          mapfile -d '' assets < <(find release-artifacts -maxdepth 1 -type f -print0 | sort -z)
-          release_id=''
-          published=false
-          cleanup_failed_draft() {
-            status=$?
-            if [[ $status -ne 0 && "$published" != true && -n "$release_id" ]]; then
-              gh api --method DELETE "repos/${{ github.repository }}/releases/$release_id" >/dev/null 2>&1 || true
+            # release-please 已建立 release（可能無資產）：直接上傳資產，不重建。
+            echo "Release $tag already exists; uploading verified assets instead of rebuilding."
+            release_id="$existing_id"
+            for asset in "${assets[@]}"; do
+              gh release upload "$tag" "$asset" --repo "${{ github.repository }}" --clobber
+            done
+          else
+            release_id=''
+            published=false
+            cleanup_failed_draft() {
+              status=$?
+              if [[ $status -ne 0 && "$published" != true && -n "$release_id" ]]; then
+                gh api --method DELETE "repos/${{ github.repository }}/releases/$release_id" >/dev/null 2>&1 || true
+              fi
+              trap - EXIT
+              exit "$status"
+            }
+            trap cleanup_failed_draft EXIT
+            release_args=(
+              "$tag" "${assets[@]}"
+              --repo "${{ github.repository }}"
+              --verify-tag
+              --draft
+              --title "$release_title"
+              --notes-file "docs/releases/$tag.md"
+            )
+            if [[ "$EXPECTED_PRERELEASE" == true ]]; then
+              release_args+=(--prerelease)
             fi
+            gh release create "${release_args[@]}"
+            release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\" and .draft == true) | .id" | head -n 1)"
+            [[ "$release_id" =~ ^[0-9]+$ ]]
+            gh api --method PATCH "repos/${{ github.repository }}/releases/$release_id" \
+              -F draft=false -F prerelease="$EXPECTED_PRERELEASE" >/dev/null
+            [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE")" == true ]]
+            published=true
             trap - EXIT
-            exit "$status"
-          }
-          trap cleanup_failed_draft EXIT
-          release_args=(
-            "$tag" "${assets[@]}"
-            --repo "${{ github.repository }}"
-            --verify-tag
-            --draft
-            --title "$release_title"
-            --notes-file "docs/releases/$tag.md"
-          )
-          if [[ "$EXPECTED_PRERELEASE" == true ]]; then
-            release_args+=(--prerelease)
           fi
-          gh release create "${release_args[@]}"
-          release_id="$(gh api --paginate "repos/${{ github.repository }}/releases?per_page=100" --jq ".[] | select(.tag_name == \"$tag\" and .draft == true) | .id" | head -n 1)"
-          [[ "$release_id" =~ ^[0-9]+$ ]]
           mapfile -t actual_assets < <(gh api --paginate "repos/${{ github.repository }}/releases/$release_id/assets" --jq '.[].name' | sort)
           mapfile -t expected_assets < <(printf '%s\n' "${assets[@]##*/}" | sort)
           [[ "$(printf '%s\n' "${actual_assets[@]}")" == "$(printf '%s\n' "${expected_assets[@]}")" ]] || {
-            echo "Draft Release assets differ from the exact verified set." >&2
+            echo "Release assets differ from the exact verified set." >&2
             exit 8
           }
-          gh api --method PATCH "repos/${{ github.repository }}/releases/$release_id" \
-            -F draft=false -F prerelease="$EXPECTED_PRERELEASE" >/dev/null
-          [[ "$(gh api "repos/${{ github.repository }}/releases/$release_id" --jq ".draft == false and .prerelease == $EXPECTED_PRERELEASE")" == true ]]
-          published=true
-          trap - EXIT
+          echo "Release $tag now carries the exact verified asset set."

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -187,7 +187,7 @@ def _assert_release_publication_boundary(release: str) -> None:
         "Release tag changed after validation",
         "Verify existing release without modifying it",
         "Existing Release assets differ from the exact verified set.",
-        "github.event_name == 'push' || inputs.publish",
+        "github.event_name == 'push' || github.event_name == 'release' || inputs.publish",
         "metadata:",
         "name: generate-release-metadata",
         "name: Re-verify exact artifact set and SHA256 catalog",

--- a/tests/test_preview_packaging.py
+++ b/tests/test_preview_packaging.py
@@ -256,7 +256,7 @@ def test_release_gate_is_pinned() -> None:
     assert "and .draft == true" in release
     assert "draft=false" in release
     assert "cleanup_failed_draft" in release
-    assert "Draft Release assets differ from the exact verified set" in release
+    assert "Release assets differ from the exact verified set" in release
     assert "needs: [resolve-release, windows, macos-preview, linux-preview]" in release
     assert "commit: ${{ steps.source.outputs.commit }}" in release
     assert release.count("ref: ${{ needs.resolve-release.outputs.commit }}") == COMMIT_REFERENCE_COUNT


### PR DESCRIPTION
## 繁體中文
修復 release-please 透過 GitHub API 建立 tag/release 後，不會觸發 `on: push: tags` 事件，導致 `release.yml` 從不自動執行、release 成為無資產空殼的問題（v4.3.0、v4.4.1 均受影響）。

改動：
- `release.yml` 新增 `release: types: [published]` 觸發器。
- 「Validate Release publication mode」允許 release 事件在 release 已存在時通過。
- 「Publish one GitHub release」改為「Publish or upload one GitHub release」：release 已存在時直接上傳資產（`gh release upload --clobber`），不存在時才建立 release。

## 简体中文
修复 release-please 通过 GitHub API 建立 tag/release 后，不会触发 `on: push: tags` 事件，导致 `release.yml` 从不自动执行、release 成为无资产空壳的问题（v4.3.0、v4.4.1 均受影响）。

改动：
- `release.yml` 新增 `release: types: [published]` 触发器。
- 「Validate Release publication mode」允许 release 事件在 release 已存在时通过。
- 「Publish one GitHub release」改为「Publish or upload one GitHub release」：release 已存在时直接上传资产（`gh release upload --clobber`），不存在时才建立 release。

## English
Fix the issue where release-please creates the tag/release via the GitHub API, which does not trigger the `on: push: tags` event, so `release.yml` never runs automatically and the release becomes an empty shell without assets (affects v4.3.0 and v4.4.1).

Changes:
- Add a `release: types: [published]` trigger to `release.yml`.
- "Validate Release publication mode" now allows release events to pass when the release already exists.
- Rename "Publish one GitHub release" to "Publish or upload one GitHub release": upload assets directly (`gh release upload --clobber`) when the release already exists, otherwise create the release.

## 日本語
release-please が GitHub API 経由で tag/release を作成するため `on: push: tags` イベントが発火せず、`release.yml` が自動実行されずに release がアセットのない空殻になる問題を修正します（v4.3.0、v4.4.1 が影響）。

変更点：
- `release.yml` に `release: types: [published]` トリガーを追加。
- 「Validate Release publication mode」で release イベント時に release 既存の場合を許可。
- 「Publish one GitHub release」を「Publish or upload one GitHub release」に改名：release 既存時はアセットを直接アップロード（`gh release upload --clobber`）、存在しない場合のみ release を作成。
