### PR TITLE
fix: 主題結構疊加層退場——黑帶與滿屏細框根治／主题结构叠加层退场——黑带与满屏细框根治／retire the structural theme overlay — black bands and stray frames cured／テーマ構造オーバーレイ撤去——黒帯と枠散乱を根治

### DIFF
--- a/presentation/dashboard_window.py
+++ b/presentation/dashboard_window.py
@@ -7,7 +7,7 @@ lazy from application.gesture_controller import GestureController
 lazy from application.presentation_ports import PresentationDatabasePort
 lazy from application.theme_pack_service import ThemePackService
 lazy from domain.theme_retint import retint_stylesheet
-lazy from domain.theme_pack import ThemePack, build_stylesheet
+lazy from domain.theme_pack import ThemePack
 lazy from domain.theme_session import ThemeResolution, ThemeSession
 lazy from presentation.dashboard_composition import DashboardDependencies
 lazy from presentation.dashboard_conversation import DashboardConversationMixin
@@ -129,9 +129,13 @@ class Dashboard(
         # appended low-specificity selectors alone lose every cascade fight
         # against the flagship's attribute selectors, which left installed
         # themes as a few stray tinted frames (v4.5.1 report, 2026-08-29).
-        stylesheet = retint_stylesheet(
-            self.styleSheet(), theme.tokens
-        ) + build_stylesheet(theme)
+        # Retint alone recolors the whole flagship shell; the old
+        # build_stylesheet overlay painted every unstyled QFrame with the
+        # pack's dark card color plus a universal border — the black bands
+        # and stray rectangles reported live on v4.6.0 (2026-08-30).  Only
+        # the pack's font choice survives as a non-structural rule.
+        stylesheet = retint_stylesheet(self.styleSheet(), theme.tokens)
+        stylesheet += f"QWidget {{ font-family:'{theme.font_family}'; }}"
         background = self.theme_pack_service.background_path(theme.theme_id)
         if background is not None:
             normalized = background.as_posix().replace("'", "\\'")

--- a/tests/test_theme_retint.py
+++ b/tests/test_theme_retint.py
@@ -76,10 +76,25 @@ def test_full_flagship_stylesheet_recolors_without_structural_drift() -> None:
     assert themed.count("}") == base.count("}")
 
 
+def test_theme_application_never_overlays_structural_rules() -> None:
+    # v4.6.0 live report (2026-08-30): the build_stylesheet overlay painted
+    # every unstyled QFrame with the pack's dark card color plus a universal
+    # border — black bands and stray rectangles across the dashboard.  Theme
+    # application must stay retint-plus-font only.
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "presentation"
+        / "dashboard_window.py"
+    ).read_text(encoding="utf-8")
+    assert "build_stylesheet(theme)" not in source
+    assert "retint_stylesheet" in source
+
+
 if __name__ == "__main__":
     test_neutrals_and_semantic_accents_stay_put()
     test_blue_violet_band_moves_to_theme_family()
     test_rgba_alpha_survives()
     test_neutral_primary_disables_retint()
     test_full_flagship_stylesheet_recolors_without_structural_drift()
+    test_theme_application_never_overlays_structural_rules()
     print("THEME_RETINT_OK")


### PR DESCRIPTION
## 繁體中文

### 問題（v4.6.0 實機回報，2026-08-30）
赤焰劍光套用後：①各分頁每個文字欄位外都有不必要的長方形框；②「今天要做」「創作靈感」拖出突兀的黑色橫帶；③計數文字（幾件未完成、幾則）對比不足難以辨認。

### 定性（實機重現）
offscreen 起真 dashboard 套用赤焰主題，三症完整重現。根因統一：`build_stylesheet` 疊加層把主題的深色 `card` token（`#241A1C`）糊上所有旗艦未明確指定背景的 QFrame（黑帶），並附上通用 `QFrame` 框線（滿屏細框）——與 #108 的 retint 已完成的整體換色互相打架。

### 修法
- `presentation/dashboard_window.py`：主題套用改為「**retint＋主題字型**」二件式，結構疊加層整段退場（背景圖規則保留）。
- `tests/test_theme_retint.py`：新增契約——主題套用源碼不得重新引入 `build_stylesheet(theme)` 疊加。
- 實機對照截圖：修復後黑帶消失、細框消失、對比正常、背景圖透出。

## 简体中文

### 问题（v4.6.0 实机回报，2026-08-30）
赤焰剑光套用后：①各分页每个文字栏位外都有不必要的长方形框；②「今天要做」「创作灵感」拖出突兀的黑色横带；③计数文字对比不足难以辨认。

### 定性（实机重现）
offscreen 起真 dashboard 套用赤焰主题，三症完整重现。根因统一：`build_stylesheet` 叠加层把主题的深色 `card` token（`#241A1C`）糊上所有旗舰未明确指定背景的 QFrame（黑带），并附上通用 `QFrame` 框线（满屏细框）——与 #108 的 retint 已完成的整体换色互相打架。

### 修法
- `presentation/dashboard_window.py`：主题套用改为「**retint＋主题字体**」二件式，结构叠加层整段退场（背景图规则保留）。
- `tests/test_theme_retint.py`：新增契约——主题套用源码不得重新引入 `build_stylesheet(theme)` 叠加。
- 实机对照截图：修复后黑带消失、细框消失、对比正常、背景图透出。

## English

### Problem (live report on v4.6.0, 2026-08-30)
With Crimson Flame Sword-Light applied: ① every text field on every page grew an unnecessary rectangle; ② "Today's tasks" / "Creative ideas" dragged jarring black bands; ③ the counter labels sat at illegible contrast.

### Diagnosis (reproduced live)
A real dashboard rendered offscreen with the crimson theme reproduced all three symptoms. One root cause: the `build_stylesheet` overlay painted the pack's dark `card` token (`#241A1C`) onto every QFrame the flagship left unstyled (the black bands) and added a universal `QFrame` border (the stray rectangles) — fighting the full recolor that the #108 retint already performs.

### Fix
- `presentation/dashboard_window.py`: theme application becomes **retint + pack font** only; the structural overlay is retired (the background-image rule stays).
- `tests/test_theme_retint.py`: a new contract forbids reintroducing the `build_stylesheet(theme)` overlay.
- Before/after live screenshots: bands gone, rectangles gone, contrast restored, backdrop visible.

## 日本語

### 問題（v4.6.0 実機報告、2026-08-30）
赤焔剣光適用後：①全ページの各テキスト欄の外側に不要な長方形枠；②「今日やること」「創作インスピレーション」に唐突な黒帯；③件数ラベルが低コントラストで判読困難。

### 定性（実機再現）
offscreen で実 dashboard に赤焔テーマを適用し、三症状を完全再現。根因は一つ：`build_stylesheet` オーバーレイが、フラッグシップが背景未指定の全 QFrame にパックの暗い `card` トークン（`#241A1C`）を塗り（黒帯）、汎用 `QFrame` 枠線を付与（枠散乱）——#108 の retint が完了済みの全体再着色と衝突していた。

### 修正
- `presentation/dashboard_window.py`：テーマ適用を「**retint＋パックフォント**」の二点のみに変更し、構造オーバーレイを撤去（背景画像規則は維持）。
- `tests/test_theme_retint.py`：`build_stylesheet(theme)` オーバーレイの再導入を禁じる契約を新設。
- 実機ビフォーアフター：黒帯消失、枠消失、コントラスト回復、背景画像が透ける。