### PR TITLE
fix: 網站白名單比對完整來源，測試旗標不再於一般啟動時寫檔／网站白名单比对完整来源，测试标志不再于一般启动时写文件／Compare the full origin in the website allowlist, and stop harness flags writing on ordinary launches／サイト許可リストで生成元全体を比較し、テスト用の旗が通常起動で書き込まないようにする

### DIFF
--- a/application/application_bootstrap.py
+++ b/application/application_bootstrap.py
@@ -40,12 +40,37 @@ def _argument_value(prefix: str) -> str:
     return argument.split("=", 1)[1] if argument else ""
 
 
+def _harness_output_path(flag: str) -> Path | None:
+    """只有測試工具啟動時才接受輸出路徑。
+
+    這兩個旗標的值原本直接進 `Path(...).write_text()`，而它會截斷目標。
+    `_write_jit_status()` 更在 `--self-test` 判斷**之前**無條件執行，於是
+    任何一次一般啟動只要帶著這個旗標，指定的檔案就被清成一行字串。
+
+    刻意不加「不得覆寫既有檔」那條：tools/profile_mohan_tachyon.py 會用
+    同一個路徑重複執行，那條規則會讓它從第二輪起靜默不寫。
+
+    殘留風險誠實標明：能決定啟動命令列的人仍可自己加上 `--self-test`。
+    但那種人通常已經能直接執行任意程式，這個原語沒讓他多拿到什麼。
+    被關掉的是「一般啟動也會寫」，那才是真正不該存在的。
+    """
+    value = _argument_value(flag)
+    if not value:
+        return None
+    if not ("--self-test" in sys.argv or "--smoke-auto-exit" in sys.argv):
+        return None
+    target = Path(value)
+    if not target.parent.is_dir():
+        return None
+    return target
+
+
 def _write_jit_status() -> None:
-    output_path = _argument_value("--jit-status-output=")
-    if not output_path:
+    target = _harness_output_path("--jit-status-output=")
+    if target is None:
         return
     expected_jit = os.environ.get("MOHAN_ENABLE_JIT") == "1"
-    Path(output_path).write_text(
+    target.write_text(
         "PACKAGED_JIT_DEFAULT_OK"
         if jit_is_enabled() == expected_jit
         else "PACKAGED_JIT_DEFAULT_FAILED",
@@ -82,9 +107,9 @@ def _run_smoke_event_loop(
     QTimer.singleShot(2_500, window.close)
     QTimer.singleShot(2_700, app.quit)
     exit_code = app.exec()
-    output_path = _argument_value("--smoke-output=")
-    if output_path:
-        Path(output_path).write_text(
+    target = _harness_output_path("--smoke-output=")
+    if target is not None:
+        target.write_text(
             "PACKAGED_EVENT_LOOP_OK"
             if exit_code == 0
             else "PACKAGED_EVENT_LOOP_FAILED",

--- a/infrastructure/flagship_windows_toolbox.py
+++ b/infrastructure/flagship_windows_toolbox.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 lazy import webbrowser
 lazy from pathlib import Path
 lazy from typing import Protocol
-lazy from urllib.parse import urlparse
+lazy from urllib.parse import ParseResult, urlparse
 
 lazy from domain.flagship_action_models import ActionRequest, ActionResult
 lazy from infrastructure.platform_contracts import PlatformServicePort
@@ -18,6 +18,42 @@ MAX_SEARCH_RESULTS = 200
 
 class ActionRegistrar(Protocol):
     def register(self, capability: str, handler, verifier=None) -> None: ...
+
+
+def _origin(parsed: ParseResult) -> tuple[str, str, int] | None:
+    """(scheme, host, port)；port 補上該 scheme 的預設值。
+
+    原本只比 `hostname`，於是 `https://portal.example/app` 這一條同時放行了
+    `http://portal.example:8080/...`：scheme 沒被要求相符（那一行檢查的是
+    白名單項目自己的 scheme），而 `hostname` 不含 port。
+    """
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    default_port = 443 if parsed.scheme == "https" else 80
+    try:
+        port = parsed.port or default_port
+    except ValueError:
+        return None
+    return parsed.scheme, parsed.hostname.lower(), port
+
+
+def _same_origin(request: ParseResult, allowed: ParseResult) -> bool:
+    request_origin = _origin(request)
+    return request_origin is not None and request_origin == _origin(allowed)
+
+
+def _path_within(request_path: str, allowed_path: str) -> bool:
+    """路徑必須落在允許的**路徑段**之下，不是字首相符。
+
+    字首比對讓 `/app` 涵蓋 `/app-delete`——相鄰但無關的路徑，對帶有 GET
+    副作用的管理介面尤其危險。
+    """
+    request_path = request_path or "/"
+    allowed_path = allowed_path or "/"
+    if allowed_path == "/":
+        return True
+    allowed_path = allowed_path.rstrip("/")
+    return request_path == allowed_path or request_path.startswith(allowed_path + "/")
 
 
 class WindowsToolbox:
@@ -103,9 +139,8 @@ class WindowsToolbox:
         if not self.allowed_websites:
             raise PermissionError("尚未設定允許開啟的網站")
         allowed = any(
-            allowed_parsed.scheme in {"http", "https"}
-            and parsed.hostname == allowed_parsed.hostname
-            and (parsed.path or "/").startswith(allowed_parsed.path or "/")
+            _same_origin(parsed, allowed_parsed)
+            and _path_within(parsed.path, allowed_parsed.path)
             for entry in self.allowed_websites
             if (allowed_parsed := urlparse(entry))
         )

--- a/tests/test_input_validation_boundaries.py
+++ b/tests/test_input_validation_boundaries.py
@@ -1,0 +1,129 @@
+"""外部輸入不得跨過它被授權的邊界。
+
+2026-09-02 稽核的兩項發現：
+
+1. 網站白名單只比 `hostname`、路徑只比字首，而那行看似檢查 scheme 的條件
+   檢查的是白名單項目自己的 scheme——請求端的 scheme 從未被約束。於是
+   允許 `https://portal.example/app` 等於同時允許 `http://portal.example:8080/app-delete`。
+2. `--jit-status-output=` 的值直接進 `write_text()`，而該函式在 `--self-test`
+   判斷之前無條件執行；任何一次一般啟動帶著這個旗標都會清掉指定的檔案。
+
+每組都同時驗證「該擋的擋住」與「該放行的仍然放行」——只驗負例的修正，
+可能只是把功能關掉。
+"""
+from __future__ import annotations
+
+lazy import sys
+
+
+def _toolbox(allowed: tuple[str, ...]):
+    from infrastructure.flagship_windows_toolbox import WindowsToolbox
+
+    return WindowsToolbox(allowed_websites=list(allowed))
+
+
+def _open(toolbox, url: str) -> bool:
+    from domain.flagship_action_models import ActionRequest
+
+    request = ActionRequest(
+        capability="open_web",
+        description="test",
+        arguments={"url": url},
+        source="test",
+    )
+    try:
+        toolbox.open_web(request)
+    except PermissionError:
+        return False
+    return True
+
+
+def test_allowed_site_still_opens() -> None:
+    """正例：修正不得把正常授權的網址一起擋掉。"""
+    toolbox = _toolbox(("https://portal.example/app",))
+    assert _open(toolbox, "https://portal.example/app/report")
+    assert _open(toolbox, "https://portal.example/app")
+
+
+def test_scheme_must_match_the_allowed_entry() -> None:
+    """允許 HTTPS 不等於允許明文 HTTP。"""
+    toolbox = _toolbox(("https://portal.example/app",))
+    assert not _open(toolbox, "http://portal.example/app"), (
+        "允許 HTTPS 的項目放行了明文 HTTP"
+    )
+
+
+def test_port_must_match_the_allowed_entry() -> None:
+    """`hostname` 不含 port，只比 hostname 會放行任意服務埠。"""
+    toolbox = _toolbox(("https://portal.example/app",))
+    assert not _open(toolbox, "https://portal.example:8443/app"), (
+        "不同服務埠被當成同一個來源"
+    )
+
+
+def test_path_must_stop_at_a_segment_boundary() -> None:
+    """`/app` 不得涵蓋 `/app-delete`——相鄰但無關的路徑。"""
+    toolbox = _toolbox(("https://portal.example/app",))
+    assert not _open(toolbox, "https://portal.example/app-delete"), (
+        "字首比對讓相鄰路徑通過；對帶有 GET 副作用的管理介面尤其危險"
+    )
+
+
+def test_root_path_entry_allows_the_whole_host() -> None:
+    """明確授權整個網站時仍應放行整站。"""
+    toolbox = _toolbox(("https://portal.example/",))
+    assert _open(toolbox, "https://portal.example/anything/at/all")
+
+
+def test_harness_output_is_ignored_on_a_normal_launch(monkeypatch, tmp_path) -> None:
+    """一般啟動帶著旗標不得寫檔——這是原本最該關掉的行為。"""
+    from application import application_bootstrap
+
+    target = tmp_path / "victim.txt"
+    target.write_text("原本的內容", encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["MoHan.exe", f"--jit-status-output={target}"]
+    )
+    assert application_bootstrap._harness_output_path("--jit-status-output=") is None
+    application_bootstrap._write_jit_status()
+    assert target.read_text(encoding="utf-8") == "原本的內容", (
+        "一般啟動仍然覆寫了指定的檔案"
+    )
+
+
+def test_harness_output_is_accepted_in_self_test_mode(monkeypatch, tmp_path) -> None:
+    """正例：測試工具本來的用途必須仍然可用。"""
+    from application import application_bootstrap
+
+    target = tmp_path / "jit.txt"
+    monkeypatch.setattr(
+        sys, "argv", ["MoHan.exe", "--self-test", f"--jit-status-output={target}"]
+    )
+    assert application_bootstrap._harness_output_path("--jit-status-output=") == target
+
+
+def test_harness_output_may_be_rewritten_across_repeated_runs(
+    monkeypatch, tmp_path
+) -> None:
+    """profiler 會用同一路徑重複執行，既存檔不得讓它靜默不寫。"""
+    from application import application_bootstrap
+
+    target = tmp_path / "smoke.txt"
+    target.write_text("上一輪", encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["MoHan.exe", "--smoke-auto-exit", f"--smoke-output={target}"]
+    )
+    assert application_bootstrap._harness_output_path("--smoke-output=") == target
+
+
+def test_harness_output_rejects_a_missing_parent_directory(
+    monkeypatch, tmp_path
+) -> None:
+    """不替呼叫者建立目錄；路徑打錯時應該不寫，而不是散落檔案。"""
+    from application import application_bootstrap
+
+    target = tmp_path / "no-such-dir" / "jit.txt"
+    monkeypatch.setattr(
+        sys, "argv", ["MoHan.exe", "--self-test", f"--jit-status-output={target}"]
+    )
+    assert application_bootstrap._harness_output_path("--jit-status-output=") is None

--- a/tests/test_input_validation_boundaries.py
+++ b/tests/test_input_validation_boundaries.py
@@ -22,9 +22,19 @@ def _toolbox(allowed: tuple[str, ...]):
     return WindowsToolbox(allowed_websites=list(allowed))
 
 
-def _open(toolbox, url: str) -> bool:
+def _open(toolbox, url: str, monkeypatch) -> bool:
+    """回傳白名單是否放行；絕不真的開瀏覽器。
+
+    第一版沒有換掉 webbrowser.open，正例在 CI runner 上真的啟動了 Edge，
+    它佔住 component_crx_cache 的檔案，臨時目錄清理時 PermissionError
+    [WinError 32]。測白名單的測試不該有任何副作用。
+    """
+    import webbrowser
+
     from domain.flagship_action_models import ActionRequest
 
+    launched: list[str] = []
+    monkeypatch.setattr(webbrowser, "open", lambda url, **_: launched.append(url) or True)
     request = ActionRequest(
         capability="open_web",
         description="test",
@@ -34,45 +44,47 @@ def _open(toolbox, url: str) -> bool:
     try:
         toolbox.open_web(request)
     except PermissionError:
+        assert not launched, "被擋下的網址不得觸發任何開啟"
         return False
+    assert launched == [url], "放行的網址必須恰好開啟一次"
     return True
 
 
-def test_allowed_site_still_opens() -> None:
+def test_allowed_site_still_opens(monkeypatch) -> None:
     """正例：修正不得把正常授權的網址一起擋掉。"""
     toolbox = _toolbox(("https://portal.example/app",))
-    assert _open(toolbox, "https://portal.example/app/report")
-    assert _open(toolbox, "https://portal.example/app")
+    assert _open(toolbox, monkeypatch=monkeypatch, url="https://portal.example/app/report")
+    assert _open(toolbox, monkeypatch=monkeypatch, url="https://portal.example/app")
 
 
-def test_scheme_must_match_the_allowed_entry() -> None:
+def test_scheme_must_match_the_allowed_entry(monkeypatch) -> None:
     """允許 HTTPS 不等於允許明文 HTTP。"""
     toolbox = _toolbox(("https://portal.example/app",))
-    assert not _open(toolbox, "http://portal.example/app"), (
+    assert not _open(toolbox, monkeypatch=monkeypatch, url="http://portal.example/app"), (
         "允許 HTTPS 的項目放行了明文 HTTP"
     )
 
 
-def test_port_must_match_the_allowed_entry() -> None:
+def test_port_must_match_the_allowed_entry(monkeypatch) -> None:
     """`hostname` 不含 port，只比 hostname 會放行任意服務埠。"""
     toolbox = _toolbox(("https://portal.example/app",))
-    assert not _open(toolbox, "https://portal.example:8443/app"), (
+    assert not _open(toolbox, monkeypatch=monkeypatch, url="https://portal.example:8443/app"), (
         "不同服務埠被當成同一個來源"
     )
 
 
-def test_path_must_stop_at_a_segment_boundary() -> None:
+def test_path_must_stop_at_a_segment_boundary(monkeypatch) -> None:
     """`/app` 不得涵蓋 `/app-delete`——相鄰但無關的路徑。"""
     toolbox = _toolbox(("https://portal.example/app",))
-    assert not _open(toolbox, "https://portal.example/app-delete"), (
+    assert not _open(toolbox, monkeypatch=monkeypatch, url="https://portal.example/app-delete"), (
         "字首比對讓相鄰路徑通過；對帶有 GET 副作用的管理介面尤其危險"
     )
 
 
-def test_root_path_entry_allows_the_whole_host() -> None:
+def test_root_path_entry_allows_the_whole_host(monkeypatch) -> None:
     """明確授權整個網站時仍應放行整站。"""
     toolbox = _toolbox(("https://portal.example/",))
-    assert _open(toolbox, "https://portal.example/anything/at/all")
+    assert _open(toolbox, monkeypatch=monkeypatch, url="https://portal.example/anything/at/all")
 
 
 def test_harness_output_is_ignored_on_a_normal_launch(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## 繁體中文

### 一、網站白名單忽略 scheme 與 port，路徑只比字首

那行看似在檢查 scheme 的條件，檢查的是白名單項目**自己**的 scheme——請求端的 scheme 從未被約束。加上 `hostname` 不含 port、路徑是純字首比對，於是允許 `https://portal.example/app` 這一條同時放行了明文 HTTP、任意服務埠與相鄰路徑。

對照舊判準實測，下列三個不該放行的網址全部回傳 `True`；最後一個對帶有 GET 副作用的內網管理介面尤其危險。

```text
http://portal.example/app
https://portal.example:8443/app
https://portal.example/app-delete
```
修正後比對完整來源（scheme、host、補上預設值的 port），並要求路徑落在路徑段邊界之內。

### 二、測試旗標在一般啟動時就會覆寫任意檔案

`--jit-status-output=` 的值直接進 `write_text()`，而 `_write_jit_status()` 在 `--self-test` 判斷**之前**無條件執行。任何一次一般啟動只要帶著這個旗標，指定的檔案就被清成一行字串。修正後只在 `--self-test` 或 `--smoke-auto-exit` 時接受。

刻意**不**加「不得覆寫既有檔」那條：`tools/profile_mohan_tachyon.py` 會用同一個路徑重複執行，那條規則會讓它從第二輪起靜默不寫。殘留風險寫進 docstring——能決定命令列的人仍可自己加上 `--self-test`，但那種人通常已經能直接執行任意程式。這裡關掉的是「一般啟動也會寫」，那才是真正不該存在的。

### 測試

新增 `tests/test_input_validation_boundaries.py` 九個測試。每一組都同時驗證「該擋的擋住」與「該放行的仍然放行」：只驗負例的修正，可能只是把功能關掉。

## 简体中文

### 一、网站白名单忽略 scheme 与 port，路径只比前缀

那行看似在检查 scheme 的条件，检查的是白名单项目**自己**的 scheme——请求端的 scheme 从未被约束。加上 `hostname` 不含 port、路径是纯前缀比对，于是允许 `https://portal.example/app` 这一条同时放行了明文 HTTP、任意服务端口与相邻路径。

对照旧判准实测，下列三个不该放行的网址全部返回 `True`；最后一个对带有 GET 副作用的内网管理界面尤其危险。

```text
http://portal.example/app
https://portal.example:8443/app
https://portal.example/app-delete
```
修复后比对完整来源（scheme、host、补上默认值的 port），并要求路径落在路径段边界之内。

### 二、测试标志在一般启动时就会覆写任意文件

`--jit-status-output=` 的值直接进 `write_text()`，而 `_write_jit_status()` 在 `--self-test` 判断**之前**无条件执行。任何一次一般启动只要带着这个标志，指定的文件就被清成一行字符串。修复后只在 `--self-test` 或 `--smoke-auto-exit` 时接受。

刻意**不**加「不得覆写既有文件」那条：`tools/profile_mohan_tachyon.py` 会用同一个路径重复执行，那条规则会让它从第二轮起静默不写。残留风险写进 docstring——能决定命令行的人仍可自己加上 `--self-test`，但那种人通常已经能直接执行任意程序。这里关掉的是「一般启动也会写」，那才是真正不该存在的。

### 测试

新增 `tests/test_input_validation_boundaries.py` 九个测试。每一组都同时验证「该挡的挡住」与「该放行的仍然放行」：只验负例的修复，可能只是把功能关掉。

## English

### 1. The website allowlist ignored scheme and port, and matched paths by prefix

The condition that looks like a scheme check actually checks the *allowlist entry's* scheme — the request's own scheme was never constrained. Combined with `hostname` excluding the port and a plain prefix comparison on the path, a single entry for `https://portal.example/app` also admitted plaintext HTTP, any service port, and adjacent paths.

Measured against the old predicate, the three URLs below that should be refused all returned `True`; the last is especially dangerous against an internal admin interface with side effects on GET.

```text
http://portal.example/app
https://portal.example:8443/app
https://portal.example/app-delete
```
 The fix compares the full origin — scheme, host, and port with its scheme default filled in — and requires the path to fall on a segment boundary.

### 2. A test harness flag overwrote arbitrary files on an ordinary launch

The value of `--jit-status-output=` went straight into `write_text()`, and `_write_jit_status()` ran unconditionally *before* the `--self-test` check. Any ordinary launch carrying that flag truncated the named file down to one string. It is now accepted only under `--self-test` or `--smoke-auto-exit`.

A "must not already exist" rule was deliberately **not** added: `tools/profile_mohan_tachyon.py` reuses one path across repeated runs, and that rule would silently stop it writing from the second round onward. The residual risk is recorded in the docstring — whoever controls the command line can add `--self-test` themselves, though anyone in that position can usually run arbitrary programs already. What this closes is the ordinary launch, which is the part that should never have existed.

### Tests

A new `tests/test_input_validation_boundaries.py` adds nine tests. Each group checks both that the refused case is refused and that the legitimate case still passes, because a fix validated only against negatives may simply have disabled the feature.

## 日本語

### 一、サイト許可リストが scheme と port を無視し、経路を前方一致で比べていた

scheme を確認しているように見えるあの条件は、許可リスト項目**自身**の scheme を見ており、要求側の scheme は一度も制約されていませんでした。`hostname` が port を含まないこと、経路が単なる前方一致であることと重なり、`https://portal.example/app` という一項目が平文 HTTP も任意のサービスポートも隣接する経路も通していました。

旧判定で実測したところ、拒否されるべき下記の三つの URL がいずれも `True` を返しました。最後のものは GET に副作用を持つ内部管理画面に対して特に危険です。

```text
http://portal.example/app
https://portal.example:8443/app
https://portal.example/app-delete
```
修正では完全な生成元（scheme、host、既定値を補った port）を比較し、経路が区切りの境界に収まることを求めます。

### 二、テスト用の旗が通常起動でも任意のファイルを上書きしていた

`--jit-status-output=` の値はそのまま `write_text()` に入り、`_write_jit_status()` は `--self-test` の判定**より前**に無条件で実行されていました。通常の起動でもこの旗を伴えば、指定されたファイルは一行の文字列に切り詰められます。現在は `--self-test` か `--smoke-auto-exit` のときだけ受け付けます。

「既存ファイルを上書きしない」という規則は意図して**加えていません**。`tools/profile_mohan_tachyon.py` は同じ経路で繰り返し実行するため、その規則では二回目以降に黙って書かなくなります。残る危険は docstring に明記しました。命令行を決められる者は自分で `--self-test` を足せますが、その立場にある者は通常すでに任意のプログラムを実行できます。ここで閉じたのは通常起動の経路であり、それこそが存在してはならなかった部分です。

### テスト

新しい `tests/test_input_validation_boundaries.py` に九件のテストを追加しました。各組で「拒むべきものを拒む」ことと「通すべきものを通す」ことの両方を確かめます。否定例だけで検証した修正は、機能を止めただけかもしれないからです。
