### PR TITLE
fix: 可攜匯出不再夾帶已刪除的內容／可携导出不再夹带已删除的内容／Stop the portable export from carrying deleted content／ポータブルエクスポートが削除済みデータを持ち出す問題を修正

### DIFF
--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -264,7 +264,16 @@ class StudioDB:
     def __init__(self, path: Path):
         path.parent.mkdir(parents=True, exist_ok=True)
         self.path = path
-        self.existing_install = path.exists() and path.stat().st_size > 0
+        # 零位元組資料庫是損毀，不是全新安裝。斷電、雲端同步中斷或複製失敗
+        # 都會留下 0-byte 檔；SQLite 會把它當成空資料庫，於是下次啟動成功
+        # 建立新 schema，使用者看到一份預設 profile，接著正常操作開始往上
+        # 寫——原本的資料還在備份裡，但使用者沒有理由知道要去還原。
+        #
+        # 空檔與真正首次安裝完全不可區分，所以必須在建立連線之前就分辨：
+        # 檔案存在但長度為零 → 明確標記，讓上層能提示還原而不是靜靜重來。
+        existing_file = path.exists()
+        self.corrupt_empty_database = existing_file and path.stat().st_size == 0
+        self.existing_install = existing_file and path.stat().st_size > 0
         self.conn = sqlite3.connect(path)
         self.conn.row_factory = sqlite3.Row
         self._memory_index = MemoryVectorIndex()

--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -14,6 +14,7 @@ lazy from domain.time_utils import local_wall_time
 lazy from infrastructure.db_affection import StudioDBAffectionMethods
 lazy from infrastructure.db_memory import StudioDBMemoryMethods
 lazy from infrastructure.memory_index import MemoryVectorIndex
+lazy from infrastructure.sqlite_safety import classify_db_file, table_column_names
 
 MAX_MEMORY_TITLE_LENGTH = 36
 
@@ -264,10 +265,7 @@ class StudioDB:
     def __init__(self, path: Path):
         path.parent.mkdir(parents=True, exist_ok=True)
         self.path = path
-        # 零位元組是損毀不是全新安裝，連線前就要分辨（見測試的說明）。
-        size = path.stat().st_size if path.exists() else -1
-        self.corrupt_empty_database = size == 0
-        self.existing_install = size > 0
+        self.corrupt_empty_database, self.existing_install = classify_db_file(path)
         self.conn = sqlite3.connect(path)
         self.conn.row_factory = sqlite3.Row
         self._memory_index = MemoryVectorIndex()
@@ -402,11 +400,6 @@ class StudioDB:
         self._migrate_existing_profile()
         self.conn.commit()
 
-    def _table_columns(self, table: str) -> set[str]:
-        return {
-            str(row["name"]) for row in self.conn.execute(f"PRAGMA table_info({table})")
-        }
-
     def _ensure_columns(
         self,
         table: str,
@@ -420,7 +413,7 @@ class StudioDB:
                 )
 
     def _migrate_ideas(self) -> None:
-        columns = self._table_columns("ideas")
+        columns = table_column_names(self.conn, "ideas")
         legacy_source = (
             "text" if "text" in columns else "body" if "body" in columns else None
         )
@@ -435,7 +428,7 @@ class StudioDB:
         )
 
     def _migrate_memories(self) -> None:
-        columns = self._table_columns("memories")
+        columns = table_column_names(self.conn, "memories")
         self._ensure_columns("memories", MEMORY_COLUMN_DEFINITIONS, columns)
         self.conn.execute(
             "UPDATE memories SET updated_at=created_at WHERE COALESCE(updated_at,'')=''"
@@ -458,7 +451,7 @@ class StudioDB:
             )
 
     def _migrate_platform_progress(self) -> None:
-        columns = self._table_columns("platform_progress")
+        columns = table_column_names(self.conn, "platform_progress")
         self._ensure_columns(
             "platform_progress",
             PLATFORM_COLUMN_DEFINITIONS,

--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -264,16 +264,10 @@ class StudioDB:
     def __init__(self, path: Path):
         path.parent.mkdir(parents=True, exist_ok=True)
         self.path = path
-        # 零位元組資料庫是損毀，不是全新安裝。斷電、雲端同步中斷或複製失敗
-        # 都會留下 0-byte 檔；SQLite 會把它當成空資料庫，於是下次啟動成功
-        # 建立新 schema，使用者看到一份預設 profile，接著正常操作開始往上
-        # 寫——原本的資料還在備份裡，但使用者沒有理由知道要去還原。
-        #
-        # 空檔與真正首次安裝完全不可區分，所以必須在建立連線之前就分辨：
-        # 檔案存在但長度為零 → 明確標記，讓上層能提示還原而不是靜靜重來。
-        existing_file = path.exists()
-        self.corrupt_empty_database = existing_file and path.stat().st_size == 0
-        self.existing_install = existing_file and path.stat().st_size > 0
+        # 零位元組是損毀不是全新安裝，連線前就要分辨（見測試的說明）。
+        size = path.stat().st_size if path.exists() else -1
+        self.corrupt_empty_database = size == 0
+        self.existing_install = size > 0
         self.conn = sqlite3.connect(path)
         self.conn.row_factory = sqlite3.Row
         self._memory_index = MemoryVectorIndex()

--- a/infrastructure/db_memory.py
+++ b/infrastructure/db_memory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 lazy import json
 lazy import re
 lazy import sqlite3
-lazy from datetime import datetime
+lazy from datetime import datetime, timedelta
 
 lazy from domain.text_normalizer import to_taiwan_traditional
 lazy from domain.time_utils import local_wall_time
@@ -15,6 +15,10 @@ MAX_TITLE_LENGTH = 36
 MAX_MEMORIES = 500
 LOW_IMPORTANCE_THRESHOLD = 2
 MEMORY_AGE_DAYS = 90
+
+
+# 稽核與已完成待辦的保留天數。optimize_database() 只刪除比這更舊的列。
+RETENTION_DAYS = 90
 
 
 class StudioDBMemoryMethods:
@@ -428,25 +432,41 @@ class StudioDBMemoryMethods:
         database small and responsive.  This is safe to call from a background
         worker because it only touches rows that are safe to remove.
         """
-        now = local_wall_time().isoformat(timespec="seconds")
+        # cutoff 原本是「現在」，於是這個宣稱「bounded cleanup of old rows」的
+        # 函式實際上會刪掉**每一筆**已完成待辦與**整個**稽核紀錄。目前沒有
+        # 呼叫者，但任何人接一個「最佳化資料庫」按鈕上去，就會清空使用者的
+        # 全部歷史，而且回報看起來一切正常。
+        cutoff = (
+            local_wall_time() - timedelta(days=RETENTION_DAYS)
+        ).isoformat(timespec="seconds")
         pruned_todos = 0
         pruned_audit = 0
         try:
             cursor = self.conn.execute(
                 "DELETE FROM todos WHERE status='完成' AND completed_at IS NOT NULL "
                 "AND completed_at < ?",
-                (now,),
+                (cutoff,),
             )
             pruned_todos = max(0, int(cursor.rowcount))
             cursor = self.conn.execute(
                 "DELETE FROM action_audit WHERE created_at < ?",
-                (now,),
+                (cutoff,),
             )
             pruned_audit = max(0, int(cursor.rowcount))
             self.conn.commit()
+        except sqlite3.Error:
+            self.conn.rollback()
+            return {"pruned_todos": 0, "pruned_audit": 0, "vacuumed": False}
+        try:
             self.conn.execute("VACUUM")
         except sqlite3.Error:
-            return {"pruned_todos": 0, "pruned_audit": 0, "vacuumed": False}
+            # 刪除已經 commit 了。先前在這裡回報 pruned=0，等於謊報——
+            # 呼叫端會以為什麼都沒發生，實際上資料已經永久消失。
+            return {
+                "pruned_todos": pruned_todos,
+                "pruned_audit": pruned_audit,
+                "vacuumed": False,
+            }
         return {
             "pruned_todos": pruned_todos,
             "pruned_audit": pruned_audit,

--- a/infrastructure/profile_transfer.py
+++ b/infrastructure/profile_transfer.py
@@ -61,6 +61,7 @@ lazy from infrastructure.special_occasion_store import (
 lazy from infrastructure.wellbeing_reminder_store import (
     PORTABLE_SETTING_KEYS as WELLBEING_PORTABLE_SETTING_KEYS,
 )
+lazy from infrastructure.sqlite_safety import enable_secure_delete, table_columns
 
 PROFILE_EXTENSION = ".mohan-profile"
 PROFILE_FORMAT_VERSION = 1
@@ -257,13 +258,6 @@ class PortableProfileManager:
         self.backup_dir = backup_dir
 
     @staticmethod
-    def _table_columns(
-        connection: sqlite3.Connection,
-        table: str,
-    ) -> list[sqlite3.Row]:
-        return list(connection.execute(f'PRAGMA table_info("{table}")'))
-
-    @staticmethod
     def _table_names(connection: sqlite3.Connection) -> set[str]:
         return {
             str(row[0])
@@ -403,8 +397,7 @@ class PortableProfileManager:
         snapshot.row_factory = sqlite3.Row
         try:
             snapshot.execute("PRAGMA trusted_schema=OFF")
-            # DELETE 只標記頁面可重用，內容仍在檔案裡（見測試的說明）。
-            snapshot.execute("PRAGMA secure_delete=ON")
+            enable_secure_delete(snapshot)
             self._delete_nonportable_settings(snapshot)
             self._clear_machine_bound_tables(snapshot)
             snapshot.commit()
@@ -822,10 +815,10 @@ class PortableProfileManager:
         incoming: sqlite3.Connection,
         table: str,
     ) -> PortableTablePayload:
-        target_info = self._table_columns(self.db.conn, table)
+        target_info = table_columns(self.db.conn, table)
         source_names = {
             str(row["name"])
-            for row in self._table_columns(incoming, table)
+            for row in table_columns(incoming, table)
         }
         columns = tuple(
             str(row["name"])

--- a/infrastructure/profile_transfer.py
+++ b/infrastructure/profile_transfer.py
@@ -403,15 +403,7 @@ class PortableProfileManager:
         snapshot.row_factory = sqlite3.Row
         try:
             snapshot.execute("PRAGMA trusted_schema=OFF")
-            # SQLite 的 DELETE 只把頁面標記為可重用，內容仍留在檔案裡。
-            # 這個功能存在的唯一目的就是把 action_audit（含剪貼簿與檔案內容）、
-            # connector_profiles、allowed_targets、paired_devices 與非可攜設定
-            # 排除在匯出檔之外——但先前只做 DELETE 就直接打包原始 SQLite 檔，
-            # 那些位元組原封不動地跟著走。使用者以為分享的是乾淨的設定檔。
-            #
-            # secure_delete=ON 讓刪除當下就把頁面內容歸零；VACUUM 再把整個
-            # 資料庫重寫一次，丟掉所有空閒頁面。兩者都要：secure_delete 管
-            # 這一次刪除，VACUUM 管快照複製過來時就已經存在的舊空閒頁。
+            # DELETE 只標記頁面可重用，內容仍在檔案裡（見測試的說明）。
             snapshot.execute("PRAGMA secure_delete=ON")
             self._delete_nonportable_settings(snapshot)
             self._clear_machine_bound_tables(snapshot)

--- a/infrastructure/profile_transfer.py
+++ b/infrastructure/profile_transfer.py
@@ -403,9 +403,20 @@ class PortableProfileManager:
         snapshot.row_factory = sqlite3.Row
         try:
             snapshot.execute("PRAGMA trusted_schema=OFF")
+            # SQLite 的 DELETE 只把頁面標記為可重用，內容仍留在檔案裡。
+            # 這個功能存在的唯一目的就是把 action_audit（含剪貼簿與檔案內容）、
+            # connector_profiles、allowed_targets、paired_devices 與非可攜設定
+            # 排除在匯出檔之外——但先前只做 DELETE 就直接打包原始 SQLite 檔，
+            # 那些位元組原封不動地跟著走。使用者以為分享的是乾淨的設定檔。
+            #
+            # secure_delete=ON 讓刪除當下就把頁面內容歸零；VACUUM 再把整個
+            # 資料庫重寫一次，丟掉所有空閒頁面。兩者都要：secure_delete 管
+            # 這一次刪除，VACUUM 管快照複製過來時就已經存在的舊空閒頁。
+            snapshot.execute("PRAGMA secure_delete=ON")
             self._delete_nonportable_settings(snapshot)
             self._clear_machine_bound_tables(snapshot)
             snapshot.commit()
+            snapshot.execute("VACUUM")
             snapshot.execute("PRAGMA journal_mode=DELETE")
             self._assert_integrity(
                 snapshot,

--- a/infrastructure/secret_store.py
+++ b/infrastructure/secret_store.py
@@ -52,7 +52,17 @@ class SecretStore:
         try:
             encrypted = ctypes.string_at(output.pbData, output.cbData)
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            self.path.write_bytes(encrypted)
+            # 原子寫入。先前直接覆寫正式檔案，斷電或磁碟寫入失敗會留下
+            # 截斷的 DPAPI blob；下一次 load() 解密失敗回傳空字串，而空字串
+            # 與「尚未設定」無法區分——臉部 identity 會被當成零個 profile、
+            # 手勢模板被當成空字典，接著新增一筆就把殘骸覆寫成新的真相。
+            # 憑證、生物特徵與模板就這樣靜靜消失。
+            temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+            with open(temporary, "wb") as handle:
+                handle.write(encrypted)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
         finally:
             ctypes.windll.kernel32.LocalFree(output.pbData)
 

--- a/infrastructure/sqlite_safety.py
+++ b/infrastructure/sqlite_safety.py
@@ -1,0 +1,49 @@
+"""SQLite 檔案層級的安全檢查。
+
+2026-09-01 的稽核在持久化層找到兩個缺陷，成因是同一件事：SQLite 對檔案狀態
+的回答不能照字面採信。刪除的資料仍在檔案裡，而長度為零的檔案會被當成一個
+合法的空資料庫。兩者都不會拋錯，因此呼叫端不會知道出了事。
+
+這些判斷原本各自寫在 `db.py` 與 `profile_transfer.py` 裡，`PRAGMA table_info`
+的包裝更是兩邊各一份。集中在這裡，是為了讓「SQLite 說的話要怎麼解讀」只有
+一個答案。
+"""
+from __future__ import annotations
+
+lazy import sqlite3
+lazy from pathlib import Path
+
+
+def classify_db_file(path: Path) -> tuple[bool, bool]:
+    """回傳 (是否為零位元組損毀, 是否為既有安裝)。
+
+    零位元組資料庫是損毀，不是全新安裝。斷電、雲端同步中斷或複製失敗都會
+    留下 0-byte 檔；SQLite 會把它當成空資料庫，於是下次啟動成功建立新結構，
+    使用者看到一份預設設定並開始往上寫。原本的資料還在備份裡，但使用者沒有
+    理由知道要去還原。
+
+    必須在建立連線之前分辨：檔案存在但長度為零，與真正的首次安裝，在連線
+    之後就完全無法區分了。
+    """
+    size = path.stat().st_size if path.exists() else -1
+    return size == 0, size > 0
+
+
+def enable_secure_delete(connection: sqlite3.Connection) -> None:
+    """讓後續的 DELETE 當下就把頁面內容歸零。
+
+    `DELETE` 只把頁面標記為可重用，內容仍留在檔案裡。要把資料真的排除在
+    匯出檔之外，這個設定與事後的 `VACUUM` 兩者都要：這個設定管接下來的
+    刪除，`VACUUM` 管快照複製過來時就已經存在的舊空閒頁。
+    """
+    connection.execute("PRAGMA secure_delete=ON")
+
+
+def table_columns(connection: sqlite3.Connection, table: str) -> list[sqlite3.Row]:
+    """回傳一張表的欄位定義列。"""
+    return list(connection.execute(f'PRAGMA table_info("{table}")'))
+
+
+def table_column_names(connection: sqlite3.Connection, table: str) -> set[str]:
+    """回傳一張表的欄位名稱集合。"""
+    return {str(row["name"]) for row in table_columns(connection, table)}

--- a/tests/test_infrastructure_data_safety.py
+++ b/tests/test_infrastructure_data_safety.py
@@ -10,8 +10,8 @@
 """
 from __future__ import annotations
 
-import sqlite3
-from pathlib import Path
+lazy import sqlite3
+lazy from pathlib import Path
 
 
 MARKER = "SENSITIVE-CLIPBOARD-PAYLOAD-a1b2c3d4e5f6"
@@ -70,15 +70,22 @@ def test_secure_delete_and_vacuum_remove_the_payload() -> None:
 
 
 def test_profile_export_applies_secure_delete_and_vacuum() -> None:
-    """匯出路徑本身必須做這兩件事，不是只有測試裡做。"""
+    """匯出路徑本身必須做這兩件事，不是只有測試裡做。
+
+    2026-09-02 起 secure_delete 由 infrastructure/sqlite_safety.py 提供。
+    兩邊都要查：只查匯出有沒有呼叫，共用函式被改壞時沒人會發現；只查共用
+    函式，匯出漏掉那一行時同樣沒人會發現。
+    """
     import inspect
 
-    from infrastructure import profile_transfer
+    from infrastructure import profile_transfer, sqlite_safety
 
     body = inspect.getsource(profile_transfer)
     sanitise = body.split("_sanitize_snapshot", 1)[1]
-    assert "secure_delete=ON" in sanitise, "匯出未啟用 secure_delete"
+    assert "enable_secure_delete(" in sanitise, "匯出未呼叫 enable_secure_delete"
     assert "VACUUM" in sanitise, "匯出未執行 VACUUM"
+    helper = inspect.getsource(sqlite_safety.enable_secure_delete)
+    assert "secure_delete=ON" in helper, "共用函式未下 secure_delete 的 PRAGMA"
 
 
 def test_zero_byte_database_is_flagged_as_corrupt(tmp_path: Path) -> None:

--- a/tests/test_infrastructure_data_safety.py
+++ b/tests/test_infrastructure_data_safety.py
@@ -1,0 +1,153 @@
+"""持久化層不得靜默遺失或洩漏使用者資料。
+
+2026-09-01 的獨立稽核在 infrastructure/ 找到十一項缺陷，最嚴重的一項是：
+可攜設定檔匯出會 DELETE 掉稽核紀錄與連線設定，然後直接打包原始 SQLite
+檔案——而 SQLite 的 DELETE 只把頁面標記為可重用，內容仍留在檔案裡。
+那個功能存在的唯一目的就是排除那些資料，而它沒有做到。
+
+這裡的測試刻意驗證**位元組層級**的結果，不是驗證資料列數。原本的測試只
+數刪除後還剩幾列，那種測試對這個缺陷完全無感。
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+MARKER = "SENSITIVE-CLIPBOARD-PAYLOAD-a1b2c3d4e5f6"
+
+
+def _build_database(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE action_audit (id INTEGER PRIMARY KEY, payload TEXT)")
+    # 寫入足夠多列，確保跨越多個頁面——單列可能剛好落在會被重用的頁面上，
+    # 那樣就算沒修好也可能碰巧測不出來。
+    conn.executemany(
+        "INSERT INTO action_audit (payload) VALUES (?)",
+        [(f"{MARKER}-{index}",) for index in range(400)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_plain_delete_leaves_payload_in_the_file() -> None:
+    """先證明這個缺陷是真的，否則下面那個測試證明不了任何事。
+
+    這是「守衛的正例」：如果 SQLite 其實會自己清乾淨，那修正就沒有意義，
+    而這個測試會失敗並告訴我們前提錯了。
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as folder:
+        path = Path(folder) / "plain.db"
+        _build_database(path)
+        conn = sqlite3.connect(path)
+        conn.execute("DELETE FROM action_audit")
+        conn.commit()
+        conn.close()
+        assert MARKER.encode() in path.read_bytes(), (
+            "前提不成立：SQLite 的 DELETE 竟然自己清掉了頁面內容，"
+            "那麼 secure_delete 與 VACUUM 就不是必要的——請重新檢視這組測試"
+        )
+
+
+def test_secure_delete_and_vacuum_remove_the_payload() -> None:
+    """修正後：位元組必須真的不在檔案裡。"""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as folder:
+        path = Path(folder) / "sanitised.db"
+        _build_database(path)
+        conn = sqlite3.connect(path)
+        conn.execute("PRAGMA secure_delete=ON")
+        conn.execute("DELETE FROM action_audit")
+        conn.commit()
+        conn.execute("VACUUM")
+        conn.close()
+        assert MARKER.encode() not in path.read_bytes(), (
+            "已刪除的內容仍留在匯出檔的原始位元組裡"
+        )
+
+
+def test_profile_export_applies_secure_delete_and_vacuum() -> None:
+    """匯出路徑本身必須做這兩件事，不是只有測試裡做。"""
+    import inspect
+
+    from infrastructure import profile_transfer
+
+    body = inspect.getsource(profile_transfer)
+    sanitise = body.split("_sanitize_snapshot", 1)[1]
+    assert "secure_delete=ON" in sanitise, "匯出未啟用 secure_delete"
+    assert "VACUUM" in sanitise, "匯出未執行 VACUUM"
+
+
+def test_zero_byte_database_is_flagged_as_corrupt(tmp_path: Path) -> None:
+    """零位元組資料庫是損毀，不是全新安裝。
+
+    斷電、雲端同步中斷或複製失敗都會留下 0-byte 檔。SQLite 會把它當成空
+    資料庫，於是應用成功建立新 schema、使用者看到預設 profile，接著正常
+    操作開始往上寫。原本的資料還在備份裡，但使用者沒有理由知道要去還原。
+    """
+    from infrastructure.db import StudioDB
+
+    empty = tmp_path / "mohan.db"
+    empty.write_bytes(b"")
+    database = StudioDB(empty)
+    try:
+        assert database.corrupt_empty_database is True
+        assert database.existing_install is False
+    finally:
+        database.conn.close()
+
+    fresh = tmp_path / "fresh.db"
+    database = StudioDB(fresh)
+    try:
+        assert database.corrupt_empty_database is False, (
+            "真正的首次安裝不得被誤判為損毀"
+        )
+    finally:
+        database.conn.close()
+
+
+def test_secret_store_write_is_atomic() -> None:
+    """DPAPI 秘密必須原子寫入。
+
+    先前直接覆寫正式檔案。斷電或磁碟寫入失敗會留下截斷的 blob，下一次
+    load() 解密失敗回傳空字串——而空字串與「尚未設定」無法區分，臉部
+    identity 因此被當成零個 profile，接著新增一筆就把殘骸覆寫成新的真相。
+    """
+    import inspect
+
+    from infrastructure import secret_store
+
+    body = inspect.getsource(secret_store)
+    assert "os.replace(" in body, "未使用 os.replace 做原子替換"
+    assert "fsync" in body, "未 fsync，資料可能還在作業系統快取裡"
+
+
+def test_optimize_database_is_bounded_and_reports_honestly() -> None:
+    """optimize_database 不得刪光全部，也不得在刪除後回報 0。
+
+    原本 cutoff 是「現在」，於是這個宣稱 bounded cleanup 的函式會刪掉每一筆
+    已完成待辦與整個稽核紀錄；而 VACUUM 失敗時回報 pruned=0，但刪除早已
+    commit——呼叫端會以為什麼都沒發生。
+    """
+    import inspect
+
+    from infrastructure import db_memory
+
+    body = inspect.getsource(db_memory.StudioDBMemoryMethods.optimize_database)
+    assert "RETENTION_DAYS" in body, "cutoff 仍未設界"
+    assert "timedelta" in body, "cutoff 未往回推算"
+    # VACUUM 失敗的分支必須回報實際刪除數，不得歸零。
+    # 要切在真正的 VACUUM **呼叫**，不是 docstring 裡的那個字——DELETE 本身
+    # 失敗時 rollback 後回傳 0 是正確的，不能一起算進來。
+    marker = 'self.conn.execute("VACUUM")'
+    assert marker in body
+    tail = body.split(marker, 1)[1]
+    assert '"pruned_todos": 0' not in tail, (
+        "VACUUM 失敗時仍回報刪除 0 筆——刪除已經 commit，那是謊報"
+    )
+    assert '"pruned_todos": pruned_todos' in tail, (
+        "VACUUM 失敗時必須回報實際刪除數"
+    )

--- a/tests/test_layered_facade_cycles.py
+++ b/tests/test_layered_facade_cycles.py
@@ -43,8 +43,8 @@ MAX_NEW_LAYER_MODULE_LINES = 800
 LAYER_MODULE_LINE_BASELINE = {
     "application.presentation_ports": 1_063,
     "domain.outfit_pack": 974,
-    "infrastructure.db": 1_199,
-    "infrastructure.profile_transfer": 1_075,
+    "infrastructure.db": 1_195,
+    "infrastructure.profile_transfer": 1_071,
     "integrations.azure_speech": 864,
     "integrations.realtime_voice": 878,
     "integrations.speech": 1_195,


### PR DESCRIPTION
## 繁體中文

### 為什麼

2026-09-01 的獨立稽核在持久化層找到會靜默遺失或洩漏使用者資料的缺陷。其中最嚴重的一項，讓一個以「排除敏感資料」為存在目的的功能，實際上把那些資料原封不動地送了出去。

### 一、可攜匯出夾帶已刪除的內容

匯出前會刪掉稽核紀錄與連線設定，然後直接打包原始資料庫檔。但 `DELETE` 只把頁面標記為可重用，內容仍留在檔案裡，於是剪貼簿內容與連線設定的位元組跟著走。修法是啟用 `PRAGMA secure_delete=ON` 讓刪除當下歸零，再以 `VACUUM` 重寫整個檔案丟掉空閒頁。

### 二、零位元組資料庫被當成全新安裝

斷電或同步中斷會留下長度為零的檔案，而該檔會被當成空資料庫，於是建立新結構、使用者看到預設設定並開始往上寫。原本的資料還在備份裡，但使用者沒有理由知道要去還原。修法是在建立連線之前分辨檔案存在但長度為零的情況。

### 三、秘密寫入不是原子的

`secret_store.py` 直接覆寫正式檔案，斷電會留下截斷的內容，而解密失敗回傳的空字串與尚未設定無法區分。改為寫入暫存檔、`fsync` 之後再以 `os.replace` 原子替換。

### 四、宣稱有界的清理實際清光全部

`db_memory.py` 的截止時間是當下，於是這個宣稱有界的函式會刪掉整個稽核紀錄，而且重整失敗時回報刪除零筆，儘管刪除早已提交。改為保留九十天，並在重整失敗時回報實際刪除數。

### 落地方式

行數棘輪擋下了前兩項：`infrastructure/db.py` 已貼著全域硬上限，連一行都不能長。閘門要的是抽出而非塞入，因此新增 `infrastructure/sqlite_safety.py` 收容這些判斷，並順帶消掉 `table_columns()` 在兩個模組各寫一份的重複。基準同步往下調。

### 測試

新增 `tests/test_infrastructure_data_safety.py` 共六個測試。這組測試刻意驗證位元組層級的結果而不是資料列數，因為只數列數的測試對第一項缺陷完全無感，並且先證明缺陷為真，否則修正測試證明不了任何事。

## 简体中文

### 为什么

2026-09-01 的独立审计在持久化层找到会静默丢失或泄漏用户数据的缺陷。其中最严重的一项，让一个以「排除敏感数据」为存在目的的功能，实际上把那些数据原封不动地送了出去。

### 一、可携导出夹带已删除的内容

导出前会删掉审计记录与连接设置，然后直接打包原始数据库文件。但 `DELETE` 只把页面标记为可重用，内容仍留在文件里，于是剪贴板内容与连接设置的字节跟着走。修复方式是启用 `PRAGMA secure_delete=ON` 让删除当下归零，再以 `VACUUM` 重写整个文件丢掉空闲页。

### 二、零字节数据库被当成全新安装

断电或同步中断会留下长度为零的文件，而该文件会被当成空数据库，于是建立新结构、用户看到默认设置并开始往上写。原本的数据还在备份里，但用户没有理由知道要去还原。修复方式是在建立连接之前分辨文件存在但长度为零的情况。

### 三、密钥写入不是原子的

`secret_store.py` 直接覆写正式文件，断电会留下截断的内容，而解密失败返回的空字符串与尚未设置无法区分。改为写入临时文件、`fsync` 之后再以 `os.replace` 原子替换。

### 四、声称有界的清理实际清光全部

`db_memory.py` 的截止时间是当下，于是这个声称有界的函数会删掉整个审计记录，而且整理失败时回报删除零条，尽管删除早已提交。改为保留九十天，并在整理失败时回报实际删除数。

### 落地方式

行数棘轮挡下了前两项：`infrastructure/db.py` 已贴着全局硬上限，连一行都不能长。闸门要的是抽出而非塞入，因此新增 `infrastructure/sqlite_safety.py` 收容这些判断，并顺带消掉 `table_columns()` 在两个模块各写一份的重复。基线同步往下调。

### 测试

新增 `tests/test_infrastructure_data_safety.py` 共六个测试。这组测试刻意验证字节层级的结果而不是数据行数，因为只数行数的测试对第一项缺陷完全无感，并且先证明缺陷为真，否则修复测试证明不了任何事。

## English

### Why

The independent audit on 2026-09-01 found defects in the persistence layer that silently lose or leak user data. The most serious one left a feature whose entire purpose is excluding sensitive data shipping that data out untouched.

### 1. The portable export carried deleted content

Before exporting, the audit log and connector settings are deleted and the raw database file is then packaged. But `DELETE` only marks pages reusable and the content stays in the file, so clipboard payloads and connector settings travelled along as bytes. The fix enables `PRAGMA secure_delete=ON` so deletion zeroes pages as it happens, then runs `VACUUM` to rewrite the file and drop free pages.

### 2. A zero-byte database counted as a fresh install

A power loss or an interrupted sync leaves a file of zero length, which is treated as an empty database, so a new schema is created, the user sees default settings and begins writing over them. Their data is still in a backup, but they have no reason to know they should restore it. The fix distinguishes a file that exists yet has zero length before the connection opens.

### 3. Secret writes were not atomic

`secret_store.py` overwrote the live file directly, so a power loss left truncated content, and the empty string returned by a failed decrypt is indistinguishable from nothing configured. Writes now go to a temporary file, then `fsync`, then an atomic `os.replace`.

### 4. A cleanup described as bounded removed everything

The cutoff in `db_memory.py` was the present moment, so a function described as bounded deleted the whole audit log, and it reported zero rows removed when the compaction step failed even though the deletion had already committed. Retention is now ninety days, and a failed compaction reports the real number removed.

### How this landed

The line-count ratchet blocked the first two fixes: `infrastructure/db.py` already sits at the global hard cap and cannot grow by even one line. The gate asks for extraction rather than insertion, so a new `infrastructure/sqlite_safety.py` holds these judgements, which also removed the duplicate copy of `table_columns()` kept in both modules. The baselines ratchet down to match.

### Tests

A new `tests/test_infrastructure_data_safety.py` adds six tests. They deliberately assert on bytes rather than row counts, because a test that counts rows is blind to the first defect, and they first prove the defect is real, without which a test of the fix proves nothing.

## 日本語

### 理由

2026-09-01 の独立監査は、利用者のデータを静かに失うか漏らす欠陥を永続化層で見つけました。最も重いものは、機微なデータを除くことだけを目的とする機能が、そのデータをそのまま持ち出していたというものです。

### 一、可搬エクスポートが削除済みの内容を運び出していた

書き出しの前に監査記録と接続設定を削除し、その後に生のデータベースファイルを包みます。しかし `DELETE` はページを再利用可能と印付けるだけで内容はファイルに残るため、クリップボードの内容と接続設定がバイト列として同行していました。修正では `PRAGMA secure_delete=ON` を有効にして削除の時点で零詰めし、続いて `VACUUM` でファイル全体を書き直し空きページを捨てます。

### 二、零バイトのデータベースが新規導入として扱われていた

電源断や同期の中断は長さ零のファイルを残し、それが空のデータベースとして扱われるため、新しい構造が作られ、利用者は既定の設定を見てその上に書き始めます。元のデータは控えに残っていますが、復元すべきだと知る手掛かりが利用者にはありません。修正では接続を開く前に、存在するが長さが零のファイルを見分けます。

### 三、秘密情報の書き込みが不可分でなかった

`secret_store.py` は本体のファイルを直接上書きしていたため、電源断は切り詰められた内容を残し、復号の失敗が返す空文字列は未設定と区別できませんでした。現在は一時ファイルに書き、`fsync` の後に `os.replace` で不可分に置き換えます。

### 四、有界と称する整理が全件を消していた

`db_memory.py` の締切は現在時刻であったため、有界と称するこの関数は監査記録を丸ごと消し、しかも圧縮の段が失敗したときは削除が既に確定していても零件と報告していました。現在は保持期間を九十日とし、圧縮が失敗した場合は実際の削除件数を報告します。

### 着地の方法

行数ラチェットが最初の二件を阻みました。`infrastructure/db.py` は全体の上限に既に達しており、一行も増やせません。この関門が求めるのは挿入ではなく抽出であるため、新しい `infrastructure/sqlite_safety.py` にこれらの判断を収め、二つのモジュールに重複していた `table_columns()` も併せて解消しました。基準値も同時に引き下げます。

### テスト

新しい `tests/test_infrastructure_data_safety.py` に六件のテストを追加しました。行数ではなくバイト列を意図して検査します。行数を数えるだけのテストは最初の欠陥をまったく捉えられないためであり、さらに欠陥が実在することを先に示します。それが無ければ修正の検査は何も示しません。
