### PR TITLE
feat: 桌面角色構圖風格三檔位／桌面角色构图风格三档位／desktop companion framing styles／デスクトップキャラクター構図スタイル三段階

### DIFF
--- a/application/adaptive_character_composition.py
+++ b/application/adaptive_character_composition.py
@@ -10,7 +10,10 @@ lazy from application.character_framing_app_bridge import CharacterFramingAppBri
 lazy from application.framing_orchestrator import FramingOrchestrator
 lazy from application.full_body_performance_bridge import FullBodyPerformanceBridge
 lazy from application.full_body_render_adapter import FullBodyRenderAdapter
-lazy from domain.character_framing import CharacterFramingDirector
+lazy from domain.character_framing import (
+    DEFAULT_FRAMING_STYLE,
+    CharacterFramingDirector,
+)
 
 DEFAULT_CHARACTER_IMAGE_SIZE = 465
 
@@ -52,11 +55,14 @@ def create_adaptive_character_composition(
     *,
     image_size: int = DEFAULT_CHARACTER_IMAGE_SIZE,
     assets: object | None = None,
+    framing_style: str = DEFAULT_FRAMING_STYLE,
 ) -> AdaptiveCharacterComposition:
     """Build the optional 2.5D runtime behind one explicit boundary."""
 
     framing = CharacterFramingAppBridge(
-        FramingOrchestrator(CharacterFramingDirector(time.monotonic))
+        FramingOrchestrator(
+            CharacterFramingDirector(time.monotonic, style=framing_style)
+        )
     )
     renderer = FullBodyRenderAdapter(
         image_size,

--- a/domain/character_framing.py
+++ b/domain/character_framing.py
@@ -107,21 +107,43 @@ class FramingDecision:
     reason: FramingReason
 
 
+# Framing styles (owner ruling 2026-08-29, after the v4.5.1 "jumping between
+# full body and half body" report): "steady" keeps the whole conversation
+# session at the half-body shot and only relaxes after a quiet cooldown;
+# "lively" is the original event-driven behaviour; "half-only" never leaves
+# the half-body shot except for the outfit preview, which needs the full
+# photograph to show the garment.
+FRAMING_STYLES = ("steady", "lively", "half-only")
+DEFAULT_FRAMING_STYLE = "steady"
+STEADY_TRANSITION_GAP_SECONDS = 8.0
+LIVELY_TRANSITION_GAP_SECONDS = 1.2
+CONVERSATION_HOLD_SECONDS = 75.0
+
+
 class CharacterFramingDirector:
     """Select a human-like shot while keeping one full-body identity source."""
 
-    minimum_transition_gap_seconds = 1.2
+    minimum_transition_gap_seconds = LIVELY_TRANSITION_GAP_SECONDS
 
     def __init__(
         self,
         clock: Callable[[], float] | None = None,
         *,
         initial_mode: FramingMode = FramingMode.HALF,
+        style: str = DEFAULT_FRAMING_STYLE,
     ) -> None:
         self._clock = clock or time.monotonic
         self._mode = initial_mode
         self._last_change_at = float("-inf")
         self._pending: tuple[FramingMode, FramingReason] | None = None
+        self._style = style if style in FRAMING_STYLES else DEFAULT_FRAMING_STYLE
+        if self._style == "steady":
+            self.minimum_transition_gap_seconds = STEADY_TRANSITION_GAP_SECONDS
+        self._last_speech_at = float("-inf")
+
+    @property
+    def style(self) -> str:
+        return self._style
 
     @property
     def mode(self) -> FramingMode:
@@ -132,10 +154,17 @@ class CharacterFramingDirector:
             return self._decision(self._mode, True, FramingReason.DAILY_COMPANION)
 
         requested, reason = self._requested(context)
+        if self._style == "half-only" and not context.outfit_preview:
+            # The owner asked for a completely still companion: everything but
+            # the outfit preview stays at the half-body shot.
+            requested, reason = FramingMode.HALF, FramingReason.DAILY_COMPANION
         fitted = self._fit_viewport(requested, context)
         if fitted != requested:
             reason = FramingReason.SMALL_VIEWPORT
         requested = fitted
+
+        if context.speech_active:
+            self._last_speech_at = float(self._clock())
 
         if context.speech_active and not context.mouth_closed:
             # Speech is fixed at the half-body shot.  Jump straight to HALF
@@ -160,9 +189,19 @@ class CharacterFramingDirector:
             return self._decision(self._mode, True, FramingReason.SPEECH_HOLD)
 
         if context.mouth_closed and self._pending is not None:
-            requested, reason = self._pending
-            requested = self._fit_viewport(requested, context)
-            self._pending = None
+            if (
+                self._style == "steady"
+                and float(self._clock()) - self._last_speech_at
+                < CONVERSATION_HOLD_SECONDS
+            ):
+                # Conversation stickiness: between turns (the user typing, the
+                # companion waiting) the shot stays half-body instead of
+                # bouncing back to full body the moment the mouth closes.
+                requested, reason = FramingMode.HALF, FramingReason.SPEECH_HOLD
+            else:
+                requested, reason = self._pending
+                requested = self._fit_viewport(requested, context)
+                self._pending = None
 
         now = float(self._clock())
         if (

--- a/presentation/companion_core.py
+++ b/presentation/companion_core.py
@@ -165,6 +165,9 @@ class CompanionCoreMixin:
                 create_adaptive_character_composition(
                     stage_frame,
                     image_size=CHARACTER_IMAGE_SIZE,
+                    framing_style=str(
+                        self.db.setting("framing_style", "steady")
+                    ),
                     assets=PoseAtlasAssets(
                         resource_path("assets/pose-atlas/v4"),
                         image_size=CHARACTER_IMAGE_SIZE,

--- a/presentation/companion_core.py
+++ b/presentation/companion_core.py
@@ -12,8 +12,6 @@ lazy from PySide6.QtGui import QImage, QPainter, QPixmap
 
 lazy from application.adaptive_character_composition import (
     DEFAULT_CHARACTER_IMAGE_SIZE as CHARACTER_IMAGE_SIZE,
-)
-lazy from application.adaptive_character_composition import (
     AdaptiveCharacterComposition,
     AdaptiveCharacterFactory,
     create_adaptive_character_composition,
@@ -165,9 +163,7 @@ class CompanionCoreMixin:
                 create_adaptive_character_composition(
                     stage_frame,
                     image_size=CHARACTER_IMAGE_SIZE,
-                    framing_style=str(
-                        self.db.setting("framing_style", "steady")
-                    ),
+                    framing_style=str(self.db.setting("framing_style", "steady")),
                     assets=PoseAtlasAssets(
                         resource_path("assets/pose-atlas/v4"),
                         image_size=CHARACTER_IMAGE_SIZE,

--- a/presentation/flagship/companion.py
+++ b/presentation/flagship/companion.py
@@ -141,6 +141,19 @@ class FlagshipCompanionMixin:
         ):
             self.proactive_mode.addItem(label, value)
         self.proactive_mode.setAccessibleName(self._t("主動寒暄模式"))
+        self.framing_style = QComboBox()
+        for label, value in (
+            (self._t("沉穩（對話期間固定半身，建議）"), "steady"),
+            (self._t("靈動（依情境切換全身與半身）"), "lively"),
+            (self._t("固定半身（僅換裝預覽顯示全身）"), "half-only"),
+        ):
+            self.framing_style.addItem(label, value)
+        self.framing_style.setAccessibleName(self._t("桌面角色構圖風格"))
+        self.framing_style.currentIndexChanged.connect(
+            lambda _index: self._proactive_interaction_touched.add(
+                "framing_style"
+            )
+        )
         self.minimum_away_minutes = QSpinBox()
         self.minimum_away_minutes.setRange(1, 30)
         self.minimum_away_minutes.setSuffix(self._t(" 分鐘"))
@@ -169,6 +182,7 @@ class FlagshipCompanionMixin:
                 "multisensory_conversation_silence_seconds"
             )
         )
+        form.addRow(self._t("桌面角色構圖風格"), self.framing_style)
         form.addRow(self._t("主動寒暄模式"), self.proactive_mode)
         form.addRow(
             self._t("歡迎回來的最短離座時間"),
@@ -191,6 +205,10 @@ class FlagshipCompanionMixin:
             str(self.db.setting("proactive_interaction_mode", "balanced"))
         )
         self.proactive_mode.setCurrentIndex(max(0, mode_index))
+        style_index = self.framing_style.findData(
+            str(self.db.setting("framing_style", "steady"))
+        )
+        self.framing_style.setCurrentIndex(max(0, style_index))
         self.minimum_away_minutes.setValue(
             max(
                 1,

--- a/presentation/flagship/localization_remote_vision.py
+++ b/presentation/flagship/localization_remote_vision.py
@@ -69,6 +69,26 @@ REMOTE_VISION_TRANSLATIONS: TranslationCatalog = frozendict({
         "Allow MoHan to greet me and check in proactively",
         "墨寒から自発的に挨拶や気遣いをすることを許可",
     ),
+    "桌面角色構圖風格": translations(
+        "桌面角色构图风格",
+        "Desktop companion framing style",
+        "デスクトップキャラクターの構図スタイル",
+    ),
+    "沉穩（對話期間固定半身，建議）": translations(
+        "沉稳（对话期间固定半身，建议）",
+        "Steady (half-body during conversations, recommended)",
+        "落ち着き（会話中は半身固定・推奨）",
+    ),
+    "靈動（依情境切換全身與半身）": translations(
+        "灵动（依情境切换全身与半身）",
+        "Lively (switches between full and half body by context)",
+        "軽やか（状況に応じて全身と半身を切り替え）",
+    ),
+    "固定半身（僅換裝預覽顯示全身）": translations(
+        "固定半身（仅换装预览显示全身）",
+        "Half-body only (full body just for outfit previews)",
+        "半身固定（衣装プレビューのみ全身表示）",
+    ),
     "安靜（不主動寒暄）": translations(
         "安静（不主动寒暄）",
         "Quiet (no proactive greetings)",

--- a/presentation/flagship/settings_security.py
+++ b/presentation/flagship/settings_security.py
@@ -145,6 +145,11 @@ class FlagshipSettingsSecurityMixin:
                     if "proactive_interaction_mode" in touched
                     else None
                 ),
+                framing_style=(
+                    str(self.framing_style.currentData())
+                    if "framing_style" in touched
+                    else None
+                ),
                 welcome_minimum_seconds=(
                     self.minimum_away_minutes.value() * 60
                     if "multisensory_welcome_minimum_seconds" in touched
@@ -228,6 +233,7 @@ class FlagshipSettingsSecurityMixin:
             # (the dashboard also writes ``proactive_interaction_mode``).
             for key, value in (
                 ("proactive_interaction_mode", validated.proactive_mode),
+                ("framing_style", validated.framing_style),
                 ("multisensory_welcome_minimum_seconds", validated.welcome_minimum_seconds),
                 ("multisensory_conversation_silence_seconds", validated.conversation_silence_seconds),
             ):

--- a/presentation/flagship/shared.py
+++ b/presentation/flagship/shared.py
@@ -165,6 +165,7 @@ class FlagshipDraftValues:
     # ``None`` means the user never touched the control, so the persisted
     # value must not be overwritten (another settings page may own it).
     proactive_mode: str | None
+    framing_style: str | None
     welcome_minimum_seconds: int | None
     conversation_silence_seconds: int | None
     security: tuple[tuple[str, str], ...]

--- a/tests/test_character_framing.py
+++ b/tests/test_character_framing.py
@@ -35,7 +35,7 @@ def context(**changes: object) -> FramingContext:
 
 def assert_human_like_context_shots() -> None:
     clock = Clock()
-    framing = CharacterFramingDirector(clock)
+    framing = CharacterFramingDirector(clock, style="lively")
     assert framing.decide(context()).mode is FramingMode.HALF
     clock.advance()
     assert framing.decide(context(owner_arrived=True)).mode is FramingMode.THREE_QUARTER
@@ -55,7 +55,7 @@ def assert_human_like_context_shots() -> None:
 
 def assert_speech_holds_and_settles_before_reframing() -> None:
     clock = Clock()
-    framing = CharacterFramingDirector(clock)
+    framing = CharacterFramingDirector(clock, style="lively")
     held = framing.decide(
         context(owner_arrived=True, speech_active=True, mouth_closed=False)
     )
@@ -77,7 +77,7 @@ def assert_speech_is_fixed_at_half_body() -> None:
     companion does not speak a few words in full-body before snapping back.
     """
     clock = Clock()
-    framing = CharacterFramingDirector(clock)
+    framing = CharacterFramingDirector(clock, style="lively")
     # Drive the director into FULL_BODY first (owner arrival).
     framing.decide(context(owner_arrived=True))
     clock.advance()
@@ -103,7 +103,7 @@ def assert_speech_is_fixed_at_half_body() -> None:
 
 def assert_large_hands_are_never_cropped() -> None:
     clock = Clock()
-    framing = CharacterFramingDirector(clock)
+    framing = CharacterFramingDirector(clock, style="lively")
     gesture = NormalizedRect(0.02, 0.20, 0.98, 0.72)
     result = framing.decide(context(gesture_bounds=gesture))
     assert result.crop.contains(gesture)
@@ -111,7 +111,7 @@ def assert_large_hands_are_never_cropped() -> None:
 
 
 def assert_small_viewport_preserves_readable_face() -> None:
-    framing = CharacterFramingDirector(Clock())
+    framing = CharacterFramingDirector(Clock(), style="lively")
     result = framing.decide(
         context(
             available_width_px=400,
@@ -124,10 +124,59 @@ def assert_small_viewport_preserves_readable_face() -> None:
 
 
 def assert_disabled_mode_is_stable() -> None:
-    framing = CharacterFramingDirector(Clock())
+    framing = CharacterFramingDirector(Clock(), style="lively")
     result = framing.decide(context(owner_arrived=True, adaptive_enabled=False))
     assert result.mode is FramingMode.HALF
     assert result.held
+
+
+def assert_steady_style_holds_half_body_between_turns() -> None:
+    # Owner ruling 2026-08-29: in the default "steady" style the whole
+    # conversation session stays at the half-body shot — the frame must not
+    # bounce back to full body the moment the mouth closes between turns.
+    clock = Clock()
+    framing = CharacterFramingDirector(clock, style="steady")
+    framing.decide(
+        context(owner_arrived=True, speech_active=True, mouth_closed=False)
+    )
+    clock.advance(10.0)
+    between_turns = framing.decide(
+        context(owner_arrived=True, speech_active=False, mouth_closed=True)
+    )
+    assert between_turns.mode is FramingMode.HALF
+    assert between_turns.reason is FramingReason.SPEECH_HOLD
+    # After the conversation cooldown the deferred full-body request resumes
+    # (stepping through THREE_QUARTER as usual).
+    clock.advance(120.0)
+    resumed = framing.decide(
+        context(owner_arrived=True, speech_active=False, mouth_closed=True)
+    )
+    assert resumed.mode is FramingMode.THREE_QUARTER
+
+
+def assert_half_only_style_never_leaves_half_body() -> None:
+    clock = Clock()
+    framing = CharacterFramingDirector(clock, style="half-only")
+    for changes in (
+        {"owner_arrived": True},
+        {"turning_away": True},
+        {"emotion_intensity": 0.9},
+    ):
+        clock.advance(20.0)
+        assert framing.decide(context(**changes)).mode is FramingMode.HALF
+    # The outfit preview is the single functional exception: the garment can
+    # only be judged on the full photograph.
+    clock.advance(20.0)
+    framing.decide(context(outfit_preview=True))
+    clock.advance(20.0)
+    framing.decide(context(outfit_preview=True))
+    clock.advance(20.0)
+    assert framing.decide(context(outfit_preview=True)).mode is FramingMode.FULL_BODY
+
+
+def assert_unknown_style_falls_back_to_steady() -> None:
+    framing = CharacterFramingDirector(Clock(), style="chaotic")
+    assert framing.style == "steady"
 
 
 def run() -> None:
@@ -137,6 +186,9 @@ def run() -> None:
     assert_large_hands_are_never_cropped()
     assert_small_viewport_preserves_readable_face()
     assert_disabled_mode_is_stable()
+    assert_steady_style_holds_half_body_between_turns()
+    assert_half_only_style_never_leaves_half_body()
+    assert_unknown_style_falls_back_to_steady()
     print("CHARACTER_FRAMING_OK")
 
 

--- a/tests/test_character_framing_app_bridge.py
+++ b/tests/test_character_framing_app_bridge.py
@@ -119,7 +119,7 @@ def cue() -> WellbeingCue:
 
 def bridge(clock: Clock | None = None) -> CharacterFramingAppBridge:
     timer = clock or Clock()
-    director = CharacterFramingDirector(timer)
+    director = CharacterFramingDirector(timer, style="lively")
     return CharacterFramingAppBridge(FramingOrchestrator(director))
 
 
@@ -165,7 +165,7 @@ def assert_equivalent_output_is_deduplicated_across_generations() -> None:
 def assert_failure_returns_last_known_good_without_mutation() -> None:
     clock = Clock()
     switchable = SwitchableOrchestrator(
-        FramingOrchestrator(CharacterFramingDirector(clock))
+        FramingOrchestrator(CharacterFramingDirector(clock, style="lively"))
     )
     app_bridge = CharacterFramingAppBridge(switchable)
     emitted = app_bridge.dispatch(value(state(1)))

--- a/tests/test_framing_orchestrator.py
+++ b/tests/test_framing_orchestrator.py
@@ -262,7 +262,7 @@ def assert_fixed_preference_wins_without_bypassing_permissions() -> None:
 
 def assert_director_preserves_speech_settle_cooldown_and_steps() -> None:
     clock = Clock()
-    orchestrator = FramingOrchestrator(CharacterFramingDirector(clock))
+    orchestrator = FramingOrchestrator(CharacterFramingDirector(clock, style="lively"))
     speaking = policy(
         speech_active=True,
         mouth_closed=False,

--- a/tests/test_layered_facade_cycles.py
+++ b/tests/test_layered_facade_cycles.py
@@ -48,7 +48,7 @@ LAYER_MODULE_LINE_BASELINE = {
     "integrations.azure_speech": 864,
     "integrations.realtime_voice": 878,
     "integrations.speech": 1_195,
-    "presentation.companion_core": 1_132,
+    "presentation.companion_core": 1_131,
     "presentation.companion_face_animation": 1_154,
     "presentation.companion_face_assets": 898,
     "presentation.companion_speech_runtime": 1_179,


### PR DESCRIPTION
## 繁體中文

### 背景（使用者實測回饋，2026-08-29）
墨寒在全身與半身構圖之間頻繁跳動：說話固定半身的規則雖存在，但嘴一閉就立即恢復先前構圖，對話中每個回合跳兩次；轉場冷卻僅 1.2 秒也放大了抖動。

### 內容
- `domain/character_framing.py`：新增構圖風格——**沉穩**（預設：整個對話會話鎖定半身，最後一次語音後 75 秒冷卻才恢復；轉場冷卻 8 秒）、**靈動**（原行為）、**固定半身**（僅換裝預覽顯示全身）；非法值自動落回沉穩。
- `presentation/flagship/companion.py` 等：設定頁桌寵卡新增「桌面角色構圖風格」下拉，touched-set 防跨頁覆寫，儲存流一致。
- 四語翻譯齊備；`tests/test_character_framing.py` 既有測試鎖定靈動行為、新增沉穩黏性／固定半身／未知值回退三測試。

## 简体中文

### 背景（用户实测回馈，2026-08-29）
墨寒在全身与半身构图之间频繁跳动：说话固定半身的规则虽存在，但嘴一闭就立即恢复先前构图，对话中每个回合跳两次；转场冷却仅 1.2 秒也放大了抖动。

### 内容
- `domain/character_framing.py`：新增构图风格——**沉稳**（默认：整个对话会话锁定半身，最后一次语音后 75 秒冷却才恢复；转场冷却 8 秒）、**灵动**（原行为）、**固定半身**（仅换装预览显示全身）；非法值自动落回沉稳。
- `presentation/flagship/companion.py` 等：设置页桌宠卡新增「桌面角色构图风格」下拉，touched-set 防跨页覆写，保存流一致。
- 四语翻译齐备；`tests/test_character_framing.py` 既有测试锁定灵动行为、新增沉稳黏性／固定半身／未知值回退三测试。

## English

### Background (live user feedback, 2026-08-29)
MoHan kept bouncing between full-body and half-body shots: the speech-holds-half rule existed, but the previous framing resumed the moment her mouth closed — twice per conversation turn — and the 1.2-second transition gap amplified the jitter.

### Content
- `domain/character_framing.py`: framing styles — **steady** (default: the whole conversation session stays half-body, resuming only after a 75-second post-speech cooldown; 8-second transition gap), **lively** (original behaviour), **half-only** (full body just for outfit previews); unknown values fall back to steady.
- `presentation/flagship/companion.py` et al.: a "framing style" selector on the companion settings card, touched-set guarded like its neighbours.
- Localization complete in four languages; `tests/test_character_framing.py` pins the lively behaviour in existing tests and adds steady-stickiness / half-only / unknown-fallback tests.

## 日本語

### 背景（ユーザー実機フィードバック、2026-08-29）
墨寒が全身と半身の構図間を頻繁に飛び跳ねる：発話中の半身固定ルールは存在したが、口を閉じた瞬間に元の構図へ復帰し、会話の各ターンで二回ジャンプ；1.2 秒の遷移クールダウンも揺れを増幅していた。

### 内容
- `domain/character_framing.py`：構図スタイルを新設——**落ち着き**（既定：会話セッション全体を半身に固定し、最終発話から 75 秒の冷却後にのみ復帰；遷移クールダウン 8 秒）、**軽やか**（従来動作）、**半身固定**（衣装プレビューのみ全身）；不正値は落ち着きへフォールバック。
- `presentation/flagship/companion.py` ほか：設定ページのコンパニオンカードに「構図スタイル」セレクタを追加、touched-set でページ間上書きを防止。
- 四言語ローカライズ完備；`tests/test_character_framing.py` は既存テストで従来動作を固定し、落ち着きスティッキネス／半身固定／不正値フォールバックの三テストを追加。