### PR TITLE
docs: v4.5.1 發行說明新增【純淨之路】段落／v4.5.1 发布说明新增【纯净之路】段落／add the "road of purity" section to the v4.5.1 release notes／v4.5.1 リリースノートに【純浄への道】セクションを追加

### DIFF
--- a/docs/releases/v4.5.1.md
+++ b/docs/releases/v4.5.1.md
@@ -23,6 +23,10 @@ v4.4.2 世代「一啟動就破相」的臉部分層錯位問題，本版完成�
 - **工具與 CI 戰區**：安裝自測加逾時與標記檔判定（根治 3.15rc1 JIT/Qt 終結掛死佔滿 120 分鐘）；語音迴歸夾具補 QPixmapCache 清除與 GC（根治 7GB CI 執行器連環 MemoryError）；氣泡延遲隱藏守衛歸一修復 MRO 單一擁有者契約。
 - **測試戰區**：永真斷言、孤兒測試收編、化石測試裁決、收集對帳七項；版本三權威同步契約修正。
 
+### 純淨之路：【為無限可能，走窄門】
+
+這一版將授權治理成文，背後是一連串不太熱鬧的抉擇：放棄全社群最順手的工具與最主流的權重，逐一查證產線上每一件工具、每一顆模型、每一份素材的授權出身——查證不過的即刻出清、明文禁用。走這條窄路不是為了標新立異，而是希望墨寒的每一行程式、每一張圖、每一個模型都經得起檢視，讓這個專案永遠保有選擇未來的自由——包含商業化在內的無限可能——不必在多年後被某一段有毒的授權條款回頭索命。
+
 ### 授權與商業化治理
 
 - 新增四語 `ASSETS-LICENSE.md`：墨寒角色美術、人設與名稱形象保留一切權利，明示「執行、開發、測試」授權與非商業二創友善條款；修復 README 四語既有的死連結與「角色素材採 MIT」矛盾句。
@@ -61,6 +65,10 @@ v4.4.2 世代「一启动就破相」的脸部分层错位问题，本版完成�
 - **UI 战区**：误触防护、隐私同意、资源泄漏、眨眼离散契约断言等十八项；云裳阁全身展示左右视角改以墨寒自身为准。
 - **工具与 CI 战区**：安装自测加超时与标记文件判定（根治 3.15rc1 JIT/Qt 终结挂死占满 120 分钟）；语音回归夹具补 QPixmapCache 清除与 GC（根治 7GB CI 执行器连环 MemoryError）；气泡延迟隐藏守卫归一修复 MRO 单一拥有者契约。
 - **测试战区**：永真断言、孤儿测试收编、化石测试裁决、收集对账七项；版本三权威同步契约修正。
+
+### 纯净之路：【为无限可能，走窄门】
+
+这一版将授权治理成文，背后是一连串不太热闹的抉择：放弃全社区最顺手的工具与最主流的权重，逐一查证产线上每一件工具、每一个模型、每一份素材的授权出身——查证不过的即刻清除、明文禁用。走这条窄路不是为了标新立异，而是希望墨寒的每一行代码、每一张图、每一个模型都经得起检视，让这个项目永远保有选择未来的自由——包含商业化在内的无限可能——不必在多年后被某一段有毒的授权条款回头索命。
 
 ### 授权与商业化治理
 
@@ -101,6 +109,10 @@ The v4.4.2-era face-layer misalignment that tore her face apart on launch is ful
 - **Tools & CI front**: installer self-test timeout with marker-file adjudication (curing the 3.15rc1 JIT/Qt finalization hang that burned 120-minute jobs); QPixmapCache clearing and forced GC in the speech-regression fixture (curing recurring MemoryError on 7 GB CI runners); the bubble-hide helper unified to restore the one-owner MRO contract.
 - **Test front**: seven items covering tautological assertions, orphan-test adoption, fossil-test rulings, and collection reconciliation; the three-authority version-sync contract was corrected.
 
+### The road of purity: through the narrow gate, toward unlimited possibility
+
+Behind the written licensing governance in this release lies a series of quiet, unglamorous choices: we walked away from the community's most convenient tools and its most popular model weights, and verified the license pedigree of every tool, every model, and every asset on the pipeline — whatever failed verification was removed at once and banned in writing. We took this narrow road not to be different for its own sake, but so that every line of code, every image, and every model in MoHan can withstand scrutiny — keeping this project forever free to choose its own future, with unlimited possibilities including commercialization, never to be ambushed years later by a single toxic license clause.
+
 ### Licensing and commercialization governance
 
 - Added the four-language `ASSETS-LICENSE.md`: MoHan's character artwork, persona, and name/likeness are All Rights Reserved with an express run/develop/test grant and fan-work friendly non-commercial terms; fixed the pre-existing dead links and the contradictory "character assets use MIT" line in all four README sections.
@@ -139,6 +151,10 @@ v4.4.2 世代の「起動した瞬間に顔が崩れる」レイヤーずれ問�
 - **UI 方面**：誤タッチ防護、プライバシー同意、リソースリーク、離散まばたき契約アサーションなど十八件；雲裳閣の全身表示の左右を墨寒自身の左右基準に変更。
 - **ツール・CI 方面**：インストーラー自己診断にタイムアウトとマーカーファイル判定（3.15rc1 JIT/Qt 終了時ハングが 120 分を食い潰す問題を根治）；音声回帰フィクスチャに QPixmapCache クリアと GC（7GB CI ランナーの連続 MemoryError を根治）；吹き出し遅延非表示ヘルパーの統一で MRO 単一所有者契約を回復。
 - **テスト方面**：恒真アサーション、孤児テスト収容、化石テスト裁定、収集照合の七件；バージョン三権威同期契約の修正。
+
+### 純浄への道：【無限の可能性のために、狭き門を行く】
+
+このバージョンでライセンスガバナンスを成文化した背後には、華やかさとは無縁の選択の連続がある：コミュニティで最も使いやすいツールと最も主流の重みをあえて手放し、産線上のすべてのツール・モデル・素材のライセンスの出自を一つずつ検証した——検証に落ちたものは即座に排除し、明文で禁止した。この狭き道を選んだのは奇をてらうためではなく、墨寒のすべてのコード・すべての絵・すべてのモデルが検証に耐えるものであってほしいからだ。このプロジェクトが未来を選ぶ自由——商用化を含む無限の可能性——を永遠に持ち続け、何年も後にたった一つの有毒なライセンス条項に足をすくわれることのないように。
 
 ### ライセンスと商用化ガバナンス
 


### PR DESCRIPTION
## 繁體中文

### 內容
- `docs/releases/v4.5.1.md` 四語各插入一節【純淨之路：為無限可能，走窄門】，置於「授權與商業化治理」之前，闡明授權治理背後的抉擇初衷：不為標新立異，而為讓專案永保選擇未來的自由（含商業化）。
- 擁有者已核准全文；合併後同步更新 GitHub Release 頁面說明。

## 简体中文

### 内容
- `docs/releases/v4.5.1.md` 四语各插入一节【纯净之路：为无限可能，走窄门】，置于「授权与商业化治理」之前，阐明授权治理背后的抉择初衷：不为标新立异，而为让项目永保选择未来的自由（含商业化）。
- 所有者已核准全文；合并后同步更新 GitHub Release 页面说明。

## English

### Content
- Insert a "road of purity: through the narrow gate, toward unlimited possibility" section into each of the four languages of `docs/releases/v4.5.1.md`, placed before "Licensing and commercialization governance", explaining the intent behind the licensing governance: not novelty for its own sake, but keeping the project forever free to choose its future (commercialization included).
- The owner has approved the full text; the GitHub Release page will be updated in sync after merge.

## 日本語

### 内容
- `docs/releases/v4.5.1.md` の四言語それぞれに【純浄への道：無限の可能性のために、狭き門を行く】の一節を「ライセンスと商用化ガバナンス」の前に挿入し、ライセンスガバナンスの背後にある選択の初心——奇をてらうためではなく、プロジェクトが未来（商用化を含む）を選ぶ自由を永遠に保つため——を明文化。
- 所有者は全文を承認済み；マージ後に GitHub Release ページの説明も同期更新する。