### PR TITLE
fix: 說話嘴補丁與底圖姿態強制同畫布，根治啟動破圖／说话嘴补丁与底图姿态强制同画布，根治启动破图／Pin the speech mouth patch and composed base to one pose canvas, fixing the startup face corruption／発話口パッチと合成ベースを同一ポーズキャンバスに固定し、起動時の顔崩れを根治

### DIFF
--- a/presentation/companion_face_animation.py
+++ b/presentation/companion_face_animation.py
@@ -36,7 +36,8 @@ lazy from domain.face_microtiming import (
     BLINK_REST_AT_MS,
     SACCADE_INTERVAL_MS,
 )
-lazy from domain.face_rig import EyeState, blink_for_eye_state
+lazy from dataclasses import replace as dataclass_replace
+lazy from domain.face_rig import EyeState, FacePose, blink_for_eye_state
 lazy from presentation.companion_blink_runtime import CompanionBlinkRuntimeMixin
 lazy from presentation.companion_face_assets import CompanionFaceAssetMethods
 lazy from presentation.companion_speech_emotion import persist_wardrobe_mood
@@ -861,7 +862,7 @@ class CompanionFaceAnimationMixin(CompanionBlinkRuntimeMixin):
             return QPixmap(closed)
         return self.face_renderer.render(
             closed,
-            motion,
+            self._speech_aligned_motion(motion),
             self._face_render_layers(
                 self.expression_pixmaps.get(
                     expression,
@@ -871,6 +872,29 @@ class CompanionFaceAnimationMixin(CompanionBlinkRuntimeMixin):
             ),
             aperture=aperture,
         )
+
+    def _speech_aligned_motion(self, motion):
+        """Pin the motion pose to the speech expression's authored canvas.
+
+        The mouth layers handed to the renderer are cut on the speech
+        expression's pose canvas, while ``face_motion_frame`` is only
+        re-posed by the audio viseme loop.  Between speech configuration and
+        the first audio cue (the startup sentence hits exactly this window)
+        the stale pose composes a different-pose base under a correctly-cut
+        patch, which shows as the reported skin block beside the mouth.  The
+        renderer base and the patch must share one canvas, so the speech
+        pose is authoritative whenever speech frames are configured.
+        """
+        motion_expression = (
+            self.speech_gesture_expression or self.speech_closed_expression
+        )
+        pose_name = self.physics_expression_poses.get(
+            motion_expression,
+            getattr(self, "idle_pose", "front"),
+        )
+        if motion.pose.value == pose_name:
+            return motion
+        return dataclass_replace(motion, pose=FacePose(pose_name))
 
     def _face_render_layers(
         self,


### PR DESCRIPTION
## 繁體中文

v4.4.2 起「一啟動就破圖」的根因：`_configure_speech_frames` 配置說話影格但不更新 `face_motion_frame`，從開始說話到第一個音訊 viseme cue 之間存在姿態同步空窗。分層渲染器以 `motion.pose`（停留在舊姿態）合成底圖，再把依說話表情姿態裁切的嘴部補丁疊上去——兩個畫布嘴不在同一位置，呈現為嘴側的錯位膚色方塊；啟動第一句話必然踩中此空窗。修法：`_mouth_aperture_pixmap` 渲染前將 motion 姿態強制對齊說話表情的授權畫布（新增 `_speech_aligned_motion`），底圖與補丁自此同源。以 `tools/render_viseme_runtime_audit.py` 於 v4.4.2／v4.5.0／修復後三版 A/B/C 對照驗證，錯位補丁完全消失；臉部與語音相關十個測試組全數通過。

## 简体中文

v4.4.2 起「一启动就破图」的根因：`_configure_speech_frames` 配置说话帧但不更新 `face_motion_frame`，从开始说话到第一个音频 viseme cue 之间存在姿态同步空窗。分层渲染器以 `motion.pose`（停留在旧姿态）合成底图，再把依说话表情姿态裁切的嘴部补丁叠上去——两个画布嘴不在同一位置，呈现为嘴侧的错位肤色方块；启动第一句话必然踩中此空窗。修法：`_mouth_aperture_pixmap` 渲染前将 motion 姿态强制对齐说话表情的授权画布（新增 `_speech_aligned_motion`），底图与补丁自此同源。以 `tools/render_viseme_runtime_audit.py` 在 v4.4.2／v4.5.0／修复后三版 A/B/C 对照验证，错位补丁完全消失；脸部与语音相关十个测试组全部通过。

## English

Root cause of the "face breaks right at startup" defect present since v4.4.2: `_configure_speech_frames` configures the speech frames but never updates `face_motion_frame`, leaving a pose-sync window between speech configuration and the first audio viseme cue. The layered renderer composes its base from `motion.pose` (still the stale pose) and then stamps a mouth patch cut on the speech expression's pose canvas — the two canvases place the mouth differently, showing as the reported misplaced skin block beside the mouth; the startup sentence always hits this window. Fix: `_mouth_aperture_pixmap` now pins the motion pose to the speech expression's authored canvas before rendering (new `_speech_aligned_motion`), so base and patch always share one canvas. Verified with `tools/render_viseme_runtime_audit.py` A/B/C contact sheets across v4.4.2 / v4.5.0 / fixed; the misplaced patch is gone and all ten face/speech test suites pass.

## 日本語

v4.4.2 以降の「起動直後に顔が崩れる」不具合の根因：`_configure_speech_frames` は発話フレームを設定するが `face_motion_frame` を更新せず、発話設定から最初の音声 viseme cue までポーズ同期の空白が生じる。レイヤードレンダラーは `motion.pose`（古いポーズのまま）でベースを合成し、その上に発話表情のポーズキャンバスで切り出した口パッチを重ねるため、二つのキャンバスで口の位置が一致せず、口の横のずれた肌色ブロックとして現れる。起動時の最初の一文は必ずこの空白を踏む。修正：`_mouth_aperture_pixmap` がレンダリング前に motion のポーズを発話表情の正規キャンバスへ固定（`_speech_aligned_motion` を新設）し、ベースとパッチのキャンバスを常に一致させる。`tools/render_viseme_runtime_audit.py` による v4.4.2／v4.5.0／修正後の A/B/C 対照で、ずれたパッチの消失を確認。顔・発話関連の 10 テストスイートすべてが合格。