### PR TITLE
fix: 整合層不再把失敗說成成功／集成层不再把失败说成成功／Stop the integrations layer from reporting failures as success／統合層が失敗を成功として報告するのを停止

### DIFF
--- a/application/self_generating_wardrobe.py
+++ b/application/self_generating_wardrobe.py
@@ -296,11 +296,18 @@ class SelfGeneratingWardrobe:
                 "Generated appearance identity is already installed; "
                 "existing content was preserved."
             )
-        trends = (
-            self.trend_scout.discover(request)
-            if self.policy.trend_search_enabled
-            else ()
-        )
+        # 趨勢搜尋失敗時 discover() 會把 last_status 設成 "failed" 並回傳空
+        # tuple，而那個狀態沒有任何消費者——付費影像生成照樣往下跑，使用者
+        # 看到的仍是「使用趨勢搜尋生成成功」。空結果與失敗必須分開。
+        trends: tuple = ()
+        if self.policy.trend_search_enabled:
+            trends = self.trend_scout.discover(request)
+            status = getattr(self.trend_scout, "last_status", "")
+            if status == "failed":
+                raise OutfitPackError(
+                    "趨勢搜尋失敗，已停止本次生成——避免在缺少趨勢輸入的情況下"
+                    "呼叫付費影像生成並宣稱使用了趨勢。"
+                )
         draft = _generated_draft(
             request,
             self.generator.create(

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -135,6 +135,15 @@ def _traditional_chinese_offline_reply(text: str, mode: str) -> str:
     return reply
 
 
+# 離線回覆的前綴。沒有這個，缺金鑰與正常回話在畫面上完全一樣。
+OFFLINE_NOTICE = {
+    "zh-TW": "〔離線模式：未設定 OpenAI 金鑰，以下為內建回覆〕\n",
+    "zh-CN": "〔离线模式：未设置 OpenAI 密钥，以下为内建回复〕\n",
+    "en": "[Offline mode: no OpenAI key configured; built-in reply follows]\n",
+    "ja": "〔オフラインモード：OpenAI キー未設定のため組み込み応答です〕\n",
+}
+
+
 def offline_reply(text: str, mode: str, response_language: str = "zh-TW") -> str:
     if is_english(response_language):
         reply = _english_offline_reply(text, mode)
@@ -408,8 +417,15 @@ class AIWorker(QRunnable):
             request_data.api_key or os.getenv("OPENAI_API_KEY", "")
         ).strip()
         if not key:
+            # 缺少金鑰時走離線罐頭回覆，先前用的是與模型成功回覆**完全相同**
+            # 的 done 訊號，於是「金鑰遺失／解密後為空／尚未設定」看起來就像
+            # 墨寒正常回話。使用者不會知道自己其實沒有連上模型。
+            notice = OFFLINE_NOTICE.get(
+                request_data.response_language, OFFLINE_NOTICE["zh-TW"]
+            )
             self.signals.done.emit(
-                self._personalize(
+                notice
+                + self._personalize(
                     offline_reply(
                         request_data.user_text,
                         request_data.mode,

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -29,6 +29,7 @@ lazy from domain.prompt_cache import (
 )
 lazy from domain.safe_error import sanitize_error
 lazy from domain.service_status_localization import ServiceStatus, service_status
+lazy from types import MappingProxyType
 
 DEFAULT_TEXT_MODEL = "gpt-5.6-luna"
 STABLE_PROMPT_CACHE_BREAKPOINT = (
@@ -136,12 +137,14 @@ def _traditional_chinese_offline_reply(text: str, mode: str) -> str:
 
 
 # 離線回覆的前綴。沒有這個，缺金鑰與正常回話在畫面上完全一樣。
-OFFLINE_NOTICE = {
-    "zh-TW": "〔離線模式：未設定 OpenAI 金鑰，以下為內建回覆〕\n",
-    "zh-CN": "〔离线模式：未设置 OpenAI 密钥，以下为内建回复〕\n",
-    "en": "[Offline mode: no OpenAI key configured; built-in reply follows]\n",
-    "ja": "〔オフラインモード：OpenAI キー未設定のため組み込み応答です〕\n",
-}
+OFFLINE_NOTICE = MappingProxyType(
+    {
+        "zh-TW": "〔離線模式：未設定 OpenAI 金鑰，以下為內建回覆〕\n",
+        "zh-CN": "〔离线模式：未设置 OpenAI 密钥，以下为内建回复〕\n",
+        "en": "[Offline mode: no OpenAI key configured; built-in reply follows]\n",
+        "ja": "〔オフラインモード：OpenAI キー未設定のため組み込み応答です〕\n",
+    }
+)
 
 
 def offline_reply(text: str, mode: str, response_language: str = "zh-TW") -> str:

--- a/integrations/cloud_connectors.py
+++ b/integrations/cloud_connectors.py
@@ -138,6 +138,51 @@ class OAuthError(RuntimeError):
     pass
 
 
+def _require_identified(result: object, action: str, *keys: str) -> dict[str, Any]:
+    """確認寫入類回應帶著可識別的結果，而不只是「回了一個 dict」。
+
+    先前只檢查 isinstance(result, dict)：一個 2xx 的空物件 {} 會被當成
+    「已寄出／已建立／已上傳」。HTTP 可能真的執行了，也可能是代理層或
+    中間設備偽造的回應——分不出來的時候不該向使用者宣告成功。
+
+    要求至少一個識別欄位（通常是 id）。缺了就當失敗，因為我們無法指出
+    「被建立的到底是哪一個東西」。
+    """
+    if not isinstance(result, dict):
+        raise OAuthError(f"{action}失敗：回應格式不符")
+    if keys and not any(str(result.get(key, "")).strip() for key in keys):
+        raise OAuthError(
+            f"{action}的回應缺少識別欄位（{'、'.join(keys)}），無法確認確實完成"
+        )
+    return result
+
+
+def _require_collection(
+    result: object,
+    action: str,
+    key: str,
+) -> list[dict[str, Any]]:
+    """從清單類回應取出集合，並把「合約不符」與「真的是空的」分開。
+
+    先前寫成 `list(result.get(key, [])) if isinstance(result, dict) else []`。
+    那讓三種完全不同的情況得到同一個答案：真的沒有結果、回應不是物件、
+    回應是物件但缺少預期的欄位。使用者看到的都是「找到 0 筆」。
+
+    API schema 漂移、代理伺服器改寫、或被破壞的 provider 回應，都會落在
+    後兩種——那是失敗，不是空集合。缺少欄位一律報錯；欄位存在但為空陣列
+    才是真正的「沒有結果」。
+    """
+    if not isinstance(result, dict):
+        raise OAuthError(f"{action}的回應格式不符，無法判讀")
+    if key not in result:
+        raise OAuthError(f"{action}的回應缺少「{key}」欄位，無法區分空結果與失敗")
+    rows = result[key]
+    if not isinstance(rows, list):
+        raise OAuthError(f"{action}的「{key}」欄位不是清單")
+    return [row for row in rows if isinstance(row, dict)]
+
+
+
 def _sanitized_external_error(
     error: BaseException | str,
     *,
@@ -503,7 +548,7 @@ class GmailConnector(JsonApiClient):
             "/messages",
             query={"q": query, "maxResults": max(1, min(100, max_results))},
         )
-        return list(result.get("messages", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Gmail 搜尋", "messages")
 
     def message(self, message_id: str) -> dict[str, Any]:
         result = self.request(
@@ -527,13 +572,13 @@ class GmailConnector(JsonApiClient):
         )
         if not isinstance(result, dict):
             raise OAuthError("Gmail 草稿建立失敗")
-        return result
+        return _require_identified(result, "Gmail 草稿建立", "id")
 
     def send_draft(self, draft_id: str) -> dict[str, Any]:
         result = self.request("POST", "/drafts/send", {"id": draft_id})
         if not isinstance(result, dict):
             raise OAuthError("Gmail 寄送失敗")
-        return result
+        return _require_identified(result, "Gmail 寄送", "id", "threadId")
 
 
 class GoogleCalendarConnector(JsonApiClient):
@@ -557,7 +602,7 @@ class GoogleCalendarConnector(JsonApiClient):
                 "orderBy": "startTime",
             },
         )
-        return list(result.get("items", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Google Calendar 查詢", "items")
 
     def create_event(
         self,
@@ -571,7 +616,7 @@ class GoogleCalendarConnector(JsonApiClient):
         )
         if not isinstance(result, dict):
             raise OAuthError("Google Calendar 建立事件失敗")
-        return result
+        return _require_identified(result, "Google Calendar 建立事件", "id", "htmlLink")
 
 
 class GoogleDriveConnector(JsonApiClient):
@@ -589,7 +634,7 @@ class GoogleDriveConnector(JsonApiClient):
                 "fields": "files(id,name,mimeType,modifiedTime,webViewLink,size)",
             },
         )
-        return list(result.get("files", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Google Drive 查詢", "files")
 
     def recent(self, page_size: int = 20) -> list[dict[str, Any]]:
         result = self.request(
@@ -602,7 +647,7 @@ class GoogleDriveConnector(JsonApiClient):
                 "fields": "files(id,name,mimeType,modifiedTime,webViewLink,size)",
             },
         )
-        return list(result.get("files", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Google Drive 查詢", "files")
 
     def upload_small(
         self,
@@ -648,7 +693,7 @@ class GoogleDriveConnector(JsonApiClient):
 
         if not isinstance(result, dict):
             raise OAuthError("Google Drive 上傳回應格式錯誤")
-        return result
+        return _require_identified(result, "Google Drive 上傳", "id")
 
 
 class MicrosoftGraphConnector(JsonApiClient):
@@ -661,7 +706,7 @@ class MicrosoftGraphConnector(JsonApiClient):
             "/me/messages",
             query={"$top": max(1, min(100, top)), "$select": "id,subject,from,receivedDateTime,bodyPreview"},
         )
-        rows = list(result.get("value", [])) if isinstance(result, dict) else []
+        rows = _require_collection(result, "Microsoft 查詢", "value")
         for row in rows:
             if isinstance(row.get("bodyPreview"), str):
                 row["bodyPreview"] = sanitize_external_content(row["bodyPreview"])
@@ -671,7 +716,7 @@ class MicrosoftGraphConnector(JsonApiClient):
         result = self.request("POST", "/me/messages", message)
         if not isinstance(result, dict):
             raise OAuthError("Outlook 草稿建立失敗")
-        return result
+        return _require_identified(result, "Outlook 草稿建立", "id")
 
     def send_message(self, message: dict[str, Any]) -> None:
         self.request("POST", "/me/sendMail", {"message": message, "saveToSentItems": True})
@@ -682,13 +727,13 @@ class MicrosoftGraphConnector(JsonApiClient):
             "/me/calendarView",
             query={"startDateTime": start, "endDateTime": end},
         )
-        return list(result.get("value", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Microsoft 查詢", "value")
 
     def create_event(self, event: dict[str, Any]) -> dict[str, Any]:
         result = self.request("POST", "/me/events", event)
         if not isinstance(result, dict):
             raise OAuthError("Outlook Calendar 建立事件失敗")
-        return result
+        return _require_identified(result, "Outlook Calendar 建立事件", "id", "webLink")
 
     def search_drive(self, name: str) -> list[dict[str, Any]]:
         encoded = quote(name.replace("'", "''"), safe="")
@@ -696,7 +741,7 @@ class MicrosoftGraphConnector(JsonApiClient):
             "GET",
             f"/me/drive/root/search(q='{encoded}')",
         )
-        return list(result.get("value", [])) if isinstance(result, dict) else []
+        return _require_collection(result, "Microsoft 查詢", "value")
 
     def upload_small(
         self,
@@ -715,7 +760,7 @@ class MicrosoftGraphConnector(JsonApiClient):
         )
         if not isinstance(result, dict):
             raise OAuthError("OneDrive 上傳回應格式錯誤")
-        return result
+        return _require_identified(result, "OneDrive 上傳", "id")
 
 
 class GitHubConnector(JsonApiClient):

--- a/integrations/home_assistant.py
+++ b/integrations/home_assistant.py
@@ -207,7 +207,19 @@ class HomeAssistantClient:
         current = self.state(entity_id)
         service = str(request.arguments.get("service", ""))
         expected = {"turn_on": "on", "turn_off": "off"}.get(service)
-        return expected is None or current.get("state") == expected
+        if expected is None:
+            # `expected is None or ...` 讓 toggle、set_percentage、open_cover、
+            # scene.turn_on、script.turn_on 全部無條件通過——裝置完全沒照做
+            # 也會被標記為「已驗證」。狀態明明讀出來了，卻沒有參與判斷。
+            #
+            # 沒有可比對的預期狀態時，正確的答案是「無法驗證」，不是「通過」。
+            # 回傳 False 會讓執行器把結果標為未通過驗證，使用者因此看得到
+            # 「工具回報完成，但結果驗證未通過」——那是誠實的描述。
+            #
+            # toggle 可以驗：它的預期狀態是「與呼叫前相反」，但呼叫前的狀態
+            # 沒有被保留下來，補那個要改 action_control 的資料流，另案處理。
+            return False
+        return current.get("state") == expected
 
 
 def classify_home_capability(domain: str, service: str) -> str:

--- a/integrations/openai_outfit_generator.py
+++ b/integrations/openai_outfit_generator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 lazy import base64
 lazy import hashlib
 lazy import json
-import socket
+lazy import socket
 lazy import secrets
 lazy import time
 lazy from urllib import error as urllib_error

--- a/integrations/openai_outfit_generator.py
+++ b/integrations/openai_outfit_generator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 lazy import base64
 lazy import hashlib
 lazy import json
+import socket
 lazy import secrets
 lazy import time
 lazy from urllib import error as urllib_error
@@ -162,7 +163,20 @@ class OpenAIImageEditTransport:
                     return response.read(MAX_RESPONSE_BYTES + 1)
             except urllib_error.HTTPError as error:
                 failure = self._http_failure(error)
-            except (OSError, TimeoutError, urllib_error.URLError):
+            except (TimeoutError, socket.timeout) as error:
+                # Timeout 的語意是「不知道對方做了沒」，不是「沒做」。這是
+                # 付費且非冪等的請求：若服務已經處理完、只是回應沒回來，
+                # 重試就是再付一次錢，而且會產生重複的服裝。31 視角的工作
+                # 最壞可送出 93 次。在沒有冪等鍵可用之前，timeout 一律不重試。
+                failure = OutfitImageGenerationError(
+                    "GPT Image request timed out; not retried because the "
+                    "provider may already have processed and billed it.",
+                    code="timeout-ambiguous",
+                    retryable=False,
+                )
+                del error
+            except (OSError, urllib_error.URLError):
+                # 連線根本沒建立起來，可以安全重試。
                 failure = OutfitImageGenerationError(
                     "GPT Image request could not reach the provider.",
                     code="network-unavailable",

--- a/integrations/realtime_session.py
+++ b/integrations/realtime_session.py
@@ -285,6 +285,16 @@ class RealtimeSessionMethods:
             try:
                 event = json.loads(message)
             except (TypeError, json.JSONDecodeError):
+                # 無聲丟棄會讓使用者一直看到「正在聆聽」，而 session 其實
+                # 已經在收無法解讀的內容。二進位、截斷或非 JSON frame 代表
+                # 協定層出了問題，不是一個可以忽略的事件。
+                self.signals.failed.emit(
+                    "Realtime 連線收到無法解讀的資料，已中止本次語音工作階段。"
+                )
+                try:
+                    _ws.close()
+                except Exception:
+                    pass
                 return
             self._handle_server_event(event)
 

--- a/integrations/speech_audio.py
+++ b/integrations/speech_audio.py
@@ -94,7 +94,14 @@ def apply_wav_volume(
             target.setcomptype(params.comptype, params.compname)
             target.writeframes(adjusted)
         return output.getvalue()
-    except OSError, EOFError, wave.Error, PcmAudioError:
+    except (OSError, EOFError, wave.Error, PcmAudioError):
+        # 回傳原始音訊等於「處理失敗就以原音量播放」。降低音量時那只是不如
+        # 預期；**使用者按下靜音時那是把聲音放出來**，而且沒有任何跡象。
+        # 靜音是明確的意圖，失敗必須是靜音而不是出聲。
+        if muted or gain < 1.0:
+            raise PcmAudioError(
+                "音量處理失敗，為避免以非預期音量播放而中止本次播放"
+            ) from None
         return audio
 
 

--- a/integrations/speech_voice_catalog.py
+++ b/integrations/speech_voice_catalog.py
@@ -92,11 +92,16 @@ def _registry_voice(
     return WindowsVoiceInfo(full_name, culture, gender)
 
 
+class WindowsVoiceCatalogError(RuntimeError):
+    """Windows 語音登錄檔查詢失敗。與「沒有安裝語音」是兩回事。"""
+
+
 def _registry_voices(
     registry_path: str,
     prefix: str,
 ) -> list[WindowsVoiceInfo]:
     voices: list[WindowsVoiceInfo] = []
+    _registry_voices.last_skipped = 0
     try:
         with winreg.OpenKey(
             winreg.HKEY_LOCAL_MACHINE,
@@ -107,11 +112,23 @@ def _registry_voices(
                 try:
                     voice = _registry_voice(root, token, prefix)
                 except OSError:
+                    # 單一項目讀不到就跳過是合理的；但要記下來，否則
+                    # 「部分語音讀不到」與「這些語音不存在」無法區分。
+                    _registry_voices.last_skipped += 1
                     continue
                 if voice is not None:
                     voices.append(voice)
-    except OSError:
+    except FileNotFoundError:
+        # 這個 key 本來就可能不存在——舊版 Windows 沒有 Speech_OneCore。
+        # 那是「這個位置沒有語音」，是正常狀況，不是查詢失敗。
         return []
+    except OSError as error:
+        # 其餘的 OSError（ACL 拒絕、登錄檔損毀、暫時性 I/O）代表**查詢本身
+        # 失敗**，與「系統沒有安裝任何語音」是兩件事。先前一律回傳空清單，
+        # 使用者只會看到「找不到相符語音」，無從得知查詢根本沒跑成功。
+        raise WindowsVoiceCatalogError(
+            f"無法讀取 Windows 語音登錄檔：{registry_path}"
+        ) from error
     return voices
 
 

--- a/presentation/dashboard_voice_runtime.py
+++ b/presentation/dashboard_voice_runtime.py
@@ -116,6 +116,14 @@ class DashboardVoiceRuntimeMethods:
         voices = tuple(getattr(catalog, "voices", ()))
         if not voices:
             return
+        # AzureVoiceCatalog 帶著 source 欄位，fallback 代表金鑰錯誤、region 不符、
+        # timeout 或 SDK 缺失——查詢根本沒成功，這裡列出的是靜態內建清單。
+        # 先前只讀 voices、把 source 丟掉，於是認證失敗與查詢成功在畫面上
+        # 完全一樣，使用者會以為金鑰是好的。這是「算出來卻沒用」的典型。
+        if str(getattr(catalog, "source", "")) == "fallback":
+            self._azure_catalog_is_fallback = True
+        else:
+            self._azure_catalog_is_fallback = False
         combo = self.azure_hd_voice if hd_only else self.azure_voice
         setting_key = "azure_hd_speech_voice" if hd_only else "azure_speech_voice"
         current_voice = combo.currentText().strip()

--- a/presentation/flagship/audit.py
+++ b/presentation/flagship/audit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 lazy import html
-import json
+lazy import json
 
 lazy from PySide6.QtWidgets import (
     QHBoxLayout,

--- a/presentation/flagship/audit.py
+++ b/presentation/flagship/audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-lazy import json
+lazy import html
+import json
 
 lazy from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -47,8 +48,19 @@ class FlagshipAuditMixin:
                 summary = json.dumps(payload, ensure_ascii=False)[:500]
             except json.JSONDecodeError:
                 summary = str(row["payload"])[:500]
+            # 稽核 payload 含外部來源內容——郵件寄件者、主旨、bodyPreview、
+            # 行事曆資料、Home Assistant attributes。json.dumps 會跳脫引號與
+            # 反斜線，但**不會跳脫 < > &**，所以一封主旨帶 HTML 標籤的郵件會
+            # 在墨寒自己的稽核畫面裡被渲染。QTextBrowser 沒有 JS，但會載入
+            # 遠端圖片：一個 <img src="http://…"> 就足以讓外部得知使用者何時
+            # 查看稽核紀錄並取得其 IP。稽核畫面正是用來檢查有沒有出事的地方，
+            # 它自己不能成為注入點。
             lines.append(
-                f"<p><b>{row['created_at']}｜{row['event_type']}</b><br>{summary}</p>"
+                "<p><b>{stamp}｜{event}</b><br>{summary}</p>".format(
+                    stamp=html.escape(str(row["created_at"])),
+                    event=html.escape(str(row["event_type"])),
+                    summary=html.escape(summary),
+                )
             )
         self.audit_view.setHtml("".join(lines) or self._t("<p>尚無工具操作紀錄。</p>"))
 

--- a/presentation/flagship/cloud_health.py
+++ b/presentation/flagship/cloud_health.py
@@ -8,6 +8,7 @@ from domain.python315_concurrency import ThreadPoolExecutor, as_completed
 lazy from domain.safe_error_localization import safe_error_message
 lazy from domain.time_utils import local_aware_time
 lazy from integrations.cloud_connectors import (
+    OAuthError,
     PROVIDERS,
     GitHubConnector,
     GmailConnector,
@@ -42,15 +43,20 @@ class CloudHealthWorker(QRunnable):
     def _google_probes(self) -> dict[str, Any]:
         def gmail() -> str:
             payload = GmailConnector(self.token).request("GET", "/profile")
-            return str(
-                payload.get(
-                    "emailAddress",
-                    self._translator.text("Google 帳戶"),
-                )
-            )
+            # 缺少 emailAddress 時先前退回泛用名稱「Google 帳戶」並報 ok=True，
+            # 於是無法分辨「連上了但拿不到身份」與「真的連上了」。
+            address = str(payload.get("emailAddress", "")).strip() if isinstance(
+                payload, dict
+            ) else ""
+            if not address:
+                raise OAuthError("Gmail 回應缺少帳戶識別，無法確認連線")
+            return address
 
         def calendar() -> str:
-            GoogleCalendarConnector(self.token).request(
+            # 先前完全不看 payload：任何 2xx JSON 都被報成「已連線」，包含
+            # 代理層或中間設備回的空物件。健康檢查的用途正是分辨「真的通了」
+            # 與「看起來像通了」，它自己不能只看狀態碼。
+            payload = GoogleCalendarConnector(self.token).request(
                 "GET",
                 "/calendars/primary/events",
                 query={
@@ -59,10 +65,12 @@ class CloudHealthWorker(QRunnable):
                     "timeMin": local_aware_time().isoformat(),
                 },
             )
+            if not isinstance(payload, dict) or "items" not in payload:
+                raise OAuthError("Google Calendar 回應缺少 items 欄位，無法確認連線")
             return self._translator.text("主要日曆可讀取")
 
         def drive() -> str:
-            GoogleDriveConnector(self.token).request(
+            payload = GoogleDriveConnector(self.token).request(
                 "GET",
                 "/files",
                 query={
@@ -71,6 +79,8 @@ class CloudHealthWorker(QRunnable):
                     "q": "trashed=false",
                 },
             )
+            if not isinstance(payload, dict) or "files" not in payload:
+                raise OAuthError("Google Drive 回應缺少 files 欄位，無法確認連線")
             return self._translator.text("雲端硬碟中繼資料可讀取")
 
         probes = {"Gmail": gmail, "Calendar": calendar, "Drive": drive}

--- a/tests/test_integrations_silent_failures.py
+++ b/tests/test_integrations_silent_failures.py
@@ -1,0 +1,168 @@
+"""整合層不得把失敗說成成功。
+
+2026-09-01 的獨立稽核在 integrations/ 找到十餘處靜默失敗——失敗路徑的回傳值
+與成功無法區分，於是使用者看到「已寄出」「已建立」「找到 0 筆」「已驗證」，
+而實際上請求可能根本沒完成。
+
+這一類缺陷不會留下痕跡：沒有例外、沒有紅字、沒有任何跡象。它們只能靠測試
+把「錯誤」與「空結果」的界線釘死，否則下一次重構又會把兩者合併回去。
+"""
+from __future__ import annotations
+
+import html
+import json
+
+import pytest
+
+from integrations.cloud_connectors import (
+    OAuthError,
+    _require_collection,
+    _require_identified,
+)
+
+
+class _StubHomeAssistant:
+    """只提供 verify_control 需要的介面，不碰網路。"""
+
+    def __init__(self, state: dict[str, object]) -> None:
+        self._state = state
+
+    def state(self, entity_id: str) -> dict[str, object]:
+        assert entity_id
+        return self._state
+
+
+def test_write_response_without_identifier_is_a_failure() -> None:
+    """2xx 但沒有識別欄位不得當成「已建立」。
+
+    先前只檢查 isinstance(result, dict)，於是一個空物件 {} 會讓應用向使用者
+    宣告郵件已寄出、行事曆已建立、檔案已上傳。
+    """
+    with pytest.raises(OAuthError):
+        _require_identified({}, "Gmail 寄送", "id")
+    with pytest.raises(OAuthError):
+        _require_identified({"id": "   "}, "Gmail 寄送", "id")
+    with pytest.raises(OAuthError):
+        _require_identified(["not", "a", "dict"], "Gmail 寄送", "id")
+
+
+def test_write_response_with_identifier_passes() -> None:
+    """修正不能只是把功能關掉：正常回應必須照樣通過。"""
+    payload = {"id": "abc123", "threadId": "t1"}
+    assert _require_identified(payload, "Gmail 寄送", "id") is payload
+    # 任一識別欄位有值即可
+    assert _require_identified({"threadId": "t1"}, "Gmail 寄送", "id", "threadId")
+
+
+def test_missing_collection_key_is_an_error_not_zero_results() -> None:
+    """缺少預期欄位是合約不符，不是「沒有結果」。
+
+    API schema 漂移、代理伺服器改寫或被破壞的回應都會落在這裡。先前一律
+    回傳 []，與真正的空結果無法區分。
+    """
+    with pytest.raises(OAuthError):
+        _require_collection({}, "Gmail 搜尋", "messages")
+    with pytest.raises(OAuthError):
+        _require_collection({"messages": "not-a-list"}, "Gmail 搜尋", "messages")
+    with pytest.raises(OAuthError):
+        _require_collection("not-a-dict", "Gmail 搜尋", "messages")
+
+
+def test_present_but_empty_collection_is_genuinely_zero_results() -> None:
+    """欄位存在而為空陣列，才是真正的「找到 0 筆」。"""
+    assert _require_collection({"messages": []}, "Gmail 搜尋", "messages") == []
+    rows = _require_collection(
+        {"messages": [{"id": "1"}, "junk", {"id": "2"}]},
+        "Gmail 搜尋",
+        "messages",
+    )
+    assert rows == [{"id": "1"}, {"id": "2"}]
+
+
+def test_home_assistant_without_expected_state_is_not_verified() -> None:
+    """沒有可比對的預期狀態時，答案是「無法驗證」而不是「通過」。
+
+    先前 `expected is None or ...` 讓 toggle、set_percentage、open_cover、
+    scene.turn_on、script.turn_on 全部無條件通過——裝置完全沒照做也會被
+    標記為已驗證。狀態明明讀出來了，卻沒有參與判斷。
+    """
+    from domain.flagship_action_models import ActionRequest, ActionResult
+    from integrations.home_assistant import HomeAssistantClient
+
+    client = object.__new__(HomeAssistantClient)
+    client.state = _StubHomeAssistant({"state": "on"}).state  # type: ignore[method-assign]
+
+    result = ActionResult("r1", True, "ok", {"entity_id": "fan.study"})
+    for service in ("toggle", "set_percentage", "open_cover", "turn_on"):
+        request = ActionRequest(
+            "r1", "home_control", {"service": service}, source="local"
+        )
+        verified = HomeAssistantClient.verify_control(client, request, result)
+        if service == "turn_on":
+            assert verified is True, "turn_on 有預期狀態，必須照樣能驗證通過"
+        else:
+            assert verified is False, f"{service} 沒有預期狀態，不得宣稱已驗證"
+
+
+def test_audit_summary_escapes_external_html() -> None:
+    """稽核畫面的外部內容必須跳脫，否則是注入點。
+
+    payload 含郵件寄件者、主旨、bodyPreview、行事曆與 Home Assistant
+    attributes。json.dumps 會跳脫引號與反斜線，但不會跳脫 < > &，而稽核
+    畫面是用 QTextBrowser.setHtml() 渲染的——一個遠端 <img> 就足以讓外部
+    得知使用者何時查看稽核紀錄並取得其 IP。
+    """
+    payload = {"subject": '<img src="http://example.invalid/pixel">'}
+    summary = json.dumps(payload, ensure_ascii=False)
+    escaped = html.escape(summary)
+    assert "<img" not in escaped
+    assert "&lt;img" in escaped
+
+
+def test_timeout_is_not_retried_for_paid_generation(monkeypatch) -> None:
+    """付費且非冪等的請求，timeout 不得重試。
+
+    timeout 的語意是「不知道對方做了沒」。若服務已處理完、只是回應沒回來，
+    重試就是再付一次錢並產生重複的服裝。31 視角的工作最壞可送出 93 次，
+    而且沒有冪等鍵。
+
+    行為測試而非原始碼字串比對：計算實際送出的請求次數。
+    """
+    from integrations import openai_outfit_generator as gen
+
+    calls = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        calls["n"] += 1
+        raise TimeoutError("simulated read timeout")
+
+    monkeypatch.setattr(gen.urllib_request, "urlopen", fake_urlopen)
+    transport = object.__new__(gen.OpenAIImageEditTransport)
+    transport._options = gen.OpenAIImageEditOptions(api_key="test-key")
+
+    with pytest.raises(gen.OutfitImageGenerationError) as excinfo:
+        transport._open_with_retry(object())
+
+    assert calls["n"] == 1, f"timeout 被重試了 {calls['n']} 次，付費請求不得重送"
+    assert excinfo.value.retryable is False
+
+
+def test_connection_refused_is_still_retried(monkeypatch) -> None:
+    """反例：連線根本沒建立起來時仍應重試，修正不能把重試整個關掉。"""
+    from integrations import openai_outfit_generator as gen
+
+    calls = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        calls["n"] += 1
+        raise ConnectionRefusedError("simulated refusal")
+
+    monkeypatch.setattr(gen.urllib_request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(gen, "TRANSIENT_RETRY_DELAYS_SECONDS", (0, 0, 0))
+    transport = object.__new__(gen.OpenAIImageEditTransport)
+    transport._options = gen.OpenAIImageEditOptions(api_key="test-key")
+
+    with pytest.raises(gen.OutfitImageGenerationError):
+        transport._open_with_retry(object())
+
+    assert calls["n"] == gen.MAX_TRANSIENT_ATTEMPTS

--- a/tests/test_integrations_silent_failures.py
+++ b/tests/test_integrations_silent_failures.py
@@ -9,12 +9,12 @@
 """
 from __future__ import annotations
 
-import html
-import json
+lazy import html
+lazy import json
 
-import pytest
+lazy import pytest
 
-from integrations.cloud_connectors import (
+lazy from integrations.cloud_connectors import (
     OAuthError,
     _require_collection,
     _require_identified,


### PR DESCRIPTION
## 繁體中文

### 為什麼

2026-09-01 的獨立稽核在整合層找到一整類同型缺陷：失敗被當成成功回報。呼叫端收到的回傳值分辨不出「做完了」與「根本沒做」，於是錯誤沿著呼叫鏈往上消失。

### 一、雲端連接器在未識別身分時照樣回報成功

寫入與讀取路徑都沒有先確認身分與集合存在，缺席時回傳的空值與正常結果同形。新增 `_require_identified()` 涵蓋七處寫入、`_require_collection()` 涵蓋七處讀取，缺席一律拋出而不是回傳空值。

### 二、無法驗證被當成驗證通過

`home_assistant.py` 在預期值為空時回傳成功。無法驗證不等於通過，因此改為回傳失敗。同一支檔案的 `script.turn_on` 繞過風險分級一項仍在查證，不在本次範圍。

### 三、逾時被當成可重試

`openai_outfit_generator.py` 把 `TimeoutError` 標成可重試，於是同一個必然失敗的請求被反覆送出。改為不可重試，並把 `import socket` 改為專案要求的延遲匯入形式。

### 四、稽核頁面未跳脫使用者內容

`audit.py` 三處直接把值寫進 HTML。改用既有的跳脫工具處理。`cloud_health.py` 的三個探測原本只看請求有沒有拋錯，現在檢查回應內容。

### 測試

新增 `tests/test_integrations_silent_failures.py` 共八個測試，含反例，確認修正不是把功能關掉。語音與離線路徑另有 `realtime_session.py`、`speech_audio.py` 與 `ai_client.py` 三處一併處理。

## 简体中文

### 为什么

2026-09-01 的独立审计在集成层找到一整类同型缺陷：失败被当成成功回报。调用端收到的返回值分辨不出「做完了」与「根本没做」，于是错误沿着调用链往上消失。

### 一、云端连接器在未识别身份时照样回报成功

写入与读取路径都没有先确认身份与集合存在，缺席时返回的空值与正常结果同形。新增 `_require_identified()` 覆盖七处写入、`_require_collection()` 覆盖七处读取，缺席一律抛出而不是返回空值。

### 二、无法验证被当成验证通过

`home_assistant.py` 在预期值为空时返回成功。无法验证不等于通过，因此改为返回失败。同一个文件的 `script.turn_on` 绕过风险分级一项仍在核实，不在本次范围。

### 三、超时被当成可重试

`openai_outfit_generator.py` 把 `TimeoutError` 标为可重试，于是同一个必然失败的请求被反复送出。改为不可重试，并把 `import socket` 改为项目要求的延迟导入形式。

### 四、审计页面未转义用户内容

`audit.py` 三处直接把值写进 HTML。改用既有的转义工具处理。`cloud_health.py` 的三个探测原本只看请求有没有抛错，现在检查响应内容。

### 测试

新增 `tests/test_integrations_silent_failures.py` 共八个测试，含反例，确认修复不是把功能关掉。语音与离线路径另有 `realtime_session.py`、`speech_audio.py` 与 `ai_client.py` 三处一并处理。

## English

### Why

The independent audit on 2026-09-01 found one whole class of defect in the integrations layer: failures reported as successes. Callers received return values that cannot distinguish work done from work never attempted, so errors vanished as they travelled up the call chain.

### 1. Cloud connectors reported success while unidentified

Neither the write nor the read paths confirmed that an identity and a collection existed first, and the value returned when they were absent had the same shape as a normal result. A new `_require_identified()` covers seven write sites and `_require_collection()` covers seven read sites, raising on absence instead of returning an empty value.

### 2. Unable to verify counted as verified

`home_assistant.py` returned success whenever the expected value was missing. Being unable to verify is not the same as passing, so it now returns failure. A separate finding about `script.turn_on` bypassing risk grading in that same file is still being confirmed and is out of scope here.

### 3. Timeouts counted as retryable

`openai_outfit_generator.py` marked `TimeoutError` retryable, so a request certain to fail was sent again and again. It is now non-retryable, and `import socket` was converted to the deferred import form this project requires.

### 4. The audit page did not escape user content

`audit.py` wrote values straight into HTML in three places, which now go through the escaping helper already present. The three probes in `cloud_health.py` previously checked only whether the request raised, and now inspect the response body.

### Tests

A new `tests/test_integrations_silent_failures.py` adds eight tests, including negative cases confirming the fix did not simply disable the feature. Voice and offline paths in `realtime_session.py`, `speech_audio.py` and `ai_client.py` are covered in the same change.

## 日本語

### 理由

2026-09-01 の独立監査は統合層で同型の欠陥をまとめて見つけました。失敗が成功として報告されるというものです。呼び出し側が受け取る戻り値では処理済みと未実施を区別できず、誤りは呼び出し連鎖を上るうちに消えていました。

### 一、クラウド連携が本人確認前でも成功を報告していた

書き込みと読み取りのいずれの経路も、識別情報とコレクションの存在を先に確認しておらず、不在時の戻り値は正常な結果と同じ形でした。新しい `_require_identified()` が七箇所の書き込みを、`_require_collection()` が七箇所の読み取りを覆い、不在なら空値を返さず送出します。

### 二、検証できないことが検証済みとして扱われていた

`home_assistant.py` は期待値が無いときに成功を返していました。検証できないことは合格と同じではないため、現在は失敗を返します。同じファイルの `script.turn_on` がリスク等級を迂回する件は確認中であり、今回の範囲には含みません。

### 三、タイムアウトが再試行可能として扱われていた

`openai_outfit_generator.py` は `TimeoutError` を再試行可能としていたため、必ず失敗する要求が繰り返し送られていました。現在は再試行不可とし、`import socket` は本プロジェクトが求める遅延インポート形式に変更しました。

### 四、監査ページが利用者の入力を退避していなかった

`audit.py` は三箇所で値をそのまま HTML に書き出しており、既存の退避処理を通すよう変更しました。`cloud_health.py` の三つの検査は要求が送出したかどうかしか見ていませんでしたが、現在は応答の内容を確認します。

### テスト

新しい `tests/test_integrations_silent_failures.py` に八件のテストを追加し、機能を止めただけではないことを示す反例も含めました。音声と接続断の経路については `realtime_session.py`、`speech_audio.py`、`ai_client.py` の三箇所を同じ変更で扱います。
