### PR TITLE
fix: 視窗最大化還原後假全螢幕死鎖根治／视窗最大化还原后假全屏死锁根治／cure the fake-fullscreen lock-up after maximize-restore／最大化復元後の疑似フルスクリーン膠着を根治

### DIFF
--- a/presentation/dashboard_shell.py
+++ b/presentation/dashboard_shell.py
@@ -14,21 +14,15 @@ lazy from PySide6.QtWidgets import (
 )
 
 lazy from application.presentation_ports import (
-    PlatformServicePort,
-    PresentationDatabasePort,
-    format_duration,
+    PlatformServicePort, PresentationDatabasePort, format_duration,
 )
 lazy from application.wardrobe_service import BUILTIN_OUTFIT_ID, WardrobeService
 lazy from domain.app_profile import (
-    personalize_text,
-    profile_setting,
-    profile_window_title,
+    personalize_text, profile_setting, profile_window_title,
 )
 lazy from domain.feature_registry import DashboardFeatureRegistry
 lazy from domain.language_support import (
-    is_english,
-    is_japanese,
-    is_simplified_chinese,
+    is_english, is_japanese, is_simplified_chinese,
 )
 lazy from domain.outfit_pack import OutfitPackError
 lazy from presentation.companion_platform import reminder_line
@@ -988,10 +982,8 @@ class DashboardShellMixin:
     def moveEvent(self, event) -> None:
         super().moveEvent(event)
         # Windows 移動視窗後可能不會觸發 Qt 的 mousePressEvent，再補一次置頂。
-        # 但最大化、還原、最小化同樣會觸發 moveEvent：在狀態轉換中 raise 會
-        # 與原生視框更新賽跑，曾把視窗卡成「最大尺寸、標題列按鈕消失」的
-        # 假全螢幕死鎖（v4.5.1 實機回報，2026-08-29）。只有一般狀態的拖動
-        # 才補置頂。
+        # 但狀態轉換（最大化／還原／最小化）也走 moveEvent：此時 raise 會與
+        # 原生視框更新賽跑成假全螢幕死鎖（v4.5.1 實機回報）——僅一般狀態補。
         if self.windowState() & (
             Qt.WindowMaximized | Qt.WindowMinimized | Qt.WindowFullScreen
         ):

--- a/presentation/dashboard_shell.py
+++ b/presentation/dashboard_shell.py
@@ -988,6 +988,14 @@ class DashboardShellMixin:
     def moveEvent(self, event) -> None:
         super().moveEvent(event)
         # Windows 移動視窗後可能不會觸發 Qt 的 mousePressEvent，再補一次置頂。
+        # 但最大化、還原、最小化同樣會觸發 moveEvent：在狀態轉換中 raise 會
+        # 與原生視框更新賽跑，曾把視窗卡成「最大尺寸、標題列按鈕消失」的
+        # 假全螢幕死鎖（v4.5.1 實機回報，2026-08-29）。只有一般狀態的拖動
+        # 才補置頂。
+        if self.windowState() & (
+            Qt.WindowMaximized | Qt.WindowMinimized | Qt.WindowFullScreen
+        ):
+            return
         self.front_raise_timer.start(0)
 
     def refresh_all(self) -> None:

--- a/tests/test_window_mro_contract.py
+++ b/tests/test_window_mro_contract.py
@@ -241,3 +241,16 @@ def test_every_owned_qtimer_has_an_explicit_stop_owner() -> None:
     )
     assert "stop" in _called_attributes(_method(platform_owner, "save_platform"))
     assert "stop" in _called_attributes(_method(platform_owner, "save_platforms"))
+
+
+def test_move_event_never_raises_during_state_transitions() -> None:
+    # v4.5.1 regression (2026-08-29): moveEvent fires for maximize/restore/
+    # minimize transitions too, and re-raising there races the native frame
+    # update — the window got stuck at maximized size with its caption
+    # buttons gone.  The handler must consult windowState() before arming
+    # the front-raise timer.
+    move_event = _method(
+        _class("presentation/dashboard_shell.py", "DashboardShellMixin"),
+        "moveEvent",
+    )
+    assert "windowState" in _called_attributes(move_event)


### PR DESCRIPTION
## 繁體中文

### 問題（v4.5.1 實機回報，2026-08-29）
視窗最大化後按還原，尺寸維持最大、高機率進入「看似全螢幕、無法縮小／放大／關閉」的死鎖。根因：`moveEvent` 的置頂補償（0ms 後 `raise_`＋`activateWindow`）在最大化、還原、最小化的狀態轉換中同樣觸發，與原生視框更新賽跑，把視窗卡成「最大尺寸＋標題列按鈕消失」。既有全螢幕防護攔不住——因為那不是正規 `WindowFullScreen` 狀態。

### 修法
- `presentation/dashboard_shell.py`：`moveEvent` 先查 `windowState()`，最大化／最小化／全螢幕狀態下不再武裝置頂計時器；只有一般狀態的拖動才補置頂（原始體驗保留）。
- `tests/test_window_mro_contract.py`：新增 AST 契約——`moveEvent` 必須諮詢 `windowState`，防止守衛被未來重構移除。

## 简体中文

### 问题（v4.5.1 实机回报，2026-08-29）
视窗最大化后按还原，尺寸维持最大、高概率进入「看似全屏、无法缩小／放大／关闭」的死锁。根因：`moveEvent` 的置顶补偿（0ms 后 `raise_`＋`activateWindow`）在最大化、还原、最小化的状态转换中同样触发，与原生窗框更新赛跑，把视窗卡成「最大尺寸＋标题栏按钮消失」。既有全屏防护拦不住——因为那不是正规 `WindowFullScreen` 状态。

### 修法
- `presentation/dashboard_shell.py`：`moveEvent` 先查 `windowState()`，最大化／最小化／全屏状态下不再武装置顶计时器；只有一般状态的拖动才补置顶（原始体验保留）。
- `tests/test_window_mro_contract.py`：新增 AST 契约——`moveEvent` 必须咨询 `windowState`，防止守卫被未来重构移除。

## English

### Problem (reported live on v4.5.1, 2026-08-29)
After maximizing and then restoring, the window kept its maximized size and frequently entered a "looks fullscreen, cannot minimize/maximize/close" lock-up. Root cause: the raise-to-front compensation in `moveEvent` (0ms-deferred `raise_` + `activateWindow`) also fires during maximize/restore/minimize transitions and races the native frame update, leaving the window stuck at maximized size with its caption buttons gone. The existing fullscreen guard cannot catch it — the state is not a genuine `WindowFullScreen`.

### Fix
- `presentation/dashboard_shell.py`: `moveEvent` now consults `windowState()` first and never arms the front-raise timer while maximized/minimized/fullscreen; only drags in the normal state re-raise (the original UX is preserved).
- `tests/test_window_mro_contract.py`: add an AST contract — `moveEvent` must consult `windowState`, so a future refactor cannot drop the guard.

## 日本語

### 問題（v4.5.1 実機報告、2026-08-29）
ウィンドウを最大化して復元すると、サイズは最大のまま維持され、高確率で「フルスクリーンに見えるが縮小／拡大／閉じる不能」の膠着に陥る。根因：`moveEvent` の前面化補償（0ms 遅延の `raise_`＋`activateWindow`）が最大化・復元・最小化の状態遷移でも発火し、ネイティブ枠更新と競合して「最大サイズ＋キャプションボタン消失」の状態に固まる。既存のフルスクリーンガードでは捕捉不能——正規の `WindowFullScreen` 状態ではないため。

### 修正
- `presentation/dashboard_shell.py`：`moveEvent` は先に `windowState()` を確認し、最大化／最小化／フルスクリーン中は前面化タイマーを起動しない；通常状態のドラッグのみ前面化を補う（従来の UX は維持）。
- `tests/test_window_mro_contract.py`：AST 契約を追加——`moveEvent` は `windowState` を必ず参照し、将来のリファクタでガードが消えないよう守門。