### PR TITLE
docs: 授權純淨承諾改寫為與現況相符／授权纯净承诺改写为与现况相符／Align the license purity commitment with current practice／ライセンス純度の約束を現状に合わせて改訂

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責�
 - **架構分層落實：** 一百七十五個根目錄相容殼檔全數退役，根目錄由 239 項瘦身至 64 項，二百零一個呼叫端改用正式分層路徑，「退役別名不得復活」已入契約。
 - **四語、四平台治理：** 軟體與主要文件同步支援繁體中文、簡體中文、英文與日文；Windows 為正式支援，macOS Apple Silicon／Intel 與 Linux 同步提供功能受限 Preview。
 - **多感知與角色表現：** 可明確授權與隨時撤銷的本機視覺感知、21 點手部資料、468／478 點 Face Mesh、語音活動偵測與安全的非阻塞融合；缺少模型、裝置、網路或額度時只停用受影響路徑，不損及既有功能。
-- **授權純淨與開源回饋：** 產線只採用 MIT／Apache 2.0／CC0／CC BY 授權（見[授權純淨承諾](docs/LICENSE-PURITY.md)）；開發期間並向上游 ai-toolkit 回饋兩顆缺陷修復。
+- **授權純淨與開源回饋：** 產線的工具與權重只採用 MIT／Apache 2.0／CC0／CC BY 授權（見[授權純淨承諾](docs/LICENSE-PURITY.md)）；開發期間並向上游 ai-toolkit 回饋兩顆缺陷修復。
 - **可稽核的工程基線：** 734 個 Python 檔、184,534 行，其中產品本體 87,565 行、測試 74,174 行、開發工具 22,795 行。
 
 ### 專案特色
@@ -633,7 +633,7 @@ Codex 协助我把想法转译成程序架构与代码；而我始终负责决�
 - **架构分层落实：** 一百七十五个根目录兼容壳文件全数退役，根目录由 239 项瘦身至 64 项，二百零一个调用端改用正式分层路径，「退役别名不得复活」已入契约。
 - **四语、四平台治理：** 软件与主要文档同步支持繁体中文、简体中文、英文与日文；Windows 为正式支持，macOS Apple Silicon／Intel 与 Linux 同步提供功能受限 Preview。
 - **多感知与角色表现：** 可明确授权与随时撤销的本机视觉感知、21 点手部数据、468／478 点 Face Mesh、语音活动检测与安全的非阻塞融合；缺少模型、设备、网络或额度时只停用受影响路径，不损及既有功能。
-- **授权纯净与开源回馈：** 产线只采用 MIT／Apache 2.0／CC0／CC BY 授权（见[授权纯净承诺](docs/LICENSE-PURITY.md)）；开发期间并向上游 ai-toolkit 回馈两颗缺陷修复。
+- **授权纯净与开源回馈：** 产线的工具与权重只采用 MIT／Apache 2.0／CC0／CC BY 授权（见[授权纯净承诺](docs/LICENSE-PURITY.md)）；开发期间并向上游 ai-toolkit 回馈两颗缺陷修复。
 - **可稽核的工程基线：** 734 个 Python 文件、184,534 行，其中产品本体 87,565 行、测试 74,174 行、开发工具 22,795 行。
 
 ### 主要功能
@@ -1064,7 +1064,7 @@ The current release is `v4.6.0`; see [Releases](https://github.com/flameblade-st
 - **Layered architecture enforced.** All one hundred and seventy-five root compatibility facades are retired, the root directory falls from 239 entries to 64, two hundred and one call sites now use formal layered paths, and "retired aliases must not return" is written into a contract.
 - **Four languages, four platforms.** The software and its principal documents carry Traditional Chinese, Simplified Chinese, English and Japanese. Windows is formally supported, while macOS Apple Silicon and Intel, plus Linux, ship as limited Previews.
 - **Multi-sensory perception and character expression.** Explicitly consented and revocable local vision, 21-point hand data, a 468/478-point face mesh, voice activity detection and a safe non-blocking fusion path. A missing model, device, network or quota disables only the affected route and leaves everything else intact.
-- **License purity and upstream contribution.** The pipeline admits only MIT, Apache 2.0, CC0 and CC BY material — see the [License Purity Commitment](docs/LICENSE-PURITY.md) — and two defect fixes went upstream to ai-toolkit during development.
+- **License purity and upstream contribution.** The pipeline's tools and weights admit only MIT, Apache 2.0, CC0 and CC BY material — see the [License Purity Commitment](docs/LICENSE-PURITY.md) — and two defect fixes went upstream to ai-toolkit during development.
 - **An auditable engineering baseline.** 734 Python files and 184,534 lines: 87,565 in the product itself, 74,174 in tests, and 22,795 in development tooling.
 
 ### Key capabilities
@@ -1495,7 +1495,7 @@ Codex は私の思いをアーキテクチャとコードへ翻訳する手助�
 - **階層アーキテクチャの徹底。** ルート直下の互換ファサード百七十五件をすべて退役させ、ルートの項目数は 239 から 64 へ、呼び出し側二百一箇所を正式な階層パスへ移行し、「退役した別名を復活させない」ことを契約に明記しました。
 - **四言語・四プラットフォーム。** ソフトウェアと主要文書は繁体中文・簡体中文・英語・日本語に対応します。Windows が正式対応、macOS Apple Silicon／Intel と Linux は機能限定 Preview です。
 - **多感覚知覚とキャラクター表現。** 明示的な同意といつでも撤回できるローカル視覚、21 点の手指データ、468／478 点フェイスメッシュ、音声区間検出、そして安全な非ブロッキング統合。モデル・機器・ネットワーク・利用枠のいずれかが欠けても、影響を受けた経路のみを停止し、他の機能は損ないません。
-- **ライセンス純度と上流への還元。** パイプラインには MIT／Apache 2.0／CC0／CC BY のみを受け入れます（[ライセンス純度に関する約束](docs/LICENSE-PURITY.md)）。開発期間中には上流の ai-toolkit へ二件の修正を還元しました。
+- **ライセンス純度と上流への還元。** パイプラインの道具と重みには MIT／Apache 2.0／CC0／CC BY のみを受け入れます（[ライセンス純度に関する約束](docs/LICENSE-PURITY.md)）。開発期間中には上流の ai-toolkit へ二件の修正を還元しました。
 - **監査可能なエンジニアリング基準値。** Python ファイル 734 件、184,534 行。内訳は製品本体 87,565 行、テスト 74,174 行、開発ツール 22,795 行です。
 
 ### 主な機能

--- a/docs/LICENSE-PURITY.md
+++ b/docs/LICENSE-PURITY.md
@@ -21,7 +21,7 @@
 
 八個模型，全部是 MIT 或 Apache 2.0。**每一顆都用 SHA256 與上游 commit 雙重釘選**，出處記錄在 [`VISION-MODEL-PROVENANCE.json`](VISION-MODEL-PROVENANCE.json)、[`MULTIMODAL-MODEL-PROVENANCE.json`](MULTIMODAL-MODEL-PROVENANCE.json)、[`HAND-MODEL-PROVENANCE.json`](HAND-MODEL-PROVENANCE.json)，可逐一驗證。
 
-上表是**隨產品出貨、在你電腦上執行**的模型。另有一條本機素材生產鏈（FLUX.2-klein-4B 與 Chroma1-HD，皆為 Apache 2.0）負責製作角色圖與佈景素材，它們不隨發行產物散布，但同樣受本白名單約束——這正是 FLUX dev 全系被排除的原因。
+上表是**隨產品出貨、在你電腦上執行**的模型。另有一條本機素材生產鏈（FLUX.2-klein-4B 與 Chroma1-HD，皆為 Apache 2.0）不隨發行產物散布，但同樣受本白名單約束——這正是 FLUX dev 全系被排除的原因。角色圖目前另借助託管生圖服務繪製：本機模型在角色一致性上尚未達到要求，待其迭代到位即轉回本機生產。這不動搖上述承諾——白名單約束的是工具與權重，而角色美術本身是擁有者的專有財產（見 [ASSETS-LICENSE](../ASSETS-LICENSE.md)），不受任何開源條款約束。
 
 ### 白名單
 
@@ -77,7 +77,7 @@
 
 八个模型，全部是 MIT 或 Apache 2.0。**每一颗都用 SHA256 与上游 commit 双重锁定**，来源记录在 [`VISION-MODEL-PROVENANCE.json`](VISION-MODEL-PROVENANCE.json)、[`MULTIMODAL-MODEL-PROVENANCE.json`](MULTIMODAL-MODEL-PROVENANCE.json)、[`HAND-MODEL-PROVENANCE.json`](HAND-MODEL-PROVENANCE.json)，可逐一验证。
 
-上表是**随产品出货、在你电脑上运行**的模型。另有一条本机素材生产链（FLUX.2-klein-4B 与 Chroma1-HD，均为 Apache 2.0）负责制作角色图与主题素材，它们不随发行产物分发，但同样受本白名单约束——这正是 FLUX dev 全系被排除的原因。
+上表是**随产品出货、在你电脑上运行**的模型。另有一条本机素材生产链（FLUX.2-klein-4B 与 Chroma1-HD，均为 Apache 2.0）不随发行产物分发，但同样受本白名单约束——这正是 FLUX dev 全系被排除的原因。角色图目前另借助托管生图服务绘制：本机模型在角色一致性上尚未达到要求，待其迭代到位即转回本机生产。这不动摇上述承诺——白名单约束的是工具与权重，而角色美术本身是所有者的专有财产（见 [ASSETS-LICENSE](../ASSETS-LICENSE.md)），不受任何开源条款约束。
 
 ### 白名单
 
@@ -133,7 +133,7 @@ Most AI projects cannot say this. Their models arrive carrying research-only, no
 
 Eight models, every one MIT or Apache 2.0. **Each is pinned twice — by SHA256 and by upstream commit** — with provenance recorded in [`VISION-MODEL-PROVENANCE.json`](VISION-MODEL-PROVENANCE.json), [`MULTIMODAL-MODEL-PROVENANCE.json`](MULTIMODAL-MODEL-PROVENANCE.json) and [`HAND-MODEL-PROVENANCE.json`](HAND-MODEL-PROVENANCE.json), so any claim here can be checked independently.
 
-The table above lists models **shipped with the product and executed on your own machine**. A separate local asset-production chain — FLUX.2-klein-4B and Chroma1-HD, both Apache 2.0 — generates character art and theme material; those never travel inside a release artifact, yet the same allowlist governs them, which is precisely why the entire FLUX dev family was excluded.
+The table above lists models **shipped with the product and executed on your own machine**. A separate local asset-production chain — FLUX.2-klein-4B and Chroma1-HD, both Apache 2.0 — never travels inside a release artifact, yet the same allowlist governs it, which is precisely why the entire FLUX dev family was excluded. Character art is currently drawn with help from a hosted image service as well: the local models do not yet meet the bar for character consistency, and production returns to them once they do. That does not weaken the promise above — the allowlist governs tools and weights, while the character artwork itself is the owner's proprietary property (see [ASSETS-LICENSE](../ASSETS-LICENSE.md)) and carries no open-source terms.
 
 ### The allowlist
 
@@ -189,7 +189,7 @@ To audit it yourself, the evidence is in the repository: [`ASSETS-LICENSE.md`](.
 
 八つのモデルはすべて MIT または Apache 2.0 です。**いずれも SHA256 と上流コミットの二重で固定**しており、出所は [`VISION-MODEL-PROVENANCE.json`](VISION-MODEL-PROVENANCE.json)、[`MULTIMODAL-MODEL-PROVENANCE.json`](MULTIMODAL-MODEL-PROVENANCE.json)、[`HAND-MODEL-PROVENANCE.json`](HAND-MODEL-PROVENANCE.json) に記録され、第三者が個別に検証できます。
 
-上の表は**製品に同梱され、利用者の PC 上で実行される**モデルです。これとは別に、キャラクター画像やテーマ素材を制作するローカル素材生成チェーン（FLUX.2-klein-4B と Chroma1-HD、いずれも Apache 2.0）がありますが、リリース成果物には同梱されません。それでも同じホワイトリストの適用対象であり、FLUX dev 系列を全面的に除外したのはそのためです。
+上の表は**製品に同梱され、利用者の PC 上で実行される**モデルです。これとは別にローカル素材生成チェーン（FLUX.2-klein-4B と Chroma1-HD、いずれも Apache 2.0）がありますが、リリース成果物には同梱されません。それでも同じホワイトリストの適用対象であり、FLUX dev 系列を全面的に除外したのはそのためです。キャラクター画像は現在、ホスト型の画像生成サービスの助けも借りて制作しています。ローカルモデルはキャラクターの同一性について要求水準にまだ届いておらず、届いた時点でローカル生産に戻します。これは上記の約束を揺るがしません。ホワイトリストが縛るのは道具と重みであり、キャラクター美術そのものは所有者の専有財産（[ASSETS-LICENSE](../ASSETS-LICENSE.md) を参照）でオープンソース条項の対象外です。
 
 ### ホワイトリスト
 


### PR DESCRIPTION
## 繁體中文

### 為什麼

`docs/LICENSE-PURITY.md` 寫著本機素材生產鏈（`FLUX.2-klein-4B` 與 `Chroma1-HD`）負責製作角色圖。這句話與出貨中的資產不符：`assets/pose-atlas/v4` 由 `v4-source` 建置，而該來源是託管生圖服務的產物。這個落差在本次改動之前就已存在。

### 改了什麼

那句話改為說明現況：本機鏈仍在、仍受白名單約束，角色圖目前另借助託管服務繪製，待本機模型的角色一致性達標即轉回本機生產。`README.md` 四語的一句「產線只採用」收緊為「產線的工具與權重只採用」——白名單管的一直是工具與權重，這樣寫在任何生產方式下都為真。

### 沒有改變的事

墨寒仍可商用，仍無非商用權重、無 copyleft 素材、無授權不明的檔案。角色美術本來就不在白名單的管轄範圍內：它是擁有者的專有財產，`ASSETS-LICENSE.md` 四語早已載明保留一切權利。本次只改敘述，不改任何授權地位。

## 简体中文

### 为什么

`docs/LICENSE-PURITY.md` 写着本机素材生产链（`FLUX.2-klein-4B` 与 `Chroma1-HD`）负责制作角色图。这句话与出货中的资产不符：`assets/pose-atlas/v4` 由 `v4-source` 构建，而该来源是托管生图服务的产物。这个落差在本次改动之前就已存在。

### 改了什么

那句话改为说明现况：本机链仍在、仍受白名单约束，角色图目前另借助托管服务绘制，待本机模型的角色一致性达标即转回本机生产。`README.md` 四语的一句「产线只采用」收紧为「产线的工具与权重只采用」——白名单管的一直是工具与权重，这样写在任何生产方式下都为真。

### 没有改变的事

墨寒仍可商用，仍无非商用权重、无 copyleft 素材、无授权不明的文件。角色美术本来就不在白名单的管辖范围内：它是所有者的专有财产，`ASSETS-LICENSE.md` 四语早已载明保留一切权利。本次只改叙述，不改任何授权地位。

## English

### Why

`docs/LICENSE-PURITY.md` states that the local asset chain — `FLUX.2-klein-4B` and `Chroma1-HD` — produces the character art. That sentence does not match what ships: `assets/pose-atlas/v4` is built from `v4-source`, which came out of a hosted image service. The gap predates this change.

### What changed

The sentence now describes the present situation: the local chain remains in place and remains bound by the allowlist, character art is currently drawn with help from a hosted service, and production returns to the local models once their character consistency meets the bar. In `README.md` the phrase covering the pipeline is tightened to name tools and weights explicitly, because the allowlist has always governed those rather than the artwork.

### What did not change

MoHan remains commercially usable, with no non-commercial weight, no copyleft material, and no file of unclear licensing. Character artwork was never inside the allowlist's scope: it is the owner's proprietary property, and `ASSETS-LICENSE.md` already records all rights reserved in four languages. This change touches wording alone and alters no licensing status.

## 日本語

### 理由

`docs/LICENSE-PURITY.md` にはローカル素材生成チェーン（`FLUX.2-klein-4B` と `Chroma1-HD`）がキャラクター画像を制作すると書かれています。この記述は出荷中の資産と一致しません。`assets/pose-atlas/v4` は `v4-source` から構築され、その出所はホスト型の画像生成サービスだからです。この乖離は今回の変更より前から存在していました。

### 変更点

当該の記述を現状の説明に改めました。ローカルチェーンは引き続き存在しホワイトリストの対象であること、キャラクター画像は現在ホスト型サービスの助けを借りて制作していること、ローカルモデルの同一性が水準に達し次第ローカル生産に戻すことです。`README.md` の該当句は「道具と重み」を明示する表現に締め直しました。ホワイトリストが縛ってきたのは常にそちらだからです。

### 変わらないこと

墨寒は引き続き商用可能であり、非商用の重みも copyleft 素材もライセンス不明のファイルもありません。キャラクター美術はもともとホワイトリストの適用範囲外です。所有者の専有財産であり、`ASSETS-LICENSE.md` が四言語で全権利の留保を既に記載しています。今回は記述のみの変更で、ライセンス上の地位は一切変えていません。
