### PR TITLE
fix: release-please 打 tag 場景空 PR 輸出防炸／release-please 打 tag 场景空 PR 输出防炸／harden release-please against empty PR output when tagging／release-please のタグ付け時の空 PR 出力対策

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ fromJSON(steps.release.outputs.pr || '{}').headBranchName || '' }}
 
       - name: Set up Python
         if: ${{ steps.release.outputs.pr }}
@@ -60,7 +60,7 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         shell: bash
         env:
-          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr || '{}').headBranchName || '' }}
         run: |
           version="$(python -c 'import json; print(json.load(open(".release-please-manifest.json"))["."])')"
           # Creates docs/releases/v<version>.md from the CHANGELOG section as


### PR DESCRIPTION
## 繁體中文

### 問題
v4.5.1 發版時，合併發版 PR 觸發的 Release Please 執行以紅燈收場：\`fromJSON(steps.release.outputs.pr)\` 在打 tag 場景下吃到空字串，於 \`ref:\` 與 \`env:\` 兩處拋出模板錯誤（\`Error reading JToken from JsonReader\`）。tag 與 GitHub Release 因先完成而未受害，但每次發版都會多一顆假紅燈。

### 修法
- 兩處表達式改為 \`fromJSON(steps.release.outputs.pr || '{}').headBranchName || ''\`：空輸出時安全求值為空字串，由既有 \`if\` 守衛正常跳過該步驟。

## 简体中文

### 问题
v4.5.1 发版时，合并发版 PR 触发的 Release Please 运行以红灯收场：\`fromJSON(steps.release.outputs.pr)\` 在打 tag 场景下吃到空字符串，于 \`ref:\` 与 \`env:\` 两处抛出模板错误（\`Error reading JToken from JsonReader\`）。tag 与 GitHub Release 因先完成而未受害，但每次发版都会多一颗假红灯。

### 修法
- 两处表达式改为 \`fromJSON(steps.release.outputs.pr || '{}').headBranchName || ''\`：空输出时安全求值为空字符串，由既有 \`if\` 守卫正常跳过该步骤。

## English

### Problem
During the v4.5.1 release, the Release Please run triggered by merging the release PR ended red: \`fromJSON(steps.release.outputs.pr)\` received an empty string in the tagging scenario and threw template errors (\`Error reading JToken from JsonReader\`) at the \`ref:\` and \`env:\` sites. The tag and the GitHub Release completed earlier and were unharmed, but every release would keep producing a false red run.

### Fix
- Rewrite both expressions as \`fromJSON(steps.release.outputs.pr || '{}').headBranchName || ''\`: empty output now evaluates safely to an empty string, and the existing \`if\` guard skips the step as intended.

## 日本語

### 問題
v4.5.1 リリース時、リリース PR のマージで起動した Release Please 実行が赤で終了：タグ付けシナリオで \`fromJSON(steps.release.outputs.pr)\` が空文字列を受け取り、\`ref:\` と \`env:\` の 2 箇所でテンプレートエラー（\`Error reading JToken from JsonReader\`）を送出。タグと GitHub Release は先に完了していたため無傷だが、毎回のリリースで偽の赤いランが残り続ける。

### 修正
- 両式を \`fromJSON(steps.release.outputs.pr || '{}').headBranchName || ''\` に書き換え：空出力は安全に空文字列へ評価され、既存の \`if\` ガードが該当ステップを正しくスキップする。