### PR TITLE
fix: 執行期預設停用 3.15 JIT／执行期默认停用 3.15 JIT／disable the 3.15 JIT by default at runtime／実行時に 3.15 JIT を既定で無効化

### DIFF
--- a/application/application_bootstrap.py
+++ b/application/application_bootstrap.py
@@ -44,9 +44,10 @@ def _write_jit_status() -> None:
     output_path = _argument_value("--jit-status-output=")
     if not output_path:
         return
+    expected_jit = os.environ.get("MOHAN_ENABLE_JIT") == "1"
     Path(output_path).write_text(
         "PACKAGED_JIT_DEFAULT_OK"
-        if jit_is_enabled()
+        if jit_is_enabled() == expected_jit
         else "PACKAGED_JIT_DEFAULT_FAILED",
         encoding="utf-8",
     )

--- a/application/runtime_bootstrap.py
+++ b/application/runtime_bootstrap.py
@@ -5,7 +5,7 @@ lazy import subprocess
 lazy import sys
 lazy from os import _exit as _process_exit
 
-JIT_DISABLE_ENV = "MOHAN_DISABLE_JIT"
+JIT_ENABLE_ENV = "MOHAN_ENABLE_JIT"
 JIT_REEXEC_ENV = "MOHAN_JIT_REEXEC"
 
 
@@ -30,25 +30,29 @@ def finalize_process_exit(code: int) -> int:
 
 
 def ensure_default_jit(module_name: str, script_path: str) -> None:
-    """Require frozen builds to start with JIT enabled before Python init.
+    """Require the runtime JIT state to match the shipped policy.
 
-    Development entry points may restart once with ``PYTHON_JIT=1``. Frozen
-    applications are started by the public launcher, which removes inherited
-    ``PYTHON*`` settings and supplies only ``PYTHON_JIT=1`` to the narrowly
-    patched bootloader. The runtime must already have JIT enabled here.
+    Stability-first since 2026-08-29: a JIT-enabled runtime crashed with
+    0xC0000409 mid-session on a user machine, so the launcher now supplies
+    ``PYTHON_JIT=0`` by default and ``MOHAN_ENABLE_JIT=1`` opts back in as an
+    explicit experiment. Frozen builds assert the state matches that policy;
+    development entry points restart once only when the experiment asks for
+    a JIT the current process does not have.
     """
+    expect_jit = os.environ.get(JIT_ENABLE_ENV) == "1"
     is_frozen_entrypoint = bool(getattr(sys, "frozen", False))
     if is_frozen_entrypoint:
-        if not jit_is_enabled():
+        if jit_is_enabled() != expect_jit:
             raise RuntimeError(
-                "Frozen MoHan runtime requires launcher-enabled JIT"
+                "Frozen MoHan runtime JIT state does not match the "
+                "launcher policy"
             )
         return
     if (
         module_name != "__main__"
     ) or sys.version_info[:2] != (3, 15):
         return
-    if os.environ.get(JIT_DISABLE_ENV) == "1" or jit_is_enabled():
+    if not expect_jit or jit_is_enabled():
         return
     jit = getattr(sys, "_jit", None)
     if not jit or not jit.is_available() or os.environ.get(JIT_REEXEC_ENV) == "1":

--- a/build.ps1
+++ b/build.ps1
@@ -43,11 +43,12 @@ if ($LASTEXITCODE -ne 0) {
     }
 }
 
-# CPython 3.15's JIT is selected before interpreter initialization.  `-X jit`
-# only records an xoption and does not enable sys._jit, so every build-time
-# child must inherit the real startup switch.  The installed public launcher
-# applies the same contract to the frozen runtime below.
-$env:PYTHON_JIT = "1"
+# CPython 3.15's JIT is selected before interpreter initialization.  After a
+# 0xC0000409 mid-session crash on a user machine (2026-08-29) joined the CI
+# JIT/Qt failure history, every build-time child and the frozen runtime now
+# run with the JIT off; MOHAN_ENABLE_JIT=1 on the launcher re-enables it as
+# an explicit experiment.
+$env:PYTHON_JIT = "0"
 
 $PythonVersion = (& $Python -c "import platform; print(platform.python_version())").Trim()
 if ($LASTEXITCODE -ne 0 -or $PythonVersion -ne "3.15.0rc1") {

--- a/build.ps1
+++ b/build.ps1
@@ -55,8 +55,8 @@ if ($LASTEXITCODE -ne 0 -or $PythonVersion -ne "3.15.0rc1") {
     throw "MoHan $Version packages must be built with Python 3.15.0rc1; found $PythonVersion."
 }
 $JitContract = (& $Python -c "import sys; print(f'{sys._jit.is_available()}:{sys._jit.is_enabled()}')").Trim()
-if ($LASTEXITCODE -ne 0 -or $JitContract -ne "True:True") {
-    throw "MoHan $Version packages require a Python 3.15.0rc1 runtime built with JIT enabled by default; found $JitContract."
+if ($LASTEXITCODE -ne 0 -or $JitContract -ne "True:False") {
+    throw "MoHan $Version packages require a JIT-capable Python 3.15.0rc1 runtime running with the JIT off (shipped policy since 2026-08-29); found $JitContract."
 }
 
 & $Python -c "import azure.cognitiveservices.speech, cryptography, cv2, numpy, opencc, sounddevice, websocket; import PySide6.QtCore, PySide6.QtGui, PySide6.QtMultimedia, PySide6.QtWidgets"

--- a/build.ps1
+++ b/build.ps1
@@ -165,7 +165,7 @@ $BuildInfo = Join-Path $ProjectRoot "build-info.json"
     repository = "flameblade-studio/MoHan-PC-Desktop-Assistant"
     python = $PythonVersion
     jit_supported = $true
-    jit_default = $true
+    jit_default = $false
 } | ConvertTo-Json | Set-Content -Encoding utf8 $BuildInfo
 
 try {

--- a/presentation/preview_app.py
+++ b/presentation/preview_app.py
@@ -379,9 +379,12 @@ def main(argv: list[str] | None = None) -> int:
     values = sys.argv[1:] if argv is None else argv
     args = parse_preview_arguments(values)
     if args.jit_status_output:
+        # Same policy marker as application_bootstrap: the state must match
+        # the shipped JIT-off default (MOHAN_ENABLE_JIT=1 flips expectation).
+        expected_jit = os.environ.get("MOHAN_ENABLE_JIT") == "1"
         args.jit_status_output.write_text(
             "PACKAGED_JIT_DEFAULT_OK"
-            if jit_is_enabled()
+            if jit_is_enabled() == expected_jit
             else "PACKAGED_JIT_DEFAULT_FAILED",
             encoding="utf-8",
         )

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -171,7 +171,7 @@ def _assert_release_runtime_and_packages(release: str) -> None:
         "Linux limited Preview AppImage",
     ):
         assert required in release
-    assert "--enable-experimental-jit=yes" in read(
+    assert "--enable-experimental-jit=yes-off" in read(
         "tools/build_python315_jit_runtime.py"
     )
     assert "sync_wordpress_download_page.py" not in release

--- a/tests/test_jit_launcher.py
+++ b/tests/test_jit_launcher.py
@@ -12,7 +12,7 @@ lazy from tools import jit_launcher
 FORWARDED_EXIT_CODE = 7
 
 
-def test_launcher_enables_jit_before_starting_sibling_runtime(
+def test_launcher_disables_jit_by_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -28,18 +28,20 @@ def test_launcher_enables_jit_before_starting_sibling_runtime(
     monkeypatch.setattr(sys, "argv", [str(launcher), "--self-test"])
     monkeypatch.setattr(subprocess, "run", run)
     monkeypatch.setenv("PYTHONHASHSEED", "unsafe-parent-value")
-    monkeypatch.delenv("MOHAN_DISABLE_JIT", raising=False)
+    monkeypatch.delenv("MOHAN_ENABLE_JIT", raising=False)
 
     assert jit_launcher.main() == FORWARDED_EXIT_CODE
     assert captured["arguments"] == [str(runtime), "--self-test"]
     assert captured["check"] is False
     environment = captured["env"]
     assert isinstance(environment, dict)
-    assert environment["PYTHON_JIT"] == "1"
+    # Stability-first default after the 2026-08-29 mid-session 0xC0000409
+    # crash on a user machine (3.15rc1 JIT/Qt failure family).
+    assert environment["PYTHON_JIT"] == "0"
     assert "PYTHONHASHSEED" not in environment
 
 
-def test_launcher_honours_explicit_jit_disable(
+def test_launcher_honours_explicit_jit_opt_in(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -53,12 +55,12 @@ def test_launcher_honours_explicit_jit_disable(
     monkeypatch.setattr(sys, "executable", str(launcher))
     monkeypatch.setattr(sys, "argv", [str(launcher)])
     monkeypatch.setattr(subprocess, "run", run)
-    monkeypatch.setenv("MOHAN_DISABLE_JIT", "1")
+    monkeypatch.setenv("MOHAN_ENABLE_JIT", "1")
 
     assert jit_launcher.main() == 0
     environment = captured["env"]
     assert isinstance(environment, dict)
-    assert "PYTHON_JIT" not in environment
+    assert environment["PYTHON_JIT"] == "1"
 
 
 if __name__ == "__main__":

--- a/tests/test_native_packaging_contract.py
+++ b/tests/test_native_packaging_contract.py
@@ -69,7 +69,7 @@ def test_windows_package_builds_installs_and_collects_native_module() -> None:
         "tools.audit_speech_runtime_chain",
         "speech runtime chain or PortAudio dependency is incomplete",
         '--collect-all "opencc"',
-        '$env:PYTHON_JIT = "1"',
+        '$env:PYTHON_JIT = "0"',
         "tools/build_pyinstaller_jit_bootloader.py",
         '.qt315-compat-full\\Lib\\site-packages',
         "6.11.1+mohan.py315.",
@@ -102,7 +102,7 @@ def test_python315_jit_bootloader_contract_is_reproducible_and_narrow() -> None:
         assert required in builder
     launcher = read("tools/jit_launcher.py")
     assert "startswith(PYTHON_ENV_PREFIX)" in launcher
-    assert 'environment["PYTHON_JIT"] = "1"' in launcher
+    assert 'environment["PYTHON_JIT"] = "0"' in launcher
 
 
 def assert_native_workflow_contract(relative: str) -> None:

--- a/tests/test_python315_runtime.py
+++ b/tests/test_python315_runtime.py
@@ -24,7 +24,7 @@ lazy from domain.language_support import TRANSCRIPTION_PROMPT_BASES
 lazy from domain.lip_sync import VISEME_MIN_HOLD_SECONDS
 lazy from presentation.preview_app import _TEXT
 lazy from application import runtime_bootstrap
-lazy from application.runtime_bootstrap import JIT_DISABLE_ENV, JIT_REEXEC_ENV
+lazy from application.runtime_bootstrap import JIT_ENABLE_ENV, JIT_REEXEC_ENV
 lazy from domain.time_utils import (
     local_aware_time,
     local_wall_time,
@@ -36,14 +36,29 @@ EXPECTED_EXCEPTION_COUNT = 3
 FROZEN_EXIT_PROBE_CODE = 7
 
 
-def test_frozen_runtime_requires_jit_default_cpython(monkeypatch) -> None:
+def test_frozen_runtime_enforces_jit_policy(monkeypatch) -> None:
+    # Policy flipped 2026-08-29 (0xC0000409 mid-session crash): the shipped
+    # default is JIT-off, and a frozen runtime that still has the JIT on
+    # violates the launcher contract; MOHAN_ENABLE_JIT=1 flips the
+    # expectation for the explicit experiment.
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.delenv("MOHAN_ENABLE_JIT", raising=False)
     monkeypatch.setattr(runtime_bootstrap, "jit_is_enabled", lambda: False)
-    with pytest.raises(RuntimeError, match="launcher-enabled JIT"):
+    runtime_bootstrap.ensure_default_jit(
+        "application.application_bootstrap",
+        "app.py",
+    )
+    monkeypatch.setattr(runtime_bootstrap, "jit_is_enabled", lambda: True)
+    with pytest.raises(RuntimeError, match="does not match the"):
         runtime_bootstrap.ensure_default_jit(
             "application.application_bootstrap",
             "app.py",
         )
+    monkeypatch.setenv("MOHAN_ENABLE_JIT", "1")
+    runtime_bootstrap.ensure_default_jit(
+        "application.application_bootstrap",
+        "app.py",
+    )
 
 
 def test_frozen_jit_exit_skips_unsafe_interpreter_finalizers(monkeypatch) -> None:
@@ -74,7 +89,7 @@ def _assert_python315_language_features() -> None:
     assert callable(sys.set_lazy_imports_filter)
     assert io.text_encoding(None) == "utf-8"
     assert re.prefixmatch(r"^MoHan", "MoHan Desktop Assistant") is not None
-    assert JIT_DISABLE_ENV == "MOHAN_DISABLE_JIT"
+    assert JIT_ENABLE_ENV == "MOHAN_ENABLE_JIT"
     assert JIT_REEXEC_ENV == "MOHAN_JIT_REEXEC"
     aware_now = local_aware_time()
     wall_now = local_wall_time()

--- a/tests/test_release_automation.py
+++ b/tests/test_release_automation.py
@@ -82,10 +82,10 @@ def test_version_runtime_and_evidence_policy() -> None:
     assert_contains(
         build_script,
         (
-            "True:True",
-            "JIT enabled by default",
+            "True:False",
+            "running with the JIT off",
             "jit_supported = $true",
-            "jit_default = $true",
+            "jit_default = $false",
             "Python 3.15.0rc1",
             "import azure.cognitiveservices.speech, cryptography, cv2, numpy, opencc, sounddevice, websocket",
             "import PySide6.QtCore, PySide6.QtGui, PySide6.QtMultimedia, PySide6.QtWidgets",

--- a/tests/test_tachyon_evidence.py
+++ b/tests/test_tachyon_evidence.py
@@ -191,7 +191,8 @@ def test_quality_gate_requires_samples_low_error_and_jit() -> None:
             "sample_read_error_percent": 1.0,
             "missed_samples_percent": 0.5,
         },
-        {"exit_code": 0, "jit_available": True, "jit_enabled": True},
+        # Shipped policy is JIT-off (2026-08-29); evidence must match it.
+        {"exit_code": 0, "jit_available": True, "jit_enabled": False},
     )
     assert passing == ()
 
@@ -202,7 +203,7 @@ def test_quality_gate_requires_samples_low_error_and_jit() -> None:
             "sample_read_error_percent": 7.0,
             "missed_samples_percent": 8.0,
         },
-        {"exit_code": 1, "jit_available": False, "jit_enabled": False},
+        {"exit_code": 1, "jit_available": False, "jit_enabled": True},
     )
     assert len(failing) == EXPECTED_FAILURE_COUNT
     assert any("below minimum" in item for item in failing)

--- a/tests/test_v312_release_consistency.py
+++ b/tests/test_v312_release_consistency.py
@@ -205,7 +205,7 @@ def test_python315_node24_and_jit_release_contract() -> None:
         "$env:MOHAN_DISABLE_JIT = $null",
     ):
         assert required in release, required
-    assert "--enable-experimental-jit=yes" in read(
+    assert "--enable-experimental-jit=yes-off" in read(
         "tools/build_python315_jit_runtime.py"
     )
 

--- a/tools/build_preview_package.py
+++ b/tools/build_preview_package.py
@@ -108,9 +108,10 @@ def _release_pose_atlas_root(required: bool) -> Path | None:
 
 def _write_build_info(path: Path, version: str, target: str) -> None:
     jit = getattr(sys, "_jit", None)
-    if not jit or not jit.is_available() or not jit.is_enabled():
+    if not jit or not jit.is_available() or jit.is_enabled():
         raise RuntimeError(
-            "Preview packages require Python 3.15 with JIT enabled by default"
+            "Preview packages require a JIT-capable Python 3.15 running "
+            "with the JIT off (shipped policy since 2026-08-29)"
         )
     path.write_text(
         json.dumps(
@@ -118,7 +119,7 @@ def _write_build_info(path: Path, version: str, target: str) -> None:
                 "version": version,
                 "repository": "flameblade-studio/MoHan-PC-Desktop-Assistant",
                 "python": platform.python_version(),
-                "jit_default": True,
+                "jit_default": False,
                 "target": target,
                 "maturity": "preview",
             },

--- a/tools/build_python315_jit_runtime.py
+++ b/tools/build_python315_jit_runtime.py
@@ -74,7 +74,7 @@ def build(source: Path, prefix: Path) -> Path:
             [
                 str(source / "configure"),
                 f"--prefix={prefix}",
-                "--enable-experimental-jit=yes",
+                "--enable-experimental-jit=yes-off",
                 "--enable-shared",
                 "--with-ensurepip=install",
             ],
@@ -124,20 +124,23 @@ def _probe(python: Path, value: str | None) -> dict[str, object]:
 
 
 def verify_runtime(python: Path) -> None:
+    # Shipped policy since 2026-08-29 (0xC0000409 family): the runtime keeps
+    # JIT capability compiled in (`yes-off`) but starts with it disabled;
+    # PYTHON_JIT=1 remains the explicit experiment switch.
     default = _probe(python, None)
-    disabled = _probe(python, "0")
+    enabled = _probe(python, "1")
     if default != {
-        "version": CPYTHON_VERSION,
-        "available": True,
-        "enabled": True,
-    }:
-        raise RuntimeError(f"CPython JIT-default contract failed: {default}")
-    if disabled != {
         "version": CPYTHON_VERSION,
         "available": True,
         "enabled": False,
     }:
-        raise RuntimeError(f"CPython PYTHON_JIT=0 contract failed: {disabled}")
+        raise RuntimeError(f"CPython JIT-off default contract failed: {default}")
+    if enabled != {
+        "version": CPYTHON_VERSION,
+        "available": True,
+        "enabled": True,
+    }:
+        raise RuntimeError(f"CPython PYTHON_JIT=1 contract failed: {enabled}")
 
 
 def main() -> int:

--- a/tools/build_python315_jit_runtime.py
+++ b/tools/build_python315_jit_runtime.py
@@ -59,7 +59,7 @@ def build(source: Path, prefix: Path) -> Path:
                 "x64",
                 "-c",
                 "Release",
-                "--experimental-jit",
+                "--experimental-jit-off",
             ],
             cwd=source,
         )

--- a/tools/frozen_jit_qt_probe.py
+++ b/tools/frozen_jit_qt_probe.py
@@ -1,7 +1,8 @@
-"""Minimal frozen-runtime probe for the Python 3.15 JIT + Qt exit contract."""
+"""Minimal frozen-runtime probe for the Python 3.15 JIT-policy + Qt exit contract."""
 
 from __future__ import annotations
 
+lazy import os
 lazy import sys
 lazy from pathlib import Path
 
@@ -33,7 +34,9 @@ def main() -> int:
             f"jit_enabled={jit_is_enabled()};qt_exit={exit_code}",
             encoding="utf-8",
         )
-    return finalize_process_exit(0 if jit_is_enabled() and exit_code == 0 else 2)
+    expect_jit = os.environ.get("MOHAN_ENABLE_JIT") == "1"
+    policy_ok = jit_is_enabled() == expect_jit
+    return finalize_process_exit(0 if policy_ok and exit_code == 0 else 2)
 
 
 if __name__ == "__main__":

--- a/tools/jit_launcher.py
+++ b/tools/jit_launcher.py
@@ -1,4 +1,4 @@
-"""Launch the embedded MoHan runtime with Python 3.15 JIT enabled."""
+"""Launch the embedded MoHan runtime; the 3.15 JIT is opt-in only."""
 
 from __future__ import annotations
 
@@ -31,8 +31,15 @@ def main() -> int:
         for key, value in os.environ.items()
         if not key.upper().startswith(PYTHON_ENV_PREFIX)
     }
-    if environment.get("MOHAN_DISABLE_JIT") != "1":
+    # Stability-first default (2026-08-29): the JIT-enabled runtime crashed
+    # with 0xC0000409 mid-session on a user machine (Windows event log,
+    # 03:13:24) — the same 3.15rc1 JIT/Qt failure family as the CI history,
+    # now during live operation rather than finalization.  The JIT stays
+    # available as an explicit experiment via MOHAN_ENABLE_JIT=1.
+    if environment.get("MOHAN_ENABLE_JIT") == "1":
         environment["PYTHON_JIT"] = "1"
+    else:
+        environment["PYTHON_JIT"] = "0"
     runtime = runtime_path()
     result = subprocess.run(
         [str(runtime), *sys.argv[1:]],

--- a/tools/profile_mohan_tachyon.py
+++ b/tools/profile_mohan_tachyon.py
@@ -959,8 +959,15 @@ def _quality_violations(
         )
     if runtime.get("jit_available") is not True:
         violations.append("target runtime did not expose the CPython JIT")
-    if runtime.get("jit_enabled") is not True:
-        violations.append("target runtime did not enable the CPython JIT")
+    # Evidence must match the shipped JIT policy (off by default since the
+    # 2026-08-29 0xC0000409 crash; MOHAN_ENABLE_JIT=1 profiles the experiment).
+    expect_jit = os.environ.get("MOHAN_ENABLE_JIT") == "1"
+    if runtime.get("jit_enabled") is not expect_jit:
+        violations.append(
+            "target runtime JIT state "
+            f"{runtime.get('jit_enabled')!r} does not match the "
+            f"shipped policy (expected {expect_jit})"
+        )
     return tuple(violations)
 
 

--- a/tools/profile_mohan_tachyon.py
+++ b/tools/profile_mohan_tachyon.py
@@ -379,10 +379,15 @@ def _profile_environment(
             for marker in ("API_KEY", "TOKEN", "SECRET", "PASSWORD")
         ):
             environment.pop(key, None)
-    environment["PYTHON_JIT"] = "1"
+    # Profile what we ship: the runtime now defaults to JIT-off (0xC0000409
+    # family, 2026-08-29), and forcing the JIT here both diverged the evidence
+    # from the product and made this gate flaky by betting each CI run on a
+    # JIT startup crash.  MOHAN_ENABLE_JIT=1 profiles the experiment instead.
+    environment["PYTHON_JIT"] = (
+        "1" if environment.get("MOHAN_ENABLE_JIT") == "1" else "0"
+    )
     environment["PYTHONUTF8"] = "1"
     environment["QT_QPA_PLATFORM"] = "offscreen"
-    environment.pop("MOHAN_DISABLE_JIT", None)
     if not use_user_profile:
         environment["MOHAN_DATA_DIR"] = str(temp_dir / "profile")
     return environment

--- a/tools/smoke_preview_package.py
+++ b/tools/smoke_preview_package.py
@@ -59,7 +59,7 @@ def _run(
         not jit_output.is_file()
         or jit_output.read_text(encoding="utf-8") != "PACKAGED_JIT_DEFAULT_OK"
     ):
-        raise RuntimeError("Preview package did not enable Python 3.15 JIT by default")
+        raise RuntimeError("Preview package JIT state did not match the shipped policy")
 
 
 def smoke_macos(package: Path, expected_version: str, *, require_pose_atlas: bool) -> None:


### PR DESCRIPTION
## 繁體中文

### 問題（v4.5.1 實機崩潰，2026-08-29 03:13）
使用者執行一鍵製衣期間，App 彈出系統錯誤視窗強制中止。Windows 事件日誌實錘：runtime 行程以 `0xC0000409`（fail-fast 堆疊保護）崩潰——與 CI 上 installer 卡死、測試 teardown 崩潰同屬 **Python 3.15rc1 JIT／Qt 失敗族**。先前的雙行程架構（launcher 非 JIT、runtime JIT＋終結期提前退出）只治了「退出時」的堆損；這次崩潰發生在**運行中**，證明 JIT 在長時間高負載下仍會觸發堆疊保護。

### 修法（穩定優先）
- `tools/jit_launcher.py`：預設 `PYTHON_JIT=0`；`MOHAN_ENABLE_JIT=1` 保留為顯式實驗旗標（JIT 對 Qt 主導的 UI App 增益本就有限）。
- `build.ps1`：打包期 child 同步關閉 JIT，註解更新病史。
- `tests/test_jit_launcher.py`／`tests/test_native_packaging_contract.py`：契約同步反轉（預設關、opt-in 開）。

## 简体中文

### 问题（v4.5.1 实机崩溃，2026-08-29 03:13）
用户执行一键制衣期间，App 弹出系统错误窗口强制中止。Windows 事件日志实锤：runtime 进程以 `0xC0000409`（fail-fast 栈保护）崩溃——与 CI 上 installer 卡死、测试 teardown 崩溃同属 **Python 3.15rc1 JIT／Qt 失败族**。先前的双进程架构（launcher 非 JIT、runtime JIT＋终结期提前退出）只治了「退出时」的堆损；这次崩溃发生在**运行中**，证明 JIT 在长时间高负载下仍会触发栈保护。

### 修法（稳定优先）
- `tools/jit_launcher.py`：默认 `PYTHON_JIT=0`；`MOHAN_ENABLE_JIT=1` 保留为显式实验旗标（JIT 对 Qt 主导的 UI App 增益本就有限）。
- `build.ps1`：打包期 child 同步关闭 JIT，注释更新病史。
- `tests/test_jit_launcher.py`／`tests/test_native_packaging_contract.py`：契约同步反转（默认关、opt-in 开）。

## English

### Problem (live crash on v4.5.1, 2026-08-29 03:13)
While the user ran one-click outfit generation, the app was force-terminated by a system error dialog. The Windows event log confirms the runtime process crashed with `0xC0000409` (fail-fast stack protection) — the same **Python 3.15rc1 JIT/Qt failure family** as the CI installer hangs and test-teardown crashes. The existing two-process design (non-JIT launcher, JIT runtime with early exit at finalization) only cured the shutdown-time corruption; this crash happened **mid-session**, proving the JIT can still trip stack protection under sustained load.

### Fix (stability first)
- `tools/jit_launcher.py`: default `PYTHON_JIT=0`; `MOHAN_ENABLE_JIT=1` remains as an explicit experiment flag (the JIT gains little in a Qt-dominated UI app anyway).
- `build.ps1`: build-time children also run without the JIT, with the case history in comments.
- `tests/test_jit_launcher.py` / `tests/test_native_packaging_contract.py`: contracts flipped accordingly (off by default, opt-in to enable).

## 日本語

### 問題（v4.5.1 実機クラッシュ、2026-08-29 03:13）
ユーザーがワンクリック衣装生成を実行中、システムエラーダイアログでアプリが強制終了。Windows イベントログにより、runtime プロセスが `0xC0000409`（fail-fast スタック保護）でクラッシュしたことを確認——CI のインストーラ停止・テスト teardown クラッシュと同じ **Python 3.15rc1 JIT／Qt 失敗族**。従来の二重プロセス構成（非 JIT ランチャー＋JIT runtime の終了期早期退出）は「終了時」の破損のみを治したが、今回は**セッション中**に発生し、持続負荷下でも JIT がスタック保護に触れることを実証した。

### 修正（安定性優先）
- `tools/jit_launcher.py`：既定を `PYTHON_JIT=0` に；`MOHAN_ENABLE_JIT=1` を明示的な実験フラグとして保持（Qt 主導の UI アプリでは JIT の利得はもともと限定的）。
- `build.ps1`：ビルド時の子プロセスも JIT 無効で実行し、コメントに病歴を更新。
- `tests/test_jit_launcher.py`／`tests/test_native_packaging_contract.py`：契約を同期反転（既定オフ・オプトインでオン）。