### PR TITLE
fix: 佈景主題色彩重映射染遍全 App／布景主题色彩重映射染遍全 App／theme-pack retint reskins the whole app／テーマパック色再マッピングでアプリ全体を再着色

### DIFF
--- a/domain/theme_retint.py
+++ b/domain/theme_retint.py
@@ -1,0 +1,131 @@
+"""Recolor the flagship stylesheet toward a theme pack's palette.
+
+The flagship stylesheet owns MoHan's page structure with a blue-violet
+palette expressed through ~100 literal colors (hex and rgba, many inside
+gradients).  Theme packs previously appended low-specificity selectors that
+the flagship's attribute selectors always beat, so an installed theme only
+tinted a handful of stray widgets (v4.5.1 live report, 2026-08-29: the
+crimson theme showed up as "a few orange frames").
+
+Instead of tokenizing every literal (a rewrite the line-count ratchet also
+forbids), this module retints the rendered stylesheet as a string transform:
+
+* Neutral colors (near-greyscale) keep their role and are never touched.
+* Accent colors outside the blue-violet band — the gold focus ring and the
+  danger reds — are semantic and stay put.
+* Colors inside the blue-violet band (hue 180°-360°) are compressed onto a
+  narrow band around the theme's primary hue, preserving their relative
+  hue offsets, saturation, and lightness — so gradients keep their depth
+  while the whole shell adopts the theme's color family.
+
+The transform is deliberately pure and Qt-free so it can be unit-tested.
+"""
+
+from __future__ import annotations
+
+lazy import colorsys
+lazy import re
+
+__all__ = ("retint_stylesheet",)
+
+# Colors with less saturation than this are treated as neutral greys/whites.
+NEUTRAL_SATURATION_THRESHOLD = 0.08
+# The flagship's own color family lives in this hue band (degrees).
+SOURCE_BAND_START = 180.0
+SOURCE_BAND_END = 360.0
+# Center of the flagship blue-violet band; offsets are measured from here.
+SOURCE_BAND_CENTER = 260.0
+# Relative hue offsets are compressed by this factor around the target hue,
+# keeping layered gradients distinguishable without scattering the palette.
+HUE_COMPRESSION = 0.30
+
+MAX_CHANNEL_VALUE = 255
+
+HEX_COLOR = re.compile(r"#([0-9a-fA-F]{6})\b")
+RGBA_COLOR = re.compile(
+    r"rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)"
+)
+
+
+def _hue_degrees(red: int, green: int, blue: int) -> tuple[float, float, float]:
+    hue, lightness, saturation = colorsys.rgb_to_hls(
+        red / 255.0, green / 255.0, blue / 255.0
+    )
+    return hue * 360.0, lightness, saturation
+
+
+def _retint_channels(
+    red: int,
+    green: int,
+    blue: int,
+    target_hue: float,
+) -> tuple[int, int, int] | None:
+    """Return retinted RGB, or None when the color must stay untouched."""
+
+    hue, lightness, saturation = _hue_degrees(red, green, blue)
+    if saturation < NEUTRAL_SATURATION_THRESHOLD:
+        return None
+    if not (SOURCE_BAND_START <= hue < SOURCE_BAND_END):
+        return None
+    offset = (hue - SOURCE_BAND_CENTER) * HUE_COMPRESSION
+    new_hue = (target_hue + offset) % 360.0
+    new_red, new_green, new_blue = colorsys.hls_to_rgb(
+        new_hue / 360.0, lightness, saturation
+    )
+    return (
+        round(new_red * 255.0),
+        round(new_green * 255.0),
+        round(new_blue * 255.0),
+    )
+
+
+def _primary_hue(tokens: object) -> float | None:
+    try:
+        primary = str(tokens["primary"])  # type: ignore[index]
+        red = int(primary[1:3], 16)
+        green = int(primary[3:5], 16)
+        blue = int(primary[5:7], 16)
+    except (KeyError, TypeError, ValueError, IndexError):
+        return None
+    hue, _, saturation = _hue_degrees(red, green, blue)
+    if saturation < NEUTRAL_SATURATION_THRESHOLD:
+        # A neutral primary (grey/white theme) has no meaningful hue to
+        # steer toward; leave the flagship palette alone.
+        return None
+    return hue
+
+
+def retint_stylesheet(stylesheet: str, tokens: object) -> str:
+    """Steer the flagship stylesheet's color family toward the theme primary.
+
+    ``tokens`` is a theme pack's token mapping; only ``primary`` is read.
+    The transform never changes stylesheet structure — only color literals.
+    """
+
+    target_hue = _primary_hue(tokens)
+    if target_hue is None:
+        return stylesheet
+
+    def _replace_hex(match: re.Match[str]) -> str:
+        value = match.group(1)
+        channels = _retint_channels(
+            int(value[0:2], 16),
+            int(value[2:4], 16),
+            int(value[4:6], 16),
+            target_hue,
+        )
+        if channels is None:
+            return match.group(0)
+        return "#{:02x}{:02x}{:02x}".format(*channels)
+
+    def _replace_rgba(match: re.Match[str]) -> str:
+        red, green, blue, alpha = (int(part) for part in match.groups())
+        if max(red, green, blue) > MAX_CHANNEL_VALUE:
+            return match.group(0)
+        channels = _retint_channels(red, green, blue, target_hue)
+        if channels is None:
+            return match.group(0)
+        return "rgba({}, {}, {}, {})".format(*channels, alpha)
+
+    recolored = HEX_COLOR.sub(_replace_hex, stylesheet)
+    return RGBA_COLOR.sub(_replace_rgba, recolored)

--- a/presentation/dashboard_window.py
+++ b/presentation/dashboard_window.py
@@ -6,6 +6,7 @@ lazy from PySide6.QtWidgets import QDialog, QLayout, QVBoxLayout
 lazy from application.gesture_controller import GestureController
 lazy from application.presentation_ports import PresentationDatabasePort
 lazy from application.theme_pack_service import ThemePackService
+lazy from domain.theme_retint import retint_stylesheet
 lazy from domain.theme_pack import ThemePack, build_stylesheet
 lazy from domain.theme_session import ThemeResolution, ThemeSession
 lazy from presentation.dashboard_composition import DashboardDependencies
@@ -124,7 +125,13 @@ class Dashboard(
         theme = resolution.payload
         if not isinstance(theme, ThemePack):
             raise TypeError("Resolved theme payload must be a theme pack.")
-        stylesheet = self.styleSheet() + build_stylesheet(theme)
+        # Retint the flagship stylesheet toward the pack's primary hue first:
+        # appended low-specificity selectors alone lose every cascade fight
+        # against the flagship's attribute selectors, which left installed
+        # themes as a few stray tinted frames (v4.5.1 report, 2026-08-29).
+        stylesheet = retint_stylesheet(
+            self.styleSheet(), theme.tokens
+        ) + build_stylesheet(theme)
         background = self.theme_pack_service.background_path(theme.theme_id)
         if background is not None:
             normalized = background.as_posix().replace("'", "\\'")

--- a/tests/test_theme_retint.py
+++ b/tests/test_theme_retint.py
@@ -1,0 +1,85 @@
+"""Contract tests for the theme retint transform.
+
+Guards the v4.5.1 fix where installed theme packs only tinted a few stray
+frames: the flagship stylesheet must adopt the pack's color family while
+neutrals, gold accents, and danger reds keep their semantic roles.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from domain.theme_retint import retint_stylesheet
+from presentation.flagship_theme import _theme_stylesheet
+
+CRIMSON_TOKENS = {"primary": "#D9481C"}
+
+
+def test_neutrals_and_semantic_accents_stay_put() -> None:
+    sheet = (
+        "QLabel { color: #ffffff; background: #24364a00; }"
+        "QFrame { border: 1px solid #b42318; }"  # danger red
+        "QLineEdit:focus { border-color: #f0d58b; }"  # gold focus
+        "QWidget { background: rgba(255, 255, 255, 26); }"
+    )
+    # #24364a00 is not matched as an 8-digit color by design; the 6-digit
+    # prefix would be desaturated navy — verify true neutrals separately.
+    result = retint_stylesheet("QLabel { color: #ffffff; }", CRIMSON_TOKENS)
+    assert result == "QLabel { color: #ffffff; }"
+    result = retint_stylesheet(sheet, CRIMSON_TOKENS)
+    assert "#b42318" in result
+    assert "#f0d58b" in result
+    assert "rgba(255, 255, 255, 26)" in result
+
+
+def test_blue_violet_band_moves_to_theme_family() -> None:
+    result = retint_stylesheet(
+        "QFrame { background: #7189c7; }", CRIMSON_TOKENS
+    )
+    assert "#7189c7" not in result
+    # The replacement must be a warm color: red channel dominates blue.
+    replacement = result.split("#")[1][:6]
+    red = int(replacement[0:2], 16)
+    blue = int(replacement[4:6], 16)
+    assert red > blue
+
+
+def test_rgba_alpha_survives() -> None:
+    result = retint_stylesheet(
+        "QFrame { background: rgba(53, 67, 133, 248); }", CRIMSON_TOKENS
+    )
+    assert result.endswith("248); }")
+    assert "rgba(53, 67, 133, 248)" not in result
+
+
+def test_neutral_primary_disables_retint() -> None:
+    sheet = "QFrame { background: #7189c7; }"
+    assert retint_stylesheet(sheet, {"primary": "#888888"}) == sheet
+    assert retint_stylesheet(sheet, {}) == sheet
+
+
+def test_full_flagship_stylesheet_recolors_without_structural_drift() -> None:
+    base = _theme_stylesheet(1.0, high_contrast=False)
+    themed = retint_stylesheet(base, CRIMSON_TOKENS)
+    assert themed != base
+    # Only color literals may change: selector/brace structure is identical.
+    strip = lambda text: [
+        line
+        for line in text.splitlines()
+        if "#" not in line and "rgba(" not in line
+    ]
+    assert strip(themed) == strip(base)
+    assert themed.count("{") == base.count("{")
+    assert themed.count("}") == base.count("}")
+
+
+if __name__ == "__main__":
+    test_neutrals_and_semantic_accents_stay_put()
+    test_blue_violet_band_moves_to_theme_family()
+    test_rgba_alpha_survives()
+    test_neutral_primary_disables_retint()
+    test_full_flagship_stylesheet_recolors_without_structural_drift()
+    print("THEME_RETINT_OK")

--- a/tests/test_theme_retint.py
+++ b/tests/test_theme_retint.py
@@ -7,13 +7,13 @@ neutrals, gold accents, and danger reds keep their semantic roles.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+lazy import sys
+lazy from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from domain.theme_retint import retint_stylesheet
-from presentation.flagship_theme import _theme_stylesheet
+lazy from domain.theme_retint import retint_stylesheet
+lazy from presentation.flagship_theme import _theme_stylesheet
 
 CRIMSON_TOKENS = {"primary": "#D9481C"}
 


### PR DESCRIPTION
## 繁體中文

### 問題（v4.5.1 實機回報，2026-08-29）
安裝並套用「赤焰劍光」DLC 佈景主題後，畫面只多出幾個橘色框，整體仍是藍紫官方配色。根因：主題包舊機制把低特異性選擇器（`QFrame`、`QPushButton`）疊在旗艦樣式表之後，但 Qt 級聯規則是特異性優先——旗艦的屬性選擇器（`QFrame[mohanRole=...]` 等，約百個色彩字面值）全面壓制主題樣式。

### 修法
- 新增 `domain/theme_retint.py`（純函式、零 Qt 依賴）：套用主題時對整份旗艦樣式表做字串級色彩重映射——藍紫色帶（色相 180°–360°）依主題主色聚攏轉色（相對色相差壓縮保留漸層層次），明度與飽和度不動；近灰白的中性色、金色點綴、危險紅一律不動；主題主色為灰階時自動停用。
- `presentation/dashboard_window.py`：套用主題時先重映射旗艦樣式表、再疊主題自身樣式。
- `tests/test_theme_retint.py`：五項契約——中性與語意色不動、藍紫帶轉暖、rgba 透明度保留、灰階主色停用、整份旗艦樣式表結構零漂移。

### 實測抽樣（赤焰劍光 primary #D9481C）
藍紫背景 `#aeb8e7`→赤陶 `#e7b3ae`、深藍指揮甲板→深赤褐、藍紫光暈 `#7189c7`→赤紅 `#c77571`；危險紅 `#b42318` 與金色 `#f0d58b` 原樣保留。

## 简体中文

### 问题（v4.5.1 实机回报，2026-08-29）
安装并套用「赤焰剑光」DLC 布景主题后，画面只多出几个橙色框，整体仍是蓝紫官方配色。根因：主题包旧机制把低特异性选择器（`QFrame`、`QPushButton`）叠在旗舰样式表之后，但 Qt 级联规则是特异性优先——旗舰的属性选择器（`QFrame[mohanRole=...]` 等，约百个色彩字面值）全面压制主题样式。

### 修法
- 新增 `domain/theme_retint.py`（纯函数、零 Qt 依赖）：套用主题时对整份旗舰样式表做字符串级色彩重映射——蓝紫色带（色相 180°–360°）依主题主色聚拢转色（相对色相差压缩保留渐变层次），明度与饱和度不动；近灰白的中性色、金色点缀、危险红一律不动；主题主色为灰阶时自动停用。
- `presentation/dashboard_window.py`：套用主题时先重映射旗舰样式表、再叠主题自身样式。
- `tests/test_theme_retint.py`：五项契约——中性与语义色不动、蓝紫带转暖、rgba 透明度保留、灰阶主色停用、整份旗舰样式表结构零漂移。

### 实测抽样（赤焰剑光 primary #D9481C）
蓝紫背景 `#aeb8e7`→赤陶 `#e7b3ae`、深蓝指挥甲板→深赤褐、蓝紫光晕 `#7189c7`→赤红 `#c77571`；危险红 `#b42318` 与金色 `#f0d58b` 原样保留。

## English

### Problem (reported live on v4.5.1, 2026-08-29)
After installing and applying the "Crimson Flame Sword-Light" DLC theme, only a few orange frames appeared while the shell stayed in the official blue-violet palette. Root cause: theme packs appended low-specificity selectors (`QFrame`, `QPushButton`) after the flagship stylesheet, but Qt's cascade prefers specificity — the flagship's attribute selectors (`QFrame[mohanRole=...]` etc., ~100 color literals) beat the theme everywhere.

### Fix
- New `domain/theme_retint.py` (pure functions, no Qt): on theme application the whole flagship stylesheet is retinted as a string transform — the blue-violet band (hue 180°–360°) is compressed onto the theme's primary hue (relative offsets preserved so gradients keep their depth) with lightness and saturation untouched; near-greyscale neutrals, the gold accents, and danger reds never move; a greyscale primary disables the retint.
- `presentation/dashboard_window.py`: retint the flagship stylesheet first, then append the pack's own styles.
- `tests/test_theme_retint.py`: five contracts — neutrals/semantic colors stay put, the blue-violet band turns warm, rgba alpha survives, greyscale primaries disable the transform, and the full flagship stylesheet shows zero structural drift.

### Sampled results (crimson primary #D9481C)
Blue-violet background `#aeb8e7`→terracotta `#e7b3ae`, deep-blue command deck→deep crimson-brown, glow `#7189c7`→crimson `#c77571`; danger `#b42318` and gold `#f0d58b` untouched.

## 日本語

### 問題（v4.5.1 実機報告、2026-08-29）
「赤焰剣光」DLC テーマを導入・適用しても、画面には橙色の枠が数個現れるだけで、全体は公式の青紫配色のままだった。根因：テーマパックの旧機構は低特異性セレクタ（`QFrame`、`QPushButton`）をフラッグシップスタイルの後ろに追記するが、Qt のカスケードは特異性優先——フラッグシップの属性セレクタ（`QFrame[mohanRole=...]` 等、約百個の色リテラル）がテーマを全面的に打ち負かす。

### 修正
- 新規 `domain/theme_retint.py`（純関数・Qt 非依存）：テーマ適用時にフラッグシップスタイル全体を文字列変換で再着色——青紫帯（色相 180°–360°）をテーマ主色へ圧縮写像（相対色相差を保持しグラデーションの深みを維持）、明度・彩度は不変；グレー系中性色、金のアクセント、危険色の赤は不動；主色がグレースケールの場合は自動無効化。
- `presentation/dashboard_window.py`：テーマ適用時に先ずフラッグシップを再着色し、その後にパック自身のスタイルを追記。
- `tests/test_theme_retint.py`：五つの契約——中性・意味色の不動、青紫帯の暖色化、rgba 透明度の保持、グレー主色での無効化、フラッグシップ全文の構造ゼロ漂移。

### 実測サンプル（赤焰剣光 primary #D9481C）
青紫背景 `#aeb8e7`→テラコッタ `#e7b3ae`、深青のコマンドデッキ→深い赤褐、光暈 `#7189c7`→赤紅 `#c77571`；危険色 `#b42318` と金色 `#f0d58b` は原样維持。