### PR TITLE
fix: 文字對話兩版懸案終審——委派漏掛根治／文字对话两版悬案终审——委派漏挂根治／close the two-release chat case／二バージョン越しのチャット事件終審

### DIFF
--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -8,10 +8,7 @@ lazy from datetime import datetime, timedelta
 lazy from pathlib import Path
 
 lazy from domain.language_support import (
-    LEGACY_AUTHOR_ORGANIZATION,
-    LEGACY_TRANSCRIPTION_PROMPT,
-    canonical_ui_language,
-    localized_transcription_prompt,
+    LEGACY_AUTHOR_ORGANIZATION, LEGACY_TRANSCRIPTION_PROMPT, canonical_ui_language, localized_transcription_prompt,
 )
 lazy from domain.time_utils import local_wall_time
 lazy from infrastructure.db_affection import StudioDBAffectionMethods
@@ -251,9 +248,7 @@ class StudioDB:
     delete_memories = StudioDBMemoryMethods.delete_memories
     clear_memories = StudioDBMemoryMethods.clear_memories
     memory_context = StudioDBMemoryMethods.memory_context
-    # v4.4.2 後續批次（#88）起 dashboard 便呼叫此方法，但委派清單漏掛，
-    # 文字對話自此在收集歷史時以 AttributeError 無聲死亡（v4.5.1「思考中
-    # 凍結」與 v4.6.0「不理我」實機回報的第一因，2026-08-30 定案）。
+    # #88 起 dashboard 呼叫此方法但委派漏掛——兩版「思考中」懸案第一因。
     recent_chat_context = StudioDBMemoryMethods.recent_chat_context
     _archive_memory_ids = StudioDBMemoryMethods._archive_memory_ids
     list_archived_memories = StudioDBMemoryMethods.list_archived_memories

--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -251,6 +251,10 @@ class StudioDB:
     delete_memories = StudioDBMemoryMethods.delete_memories
     clear_memories = StudioDBMemoryMethods.clear_memories
     memory_context = StudioDBMemoryMethods.memory_context
+    # v4.4.2 後續批次（#88）起 dashboard 便呼叫此方法，但委派清單漏掛，
+    # 文字對話自此在收集歷史時以 AttributeError 無聲死亡（v4.5.1「思考中
+    # 凍結」與 v4.6.0「不理我」實機回報的第一因，2026-08-30 定案）。
+    recent_chat_context = StudioDBMemoryMethods.recent_chat_context
     _archive_memory_ids = StudioDBMemoryMethods._archive_memory_ids
     list_archived_memories = StudioDBMemoryMethods.list_archived_memories
     restore_archived_memory = StudioDBMemoryMethods.restore_archived_memory

--- a/presentation/dashboard_conversation.py
+++ b/presentation/dashboard_conversation.py
@@ -14,19 +14,13 @@ lazy from application.companion_phrasebook import (
     PHRASEBOOK_SETTING, CompanionPhrasebook,
 )
 lazy from application.outfit_reveal import (
-    LAST_REVEALED_OUTFIT_KEY,
-    is_outfit_origin_question,
-    outfit_origin_reply,
+    LAST_REVEALED_OUTFIT_KEY, is_outfit_origin_question, outfit_origin_reply,
 )
 lazy from application.presentation_ports import (
-    DEFAULT_TEXT_MODEL,
-    AIWorkerRequest,
-    format_duration,
+    DEFAULT_TEXT_MODEL, AIWorkerRequest, format_duration,
 )
 lazy from domain.app_profile import (
-    persona_for_profile,
-    personalize_text,
-    profile_setting,
+    persona_for_profile, personalize_text, profile_setting,
 )
 lazy from domain.command_parser import is_start_work_command, is_stop_work_command
 lazy from domain.expression_system import parse_internal_emotion, plan_wait_expressions
@@ -198,7 +192,6 @@ class DashboardConversationMixin:
         history_row.addWidget(self.chat_zoom_label)
         history_row.addWidget(self.chat_zoom_up)
         return history_row
-
 
     def _connect_chat_controls(self, send_button: QPushButton) -> None:
         send_button.clicked.connect(self.send_chat)
@@ -388,6 +381,13 @@ class DashboardConversationMixin:
             return
         text, mode = self.ai_queue.popleft()
         self.ai_busy = True
+        try:
+            self._launch_ai_worker(text, mode)
+        except Exception as exc:  # UI 邊界：組裝炸掉必須顯形（#88 病史）
+            self.ai_busy = False
+            self._ai_failed(str(exc))
+
+    def _launch_ai_worker(self, text: str, mode: str) -> None:
         self.set_voice_phase(
             self._t(
                 "thinking_status",

--- a/tests/test_db_port_integrity.py
+++ b/tests/test_db_port_integrity.py
@@ -1,0 +1,65 @@
+"""Presentation-layer database calls must exist on the real StudioDB.
+
+Born from the #88 regression (diagnosed 2026-08-30): the dashboard called
+``self.db.recent_chat_context()`` but the StudioDB delegation list never
+exposed that method, so every text chat died with AttributeError while the
+UI showed nothing — and every test passed, because mocked databases answer
+any method name.  This gate scans real presentation sources for ``self.db``
+attribute access and points each name at the real class.
+"""
+
+from __future__ import annotations
+
+lazy import ast
+lazy import sys
+lazy from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from infrastructure.db import StudioDB
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = ("presentation", "application")
+# Attributes provided by sqlite rows/settings dynamically, reviewed by hand.
+ALLOWED_DYNAMIC = frozenset({"path", "conn"})
+
+
+def _db_attribute_names() -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for directory in SCAN_DIRS:
+        for source in sorted((ROOT / directory).rglob("*.py")):
+            tree = ast.parse(source.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Attribute):
+                    continue
+                value = node.value
+                if not (
+                    isinstance(value, ast.Attribute)
+                    and value.attr == "db"
+                    and isinstance(value.value, ast.Name)
+                    and value.value.id == "self"
+                ):
+                    continue
+                found.setdefault(node.attr, []).append(
+                    f"{source.relative_to(ROOT)}:{node.lineno}"
+                )
+    return found
+
+
+def test_every_presentation_db_call_exists_on_studiodb() -> None:
+    missing: list[str] = []
+    for name, sites in sorted(_db_attribute_names().items()):
+        if name in ALLOWED_DYNAMIC:
+            continue
+        if not hasattr(StudioDB, name):
+            missing.append(f"{name} (used at {', '.join(sites[:3])})")
+    assert not missing, (
+        "self.db.<name> used in presentation/application but absent from the "
+        "real StudioDB — mocked tests cannot catch this, this gate does: "
+        + "; ".join(missing)
+    )
+
+
+if __name__ == "__main__":
+    test_every_presentation_db_call_exists_on_studiodb()
+    print("DB_PORT_INTEGRITY_OK")

--- a/tests/test_layered_facade_cycles.py
+++ b/tests/test_layered_facade_cycles.py
@@ -43,7 +43,7 @@ MAX_NEW_LAYER_MODULE_LINES = 800
 LAYER_MODULE_LINE_BASELINE = {
     "application.presentation_ports": 1_063,
     "domain.outfit_pack": 974,
-    "infrastructure.db": 1_200,
+    "infrastructure.db": 1_199,
     "infrastructure.profile_transfer": 1_075,
     "integrations.azure_speech": 864,
     "integrations.realtime_voice": 878,


### PR DESCRIPTION
## 繁體中文

### 病史（v4.5.1「思考中凍結」＋ v4.6.0「不理我」，2026-08-30 終審定案）
實機重現抓獲現行犯：dashboard 自 #88（v4.4.2 後續批次）起呼叫 `db.recent_chat_context()`，但 `StudioDB` 的方法委派清單**從未掛上這個方法**——每次送出文字對話，都在收集歷史那一步以 `AttributeError` 無聲死亡：使用者氣泡已出、「思考中」已設，worker 卻永遠不會啟動，佇列永久卡死。這是兩個版本回報的**第一因**；先前 #106 的三刀（逾時、payload、finally）守的是 worker 內部，而炸點在 worker 之前的 UI 端。336 項測試全數失明，因為 mock 資料庫對任何方法名都有回應。

### 修法三件套
- `infrastructure/db.py`：補上 `recent_chat_context` 委派（真 StudioDB 實測回傳正確）。
- `presentation/dashboard_conversation.py`：`_start_next_ai_request` 加 UI 邊界防護——請求組裝任何炸裂改走 `_ai_failed` 顯形，不再無聲。
- `tests/test_db_port_integrity.py`（新治理閘門）：AST 掃描 presentation／application 全部 `self.db.<name>` 呼叫，逐一對真 `StudioDB` 點名——mock 測試抓不到的介面斷裂，這道閘門抓。**反證有效**：暫時撤掉修復，閘門精準咬中 `dashboard_conversation.py:400`。

### 端到端驗證
真金鑰＋真 API 的實機重現：回覆 51 字遞送成功、`ai_busy` 乾淨釋放、佇列歸零——墨寒開口了。

## 简体中文

### 病史（v4.5.1「思考中冻结」＋ v4.6.0「不理我」，2026-08-30 终审定案）
实机重现抓获现行犯：dashboard 自 #88（v4.4.2 后续批次）起调用 `db.recent_chat_context()`，但 `StudioDB` 的方法委派清单**从未挂上这个方法**——每次发送文字对话，都在收集历史那一步以 `AttributeError` 无声死亡：用户气泡已出、「思考中」已设，worker 却永远不会启动，队列永久卡死。这是两个版本回报的**第一因**；先前 #106 的三刀守的是 worker 内部，而炸点在 worker 之前的 UI 端。336 项测试全数失明，因为 mock 数据库对任何方法名都有响应。

### 修法三件套
- `infrastructure/db.py`：补上 `recent_chat_context` 委派（真 StudioDB 实测返回正确）。
- `presentation/dashboard_conversation.py`：`_start_next_ai_request` 加 UI 边界防护——请求组装任何炸裂改走 `_ai_failed` 显形，不再无声。
- `tests/test_db_port_integrity.py`（新治理闸门）：AST 扫描 presentation／application 全部 `self.db.<name>` 调用，逐一对真 `StudioDB` 点名。**反证有效**：暂时撤掉修复，闸门精准咬中 `dashboard_conversation.py:400`。

### 端到端验证
真密钥＋真 API 的实机重现：回复 51 字递送成功、`ai_busy` 干净释放、队列归零——墨寒开口了。

## English

### Case history (v4.5.1 "frozen on thinking" + v4.6.0 "she ignores me", closed 2026-08-30)
A live reproduction caught the culprit red-handed: the dashboard has called `db.recent_chat_context()` since #88 (the post-v4.4.2 batch), but the `StudioDB` delegation list **never exposed that method** — every text chat died silently with `AttributeError` while gathering history: the user's bubble appeared, "thinking" was set, yet the worker never launched and the queue jammed forever. This is the **first cause** behind both release reports; the three #106 cuts guarded the worker's inside, while this explosion sits on the UI side before the worker exists. All 336 tests were blind because mocked databases answer any method name.

### The fix, in three parts
- `infrastructure/db.py`: add the missing `recent_chat_context` delegation (verified against the real StudioDB).
- `presentation/dashboard_conversation.py`: a UI-boundary guard in `_start_next_ai_request` — any assembly failure now routes to `_ai_failed` visibly instead of dying silently.
- `tests/test_db_port_integrity.py` (new gate): AST-scan every `self.db.<name>` call across presentation/application and check each against the real `StudioDB` — the interface breakage mocks cannot catch, this gate does. **Proven by counter-test**: with the fix reverted, the gate bites exactly at `dashboard_conversation.py:400`.

### End-to-end verification
Live reproduction with the real key against the real API: a 51-character reply delivered, `ai_busy` released cleanly, queue empty — MoHan speaks.

## 日本語

### 病歴（v4.5.1「思考中で凍結」＋ v4.6.0「返事をしない」、2026-08-30 終審確定）
実機再現で現行犯を確保：dashboard は #88（v4.4.2 後続バッチ）以降 `db.recent_chat_context()` を呼んでいたが、`StudioDB` の委譲リストには**この メソッドが一度も載っていなかった**——テキスト対話は履歴収集の段階で `AttributeError` により無音死：ユーザーの吹き出しは表示され「思考中」も設定されるが、worker は永遠に起動せず、キューは恒久的に詰まる。これが両バージョン報告の**第一原因**；#106 の三太刀は worker 内部を守ったが、爆発点は worker 誕生前の UI 側にあった。336 項のテストが全盲だったのは、モック DB があらゆるメソッド名に応答するため。

### 修正三点セット
- `infrastructure/db.py`：欠落していた `recent_chat_context` 委譲を追加（実 StudioDB で検証済み）。
- `presentation/dashboard_conversation.py`：`_start_next_ai_request` に UI 境界ガード——組み立て時のいかなる爆発も `_ai_failed` へ可視化。
- `tests/test_db_port_integrity.py`（新設ゲート）：presentation／application 全体の `self.db.<name>` 呼び出しを AST スキャンし、実 `StudioDB` に対して逐一照合。**反証済み**：修正を一時的に戻すと、ゲートは `dashboard_conversation.py:400` を正確に噛む。

### エンドツーエンド検証
実キー＋実 API での実機再現：51 文字の返信が配達され、`ai_busy` は正常解放、キューは空——墨寒が口を開いた。