### PR TITLE
fix: 日文介面補上保存設定鍵／日文界面补上保存设置键／add the missing Japanese save-settings label／日本語 UI に設定保存ラベルを追加

### DIFF
--- a/presentation/ui_localization.py
+++ b/presentation/ui_localization.py
@@ -591,6 +591,7 @@ _JAPANESE: Mapping[str, str] = deep_freeze({
      'theme_preview': 'テーマプレビュー',
      'theme_section_title': '<b>コントロールセンターのテーマ</b>',
      'theme_restore': 'テーマを元に戻す',
+     'save_settings': '設定を保存',
      'theme_source_official': '炎剣公式',
      'theme_source_user': 'ユーザー制作',
      'package_rejected_unsafe_or_missing': '危険な内容または不足ファイルがあるため、パッケージ全体を拒否しました',


### PR DESCRIPTION
## 繁體中文

補上日文語言表缺漏的 `save_settings` 鍵——原本回退顯示繁中「保存設定」，現改為「設定を保存」。全貌（日文僅 85/483 鍵）另立 issue 由擁有者裁決。

## 简体中文

补上日文语言表缺漏的 `save_settings` 键——原本回退显示繁中“保存設定”，现改为“設定を保存”。全貌（日文仅 85/483 键）另立 issue 由所有者裁决。

## English

Adds the missing `save_settings` key to the Japanese table — it previously fell back to the Traditional Chinese label, and now reads 設定を保存. The full gap (only 85/483 Japanese keys) is filed as a separate issue for the owner to rule on.

## 日本語

日本語テーブルに欠けていた `save_settings` キーを追加——従来は繁体字中国語へフォールバックしていたが、「設定を保存」と表示されるようにした。全体像（日本語は 85/483 キーのみ）は別 issue としてオーナーの裁定に委ねる。
