### PR TITLE
test: 棘輪行數閘門——新檔 800 行上限、17 檔基線只降不升與天花板逐版下調／棘轮行数闸门——新档 800 行上限、17 档基线只降不升与天花板逐版下调／Ratchet line-count gate: 800-line cap for new modules, down-only baselines for 17 files, per-release ceiling step-down／ラチェット行数ゲート：新規 800 行上限・17 ファイルの下降専用ベースライン・リリース毎の上限段階引き下げ

### DIFF
--- a/tests/test_layered_facade_cycles.py
+++ b/tests/test_layered_facade_cycles.py
@@ -23,7 +23,40 @@ LAYER_NAMES = (
     "integrations",
     "infrastructure",
 )
+# Layer-module line-count ratchet (approved by the project owner on 2026-08-28):
+# * MAX_LAYER_MODULE_LINES is the global ceiling; the release plan steps it
+#   down (v4.5.x = 1200, v4.6 = 1100, then -100 per release) until it meets
+#   MAX_NEW_LAYER_MODULE_LINES.
+# * Modules absent from LAYER_MODULE_LINE_BASELINE are new and must stay
+#   within MAX_NEW_LAYER_MODULE_LINES.
+# * Baselined modules may never exceed min(baseline, MAX_LAYER_MODULE_LINES),
+#   and the baseline only moves down: whoever slims a module must lower its
+#   entry to the new measured count in the same PR (and say so in the PR
+#   body); entries at or below MAX_NEW_LAYER_MODULE_LINES must be removed so
+#   the module is gated as new from then on.
 MAX_LAYER_MODULE_LINES = 1_200
+MAX_NEW_LAYER_MODULE_LINES = 800
+# Measured 2026-08-28 with the gate's own counting rule
+# (utf-8-sig decode + str.splitlines()).
+LAYER_MODULE_LINE_BASELINE = {
+    "application.presentation_ports": 1_063,
+    "domain.outfit_pack": 974,
+    "infrastructure.db": 1_170,
+    "infrastructure.profile_transfer": 1_075,
+    "integrations.azure_speech": 864,
+    "integrations.realtime_voice": 878,
+    "integrations.speech": 1_191,
+    "presentation.companion_core": 1_077,
+    "presentation.companion_face_animation": 1_160,
+    "presentation.companion_face_assets": 884,
+    "presentation.companion_speech_runtime": 1_199,
+    "presentation.companion_visual_dynamics": 960,
+    "presentation.dashboard_conversation": 857,
+    "presentation.dashboard_settings": 888,
+    "presentation.dashboard_shell": 1_200,
+    "presentation.dashboard_today_memory": 819,
+    "presentation.dashboard_voice": 1_078,
+}
 MAX_ROOT_APP_LINES = 50
 NON_PRODUCT_PYTHON_DIRECTORIES = frozenset({
     "artifacts",  # ignored local generation, training, and validation evidence
@@ -991,20 +1024,62 @@ def test_layer_packages_have_no_reverse_dependencies() -> None:
     )
 
 
+def layer_module_line_counts() -> dict[str, int]:
+    return {
+        module: len(source.splitlines())
+        for module, (_path, source) in discover_local_modules().items()
+        if module.partition(".")[0] in LAYER_NAMES
+    }
+
+
+def layer_module_line_limit(module: str) -> int:
+    baseline = LAYER_MODULE_LINE_BASELINE.get(module, MAX_NEW_LAYER_MODULE_LINES)
+    return min(baseline, MAX_LAYER_MODULE_LINES)
+
+
 def test_layer_implementations_do_not_hide_in_new_giant_modules() -> None:
     oversized = tuple(
         sorted(
-            (len(source.splitlines()), module)
-            for module, (_path, source) in discover_local_modules().items()
-            if module.partition(".")[0] in LAYER_NAMES
-            and len(source.splitlines()) > MAX_LAYER_MODULE_LINES
+            f"{module}={lines} (limit {layer_module_line_limit(module)})"
+            for module, lines in layer_module_line_counts().items()
+            if lines > layer_module_line_limit(module)
         )
     )
     assert not oversized, (
-        f"Layer modules must stay within {MAX_LAYER_MODULE_LINES} lines: "
-        + ", ".join(
-            f"{module}={lines}" for lines, module in oversized
+        "Layer modules must honour the line-count ratchet (new modules stay "
+        f"within {MAX_NEW_LAYER_MODULE_LINES} lines, baselined modules within "
+        f"min(baseline, {MAX_LAYER_MODULE_LINES})): " + ", ".join(oversized)
+    )
+
+
+def test_layer_module_line_baseline_only_ratchets_down() -> None:
+    counts = layer_module_line_counts()
+    orphaned = tuple(sorted(frozenset(LAYER_MODULE_LINE_BASELINE) - frozenset(counts)))
+    assert not orphaned, (
+        "Line-count baseline lists modules that no longer exist; remove them: "
+        + ", ".join(orphaned)
+    )
+    stale = tuple(
+        sorted(
+            f"{module}: baseline {baseline} -> measured {counts[module]}"
+            for module, baseline in LAYER_MODULE_LINE_BASELINE.items()
+            if counts[module] < baseline
         )
+    )
+    assert not stale, (
+        "Slimmed modules must ratchet their baseline down to the measured "
+        "count in the same PR: " + ", ".join(stale)
+    )
+    graduated = tuple(
+        sorted(
+            f"{module}={baseline}"
+            for module, baseline in LAYER_MODULE_LINE_BASELINE.items()
+            if baseline <= MAX_NEW_LAYER_MODULE_LINES
+        )
+    )
+    assert not graduated, (
+        f"Baseline entries at or below {MAX_NEW_LAYER_MODULE_LINES} lines "
+        "must be removed so the module is gated as new: " + ", ".join(graduated)
     )
 
 


### PR DESCRIPTION
## 繁體中文

依 2026-08-28 專案擁有者核准的「棘輪行數閘門」設計，改造五層架構的檔案行數閘門：

- `tests/test_layered_facade_cycles.py`：不在基線清單內的新層模組，上限改為 `MAX_NEW_LAYER_MODULE_LINES = 800` 行。
- 以閘門相同的計數規則（`utf-8-sig` 解碼＋`str.splitlines()`）於 2026-08-28 實掃，將 17 個既有超過 800 行的模組建入 `LAYER_MODULE_LINE_BASELINE`，每檔上限為 `min(baseline, MAX_LAYER_MODULE_LINES)`，不得超過自己的基線。
- 新增 `test_layer_module_line_baseline_only_ratchets_down`：模組瘦身後必須在同一 PR 將基線下修至實測值（只降不升）；基線降到 `800` 行以下的條目必須移除、改以新檔規則把關；已不存在的模組條目一律剔除。
- 全域天花板維持 `MAX_LAYER_MODULE_LINES = 1_200`，並以註解記錄逐版下調政策：v4.6 起 `1200` → `1100`，之後每版再降 `100`，直到與新檔上限會合。
- 驗證：`pytest tests/test_layered_facade_cycles.py -q` 21 項全數通過；另以 4 組負面探針確認超限新檔、超基線、基線未下修、應移除條目四種違規都會被擋下；全庫 `ruff check .` 通過。

## 简体中文

依 2026-08-28 项目所有者核准的「棘轮行数闸门」设计，改造五层架构的文件行数闸门：

- `tests/test_layered_facade_cycles.py`：不在基线清单内的新层模块，上限改为 `MAX_NEW_LAYER_MODULE_LINES = 800` 行。
- 以闸门相同的计数规则（`utf-8-sig` 解码＋`str.splitlines()`）于 2026-08-28 实扫，将 17 个既有超过 800 行的模块建入 `LAYER_MODULE_LINE_BASELINE`，每档上限为 `min(baseline, MAX_LAYER_MODULE_LINES)`，不得超过自己的基线。
- 新增 `test_layer_module_line_baseline_only_ratchets_down`：模块瘦身后必须在同一 PR 将基线下修至实测值（只降不升）；基线降到 `800` 行以下的条目必须移除、改以新档规则把关；已不存在的模块条目一律剔除。
- 全局天花板维持 `MAX_LAYER_MODULE_LINES = 1_200`，并以注释记录逐版下调政策：v4.6 起 `1200` → `1100`，之后每版再降 `100`，直到与新档上限会合。
- 验证：`pytest tests/test_layered_facade_cycles.py -q` 21 项全数通过；另以 4 组负面探针确认超限新档、超基线、基线未下修、应移除条目四种违规都会被挡下；全库 `ruff check .` 通过。

## English

Implements the "ratchet line-count gate" design approved by the project owner on 2026-08-28, reshaping the five-layer file line-count gate:

- `tests/test_layered_facade_cycles.py`: new layer modules absent from the baseline list are now capped at `MAX_NEW_LAYER_MODULE_LINES = 800` lines.
- Measured on 2026-08-28 with the gate's own counting rule (`utf-8-sig` decode + `str.splitlines()`), the 17 existing modules above 800 lines enter `LAYER_MODULE_LINE_BASELINE`; each is capped at `min(baseline, MAX_LAYER_MODULE_LINES)` and may never exceed its own baseline.
- Adds `test_layer_module_line_baseline_only_ratchets_down`: slimming a module requires lowering its baseline to the measured count in the same PR (down-only); entries at or below `800` lines must be removed so the new-module rule takes over; entries for modules that no longer exist are rejected.
- The global ceiling stays at `MAX_LAYER_MODULE_LINES = 1_200`, with the per-release step-down policy recorded in a comment: from v4.6 `1200` → `1100`, then another `100` lower per release until it meets the new-module cap.
- Verification: `pytest tests/test_layered_facade_cycles.py -q` passes all 21 tests; 4 negative probes confirm the gate rejects all four violation kinds (oversized new module, over-baseline, stale baseline, entry due for removal); repo-wide `ruff check .` passes.

## 日本語

2026-08-28 にプロジェクトオーナーが承認した「ラチェット行数ゲート」設計に基づき、五層アーキテクチャのファイル行数ゲートを改造：

- `tests/test_layered_facade_cycles.py`：ベースライン一覧にない新規レイヤーモジュールの上限を `MAX_NEW_LAYER_MODULE_LINES = 800` 行に変更。
- ゲートと同一の計数規則（`utf-8-sig` デコード＋`str.splitlines()`）で 2026-08-28 に実測し、既存の 800 行超 17 モジュールを `LAYER_MODULE_LINE_BASELINE` に登録。各ファイルの上限は `min(baseline, MAX_LAYER_MODULE_LINES)` で、自身のベースラインを超えてはならない。
- `test_layer_module_line_baseline_only_ratchets_down` を新設：モジュールを痩身したら同じ PR でベースラインを実測値まで引き下げること（下降専用）。`800` 行以下となったエントリは削除して新規ファイル規則に移行し、存在しないモジュールのエントリは排除する。
- グローバル上限は `MAX_LAYER_MODULE_LINES = 1_200` を維持し、リリース毎の段階引き下げ方針をコメントに記録：v4.6 で `1200` → `1100`、以降はリリース毎にさらに `100` ずつ引き下げ、新規ファイル上限に到達するまで続行。
- 検証：`pytest tests/test_layered_facade_cycles.py -q` で 21 件すべて合格。4 組の負面プローブで、新規ファイル超過・ベースライン超過・ベースライン未更新・削除すべきエントリの 4 種の違反がすべて遮断されることを確認。リポジトリ全体の `ruff check .` も合格。
