### PR TITLE
docs: v4.6.0 發行說明人工定稿／v4.6.0 发布说明人工定稿／hand-polished v4.6.0 release notes／v4.6.0 リリースノート人手推敲版

### DIFF
--- a/docs/releases/v4.6.0.md
+++ b/docs/releases/v4.6.0.md
@@ -4,106 +4,126 @@
 
 > Windows 為正式支援平台；macOS 與 Linux 維持功能受限 Preview。
 
-本檔案由 CHANGELOG 自動產生，作為四語發行說明初稿；正式發布前請人工潤飾。
+### 發行宣告：【八十六項體檢漏掉的，一夜實測全獵回】
 
-### ✨ 新功能
+v4.5.1 出廠前通過了八十六項靜態體檢與全套自動化測試，然後我坐下來，像一位普通使用者那樣打開了墨寒——一個晚上，四顆重大缺陷現形：對話凍結在「思考中」、視窗卡成假全螢幕、贊助贈送的佈景主題只剩幾個框、一鍵製衣被系統崩潰強制中止。這一夜教會我的事，比八十六項體檢更貴重：**測試套件證明程式沒有寫錯，只有實機實操證明產品真的能用。**「像使用者一樣操作」自此列為每次發版前的必修科目——這個版本的每一項修復，都以實機重現、實機驗證收尾。
 
-- 雲端製衣畫質選項 ([#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/110)) ([e938da5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/e938da5806c2d33bddc627ef1c35bd41f56a583c))
+### 一夜獵四蟲
 
-### 🐛 修正
+- **「思考中」永久凍結根治**（[#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/106)）：三層病灶一次清除——回應讀取逾時的例外逃逸、請求組裝在防護圈外遇毒資料無聲死亡、回話收尾例外鎖死佇列。對話 worker 全程納入防護、逾時放寬至 150 秒對齊推理模型現實、收尾改 finally 鐵閘，三個回歸測試守門。
+- **假全螢幕死鎖根治**（[#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/107)）：視窗最大化後還原，置頂補償與原生視框更新賽跑，把視窗卡成「最大尺寸、按鈕失蹤」。狀態轉換中不再置頂，AST 契約防止守衛被未來重構移除。
+- **佈景主題色彩重映射**（[#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/108)）：DLC 主題舊機制在 Qt 級聯戰全敗給旗艦屬性選擇器。新引擎對整份旗艦樣式表做色彩重映射——藍紫色帶依主題主色聚攏轉色、明暗層次保留、金色點綴與警示紅不動。「赤焰劍光」自此真正染遍全 App。
+- **3.15 JIT 運行中崩潰根治**（[#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/109)）：Windows 事件日誌實錘 0xC0000409 崩潰於一鍵製衣運行中——先前的緩解只治了退出期。JIT 政策全面反轉為「能力保留、預設關閉」：啟動器、打包契約、自建 CPython（`yes-off`）、啟動守門、探針與煙霧標記八條線一致對齊，`MOHAN_ENABLE_JIT=1` 保留為顯式實驗通道。
 
-- release-please 工作流在打 tag 場景不再因空 PR 輸出而失敗 ([#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/102)) ([9eeb52a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/9eeb52a81dc0315c9b1f6373467d59e570784be1))
-- 佈景主題色彩重映射染遍全 App ([#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/108)) ([a3dfacf](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/a3dfacf8c0a2285f6a04149f53ea55fc9758a370))
-- 執行期預設停用 3.15 JIT ([#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/109)) ([b3b1e2e](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/b3b1e2efdf3bcf0a0116a72ff6709ad4c5605a4e))
-- 文字對話逾時凍結「思考中」根治 ([#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/106)) ([af7b93a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/af7b93a35f0ce344d9ffaa64e3855ce8e2930b54))
-- 視窗最大化還原後假全螢幕死鎖根治 ([#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/107)) ([1295718](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/129571897e369de3e65169d47f4eced203f5f057))
+### 新功能與治理
 
-### ♻️ 重構
+- **雲端製衣畫質三檔位**（[#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/110)）：快速／標準／精緻，雲裳閣直選——之前寫死中檔且不可見，實測回饋催生的正式產品功能。
+- **根目錄殼檔退役**（[#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/103)）：一百七十五個相容殼檔全數退役，根目錄由 239 項瘦身至 64 項，二百零一個呼叫端改用正式分層路徑，「退役別名不得復活」入契約。
+- **發版基礎設施防炸**（[#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/102)）：release-please 打 tag 場景的空輸出模板炸彈拆除——本版發行即其首次實戰驗證，全綠通過。
+- **README 四語重編**（[#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/101)）與 **v4.5.1【純淨之路】段落**（[#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/104)）。
 
-- 退役根目錄一百七十五個相容殼檔 ([#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/103)) ([5adedf4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/5adedf42dbb52e33cb4388b112a937ff7bb71f13))
+### 開源回饋：先行者嘉惠後人
 
-### 📚 文件
+修復自身的同時，本版開發期間在上游 ai-toolkit 發現並回饋了兩顆缺陷（[ostris/ai-toolkit#1021](https://github.com/ostris/ai-toolkit/pull/1021)、[#1023](https://github.com/ostris/ai-toolkit/pull/1023)）——文字編碼器裝置分支缺失讓嵌入快取慢上兩百倍、樣張生成撞上快取佔位符炸毀整場訓練。踩到的坑填平了留給後面的人，這是炎劍工作室的先行者信條。
 
-- v4.5.1 發行說明新增【純淨之路】四語段落 ([#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/104)) ([0cc93d5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/0cc93d5f9846d141fc1c94f3d8662b384f8672b3))
-- 梳理四語 README——v4.5.1 最新摘要、版號段落精簡與 Ko-fi DLC 專區 ([#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/101)) ([c5d86d4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/c5d86d434415fd2d63aa05c6db61bbf198de3689))
+### 發行資產與典藏
+
+- Windows：Setup.exe／MSI／ZIP；macOS（arm64＋x86_64）與 Linux 為 Preview 資產。
+- 供應鏈證據：SBOM、原生證據、效能證據、SHA256 校驗與自動更新描述檔。
+- 本版 Zenodo DOI 上傳以此版為準（v4.5.1 依擁有者裁決不上傳）。
 
 ## 简体中文
 
 > Windows 是正式支持平台；macOS 与 Linux 继续作为功能受限 Preview。
 
-本文件由 CHANGELOG 自动生成，作为四语发布说明初稿；正式发布前请人工润饰。
+### 发布宣告：【八十六项体检漏掉的，一夜实测全猎回】
 
-### 新功能
+v4.5.1 出厂前通过了八十六项静态体检与全套自动化测试，然后我坐下来，像一位普通用户那样打开了墨寒——一个晚上，四个重大缺陷现形：对话冻结在「思考中」、窗口卡成假全屏、赞助赠送的布景主题只剩几个框、一键制衣被系统崩溃强制中止。这一夜教会我的事，比八十六项体检更贵重：**测试套件证明程序没有写错，只有实机实操证明产品真的能用。**「像用户一样操作」自此列为每次发版前的必修科目——这个版本的每一项修复，都以实机重现、实机验证收尾。
 
-- 云端制衣画质选项 ([#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/110)) ([e938da5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/e938da5806c2d33bddc627ef1c35bd41f56a583c))
+### 一夜猎四虫
 
-### 修复
+- **「思考中」永久冻结根治**（[#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/106)）：三层病灶一次清除——响应读取超时的异常逃逸、请求组装在防护圈外遇毒数据无声死亡、回话收尾异常锁死队列。对话 worker 全程纳入防护、超时放宽至 150 秒对齐推理模型现实、收尾改 finally 铁闸，三个回归测试守门。
+- **假全屏死锁根治**（[#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/107)）：窗口最大化后还原，置顶补偿与原生窗框更新赛跑，把窗口卡成「最大尺寸、按钮失踪」。状态转换中不再置顶，AST 契约防止守卫被未来重构移除。
+- **布景主题色彩重映射**（[#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/108)）：DLC 主题旧机制在 Qt 级联战全败给旗舰属性选择器。新引擎对整份旗舰样式表做色彩重映射——蓝紫色带依主题主色聚拢转色、明暗层次保留、金色点缀与警示红不动。「赤焰剑光」自此真正染遍全 App。
+- **3.15 JIT 运行中崩溃根治**（[#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/109)）：Windows 事件日志实锤 0xC0000409 崩溃于一键制衣运行中——先前的缓解只治了退出期。JIT 政策全面反转为「能力保留、默认关闭」：启动器、打包契约、自建 CPython（`yes-off`）、启动守门、探针与烟雾标记八条线一致对齐，`MOHAN_ENABLE_JIT=1` 保留为显式实验通道。
 
-- release-please 工作流在打 tag 场景不再因空 PR 输出而失败 ([#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/102)) ([9eeb52a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/9eeb52a81dc0315c9b1f6373467d59e570784be1))
-- 布景主题色彩重映射染遍全 App ([#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/108)) ([a3dfacf](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/a3dfacf8c0a2285f6a04149f53ea55fc9758a370))
-- 执行期默认停用 3.15 JIT ([#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/109)) ([b3b1e2e](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/b3b1e2efdf3bcf0a0116a72ff6709ad4c5605a4e))
-- 文字对话超时冻结「思考中」根治 ([#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/106)) ([af7b93a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/af7b93a35f0ce344d9ffaa64e3855ce8e2930b54))
-- 视窗最大化还原后假全屏死锁根治 ([#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/107)) ([1295718](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/129571897e369de3e65169d47f4eced203f5f057))
+### 新功能与治理
 
-### 重构
+- **云端制衣画质三档位**（[#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/110)）：快速／标准／精致，云裳阁直选——之前写死中档且不可见，实测回馈催生的正式产品功能。
+- **根目录壳文件退役**（[#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/103)）：一百七十五个兼容壳文件全数退役，根目录由 239 项瘦身至 64 项，二百零一个调用端改用正式分层路径，「退役别名不得复活」入契约。
+- **发版基础设施防炸**（[#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/102)）：release-please 打 tag 场景的空输出模板炸弹拆除——本版发布即其首次实战验证，全绿通过。
+- **README 四语重编**（[#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/101)）与 **v4.5.1【纯净之路】段落**（[#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/104)）。
 
-- 退役根目录一百七十五个兼容壳文件 ([#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/103)) ([5adedf4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/5adedf42dbb52e33cb4388b112a937ff7bb71f13))
+### 开源回馈：先行者嘉惠后人
 
-### 文档
+修复自身的同时，本版开发期间在上游 ai-toolkit 发现并回馈了两个缺陷（[ostris/ai-toolkit#1021](https://github.com/ostris/ai-toolkit/pull/1021)、[#1023](https://github.com/ostris/ai-toolkit/pull/1023)）——文本编码器设备分支缺失让嵌入缓存慢上两百倍、样张生成撞上缓存占位符炸毁整场训练。踩到的坑填平了留给后面的人，这是炎剑工作室的先行者信条。
 
-- v4.5.1 发布说明新增【纯净之路】四语段落 ([#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/104)) ([0cc93d5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/0cc93d5f9846d141fc1c94f3d8662b384f8672b3))
-- 梳理四语 README——v4.5.1 最新摘要、版本号段落精简与 Ko-fi DLC 专区 ([#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/101)) ([c5d86d4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/c5d86d434415fd2d63aa05c6db61bbf198de3689))
+### 发行资产与典藏
+
+- Windows：Setup.exe／MSI／ZIP；macOS（arm64＋x86_64）与 Linux 为 Preview 资产。
+- 供应链证据：SBOM、原生证据、性能证据、SHA256 校验与自动更新描述文件。
+- 本版 Zenodo DOI 上传以此版为准（v4.5.1 依所有者裁决不上传）。
 
 ## English
 
 > Windows is the formally supported platform; macOS and Linux remain limited Previews.
 
-This file was generated automatically from the CHANGELOG as a four-language release-notes draft; polish it manually before the release is published.
+### Release proclamation: What eighty-six audits missed, one night of real use hunted down
 
-### New features
+Before v4.5.1 shipped, it passed an eighty-six-item static audit and the full automated test suite. Then I sat down and opened MoHan the way an ordinary user would — and in a single evening, four major defects surfaced: chat frozen on "thinking", the window stuck in a fake fullscreen, the sponsor-gift theme reduced to a few stray frames, and one-click outfit generation killed by a system crash. What that night taught me is worth more than any audit: **test suites prove the code is not wrong; only hands-on use proves the product actually works.** "Operate it like a user" is now a mandatory pre-release discipline — every fix in this release ends with a live reproduction and a live verification.
 
-- cloud outfit image-quality option ([#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/110)) ([e938da5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/e938da5806c2d33bddc627ef1c35bd41f56a583c))
+### Four bugs, one night
 
-### Fixes
+- **The permanent "thinking" freeze, cured** ([#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/106)): three layers cleared at once — a read-timeout exception escaping the worker, payload assembly dying silently outside the guard on poisoned history, and the reply-delivery path locking the queue on error. The chat worker is now guarded end to end, the timeout widened to 150 s for reasoning-model reality, delivery wrapped in a finally gate, with three regression tests standing watch.
+- **The fake-fullscreen lock-up, cured** ([#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/107)): after maximize-and-restore, the raise-to-front compensation raced the native frame update and left the window at maximized size with its caption buttons gone. No more re-raising during state transitions, with an AST contract so no future refactor drops the guard.
+- **Theme-pack retint** ([#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/108)): the old mechanism lost every cascade fight against the flagship's attribute selectors. The new engine retints the whole flagship stylesheet toward the theme's primary hue — depth preserved, gold accents and danger reds untouched. "Crimson Flame Sword-Light" finally reskins the entire app.
+- **The mid-session 3.15 JIT crash, cured** ([#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/109)): the Windows event log confirmed a 0xC0000409 crash during outfit generation — earlier mitigations only covered shutdown. The JIT policy is now "capability kept, off by default" across eight aligned fronts: launcher, packaging contract, self-built CPython (`yes-off`), startup guard, probes, and smoke markers, with `MOHAN_ENABLE_JIT=1` as the explicit experiment channel.
 
-- stop the release-please workflow from failing on empty PR output in the tagging scenario ([#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/102)) ([9eeb52a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/9eeb52a81dc0315c9b1f6373467d59e570784be1))
-- theme-pack retint reskins the whole app ([#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/108)) ([a3dfacf](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/a3dfacf8c0a2285f6a04149f53ea55fc9758a370))
-- disable the 3.15 JIT by default at runtime ([#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/109)) ([b3b1e2e](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/b3b1e2efdf3bcf0a0116a72ff6709ad4c5605a4e))
-- cure the permanent "thinking" freeze on chat timeout ([#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/106)) ([af7b93a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/af7b93a35f0ce344d9ffaa64e3855ce8e2930b54))
-- cure the fake-fullscreen lock-up after maximize-restore ([#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/107)) ([1295718](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/129571897e369de3e65169d47f4eced203f5f057))
+### Features and governance
 
-### Refactor
+- **Three cloud outfit quality tiers** ([#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/110)): fast / standard / fine, selectable in the wardrobe — previously hard-coded and invisible; a product feature born from live feedback.
+- **Root facade retirement** ([#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/103)): one hundred seventy-five compatibility facades retired, the repository root slimmed from 239 entries to 64, two hundred one call sites moved to canonical layered paths, and "retired aliases must not resurrect" added to the contract.
+- **Release infrastructure hardening** ([#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/102)): the release-please empty-output template bomb in the tagging scenario is defused — this very release was its first live validation, fully green.
+- **Four-language README rework** ([#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/101)) and the **v4.5.1 "road of purity" section** ([#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/104)).
 
-- Retire the 175 root compatibility facades ([#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/103)) ([5adedf4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/5adedf42dbb52e33cb4388b112a937ff7bb71f13))
+### Upstream giving: pioneers pave the road behind them
 
-### Documentation
+While fixing our own, this cycle also found and fed back two defects to upstream ai-toolkit ([ostris/ai-toolkit#1021](https://github.com/ostris/ai-toolkit/pull/1021), [#1023](https://github.com/ostris/ai-toolkit/pull/1023)) — a missing text-encoder device branch that made embedding caching two hundred times slower, and sampling crashing whole training runs on the cache placeholder. Filling the potholes you hit for those who come after is Flameblade Studio's pioneer creed.
 
-- add the four-language "road of purity" section to the v4.5.1 release notes ([#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/104)) ([0cc93d5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/0cc93d5f9846d141fc1c94f3d8662b384f8672b3))
-- Streamline the four-language README with v4.5.1 highlights, leaner version banners and a Ko-fi DLC spotlight ([#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/101)) ([c5d86d4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/c5d86d434415fd2d63aa05c6db61bbf198de3689))
+### Release assets and archival
+
+- Windows: Setup.exe / MSI / ZIP; macOS (arm64 + x86_64) and Linux ship as Preview assets.
+- Supply-chain evidence: SBOM, native evidence, performance evidence, SHA256 checksums, and the auto-update descriptor.
+- The Zenodo DOI upload applies to this release (v4.5.1 skipped by owner ruling).
 
 ## 日本語
 
-> Windows は正式サポートプラットフォームです。macOS と Linux は機能限定 Preview を継続します。
+> Windows が正式サポートプラットフォームです；macOS と Linux は機能制限付き Preview として継続します。
 
-本ファイルは CHANGELOG から自動生成された四言語リリースノートの草稿です。正式公開前に人手で推敲してください。
+### リリース宣言：【八十六項目の健診が見逃したものを、一夜の実機使用が狩り尽くした】
 
-### 新機能
+v4.5.1 は出荷前に八十六項目の静的監査と全自動テストを通過した。その後、私は腰を下ろし、ごく普通のユーザーとして墨寒を開いた——たった一晩で、四つの重大欠陥が姿を現した：会話は「思考中」のまま凍結、ウィンドウは疑似フルスクリーンで膠着、スポンサー特典のテーマは数個の枠だけ、ワンクリック衣装生成はシステムクラッシュで強制中止。この一夜が私に教えてくれたことは、どの監査よりも貴重だった：**テストスイートはコードが間違っていないことを証明するが、製品が本当に使えることを証明できるのは実機操作だけである。**「ユーザーのように操作する」は、以後すべてのリリース前の必修科目となった——本バージョンの修正はすべて、実機での再現と実機での検証で締めくくられている。
 
-- クラウド衣装生成の画質オプション ([#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/110)) ([e938da5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/e938da5806c2d33bddc627ef1c35bd41f56a583c))
+### 一夜で四匹の虫を狩る
 
-### 修正
+- **「思考中」永久凍結の根治**（[#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/106)）：三層の病巣を一掃——読み取りタイムアウト例外の逃逸、防護圏外のリクエスト組立が毒データで無音死、応答仕上げの例外によるキュー封鎖。会話 worker を全域防護し、タイムアウトを推論モデルの現実に合わせ 150 秒へ緩和、仕上げは finally ゲート化、三つの回帰テストが守門する。
+- **疑似フルスクリーン膠着の根治**（[#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/107)）：最大化から復元すると、前面化補償がネイティブ枠更新と競合し「最大サイズ・ボタン消失」で固まる。状態遷移中の前面化を停止し、AST 契約でガードの消失を防止。
+- **テーマパック色再マッピング**（[#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/108)）：旧機構はフラッグシップの属性セレクタにカスケードで全敗。新エンジンはスタイル全文をテーマ主色へ再着色——階調を保持し、金のアクセントと危険色の赤は不動。「赤焔剣光」はついにアプリ全体を染め上げる。
+- **3.15 JIT セッション中クラッシュの根治**（[#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/109)）：Windows イベントログが衣装生成中の 0xC0000409 を実証——従来の緩和は終了期のみだった。JIT ポリシーを「能力保持・既定オフ」へ全面反転：ランチャー、パッケージ契約、自前ビルド CPython（`yes-off`）、起動ガード、プローブ、スモークマーカーの八戦線を整合させ、`MOHAN_ENABLE_JIT=1` を明示的な実験チャネルとして保持。
 
-- タグ付けシナリオで release-please ワークフローが空の PR 出力で失敗しないよう修正 ([#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/102)) ([9eeb52a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/9eeb52a81dc0315c9b1f6373467d59e570784be1))
-- テーマパック色再マッピングでアプリ全体を再着色 ([#108](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/108)) ([a3dfacf](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/a3dfacf8c0a2285f6a04149f53ea55fc9758a370))
-- 実行時に 3.15 JIT を既定で無効化 ([#109](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/109)) ([b3b1e2e](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/b3b1e2efdf3bcf0a0116a72ff6709ad4c5605a4e))
-- チャットのタイムアウトによる「思考中」永久凍結を根治 ([#106](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/106)) ([af7b93a](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/af7b93a35f0ce344d9ffaa64e3855ce8e2930b54))
-- 最大化復元後の疑似フルスクリーン膠着を根治 ([#107](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/107)) ([1295718](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/129571897e369de3e65169d47f4eced203f5f057))
+### 新機能とガバナンス
 
-### リファクタリング
+- **クラウド衣装生成の画質三段階**（[#110](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/110)）：高速／標準／高精細を雲裳閣で直接選択——従来は中位固定かつ不可視。実機フィードバックが生んだ正式なプロダクト機能。
+- **ルートファサードの退役**（[#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/103)）：互換ファサード百七十五個を全数退役、ルートは 239 項目から 64 項目へ、二百一の呼び出し元を正式な階層パスへ移行、「退役エイリアスの復活禁止」を契約化。
+- **リリース基盤の防爆**（[#102](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/102)）：release-please のタグ付け時の空出力テンプレート爆弾を解体——本リリースがその初の実戦検証であり、全緑で通過。
+- **README 四言語再編**（[#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/101)）と **v4.5.1【純浄への道】セクション**（[#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pull/104)）。
 
-- ルートの互換ファサード 175 件を退役 ([#103](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/103)) ([5adedf4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/5adedf42dbb52e33cb4388b112a937ff7bb71f13))
+### オープンソースへの還元：先行者は後人のために道を拓く
 
-### ドキュメント
+自らを修復すると同時に、本サイクルでは上流の ai-toolkit に二つの欠陥を発見・還元した（[ostris/ai-toolkit#1021](https://github.com/ostris/ai-toolkit/pull/1021)、[#1023](https://github.com/ostris/ai-toolkit/pull/1023)）——テキストエンコーダのデバイス分岐欠落による埋め込みキャッシュの二百倍の低速化、そしてキャッシュ用プレースホルダに衝突してトレーニング全体を落とすサンプリング。踏んだ穴を埋めて後から来る人に残す——それが炎剣工作室の先行者信条である。
 
-- v4.5.1 リリースノートに四言語の【純浄への道】セクションを追加 ([#104](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/104)) ([0cc93d5](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/0cc93d5f9846d141fc1c94f3d8662b384f8672b3))
-- 四言語 README を整理——v4.5.1 ハイライト・バージョン欄の簡素化・Ko-fi DLC コーナー ([#101](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues/101)) ([c5d86d4](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/commit/c5d86d434415fd2d63aa05c6db61bbf198de3689))
+### リリース資産と典蔵
+
+- Windows：Setup.exe／MSI／ZIP；macOS（arm64＋x86_64）と Linux は Preview 資産。
+- サプライチェーン証拠：SBOM、ネイティブ証拠、性能証拠、SHA256 チェックサム、自動更新記述ファイル。
+- 本バージョンの Zenodo DOI アップロードはこのリリースを対象とする（v4.5.1 は所有者裁定により見送り）。

--- a/docs/releases/v4.6.0.md
+++ b/docs/releases/v4.6.0.md
@@ -98,7 +98,7 @@ While fixing our own, this cycle also found and fed back two defects to upstream
 
 ## 日本語
 
-> Windows が正式サポートプラットフォームです；macOS と Linux は機能制限付き Preview として継続します。
+> Windows が正式サポートプラットフォームです；macOS と Linux は機能限定 Preview として継続します。
 
 ### リリース宣言：【八十六項目の健診が見逃したものを、一夜の実機使用が狩り尽くした】
 


### PR DESCRIPTION
## 繁體中文
- `docs/releases/v4.6.0.md` 自動初稿改寫為四語完整敘事：發行宣告【八十六項體檢漏掉的，一夜實測全獵回】（擁有者第一人稱）、一夜獵四蟲、新功能與治理、開源回饋（ai-toolkit#1021／#1023）、資產典藏。
- 合併後待打包 run 完成，以 `gh release edit` 將定稿蓋上 v4.6.0 Release 頁。

## 简体中文
- `docs/releases/v4.6.0.md` 自动初稿改写为四语完整叙事：发布宣告【八十六项体检漏掉的，一夜实测全猎回】（所有者第一人称）、一夜猎四虫、新功能与治理、开源回馈（ai-toolkit#1021／#1023）、资产典藏。
- 合并后待打包 run 完成，以 `gh release edit` 将定稿盖上 v4.6.0 Release 页。

## English
- Rewrite the auto-drafted `docs/releases/v4.6.0.md` into a full four-language narrative: the proclamation "What eighty-six audits missed, one night of real use hunted down" (owner's first person), four bugs in one night, features and governance, upstream giving (ai-toolkit#1021 / #1023), and assets.
- After merge and once the packaging run completes, the polished notes replace the v4.6.0 release body via `gh release edit`.

## 日本語
- 自動生成初稿の `docs/releases/v4.6.0.md` を四言語の完全な物語へ書き換え：リリース宣言【八十六項目の健診が見逃したものを、一夜の実機使用が狩り尽くした】（所有者の一人称）、一夜四虫狩り、新機能とガバナンス、上流への還元（ai-toolkit#1021／#1023）、資産典蔵。
- マージ後、パッケージング run の完了を待って `gh release edit` で v4.6.0 リリースページへ反映する。