### PR TITLE
fix: 控制中心上下邊緣與四角可調整大小／控制中心上下边缘与四角可调整大小／dashboard top/bottom and corner resizing／ダッシュボード上下端と四隅のリサイズ復旧

### DIFF
--- a/presentation/dashboard_window.py
+++ b/presentation/dashboard_window.py
@@ -145,6 +145,15 @@ class Dashboard(
         if hasattr(self, "chat"):
             self.apply_chat_zoom(self.chat_zoom_percent, persist=False)
 
+    def hasHeightForWidth(self) -> bool:
+        # Word-wrapped labels propagate height-for-width up to this top-level
+        # layout, and Qt then treats the window height as a function of its
+        # width: the native frame accepts horizontal resizes but refuses the
+        # top/bottom edges and all four corners (v4.5.1 live report,
+        # 2026-08-29). The dashboard scrolls its own content, so the window
+        # height must stay a free variable.
+        return False
+
     def showEvent(self, event) -> None:
         if not event.spontaneous():
             # 「取消（不要保存）」的回滾基準改為每次開啟控制中心時刷新：

--- a/tests/test_dashboard_resize_contract.py
+++ b/tests/test_dashboard_resize_contract.py
@@ -1,0 +1,57 @@
+"""Dashboard window resize contract.
+
+v4.5.1 live report (2026-08-29): the dashboard could be resized from its
+left/right edges but not from the top/bottom edges or any corner.  Cause:
+word-wrapped labels propagate height-for-width up to the top-level layout,
+and Qt then treats the window height as a function of its width, so the
+native frame refuses vertical resizing.  The window overrides
+``hasHeightForWidth`` to keep its height a free variable; this contract
+keeps that override alive.
+"""
+
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtWidgets import QApplication
+
+lazy from infrastructure.db import StudioDB
+
+
+def test_dashboard_height_stays_a_free_variable() -> None:
+    with TemporaryDirectory() as temp_dir:
+        os.environ["LOCALAPPDATA"] = temp_dir
+        db_path = Path(temp_dir) / "YanJianStudio" / "MoHan" / "mohan.db"
+        preflight = StudioDB(db_path)
+        preflight.set_setting("tts_enabled", False)
+        preflight.close()
+        from presentation.companion_window import CompanionWindow
+
+        app = QApplication.instance() or QApplication([])
+        window = CompanionWindow(startup_speech=False)
+        dashboard = window.dashboard
+        try:
+            dashboard.show()
+            app.processEvents()
+            # The layout may legitimately be height-for-width internally
+            # (word-wrapped labels), but the WINDOW must not be: that is what
+            # the native frame consults when deciding whether the top/bottom
+            # edges and corners may resize.
+            assert dashboard.hasHeightForWidth() is False
+            assert dashboard.sizePolicy().hasHeightForWidth() is False
+            assert dashboard.maximumHeight() > dashboard.minimumHeight()
+        finally:
+            dashboard.close()
+            window.close()
+            app.processEvents()
+
+
+if __name__ == "__main__":
+    test_dashboard_height_stays_a_free_variable()
+    print("DASHBOARD_RESIZE_CONTRACT_OK")


### PR DESCRIPTION
## 繁體中文

### 問題（v4.5.1 實機回報，2026-08-29）
控制中心視窗左右邊緣可拖曳調整大小，上下邊緣與四角完全不行。

### 定性（量化實測）
換行文字標籤（wordWrap）把 height-for-width 特性一路傳播到頂層版面——實測 layout `hasHeightForWidth=True`、`minimumSizeHint` 膨脹至 1152×1118。Qt 對這種頂層視窗把高度視為寬度的函數：水平調整被接受（高度隨之計算），**垂直自由調整被原生視框拒絕**——與症狀完全吻合。

### 修法
- `presentation/dashboard_window.py`：視窗覆寫 `hasHeightForWidth()` 回傳 False——高度回歸自由變數；版面內部的換行排版不受影響（layout 自身仍可 hfw）。
- `tests/test_dashboard_resize_contract.py`：契約守門——視窗級 hfw 必須為 False、最大高度必須大於最小高度。
- 誠實聲明：offscreen 已驗證 widget 級判定翻轉；原生視框的實際拖曳行為需擁有者實機確認。

## 简体中文

### 问题（v4.5.1 实机回报，2026-08-29）
控制中心窗口左右边缘可拖拽调整大小，上下边缘与四角完全不行。

### 定性（量化实测）
换行文本标签（wordWrap）把 height-for-width 特性一路传播到顶层布局——实测 layout `hasHeightForWidth=True`、`minimumSizeHint` 膨胀至 1152×1118。Qt 对这种顶层窗口把高度视为宽度的函数：水平调整被接受（高度随之计算），**垂直自由调整被原生窗框拒绝**——与症状完全吻合。

### 修法
- `presentation/dashboard_window.py`：窗口覆写 `hasHeightForWidth()` 返回 False——高度回归自由变量；布局内部的换行排版不受影响。
- `tests/test_dashboard_resize_contract.py`：契约守门——窗口级 hfw 必须为 False、最大高度必须大于最小高度。
- 诚实声明：offscreen 已验证 widget 级判定翻转；原生窗框的实际拖拽行为需所有者实机确认。

## English

### Problem (live report on v4.5.1, 2026-08-29)
The dashboard window resized from its left/right edges, but the top/bottom edges and all four corners refused to drag.

### Diagnosis (measured)
Word-wrapped labels propagate height-for-width all the way up to the top-level layout — measured `hasHeightForWidth=True` with a `minimumSizeHint` inflated to 1152×1118. Qt then treats the window height as a function of its width: horizontal resizes are accepted (height recomputed), while **free vertical resizing is refused by the native frame** — matching the symptom exactly.

### Fix
- `presentation/dashboard_window.py`: the window overrides `hasHeightForWidth()` to return False, making the height a free variable again; internal word-wrap layout is unaffected.
- `tests/test_dashboard_resize_contract.py`: contract gate — window-level hfw must be False and the maximum height must exceed the minimum.
- Honest note: the widget-level flip is verified offscreen; the native frame's actual drag behaviour needs the owner's on-machine confirmation.

## 日本語

### 問題（v4.5.1 実機報告、2026-08-29）
ダッシュボードウィンドウは左右端からはリサイズできるが、上下端と四隅では一切ドラッグできない。

### 定性（計測済み）
折り返しラベル（wordWrap）が height-for-width 特性をトップレベルレイアウトまで伝播——実測で layout `hasHeightForWidth=True`、`minimumSizeHint` は 1152×1118 まで膨張。Qt はこの種のトップレベルウィンドウの高さを幅の関数として扱う：水平リサイズは受理（高さは再計算）される一方、**垂直方向の自由なリサイズはネイティブ枠に拒否される**——症状と完全に一致。

### 修正
- `presentation/dashboard_window.py`：ウィンドウが `hasHeightForWidth()` を False にオーバーライド——高さを自由変数へ戻す；レイアウト内部の折り返し配置は影響を受けない。
- `tests/test_dashboard_resize_contract.py`：契約ゲート——ウィンドウレベルの hfw は False、最大高さは最小高さを上回ること。
- 誠実な注記：offscreen ではウィジェットレベルの判定反転を検証済み；ネイティブ枠の実際のドラッグ挙動は所有者の実機確認が必要。