### PR TITLE
fix: 選取反白 WCAG 達標＋全樣式表對比治理閘門／选取反白 WCAG 达标＋全样式表对比治理闸门／WCAG-compliant selection contrast plus a stylesheet-wide governance gate／選択ハイライトの WCAG 達成と全スタイルシート対比ガバナンスゲート

### DIFF
--- a/presentation/flagship_theme.py
+++ b/presentation/flagship_theme.py
@@ -60,6 +60,9 @@ def _theme_stylesheet(scale: float, *, high_contrast: bool) -> str:
             "line": "#315f7d",
             "silver": "#d8e8f2",
             "glow": "#0078b8",
+            # White selected text on this needs >=4.5:1 (WCAG 1.4.3); the
+            # glow itself stays for decorative uses (scrollbars, splitters).
+            "selection": "#005a85",
             "focus": "#0078b8",
             "disabled": "#687985",
             "action": "#a63d00",
@@ -73,6 +76,8 @@ def _theme_stylesheet(scale: float, *, high_contrast: bool) -> str:
             "line": "#9aaed0",
             "silver": "#dce6f5",
             "glow": "#7189c7",
+            # 5.47:1 against white selected text (glow alone is only 3.44:1).
+            "selection": "#56679f",
             "focus": "#f0d58b",
             "disabled": "#667085",
             "action": "#6d67b7",
@@ -436,7 +441,7 @@ QWidget[mohanFlagshipTheme="true"] QSpinBox {{
     border: 1px solid {colors['line']};
     border-radius: {_scaled(8, scale)}px;
     padding: {padding_y}px {padding_x}px;
-    selection-background-color: {colors['glow']};
+    selection-background-color: {colors['selection']};
     selection-color: #ffffff;
 }}
 QWidget[mohanFlagshipTheme="true"] QComboBox QAbstractItemView {{
@@ -444,7 +449,7 @@ QWidget[mohanFlagshipTheme="true"] QComboBox QAbstractItemView {{
     background: rgba(255, 250, 247, 255);
     border: 1px solid {colors['line']};
     border-radius: {_scaled(8, scale)}px;
-    selection-background-color: {colors['glow']};
+    selection-background-color: {colors['selection']};
     selection-color: #ffffff;
     outline: 0;
 }}
@@ -457,7 +462,7 @@ QWidget[mohanFlagshipTheme="true"] QComboBox QAbstractItemView::item:hover {{
     color: {colors['ink']};
 }}
 QWidget[mohanFlagshipTheme="true"] QComboBox QAbstractItemView::item:selected {{
-    background: {colors['glow']};
+    background: {colors['selection']};
     color: #ffffff;
 }}
 QWidget[mohanFlagshipTheme="true"] QListWidget {{

--- a/tests/test_wcag_contrast_governance.py
+++ b/tests/test_wcag_contrast_governance.py
@@ -1,0 +1,90 @@
+"""WCAG 1.4.3 contrast governance over every application stylesheet.
+
+Owner ruling 2026-08-29 («WCAG 對比度治理應該要徹查漏網之魚»): any rule that
+pairs a text color with a background in the same block must reach 4.5:1.
+Disabled-state selectors are exempt per WCAG 1.4.3 (inactive UI components),
+and that exemption is explicit and reviewed here rather than silent.
+"""
+
+from __future__ import annotations
+
+lazy import re
+lazy import sys
+lazy from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from domain.theme_pack import _contrast_ratio
+lazy from presentation.dashboard_control_style import POPUP_STYLE
+lazy from presentation.flagship_theme import _theme_stylesheet
+lazy from presentation.presentation_resources import LIGHT_MENU_STYLE, STYLE
+
+MINIMUM_RATIO = 4.5
+RULE = re.compile(r"([^{}]+)\{([^{}]*)\}")
+FOREGROUND = re.compile(r"(?<![-\w])color\s*:\s*(#[0-9a-fA-F]{6})")
+BACKGROUND = re.compile(r"(?<![-\w])background(?:-color)?\s*:\s*(#[0-9a-fA-F]{6})")
+SELECTION_BG = re.compile(r"selection-background-color\s*:\s*(#[0-9a-fA-F]{6})")
+SELECTION_FG = re.compile(r"selection-color\s*:\s*(#[0-9a-fA-F]{6})")
+# WCAG 1.4.3 exempts inactive (disabled) components from the 4.5:1 minimum.
+EXEMPT_SELECTOR = re.compile(r":disabled")
+
+
+def _violations(name: str, stylesheet: str) -> list[str]:
+    found: list[str] = []
+    for match in RULE.finditer(stylesheet):
+        selector = " ".join(match.group(1).split())
+        body = match.group(2)
+        exempt = bool(EXEMPT_SELECTOR.search(selector))
+        checks: list[tuple[str, str, str]] = []
+        foreground = FOREGROUND.search(body)
+        background = BACKGROUND.search(body)
+        if foreground and background:
+            checks.append((foreground.group(1), background.group(1), "text"))
+        sel_fg = SELECTION_FG.search(body)
+        sel_bg = SELECTION_BG.search(body)
+        if sel_fg and sel_bg:
+            checks.append((sel_fg.group(1), sel_bg.group(1), "selection"))
+        for fg, bg, kind in checks:
+            ratio = _contrast_ratio(bg, fg)
+            if ratio < MINIMUM_RATIO and not exempt:
+                found.append(
+                    f"{name}: {selector[:70]} [{kind}] "
+                    f"{fg} on {bg} = {ratio:.2f}"
+                )
+    return found
+
+
+def test_all_stylesheets_meet_wcag_contrast() -> None:
+    violations: list[str] = []
+    violations += _violations("STYLE", STYLE)
+    violations += _violations("LIGHT_MENU_STYLE", LIGHT_MENU_STYLE)
+    violations += _violations("POPUP_STYLE", POPUP_STYLE)
+    violations += _violations(
+        "FLAGSHIP", _theme_stylesheet(1.0, high_contrast=False)
+    )
+    violations += _violations(
+        "FLAGSHIP_HIGH_CONTRAST", _theme_stylesheet(1.0, high_contrast=True)
+    )
+    assert not violations, (
+        "Same-rule text/background pairs below WCAG 4.5:1 "
+        "(disabled states are the only reviewed exemption): "
+        + "; ".join(violations)
+    )
+
+
+def test_flagship_selection_colors_are_readable() -> None:
+    # The regression this file was born from: white selected text sat on the
+    # decorative glow color at 3.44:1 in the flagship theme.
+    for high_contrast in (False, True):
+        sheet = _theme_stylesheet(1.0, high_contrast=high_contrast)
+        for bg in SELECTION_BG.findall(sheet):
+            assert _contrast_ratio(bg, "#ffffff") >= MINIMUM_RATIO, (
+                high_contrast,
+                bg,
+            )
+
+
+if __name__ == "__main__":
+    test_all_stylesheets_meet_wcag_contrast()
+    test_flagship_selection_colors_are_readable()
+    print("WCAG_CONTRAST_GOVERNANCE_OK")


### PR DESCRIPTION
## 繁體中文

### 背景（擁有者徹查指令，2026-08-29）
使用者回報一鍵製衣時出現黑底低對比的警示小視窗，下令徹查 WCAG 對比度治理漏網之魚。

### 調查結論
- **實機渲染驗證**：App 內 QMessageBox（有 parent 與無 parent 兩情境）皆為淺底深字，清白——App 級樣式表的 `QDialog` 規則覆蓋完整。
- **黑底小視窗定性**：實為 Windows 系統的應用程式崩潰對話框（0xC0000409），系統框配色不受任何應用控制；其成因已由 #109（JIT 停用）根治，該框不會再出現。
- **量化掃描揪出真漏網**：旗艦主題「選取反白」——白字配裝飾光暈色 `#7189c7` 僅 **3.44:1**（三處同源：輸入框選取、下拉選中、清單選中）。

### 修法
- `presentation/flagship_theme.py`：新增 `selection` 專用色 token——一般主題 `#56679f`（**5.47:1**）、高對比主題 `#005a85`（**7.5:1**）；裝飾用途（捲軸、分隔柄）保留原光暈色。主題色彩重映射因保留明度，重映射後對比自動維持達標。
- `tests/test_wcag_contrast_governance.py`（新增治理閘門）：五份樣式表（STYLE／LIGHT_MENU／POPUP／旗艦一般／旗艦高對比）內，同規則的文字／背景與選取色對一律 ≥4.5:1；停用態（`:disabled`）為唯一豁免，依 WCAG 1.4.3 明文（inactive UI components）且豁免邏輯在測試中顯式可審。

## 简体中文

### 背景（所有者彻查指令，2026-08-29）
用户回报一键制衣时出现黑底低对比的警示小窗口，下令彻查 WCAG 对比度治理漏网之鱼。

### 调查结论
- **实机渲染验证**：App 内 QMessageBox（有 parent 与无 parent 两情境）皆为浅底深字，清白——App 级样式表的 `QDialog` 规则覆盖完整。
- **黑底小窗口定性**：实为 Windows 系统的应用程序崩溃对话框（0xC0000409），系统框配色不受任何应用控制；其成因已由 #109（JIT 停用）根治，该框不会再出现。
- **量化扫描揪出真漏网**：旗舰主题「选取反白」——白字配装饰光晕色 `#7189c7` 仅 **3.44:1**（三处同源：输入框选取、下拉选中、列表选中）。

### 修法
- `presentation/flagship_theme.py`：新增 `selection` 专用色 token——一般主题 `#56679f`（**5.47:1**）、高对比主题 `#005a85`（**7.5:1**）；装饰用途（滚动条、分隔柄）保留原光晕色。主题色彩重映射因保留明度，重映射后对比自动维持达标。
- `tests/test_wcag_contrast_governance.py`（新增治理闸门）：五份样式表内，同规则的文字／背景与选取色对一律 ≥4.5:1；停用态（`:disabled`）为唯一豁免，依 WCAG 1.4.3 明文且豁免逻辑在测试中显式可审。

## English

### Background (owner's sweep order, 2026-08-29)
The user reported a dark, low-contrast alert window during one-click outfit generation and ordered a full sweep for WCAG contrast leaks.

### Findings
- **Live-render verification**: in-app QMessageBoxes (parented and orphaned) are light-background/dark-text — clean; the app-level `QDialog` rule covers them.
- **The dark window identified**: it was the Windows application-crash dialog (0xC0000409), whose colors no application controls; its root cause is already cured by #109 (JIT off), so the dialog will not appear again.
- **The quantitative sweep found the real leak**: flagship-theme selection highlights — white text on the decorative glow `#7189c7` at only **3.44:1** (three sibling sites: line-edit selection, combo selection, list selection).

### Fix
- `presentation/flagship_theme.py`: a dedicated `selection` color token — `#56679f` (**5.47:1**) in the normal theme, `#005a85` (**7.5:1**) in high contrast; decorative uses (scrollbars, splitter handles) keep the glow. The theme retint preserves lightness, so retinted themes inherit compliant ratios automatically.
- `tests/test_wcag_contrast_governance.py` (new gate): across five stylesheets, every same-rule text/background and selection pair must reach 4.5:1; `:disabled` states are the single exemption, per WCAG 1.4.3 (inactive UI components), reviewed explicitly in the test.

## 日本語

### 背景（所有者の徹底調査指令、2026-08-29）
ワンクリック衣装生成時に黒背景・低コントラストの警告ウィンドウが出たとの報告を受け、WCAG コントラストガバナンスの漏れの徹底調査が命じられた。

### 調査結果
- **実機レンダリング検証**：アプリ内 QMessageBox（親あり・親なし両方）は明背景・濃色文字で問題なし——アプリレベルの `QDialog` 規則が全てをカバー。
- **黒いウィンドウの正体**：Windows のアプリケーションクラッシュダイアログ（0xC0000409）であり、その配色はいかなるアプリも制御不能；原因自体は #109（JIT 無効化）で根治済みのため、当該ダイアログは今後現れない。
- **定量スキャンが真の漏れを発見**：フラッグシップテーマの選択ハイライト——装飾用グロー色 `#7189c7` 上の白文字がわずか **3.44:1**（入力欄選択・コンボ選択・リスト選択の三箇所同源）。

### 修正
- `presentation/flagship_theme.py`：`selection` 専用色トークンを新設——通常テーマ `#56679f`（**5.47:1**）、ハイコントラスト `#005a85`（**7.5:1**）；装飾用途（スクロールバー、スプリッタ）はグローを維持。テーマ再着色は明度を保持するため、再着色後も適合比率を自動継承。
- `tests/test_wcag_contrast_governance.py`（新設ゲート）：五つのスタイルシート全体で、同一規則内の文字／背景と選択色ペアは必ず 4.5:1 以上；`:disabled` 状態のみ WCAG 1.4.3（inactive UI components）明文に基づく唯一の免除とし、免除ロジックはテスト内で明示的に監査可能。