### PR TITLE
fix: 伺服器端腳本與情境改按風險上限分級／服务器端脚本与情境改按风险上限分级／Grade server-side scripts and scenes at the risk ceiling／サーバー側のスクリプトとシーンをリスク上限で判定する

### DIFF
--- a/domain/flagship_action_models.py
+++ b/domain/flagship_action_models.py
@@ -68,6 +68,10 @@ CAPABILITY_RISK: Final[frozendict[str, RiskLevel]] = frozendict({
     "home_lock": RiskLevel.RED,
     "home_alarm": RiskLevel.RED,
     "home_heat": RiskLevel.RED,
+    # 伺服器端的腳本與情境，內容對用戶端不可見：它能做的事等於那個
+    # Home Assistant 帳號能做的一切，包含解鎖門與解除警報。無法分級的
+    # 東西只能按上限分級。
+    "home_routine": RiskLevel.RED,
     "camera_view": RiskLevel.YELLOW,
     "microphone_access": RiskLevel.BLUE,
     "realtime_session": RiskLevel.YELLOW,

--- a/integrations/ai_client.py
+++ b/integrations/ai_client.py
@@ -253,6 +253,7 @@ class ActionPlannerWorker(QRunnable):
                                     "home_lock",
                                     "home_alarm",
                                     "home_heat",
+                                    "home_routine",
                                 ],
                             },
                             "description": {"type": "string"},

--- a/integrations/home_assistant.py
+++ b/integrations/home_assistant.py
@@ -13,6 +13,8 @@ lazy from domain.safe_error import sanitize_error
 
 HIGH_RISK_DOMAINS = frozenset({"lock", "alarm_control_panel"})
 HEAT_DOMAINS = frozenset({"climate", "water_heater"})
+# 內容不可見的網域：用戶端無從得知它們會觸發什麼。
+OPAQUE_DOMAINS = frozenset({"script", "scene"})
 IPV4_OCTET_COUNT = 4
 PRIVATE_CLASS_A_FIRST_OCTET = 10
 PRIVATE_CLASS_B_FIRST_OCTET = 172
@@ -227,6 +229,12 @@ def classify_home_capability(domain: str, service: str) -> str:
         return "home_lock" if domain == "lock" else "home_alarm"
     if domain in HEAT_DOMAINS and service != "turn_off":
         return "home_heat"
+    if domain in OPAQUE_DOMAINS:
+        # script.turn_on 原本落在 home_control（BLUE，零確認），但腳本內容
+        # 在伺服器上、用戶端看不見。一個名為「夜間模式」的腳本可以同時
+        # lock.unlock 與 alarm_control_panel.alarm_disarm，而那兩件事直接
+        # 表達時是 RED、需要兩次確認。scene 同理：情境可以把門鎖設成解鎖。
+        return "home_routine"
     return "home_control"
 
 

--- a/presentation/flagship/home.py
+++ b/presentation/flagship/home.py
@@ -31,6 +31,7 @@ HOME_CAPABILITIES = (
     "home_lock",
     "home_alarm",
     "home_heat",
+    "home_routine",
 )
 
 
@@ -198,6 +199,7 @@ class FlagshipHomeMixin:
             "home_lock",
             "home_alarm",
             "home_heat",
+            "home_routine",
         ):
             self.executor.register(
                 capability,

--- a/presentation/flagship/localization_workflows.py
+++ b/presentation/flagship/localization_workflows.py
@@ -106,11 +106,16 @@ WORKFLOW_TRANSLATIONS: TranslationCatalog = frozendict({
         "控制一般智能设备", "Control standard smart devices", "一般スマート機器を操作"
     ),
     "控制門鎖": translations("控制门锁", "Control door locks", "ドアロックを操作"),
-    "控制警報": translations("控制警报", "Control alarms", "ĵ報を操作"),
+    "控制警報": translations("控制警报", "Control alarms", "警報を操作"),
     "控制加熱與高溫設備": translations(
         "控制加热与高温设备",
         "Control heating and high-temperature devices",
         "暖房・高温機器を操作",
+    ),
+    "執行智慧家庭腳本或情境": translations(
+        "执行智能家庭脚本或情境",
+        "Run a smart-home script or scene",
+        "スマートホームのスクリプトまたはシーンを実行",
     ),
     "使用攝影機": translations("使用摄像头", "Use the camera", "カメラを使用"),
     "遠端查看本程式畫面": translations(

--- a/presentation/flagship/shared.py
+++ b/presentation/flagship/shared.py
@@ -103,6 +103,7 @@ CORE_PERMISSION_LABELS = frozendict({
     "home_lock": "控制門鎖",
     "home_alarm": "控制警報",
     "home_heat": "控制加熱與高溫設備",
+    "home_routine": "執行智慧家庭腳本或情境",
     "camera_view": "使用攝影機",
     "microphone_access": "使用麥克風",
     "realtime_session": "啟動 Realtime 雲端對話",

--- a/presentation/flagship/workflow_editor.py
+++ b/presentation/flagship/workflow_editor.py
@@ -126,6 +126,7 @@ class WorkflowEditor(QDialog):
             "home_lock",
             "home_alarm",
             "home_heat",
+            "home_routine",
         }:
             return self._home_arguments(capability, raw_argument)
         try:

--- a/tests/test_home_routine_risk_grading.py
+++ b/tests/test_home_routine_risk_grading.py
@@ -1,0 +1,106 @@
+"""內容不可見的智慧家庭動作，必須按風險上限分級。
+
+2026-09-02 稽核：`script.turn_on` 落在 `home_control`（BLUE，零確認），
+但腳本內容在伺服器上，用戶端看不見。一個名為「夜間模式」的腳本可以同時
+執行 `lock.unlock` 與 `alarm_control_panel.alarm_disarm`——而那兩件事直接
+表達時是 RED、需要兩次確認。使用者以為自己只授權了一般家電控制。
+
+`scene` 同一個問題：情境會設定實體狀態，其中可以包含把門鎖設成解鎖。
+
+無法分級的東西只能按上限分級。這裡的測試同時確認低風險動作**沒有**被
+一起升級——把所有東西都變成 RED 不是修正，是把功能關掉。
+"""
+from __future__ import annotations
+
+
+def test_server_side_script_is_not_low_risk() -> None:
+    from integrations.home_assistant import classify_home_capability
+
+    assert classify_home_capability("script", "turn_on") == "home_routine", (
+        "伺服器端腳本仍被當成一般家電控制"
+    )
+
+
+def test_scene_is_not_low_risk() -> None:
+    from integrations.home_assistant import classify_home_capability
+
+    assert classify_home_capability("scene", "turn_on") == "home_routine"
+
+
+def test_routine_capability_is_graded_at_the_ceiling() -> None:
+    from domain.flagship_action_models import CAPABILITY_RISK, RiskLevel
+
+    assert CAPABILITY_RISK["home_routine"] is RiskLevel.RED
+
+
+def test_ordinary_devices_are_still_low_risk() -> None:
+    """正例：修正不得把一般家電一起升級成需要兩次確認。"""
+    from domain.flagship_action_models import CAPABILITY_RISK, RiskLevel
+    from integrations.home_assistant import classify_home_capability
+
+    for domain in ("light", "switch", "fan", "cover", "media_player"):
+        capability = classify_home_capability(domain, "turn_on")
+        assert capability == "home_control", f"{domain} 被誤升級為 {capability}"
+    assert CAPABILITY_RISK["home_control"] is RiskLevel.BLUE
+
+
+def test_existing_high_risk_domains_are_unchanged() -> None:
+    from integrations.home_assistant import classify_home_capability
+
+    assert classify_home_capability("lock", "unlock") == "home_lock"
+    assert classify_home_capability("alarm_control_panel", "alarm_disarm") == (
+        "home_alarm"
+    )
+    assert classify_home_capability("climate", "set_temperature") == "home_heat"
+    assert classify_home_capability("climate", "turn_off") == "home_control"
+
+
+def test_every_home_capability_is_registered_everywhere() -> None:
+    """新增一個家庭能力需要改七個地方；漏掉任何一處都會壞得很安靜。
+
+    漏掉風險表 → 分級查不到；漏掉 HOME_CAPABILITIES → 權限設定裡沒有這一
+    項可調；漏掉執行器註冊 → 動作找不到執行者；漏掉標籤 → 確認視窗顯示
+    原始鍵名。這個守衛存在的理由是：這次修正本身就要同時改七處。
+    """
+    from domain.flagship_action_models import CAPABILITY_RISK
+    from presentation.flagship.home import HOME_CAPABILITIES
+    from presentation.flagship.shared import CORE_PERMISSION_LABELS
+
+    graded = {name for name in CAPABILITY_RISK if name.startswith("home_")}
+    listed = set(HOME_CAPABILITIES)
+    labelled = {
+        name for name in CORE_PERMISSION_LABELS if name.startswith("home_")
+    }
+
+    assert graded == listed, (
+        f"風險表與 HOME_CAPABILITIES 不一致：只在風險表 {graded - listed}；"
+        f"只在清單 {listed - graded}"
+    )
+    assert graded <= labelled, f"缺少標籤：{graded - labelled}"
+
+    # 標籤存在還不夠：非繁體中文的介面會拿標籤字串去查翻譯表，查不到就
+    # 直接 KeyError。這個修正本身就漏了這一步，三個語言的設定往返測試
+    # 才把它抓出來。
+    from presentation.flagship_ui_localization import FLAGSHIP_TRANSLATIONS
+
+    missing = {
+        CORE_PERMISSION_LABELS[name]
+        for name in graded
+        if CORE_PERMISSION_LABELS[name] not in FLAGSHIP_TRANSLATIONS
+    }
+    assert not missing, f"標籤缺少四語翻譯，非繁中介面會直接崩潰：{missing}"
+
+
+def test_routine_capability_reaches_the_executor_and_the_editor() -> None:
+    """註冊迴圈與工作流程編輯器都必須認得這個能力。"""
+    import inspect
+
+    from presentation.flagship import home, workflow_editor
+
+    registration = inspect.getsource(home).split("executor.register(\"home_read\"", 1)[1]
+    assert "home_routine" in registration.split("def ", 1)[0], (
+        "執行器註冊迴圈沒有涵蓋 home_routine"
+    )
+    assert "home_routine" in inspect.getsource(workflow_editor), (
+        "工作流程編輯器無法為 home_routine 產生參數"
+    )


### PR DESCRIPTION
## 繁體中文

### 為什麼

`script.turn_on` 原本落在 `home_control`（BLUE，零確認），但腳本內容在 Home Assistant 伺服器上，用戶端看不見。一個名為「夜間模式」的腳本可以同時執行 `lock.unlock` 與 `alarm_control_panel.alarm_disarm`——那兩件事直接表達時是 RED、需要兩次確認。使用者以為自己只授權了一般家電控制，實際授權範圍是那個帳號能做的一切。

`scene` 是同一個問題，稽核沒提但成因相同：情境會設定實體狀態，其中可以包含把門鎖設成解鎖。一併納入。

### 修法

無法分級的東西只能按上限分級：新增 `home_routine` 能力，等級 RED。低風險動作未受影響——`light`、`switch`、`fan`、`cover`、`media_player` 仍是 `home_control`（BLUE），`lock`、`alarm_control_panel`、`climate` 的既有分級不變。測試對這兩側都有斷言：把所有東西都升成 RED 不是修正，是把功能關掉。

### 這次修正自己漏了一處

新增一個家庭能力需要同時改七個地方：風險表、分級函式、`HOME_CAPABILITIES`、執行器註冊、標籤、AI 工具列舉、工作流程編輯器。而實際上有第八處——四語翻譯。漏掉它時繁體中文正常，另外三個語言在設定往返時直接 `KeyError`，由既有測試抓出來。因此新增的測試裡放了一致性守衛，涵蓋含翻譯在內的所有登記點。

### 順帶修正

「控制警報」的日文寫成 `ĵ報を操作`，`ĵ` 是世界語字母，會直接顯示在日文介面上。改為 `警報を操作`。

## 简体中文

### 为什么

`script.turn_on` 原本落在 `home_control`（BLUE，零确认），但脚本内容在 Home Assistant 服务器上，客户端看不见。一个名为「夜间模式」的脚本可以同时执行 `lock.unlock` 与 `alarm_control_panel.alarm_disarm`——那两件事直接表达时是 RED、需要两次确认。用户以为自己只授权了一般家电控制，实际授权范围是那个账号能做的一切。

`scene` 是同一个问题，审计没提但成因相同：情境会设置实体状态，其中可以包含把门锁设成解锁。一并纳入。

### 修复方式

无法分级的东西只能按上限分级：新增 `home_routine` 能力，等级 RED。低风险动作未受影响——`light`、`switch`、`fan`、`cover`、`media_player` 仍是 `home_control`（BLUE），`lock`、`alarm_control_panel`、`climate` 的既有分级不变。测试对这两侧都有断言：把所有东西都升成 RED 不是修复，是把功能关掉。

### 这次修复自己漏了一处

新增一个家庭能力需要同时改七个地方：风险表、分级函数、`HOME_CAPABILITIES`、执行器注册、标签、AI 工具枚举、工作流程编辑器。而实际上有第八处——四语翻译。漏掉它时繁体中文正常，另外三个语言在设置往返时直接 `KeyError`，由既有测试抓出来。因此新增的测试里放了一致性守卫，涵盖含翻译在内的所有登记点。

### 顺带修复

「控制警报」的日文写成 `ĵ報を操作`，`ĵ` 是世界语字母，会直接显示在日文界面上。改为 `警報を操作`。

## English

### Why

`script.turn_on` sat in `home_control` (BLUE, zero confirmations), yet the script's contents live on the Home Assistant server where the client cannot see them. A script named "night mode" may run both `lock.unlock` and `alarm_control_panel.alarm_disarm` — expressed directly those are RED and require two confirmations. The user believes they granted ordinary appliance control; what they actually granted is everything that account can do.

`scene` is the same problem, unmentioned by the audit but identical in cause: a scene sets entity states, and those states can include a lock set to unlocked. It is covered here too.

### The fix

Something that cannot be graded must be graded at the ceiling: a new `home_routine` capability at RED. Low-risk actions are untouched — `light`, `switch`, `fan`, `cover` and `media_player` remain `home_control` at BLUE, and the existing grades for `lock`, `alarm_control_panel` and `climate` are unchanged. The tests assert both sides, because promoting everything to RED is not a fix but a way of disabling the feature.

### This change missed one of its own registration points

Adding a home capability means touching seven places: the risk table, the classifier, `HOME_CAPABILITIES`, executor registration, labels, the AI tool enumeration, and the workflow editor. There is in fact an eighth — the four-language translations. Omitting it left Traditional Chinese working while the other three raised `KeyError` during the settings round trip, which an existing test caught. The new tests therefore carry a consistency guard covering every registration point, translations included.

### Also fixed

The Japanese for "control alarms" read `ĵ報を操作`, where `ĵ` is an Esperanto letter that would appear directly in the Japanese interface. It now reads `警報を操作`.

## 日本語

### 理由

`script.turn_on` は `home_control`（BLUE、確認なし）に分類されていましたが、スクリプトの中身は Home Assistant のサーバー側にあり、クライアントからは見えません。「ナイトモード」という名前のスクリプトが `lock.unlock` と `alarm_control_panel.alarm_disarm` を同時に実行することもあり、それらを直接表した場合は RED で二回の確認が要ります。利用者は一般家電の操作だけを許可したつもりでも、実際に許可した範囲はそのアカウントにできる全てです。

`scene` も同じ問題で、監査は触れていませんが原因は同一です。シーンは実体の状態を設定し、その状態には解錠されたドアロックを含められます。ここで併せて扱います。

### 修正方法

等級を判定できないものは上限で判定するほかありません。新しい `home_routine` 能力を RED として追加しました。低リスクの操作には影響しません。`light`、`switch`、`fan`、`cover`、`media_player` は `home_control`（BLUE）のままで、`lock`、`alarm_control_panel`、`climate` の既存の等級も変わりません。テストは両側を確かめます。全てを RED に上げるのは修正ではなく機能の停止だからです。

### この修正自身が登録箇所を一つ落としていた

家庭向け能力を追加するには七箇所を同時に触る必要があります。リスク表、分類関数、`HOME_CAPABILITIES`、実行器への登録、ラベル、AI ツールの列挙、ワークフロー編集器です。実際には八箇所目がありました。四言語の翻訳です。これを落とすと繁体字中国語だけが動き、他の三言語は設定の往復で `KeyError` になり、既存のテストがそれを捉えました。そこで新しいテストには、翻訳を含む全ての登録箇所を覆う整合性の番人を置きました。

### 併せて修正

「警報の操作」の日本語が `ĵ報を操作` になっていました。`ĵ` はエスペラントの文字で、日本語画面にそのまま表示されます。`警報を操作` に修正しました。
