### PR TITLE
fix: 文字對話逾時凍結「思考中」根治／文字对话超时冻结「思考中」根治／cure the permanent "thinking" freeze on chat timeout／チャットのタイムアウトによる「思考中」永久凍結を根治

### DIFF
--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -388,6 +388,16 @@ class AIWorker(QRunnable):
         )
 
     def run(self) -> None:
+        # UI task boundary: ANY escape (payload assembly included — a bad
+        # history row raised here, outside the old try, and froze the
+        # dashboard on "thinking" across restarts because the poisoned
+        # history reloads from the DB every time) must reach signals.failed.
+        try:
+            self._run_request()
+        except Exception as exc:
+            self.signals.failed.emit(str(sanitize_error(exc)))
+
+    def _run_request(self) -> None:
         request_data = self.request
         key = (
             request_data.api_key or os.getenv("OPENAI_API_KEY", "")
@@ -479,7 +489,7 @@ class AIWorker(QRunnable):
             method="POST",
         )
         try:
-            with urlopen(req, timeout=45) as response:
+            with urlopen(req, timeout=150) as response:
                 data = json.load(response)
             self._report_prompt_cache_telemetry(data)
             text = data.get("output_text", "").strip()

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -502,7 +502,13 @@ class AIWorker(QRunnable):
                     )
                 )
             self.signals.done.emit(text)
-        except (URLError, HTTPError, ValueError) as exc:
+        except Exception as exc:
+            # Same UI-task-boundary contract as the planner worker above: a
+            # mid-read socket timeout raises TimeoutError, which the previous
+            # (URLError, HTTPError, ValueError) tuple let escape — the runnable
+            # then died silently inside the thread pool, ai_busy was never
+            # released, and the dashboard froze on "thinking" until restart
+            # (reported on v4.5.1, 2026-08-29).
             self.signals.failed.emit(str(sanitize_error(exc)))
 
     def _report_prompt_cache_telemetry(self, response: object) -> None:

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -5,7 +5,6 @@ lazy import os
 lazy from collections.abc import Callable
 lazy from dataclasses import dataclass, field
 lazy from typing import NotRequired, TypedDict, Unpack
-lazy from urllib.error import HTTPError, URLError
 lazy from urllib.request import Request, urlopen
 
 lazy from PySide6.QtCore import QObject, QRunnable, Signal

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -146,6 +146,11 @@ def offline_reply(text: str, mode: str, response_language: str = "zh-TW") -> str
         reply = _traditional_chinese_offline_reply(text, mode)
     return reply
 
+# Chat/planner read timeout. 45s starved reasoning-model responses and the
+# escaped TimeoutError froze the dashboard (v4.5.1, 2026-08-29); 150s covers
+# slow reasoning turns while the worker's failure path shows real errors.
+REQUEST_TIMEOUT_SECONDS = 150
+
 
 class AIWorkerSignals(QObject):
     done = Signal(str)
@@ -302,7 +307,7 @@ class ActionPlannerWorker(QRunnable):
             method="POST",
         )
         try:
-            with urlopen(request, timeout=45) as response:
+            with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
                 data = json.load(response)
             calls = [
                 item
@@ -489,7 +494,7 @@ class AIWorker(QRunnable):
             method="POST",
         )
         try:
-            with urlopen(req, timeout=150) as response:
+            with urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
                 data = json.load(response)
             self._report_prompt_cache_telemetry(data)
             text = data.get("output_text", "").strip()

--- a/presentation/dashboard_conversation.py
+++ b/presentation/dashboard_conversation.py
@@ -6,19 +6,12 @@ from PySide6.QtCore import QTimer
 lazy from PySide6.QtCore import Qt
 lazy from PySide6.QtGui import QFont
 lazy from PySide6.QtWidgets import (
-    QApplication,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
+    QApplication, QHBoxLayout, QLabel, QLineEdit,
+    QMessageBox, QPushButton, QVBoxLayout, QWidget,
 )
 
 lazy from application.companion_phrasebook import (
-    PHRASEBOOK_SETTING,
-    CompanionPhrasebook,
+    PHRASEBOOK_SETTING, CompanionPhrasebook,
 )
 lazy from application.outfit_reveal import (
     LAST_REVEALED_OUTFIT_KEY,
@@ -672,11 +665,8 @@ class DashboardConversationMixin:
 
 
     def _ai_done(self, text: str) -> None:
-        # ai_busy release is a hard gate: _reply drives speech, expressions,
-        # and the desktop companion (busiest while camera presence is on), and
-        # any exception it raises dies silently in the Qt event loop — the old
-        # flow then never reset ai_busy, freezing the dashboard on "thinking"
-        # while later messages only queued (reported on v4.5.1, 2026-08-29).
+        # finally 鐵閘：_reply（語音／表情／桌寵）拋例外會被 Qt 事件圈吞掉，
+        # 舊流程 ai_busy 永不釋放、面板凍在思考中（v4.5.1 實機回報）。
         try:
             self._finish_ai_wait_expression()
             tagged = parse_internal_emotion(text)
@@ -837,8 +827,7 @@ class DashboardConversationMixin:
             )
         else:
             message = "雲端傳音暫時中斷。妾仍在，只是此刻無法借用外部智識。"
-        # Same hard gate as _ai_done: the failure reply must never leave
-        # ai_busy stuck when speech or expression delivery raises.
+        # 與 _ai_done 相同的 finally 鐵閘。
         try:
             self._reply(message, "worried")
             self.api_status.setText(

--- a/presentation/dashboard_conversation.py
+++ b/presentation/dashboard_conversation.py
@@ -672,22 +672,29 @@ class DashboardConversationMixin:
 
 
     def _ai_done(self, text: str) -> None:
-        self._finish_ai_wait_expression()
-        tagged = parse_internal_emotion(text)
-        clean = tagged.text or "妾在。主上方才所言，容妾再細想一遍。"
-        expression = (
-            tagged.expression
-            if tagged.valid_tag and tagged.expression is not None
-            else self._reply_expression(clean)
-        )
-        self._reply(
-            clean,
-            expression,
-            intensity=tagged.intensity,
-            source="ai_tag" if tagged.valid_tag else "fallback",
-        )
-        self.ai_busy = False
-        self._start_next_ai_request()
+        # ai_busy release is a hard gate: _reply drives speech, expressions,
+        # and the desktop companion (busiest while camera presence is on), and
+        # any exception it raises dies silently in the Qt event loop — the old
+        # flow then never reset ai_busy, freezing the dashboard on "thinking"
+        # while later messages only queued (reported on v4.5.1, 2026-08-29).
+        try:
+            self._finish_ai_wait_expression()
+            tagged = parse_internal_emotion(text)
+            clean = tagged.text or "妾在。主上方才所言，容妾再細想一遍。"
+            expression = (
+                tagged.expression
+                if tagged.valid_tag and tagged.expression is not None
+                else self._reply_expression(clean)
+            )
+            self._reply(
+                clean,
+                expression,
+                intensity=tagged.intensity,
+                source="ai_tag" if tagged.valid_tag else "fallback",
+            )
+        finally:
+            self.ai_busy = False
+            self._start_next_ai_request()
 
 
     @staticmethod
@@ -830,16 +837,20 @@ class DashboardConversationMixin:
             )
         else:
             message = "雲端傳音暫時中斷。妾仍在，只是此刻無法借用外部智識。"
-        self._reply(message, "worried")
-        self.api_status.setText(
-            self._t(
-                "api_connection_failed",
-                "OpenAI API：連線失敗（{error}）",
-                error=error[:70],
+        # Same hard gate as _ai_done: the failure reply must never leave
+        # ai_busy stuck when speech or expression delivery raises.
+        try:
+            self._reply(message, "worried")
+            self.api_status.setText(
+                self._t(
+                    "api_connection_failed",
+                    "OpenAI API：連線失敗（{error}）",
+                    error=error[:70],
+                )
             )
-        )
-        self.ai_busy = False
-        self._start_next_ai_request()
+        finally:
+            self.ai_busy = False
+            self._start_next_ai_request()
 
 
     def _voice_text(self, text: str) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,6 +149,32 @@ def _assert_ai_worker_defaults() -> None:
     assert replies == ["主上，妾在。"]
 
 
+def _assert_ai_worker_timeout_emits_failed() -> None:
+    # v4.5.1 regression (2026-08-29): a mid-read socket timeout raises
+    # TimeoutError, which the old (URLError, HTTPError, ValueError) tuple let
+    # escape — the runnable died silently, ai_busy never released, and the
+    # dashboard froze on "thinking" until restart.  Any exception must reach
+    # signals.failed instead.
+    failures: list[str] = []
+    replies: list[str] = []
+    worker = AIWorker(
+        AIWorkerRequest(
+            user_text="主上問候",
+            mode="陪伴",
+            api_key="sk-test",
+        )
+    )
+    worker.signals.done.connect(replies.append)
+    worker.signals.failed.connect(failures.append)
+    with patch(
+        "integrations.ai_client.urlopen",
+        side_effect=TimeoutError("The read operation timed out"),
+    ):
+        worker.run()
+    assert replies == []
+    assert len(failures) == 1
+
+
 def _assert_work_sessions(db: StudioDB) -> None:
     assert db.start_work() is True
     assert db.start_work() is False
@@ -264,6 +290,7 @@ def _assert_database_contracts() -> None:
         _assert_custom_model_is_preserved(temp_dir)
         _assert_voice_defaults_migrate_safely(temp_dir)
         _assert_ai_worker_defaults()
+        _assert_ai_worker_timeout_emits_failed()
         _assert_work_sessions(db)
         _assert_todos_and_ideas(db)
         _assert_platform_progress(db)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -175,6 +175,28 @@ def _assert_ai_worker_timeout_emits_failed() -> None:
     assert len(failures) == 1
 
 
+def _assert_ai_worker_bad_history_emits_failed() -> None:
+    # Companion regression to the timeout fix: payload assembly ran OUTSIDE
+    # the old try block, so a poisoned history row (missing keys) raised
+    # before the request and froze the dashboard across restarts — the bad
+    # history reloads from the DB on every attempt.
+    failures: list[str] = []
+    replies: list[str] = []
+    worker = AIWorker(
+        AIWorkerRequest(
+            user_text="主上問候",
+            mode="陪伴",
+            api_key="sk-test",
+            history=({"role": "user"},),
+        )
+    )
+    worker.signals.done.connect(replies.append)
+    worker.signals.failed.connect(failures.append)
+    worker.run()
+    assert replies == []
+    assert len(failures) == 1
+
+
 def _assert_work_sessions(db: StudioDB) -> None:
     assert db.start_work() is True
     assert db.start_work() is False
@@ -291,6 +313,7 @@ def _assert_database_contracts() -> None:
         _assert_voice_defaults_migrate_safely(temp_dir)
         _assert_ai_worker_defaults()
         _assert_ai_worker_timeout_emits_failed()
+        _assert_ai_worker_bad_history_emits_failed()
         _assert_work_sessions(db)
         _assert_todos_and_ideas(db)
         _assert_platform_progress(db)

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -28,7 +28,7 @@ lazy from domain.prompt_cache import (
     prompt_cache_prefix_fingerprint,
 )
 
-REQUEST_TIMEOUT_SECONDS = 45
+from integrations.ai_client import REQUEST_TIMEOUT_SECONDS
 EXACT_TOKEN_COUNT = 1024
 SHORT_TOKEN_COUNT = 1023
 CACHE_KEY_MAX_LENGTH = 64

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -28,7 +28,7 @@ lazy from domain.prompt_cache import (
     prompt_cache_prefix_fingerprint,
 )
 
-from integrations.ai_client import REQUEST_TIMEOUT_SECONDS
+lazy from integrations.ai_client import REQUEST_TIMEOUT_SECONDS
 EXACT_TOKEN_COUNT = 1024
 SHORT_TOKEN_COUNT = 1023
 CACHE_KEY_MAX_LENGTH = 64


### PR DESCRIPTION
## 繁體中文

### 問題（v4.5.1 實機回報，2026-08-29）
文字對話送出後永遠停在「墨寒思考中…」，之後所有訊息只排隊不回話，重啟才能恢復。根因：OpenAI 回應**讀取中途**逾時拋 `TimeoutError`，文字 worker 的舊捕捉清單 `(URLError, HTTPError, ValueError)` 接不住——worker 在 Qt 執行緒池內無聲死亡，`done`／`failed` 都不發射，`ai_busy` 永不釋放。同檔案的規劃 worker 早已為此採 `except Exception`（註解明言 socket 逾時必須釋放狀態），文字 worker 未跟上，屬不對稱缺陷。

### 修法
- `integrations/ai_client.py`：文字 worker 對齊規劃 worker 的 UI 任務邊界契約，改為 `except Exception` 並附病史註解。
- `tests/test_core.py`：新增回歸測試——`urlopen` 拋 `TimeoutError` 時 `signals.failed` 必達、`done` 不發。

## 简体中文

### 问题（v4.5.1 实机回报，2026-08-29）
文字对话发送后永远停在「墨寒思考中…」，之后所有消息只排队不回话，重启才能恢复。根因：OpenAI 响应**读取中途**超时抛 `TimeoutError`，文字 worker 的旧捕捉清单 `(URLError, HTTPError, ValueError)` 接不住——worker 在 Qt 线程池内无声死亡，`done`／`failed` 都不发射，`ai_busy` 永不释放。同文件的规划 worker 早已为此采 `except Exception`（注释明言 socket 超时必须释放状态），文字 worker 未跟上，属不对称缺陷。

### 修法
- `integrations/ai_client.py`：文字 worker 对齐规划 worker 的 UI 任务边界契约，改为 `except Exception` 并附病史注释。
- `tests/test_core.py`：新增回归测试——`urlopen` 抛 `TimeoutError` 时 `signals.failed` 必达、`done` 不发。

## English

### Problem (reported live on v4.5.1, 2026-08-29)
After sending a chat message the dashboard stayed on "thinking…" forever, every later message only queued up, and only a restart recovered. Root cause: a **mid-read** timeout on the OpenAI response raises `TimeoutError`, which the text worker's old `(URLError, HTTPError, ValueError)` tuple did not catch — the runnable died silently inside the Qt thread pool, neither `done` nor `failed` fired, and `ai_busy` was never released. The planner worker in the same file already uses `except Exception` for exactly this reason (its comment says socket timeouts must always release the state); the text worker never caught up — an asymmetry defect.

### Fix
- `integrations/ai_client.py`: align the text worker with the planner worker's UI-task-boundary contract via `except Exception`, with a case-history comment.
- `tests/test_core.py`: add a regression test — when `urlopen` raises `TimeoutError`, `signals.failed` must fire and `done` must not.

## 日本語

### 問題（v4.5.1 実機報告、2026-08-29）
チャット送信後、ダッシュボードが「思考中…」のまま永久に停止し、以降のメッセージはキューに溜まるだけで、再起動でしか回復しない。根因：OpenAI 応答の**読み取り中**タイムアウトは `TimeoutError` を送出するが、テキスト worker の旧捕捉タプル `(URLError, HTTPError, ValueError)` では捕まえられない——runnable は Qt スレッドプール内で無音のまま死亡し、`done` も `failed` も発火せず、`ai_busy` が永遠に解放されない。同ファイルのプランナー worker は同じ理由で既に `except Exception` を採用済み（コメントに socket タイムアウトは必ず状態を解放すべしと明記）；テキスト worker が追随していなかった非対称欠陥。

### 修正
- `integrations/ai_client.py`：テキスト worker をプランナー worker の UI タスク境界契約に合わせ `except Exception` に変更し、病歴コメントを付記。
- `tests/test_core.py`：回帰テストを追加——`urlopen` が `TimeoutError` を送出した際、`signals.failed` が必ず発火し `done` は発火しないことを検証。