### PR TITLE
fix: 失敗不再偽裝成成功，稽核不再保存剪貼簿全文／失败不再伪装成成功，审计不再保存剪贴板全文／Stop failures posing as success, and stop the audit log storing the full clipboard／失敗を成功に見せかけず、監査記録にクリップボード全文を残さない

### DIFF
--- a/application/background_agents.py
+++ b/application/background_agents.py
@@ -115,8 +115,26 @@ class ManagerWorkerScheduler:
                 self._futures.pop(worker_id, None)
                 try:
                     candidates.extend(future.result())
-                except (OSError, RuntimeError, ValueError):
-                    continue
+                except (OSError, RuntimeError, ValueError) as error:
+                    # 原本 continue：worker 讀報告時 PermissionError，drain() 回傳
+                    # []，呼叫端把「診斷報告無法讀取」顯示成「沒有診斷問題」，
+                    # 且每次輪詢都靜默重演。失敗必須以觀察結果的形式浮上來，
+                    # 走同一條去重與冷卻，而不是消失。
+                    candidates.append(
+                        AgentObservation(
+                            worker_id=worker_id,
+                            event_key="worker-failed",
+                            message=(
+                                f"{worker_id} 無法完成檢查：{type(error).__name__}"
+                            ),
+                            expression="worried_front",
+                            priority=1,
+                            metadata={
+                                "status": "failed",
+                                "error": type(error).__name__,
+                            },
+                        )
+                    )
             candidates.sort(key=lambda item: (-item.priority, item.event_key))
             delivered: list[AgentObservation] = []
             for observation in candidates:

--- a/application/flagship_action_runtime.py
+++ b/application/flagship_action_runtime.py
@@ -32,6 +32,34 @@ Confirm = Callable[[ActionRequest, PolicyDecision, int], bool]
 Audit = Callable[[str, dict[str, Any]], None]
 
 
+# 稽核紀錄裡不該原樣保存的欄位。UI 只顯示摘要 500 字，資料庫卻存到
+# 100,000 字；clipboard_read 把整段剪貼簿放進 result.data["text"]，
+# clipboard_write 把要寫入的文字放進 request.arguments["text"]，兩者都以
+# 未加密 JSON 進 SQLite，而 clear_audit_before() 沒有正式呼叫者，不是短期
+# 環形紀錄。金鑰、密碼、私訊都可能在剪貼簿裡。
+REDACTED_AUDIT_KEYS = frozenset(
+    {"text", "content", "body", "password", "token", "secret"}
+)
+AUDIT_PREVIEW_CHARS = 64
+
+
+def redact_audit_payload(value: object) -> object:
+    """遞迴遮罩敏感欄位，只留長度與短預覽：稽核仍可讀，但不再是資料倉。"""
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, item in value.items():
+            if key in REDACTED_AUDIT_KEYS and isinstance(item, str):
+                preview = item[:AUDIT_PREVIEW_CHARS]
+                more = "..." if len(item) > AUDIT_PREVIEW_CHARS else ""
+                redacted[key] = f"<redacted {len(item)} chars: {preview}{more}>"
+            else:
+                redacted[key] = redact_audit_payload(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_audit_payload(item) for item in value]
+    return value
+
+
 class CancellationRegistry:
     def __init__(self) -> None:
         self._events: dict[str, threading.Event] = {}
@@ -94,7 +122,7 @@ class ActionExecutor:
 
     def execute(self, plan: ActionPlan) -> list[ActionResult]:
         cancel_event = self.cancellations.begin(plan.plan_id)
-        self.audit("plan_started", plan.to_dict())
+        self.audit("plan_started", redact_audit_payload(plan.to_dict()))
         results: list[ActionResult] = []
         try:
             for request in plan.steps:
@@ -208,8 +236,8 @@ class ActionExecutor:
             "action_result",
             {
                 "plan_id": plan.plan_id,
-                "request": asdict(request),
-                "result": asdict(result),
+                "request": redact_audit_payload(asdict(request)),
+                "result": redact_audit_payload(asdict(result)),
             },
         )
 

--- a/application/wardrobe_storage.py
+++ b/application/wardrobe_storage.py
@@ -32,7 +32,14 @@ class WardrobeStorageStatus:
     total_bytes: int
 
 
-def _directory_bytes(root: Path) -> int:
+def _directory_bytes(root: Path) -> int | None:
+    """回傳目錄總位元組；量不完整時回傳 None，而不是部分總量。
+
+    原本任一 stat() 拋 OSError 就 return 目前累計值。quarantine 實際 6.4 GiB、
+    掃到 800 MiB 時一個檔案因 ACL 變更或同步程式搬走而失敗，函式回傳 800 MiB，
+    低於 6 GiB 上限，生成器繼續寫 draft——這是 fail-open，可能把磁碟寫滿。
+    「量測失敗」與「量到很少」必須是兩個不同的回傳值。
+    """
     if not root.is_dir():
         return 0
     total = 0
@@ -41,7 +48,7 @@ def _directory_bytes(root: Path) -> int:
             try:
                 total += path.stat().st_size
             except OSError:
-                return total
+                return None
     return total
 
 
@@ -92,9 +99,13 @@ class WardrobeStorageGuard:
             for path in packages.glob("generated-*.mohan-outfit")
             if path.is_file()
         ) if packages.is_dir() else 0
-        total = generated_bytes + _directory_bytes(self.quarantine_root)
+        quarantine_bytes = _directory_bytes(self.quarantine_root)
+        total = generated_bytes + (quarantine_bytes or 0)
         reason = "ready"
-        if installed >= self.policy.max_installed_packages:
+        if quarantine_bytes is None:
+            # 量不準就不放行：上限檢查的前提是總量可信。
+            reason = "storage-unmeasurable"
+        elif installed >= self.policy.max_installed_packages:
             reason = "package-limit"
         elif jobs >= self.policy.max_quarantine_jobs:
             reason = "quarantine-limit"

--- a/integrations/openai_outfit_generator.py
+++ b/integrations/openai_outfit_generator.py
@@ -720,51 +720,70 @@ class GeneratedOutfitImageAuditor:
     ) -> tuple[str, ...]:
         issues: list[str] = []
         for view_id, entries in poses.items():
-            issue_id = f"{category}:{view_id}"
             if not isinstance(entries, list) or not entries:
-                issues.append(f"{issue_id}:missing-layer")
+                issues.append(f"{category}:{view_id}:missing-layer")
                 continue
-            path = entries[0].get("path") if isinstance(entries[0], dict) else None
-            if not isinstance(path, str):
-                issues.append(f"{issue_id}:invalid-path")
-                continue
-            image = cv2.imread(str(source / Path(*path.split("/"))), cv2.IMREAD_UNCHANGED)
-            expected = FULL_SIZE if view_id in POSE_ATLAS_SILHOUETTES else HALF_SIZE
+            # 原本只驗 entries[0]。manifest 契約允許多層，第二層可以尺寸與
+            # SHA-256 都正確、Alpha 卻 100% 不透明並蓋住臉，稽核照樣放行，
+            # install_after_audit=True 直接安裝。每一層都要過同一套檢查。
+            for layer_index, entry in enumerate(entries):
+                issue_id = (
+                    f"{category}:{view_id}"
+                    if len(entries) == 1
+                    else f"{category}:{view_id}:layer{layer_index}"
+                )
+                issues.extend(self._audit_layer(source, view_id, issue_id, entry))
+        return tuple(issues)
+
+    def _audit_layer(
+        self,
+        source: Path,
+        view_id: str,
+        issue_id: str,
+        entry: object,
+    ) -> tuple[str, ...]:
+        issues: list[str] = []
+        path = entry.get("path") if isinstance(entry, dict) else None
+        if not isinstance(path, str):
+            issues.append(f"{issue_id}:invalid-path")
+            return tuple(issues)
+        image = cv2.imread(str(source / Path(*path.split("/"))), cv2.IMREAD_UNCHANGED)
+        expected = FULL_SIZE if view_id in POSE_ATLAS_SILHOUETTES else HALF_SIZE
+        if (
+            image is None
+            or image.ndim != IMAGE_DIMENSIONS
+            or image.shape[2] != RGBA_CHANNELS
+        ):
+            issues.append(f"{issue_id}:not-rgba")
+            return tuple(issues)
+        if (image.shape[1], image.shape[0]) != expected:
+            issues.append(f"{issue_id}:wrong-size")
+            return tuple(issues)
+        nonzero = int(np.count_nonzero(image[:, :, 3]))
+        pixels = expected[0] * expected[1]
+        if nonzero < max(64, pixels // 5000):
+            issues.append(f"{issue_id}:empty")
+        elif nonzero > pixels * 0.72:
+            issues.append(f"{issue_id}:overbroad-alpha")
+        if self._root is not None:
+            protected_path = _protected_face_path(self._root, view_id)
+            protected = cv2.imread(str(protected_path), cv2.IMREAD_UNCHANGED)
             if (
-                image is None
-                or image.ndim != IMAGE_DIMENSIONS
-                or image.shape[2] != RGBA_CHANNELS
+                protected is None
+                or protected.ndim != IMAGE_DIMENSIONS
+                or protected.shape[2] != RGBA_CHANNELS
+                or protected.shape[:2] != image.shape[:2]
             ):
-                issues.append(f"{issue_id}:not-rgba")
-                continue
-            if (image.shape[1], image.shape[0]) != expected:
-                issues.append(f"{issue_id}:wrong-size")
-                continue
-            nonzero = int(np.count_nonzero(image[:, :, 3]))
-            pixels = expected[0] * expected[1]
-            if nonzero < max(64, pixels // 5000):
-                issues.append(f"{issue_id}:empty")
-            elif nonzero > pixels * 0.72:
-                issues.append(f"{issue_id}:overbroad-alpha")
-            if self._root is not None:
-                protected_path = _protected_face_path(self._root, view_id)
-                protected = cv2.imread(str(protected_path), cv2.IMREAD_UNCHANGED)
-                if (
-                    protected is None
-                    or protected.ndim != IMAGE_DIMENSIONS
-                    or protected.shape[2] != RGBA_CHANNELS
-                    or protected.shape[:2] != image.shape[:2]
-                ):
-                    issues.append(f"{issue_id}:protected-mask-unavailable")
-                    continue
-                face_alpha = (
-                    protected[:, :, RGBA_CHANNELS - 1] > ALPHA_CONTENT_THRESHOLD
-                )
-                face_pixels = int(np.count_nonzero(face_alpha))
-                outfit_alpha = (
-                    image[:, :, RGBA_CHANNELS - 1] > ALPHA_CONTENT_THRESHOLD
-                )
-                overlap = int(np.count_nonzero(outfit_alpha & face_alpha))
-                if face_pixels and overlap / face_pixels > MAX_FACE_OVERLAP_RATIO:
-                    issues.append(f"{issue_id}:face-overlap")
+                issues.append(f"{issue_id}:protected-mask-unavailable")
+                return tuple(issues)
+            face_alpha = (
+                protected[:, :, RGBA_CHANNELS - 1] > ALPHA_CONTENT_THRESHOLD
+            )
+            face_pixels = int(np.count_nonzero(face_alpha))
+            outfit_alpha = (
+                image[:, :, RGBA_CHANNELS - 1] > ALPHA_CONTENT_THRESHOLD
+            )
+            overlap = int(np.count_nonzero(outfit_alpha & face_alpha))
+            if face_pixels and overlap / face_pixels > MAX_FACE_OVERLAP_RATIO:
+                issues.append(f"{issue_id}:face-overlap")
         return tuple(issues)

--- a/tests/test_silent_failures_and_audit_data.py
+++ b/tests/test_silent_failures_and_audit_data.py
@@ -1,0 +1,293 @@
+"""失敗不得偽裝成成功；稽核紀錄不得變成資料倉。
+
+2026-09-02 稽核第 4 批，四項成因各異但後果同型——呼叫端拿到的值分不出
+「沒事」與「壞了」：
+
+1. `_directory_bytes()` 遇到 stat() 失敗就回傳部分總量，容量檢查以此放行。
+2. `drain()` 吞掉 worker 例外後回傳 []，與「沒有事件」無法區分。
+3. 服裝稽核只檢查每個 pose 的 entries[0]，後層任何缺陷都能出貨。
+4. 稽核紀錄原樣保存剪貼簿全文（UI 顯示 500 字，資料庫存到 100,000 字）。
+
+每組都同時驗證「該擋的擋住」與「該放行的仍然放行」。
+"""
+from __future__ import annotations
+
+lazy import struct
+lazy import zlib
+lazy from concurrent.futures import Future
+lazy from pathlib import Path
+
+
+# ── 1) 容量掃描 fail-closed ───────────────────────────────────────────────
+
+def test_directory_bytes_reports_measurement_failure_as_none(tmp_path, monkeypatch) -> None:
+    """量不完整必須回傳 None，而不是到目前為止的部分總量。"""
+    from application import wardrobe_storage
+
+    (tmp_path / "a.bin").write_bytes(b"x" * 1000)
+    (tmp_path / "b.bin").write_bytes(b"x" * 1000)
+    real_stat = Path.stat
+    calls = {"n": 0}
+
+    def flaky_stat(self, *args, **kwargs):
+        if self.name == "b.bin":
+            raise PermissionError("ACL changed mid-scan")
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", flaky_stat)
+    assert wardrobe_storage._directory_bytes(tmp_path) is None, (
+        "stat() 失敗後仍回傳了部分總量——這會讓容量檢查以錯誤的小數字放行"
+    )
+    del calls
+
+
+def test_directory_bytes_still_measures_a_healthy_tree(tmp_path) -> None:
+    """正例：沒有失敗時要量到完整總量。"""
+    from application import wardrobe_storage
+
+    top_level_bytes = 1000
+    nested_bytes = 500
+    (tmp_path / "a.bin").write_bytes(b"x" * top_level_bytes)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.bin").write_bytes(b"x" * nested_bytes)
+    assert wardrobe_storage._directory_bytes(tmp_path) == top_level_bytes + nested_bytes
+
+
+def test_storage_guard_refuses_generation_when_usage_is_unmeasurable(
+    tmp_path, monkeypatch
+) -> None:
+    """量測失敗 → 不放行，且理由要能被辨認。"""
+    from datetime import UTC, datetime
+
+    from application import wardrobe_storage
+
+    outfit_store = tmp_path / "outfits"
+    quarantine = tmp_path / "quarantine"
+    outfit_store.mkdir()
+    quarantine.mkdir()
+    (quarantine / "job" ).mkdir()
+    (quarantine / "job" / "blob.bin").write_bytes(b"x" * 10)
+    monkeypatch.setattr(wardrobe_storage, "_directory_bytes", lambda root: None)
+
+    guard = wardrobe_storage.WardrobeStorageGuard(outfit_store, quarantine)
+    status = guard.inspect(datetime.now(UTC), None, special_occasion=True)
+    assert status.allowed is False
+    assert status.reason == "storage-unmeasurable"
+
+
+def test_storage_guard_still_allows_when_measurement_succeeds(tmp_path) -> None:
+    """正例：健康狀態下 ready 仍要放行。"""
+    from datetime import UTC, datetime
+
+    from application import wardrobe_storage
+
+    outfit_store = tmp_path / "outfits"
+    quarantine = tmp_path / "quarantine"
+    outfit_store.mkdir()
+    quarantine.mkdir()
+    guard = wardrobe_storage.WardrobeStorageGuard(outfit_store, quarantine)
+    status = guard.inspect(datetime.now(UTC), None, special_occasion=True)
+    assert status.allowed is True
+    assert status.reason == "ready"
+
+
+# ── 2) 背景 worker 失敗要浮上來 ───────────────────────────────────────────
+
+class _BrokenWorker:
+    worker_id = "diagnostic-report"
+    interval_seconds = 1.0
+
+    def poll(self):
+        raise PermissionError("report locked by ACL")
+
+
+class _QuietWorker:
+    worker_id = "quiet"
+    interval_seconds = 1.0
+
+    def poll(self):
+        return []
+
+
+def _scheduler_with_done_future(worker, exc: BaseException | None):
+    from application.background_agents import ManagerWorkerScheduler
+
+    scheduler = ManagerWorkerScheduler((worker,), clock=lambda: 1000.0)
+    future: Future = Future()
+    if exc is None:
+        future.set_result([])
+    else:
+        future.set_exception(exc)
+    scheduler._futures[worker.worker_id] = future
+    return scheduler
+
+
+def test_worker_failure_surfaces_as_an_observation() -> None:
+    """worker 拋錯時 drain() 不得回傳空清單。"""
+    scheduler = _scheduler_with_done_future(_BrokenWorker(), PermissionError("locked"))
+    delivered = scheduler.drain()
+    assert delivered, "worker 失敗被吞掉，drain() 回傳 []，與『沒有事件』無法區分"
+    observation = delivered[0]
+    assert observation.worker_id == "diagnostic-report"
+    assert observation.event_key == "worker-failed"
+    assert observation.metadata.get("status") == "failed"
+    assert observation.metadata.get("error") == "PermissionError"
+
+
+def test_quiet_worker_still_yields_nothing() -> None:
+    """正例：真的沒有事件時仍要回傳空清單，不得憑空製造觀察。"""
+    scheduler = _scheduler_with_done_future(_QuietWorker(), None)
+    assert scheduler.drain() == []
+
+
+def test_worker_failure_is_deduplicated_like_any_other_event() -> None:
+    """失敗走同一條去重與冷卻：連續兩次 drain 不會重複打擾使用者。"""
+    scheduler = _scheduler_with_done_future(_BrokenWorker(), PermissionError("locked"))
+    assert scheduler.drain()
+    scheduler._futures["diagnostic-report"] = _scheduler_with_done_future(
+        _BrokenWorker(), PermissionError("locked")
+    )._futures["diagnostic-report"]
+    assert scheduler.drain() == [], "同一個失敗在冷卻期內被重複送出"
+
+
+# ── 3) 服裝稽核檢查每一層 ─────────────────────────────────────────────────
+
+def _png(width: int, height: int, alpha: int, coverage: float = 1.0) -> bytes:
+    """最小 RGBA PNG。alpha 只塗在左上角 coverage 比例的區塊，其餘全透明。
+
+    稽核數的是非零 alpha 像素數：一張「合格的服裝層」必須大部分透明。
+    第一版夾具把每個像素都塗成 alpha 40，全幅非零，於是合格層被判 overbroad
+    ——那是夾具不像真實資產，不是產品誤判。
+    """
+    rows = max(1, int(height * coverage))
+    cols = max(1, int(width * coverage))
+    painted = bytes([200, 200, 200, alpha]) * cols + bytes(4) * (width - cols)
+    clear = bytes(4) * width
+    raw = b"".join(
+        b"\x00" + (painted if y < rows else clear) for y in range(height)
+    )
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _manifest(view_id: str, layers: list[str]) -> dict[str, object]:
+    return {
+        "looks": [
+            {
+                "variants": [
+                    {
+                        "poses": {
+                            view_id: [
+                                {"slot": f"layer{i}", "path": path}
+                                for i, path in enumerate(layers)
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_auditor_inspects_every_layer_not_only_the_first(tmp_path) -> None:
+    """第一層合格、第二層 Alpha 全不透明——舊稽核放行，新稽核必須擋。"""
+    from integrations.openai_outfit_generator import (
+        HALF_SIZE,
+        GeneratedOutfitImageAuditor,
+    )
+
+    view_id = "cheek-rest"  # 半身視角，避開需要專案根目錄的臉部遮罩檢查
+    width, height = HALF_SIZE
+    source = tmp_path / "source" / "assets"
+    source.mkdir(parents=True)
+    (source / "good.png").write_bytes(_png(width, height, alpha=200, coverage=0.3))
+    (source / "opaque.png").write_bytes(_png(width, height, alpha=255))
+
+    auditor = GeneratedOutfitImageAuditor(project_root=None)
+    issues = auditor.audit(
+        tmp_path,
+        _manifest(view_id, ["assets/good.png", "assets/opaque.png"]),
+    )
+    assert any(issue.endswith(":layer1:overbroad-alpha") for issue in issues), (
+        f"第二層 100% 不透明卻未被標記：{issues}"
+    )
+    assert not any(issue.endswith(":layer0:overbroad-alpha") for issue in issues), (
+        "合格的第一層被誤判"
+    )
+
+
+def test_single_layer_issue_ids_are_unchanged(tmp_path) -> None:
+    """正例：單層 pose 的 issue id 維持原格式，不影響既有消費者。"""
+    from integrations.openai_outfit_generator import (
+        HALF_SIZE,
+        GeneratedOutfitImageAuditor,
+    )
+
+    view_id = "cheek-rest"
+    width, height = HALF_SIZE
+    source = tmp_path / "source" / "assets"
+    source.mkdir(parents=True)
+    (source / "opaque.png").write_bytes(_png(width, height, alpha=255))
+
+    issues = GeneratedOutfitImageAuditor(project_root=None).audit(
+        tmp_path, _manifest(view_id, ["assets/opaque.png"])
+    )
+    assert f"garment:{view_id}:overbroad-alpha" in issues
+    assert not any(":layer0:" in issue for issue in issues)
+
+
+# ── 4) 稽核 payload 遮罩 ──────────────────────────────────────────────────
+
+def test_audit_redacts_clipboard_text_but_keeps_shape() -> None:
+    from application.flagship_action_runtime import redact_audit_payload
+
+    secret = "sk-live-" + "a" * 200
+    payload = {
+        "plan_id": "p1",
+        "request": {"capability": "clipboard_write", "arguments": {"text": secret}},
+        "result": {"success": True, "data": {"text": secret}},
+    }
+    redacted = redact_audit_payload(payload)
+    flat = repr(redacted)
+    assert secret not in flat, "剪貼簿全文仍原樣進入稽核紀錄"
+    assert "sk-live-" in flat, "遮罩後應保留短預覽，否則稽核失去可讀性"
+    assert "208 chars" in flat, "遮罩後應保留長度"
+    assert redacted["plan_id"] == "p1"
+    assert redacted["request"]["capability"] == "clipboard_write"
+    assert redacted["result"]["success"] is True
+
+
+def test_audit_redaction_leaves_non_sensitive_fields_alone() -> None:
+    """正例：路徑、能力名稱、布林值等必須原樣保留。"""
+    from application.flagship_action_runtime import redact_audit_payload
+
+    payload = {"capability": "open_folder", "arguments": {"path": "D:/x"}, "ok": True}
+    assert redact_audit_payload(payload) == payload
+
+
+def test_plan_started_and_action_result_both_go_through_redaction() -> None:
+    """兩個稽核入口都要遮罩：clipboard_write 的文字在 plan_started 就出現了。"""
+    import inspect
+
+    from application import flagship_action_runtime as module
+
+    source = inspect.getsource(module)
+    assert 'self.audit("plan_started", redact_audit_payload(' in source
+    record = source.split("def _record_result", 1)[1].split("def ", 1)[0]
+    redacted_fields = 2  # request 與 result
+    assert record.count("redact_audit_payload(") == redacted_fields, (
+        "request 與 result 都必須經過遮罩"
+    )


### PR DESCRIPTION
## 繁體中文

### 為什麼

2026-09-02 稽核的最後四項，成因各異但後果同型：呼叫端拿到的值分不出「沒事」與「壞了」。四項全部修正並附測試，每組都同時驗證「該擋的擋住」與「該放行的仍然放行」。

### 一、容量掃描把部分總量當成完整總量

`_directory_bytes()` 遇到任一 `stat()` 失敗就回傳到目前為止的累計值。暫存區實際 6.4 GiB、掃到 800 MiB 時一個檔案因 ACL 變更或同步程式搬走而失敗，函式回傳 800 MiB，低於上限，生成器繼續寫入——這是 fail-open，可能把磁碟寫滿。修正後量測失敗回傳 `None`，`inspect()` 對應為 `storage-unmeasurable` 且不放行：上限檢查的前提是總量可信。

### 二、背景 worker 的失敗被轉成「沒有事件」

`drain()` 對 `OSError`、`RuntimeError`、`ValueError` 只做 `continue`，最終回傳空清單。診斷報告因權限讀不到時，使用者看到的是「沒有診斷問題」，而且每次輪詢都靜默重演。修正後失敗以觀察結果的形式浮上來，走同一條去重與冷卻，不會重複打擾，也不會消失。

### 三、服裝稽核只檢查每個姿勢的第一層

`_audit_poses()` 只載入 `entries[0]`。manifest 契約允許多層，第二層可以尺寸與雜湊都正確、Alpha 卻完全不透明並蓋住臉，稽核照樣放行並直接安裝。修正後每一層都過同一套檢查；多層時 issue 識別碼加上層序號，單層時維持原格式，不影響既有消費者。

### 四、稽核紀錄原樣保存剪貼簿全文

`clipboard_read` 把整段剪貼簿放進結果，`clipboard_write` 把要寫入的文字放進參數，兩者都以未加密 JSON 進資料庫。介面只顯示 500 字，資料庫卻存到 100,000 字，而清理函式沒有正式呼叫者。金鑰、密碼、私訊都可能在剪貼簿裡。修正後 `redact_audit_payload()` 遞迴遮罩 `text` 等欄位，只留長度與短預覽：稽核仍可讀，但不再是資料倉。`plan_started` 與 `action_result` 兩個入口都經過遮罩。

### 測試

新增 `tests/test_silent_failures_and_audit_data.py` 十二個測試。既有的 `tests/test_wardrobe_storage.py`、`tests/test_background_agents.py`、`tests/test_self_generating_wardrobe.py` 與 `tests/test_openai_outfit_generator.py` 全部維持通過，完整回歸以 `tests/run_all.py` 執行。

## 简体中文

### 为什么

2026-09-02 审计的最后四项，成因各异但后果同型：调用端拿到的值分不出「没事」与「坏了」。四项全部修复并附测试，每组都同时验证「该挡的挡住」与「该放行的仍然放行」。

### 一、容量扫描把部分总量当成完整总量

`_directory_bytes()` 遇到任一 `stat()` 失败就返回到目前为止的累计值。暂存区实际 6.4 GiB、扫到 800 MiB 时一个文件因 ACL 变更或同步程序搬走而失败，函数返回 800 MiB，低于上限，生成器继续写入——这是 fail-open，可能把磁盘写满。修复后测量失败返回 `None`，`inspect()` 对应为 `storage-unmeasurable` 且不放行：上限检查的前提是总量可信。

### 二、后台 worker 的失败被转成「没有事件」

`drain()` 对 `OSError`、`RuntimeError`、`ValueError` 只做 `continue`，最终返回空列表。诊断报告因权限读不到时，用户看到的是「没有诊断问题」，而且每次轮询都静默重演。修复后失败以观察结果的形式浮上来，走同一条去重与冷却，不会重复打扰，也不会消失。

### 三、服装审计只检查每个姿势的第一层

`_audit_poses()` 只加载 `entries[0]`。manifest 契约允许多层，第二层可以尺寸与哈希都正确、Alpha 却完全不透明并盖住脸，审计照样放行并直接安装。修复后每一层都过同一套检查；多层时 issue 标识符加上层序号，单层时维持原格式，不影响既有消费者。

### 四、审计记录原样保存剪贴板全文

`clipboard_read` 把整段剪贴板放进结果，`clipboard_write` 把要写入的文字放进参数，两者都以未加密 JSON 进数据库。界面只显示 500 字，数据库却存到 100,000 字，而清理函数没有正式调用者。密钥、密码、私信都可能在剪贴板里。修复后 `redact_audit_payload()` 递归遮罩 `text` 等字段，只留长度与短预览：审计仍可读，但不再是数据仓。`plan_started` 与 `action_result` 两个入口都经过遮罩。

### 测试

新增 `tests/test_silent_failures_and_audit_data.py` 十二个测试。既有的 `tests/test_wardrobe_storage.py`、`tests/test_background_agents.py`、`tests/test_self_generating_wardrobe.py` 与 `tests/test_openai_outfit_generator.py` 全部维持通过，完整回归以 `tests/run_all.py` 执行。

## English

### Why

The final four findings from the 2026-09-02 audit have different causes but the same shape of consequence: the caller receives a value that cannot distinguish "fine" from "broken". All four are fixed with tests, and each group checks both that the refused case is refused and that the legitimate case still passes.

### 1. The storage scan treated a partial total as a complete one

`_directory_bytes()` returned the running sum as soon as any `stat()` failed. With 6.4 GiB actually in quarantine, a single file moved by a sync tool or hit by an ACL change at the 800 MiB mark made the function report 800 MiB, under the limit, and generation carried on writing — a fail-open that can fill the disk. The fix returns `None` when measurement fails, and `inspect()` maps that to `storage-unmeasurable` and refuses: a limit check is only meaningful when the total is trustworthy.

### 2. A background worker's failure became "no events"

`drain()` merely did `continue` on `OSError`, `RuntimeError` and `ValueError`, ending with an empty list. When a diagnostic report could not be read for permission reasons, the user saw "no diagnostic issues", and every poll repeated the silence. Failures now surface as observations and travel through the same dedupe and cooldown, so they neither nag nor vanish.

### 3. The outfit audit inspected only the first layer of each pose

`_audit_poses()` loaded only `entries[0]`. The manifest contract allows multiple layers, and a second layer with correct size and hash but fully opaque alpha covering the face passed the audit and was installed directly. Every layer now goes through the same checks; issue identifiers gain a layer index when there are several layers and keep the original format for a single one, so existing consumers are unaffected.

### 4. The audit log stored the full clipboard verbatim

`clipboard_read` placed the entire clipboard into the result and `clipboard_write` placed the text to be written into the arguments, both stored as unencrypted JSON in the database. The interface shows 500 characters while the database keeps up to 100,000, and the cleanup function has no production caller. Keys, passwords and private messages all end up on the clipboard. `redact_audit_payload()` now recursively masks `text` and similar fields, keeping only the length and a short preview: the audit stays readable without becoming a data warehouse. Both the `plan_started` and `action_result` entry points pass through it.

### Tests

A new `tests/test_silent_failures_and_audit_data.py` adds twelve tests. The existing `tests/test_wardrobe_storage.py`, `tests/test_background_agents.py`, `tests/test_self_generating_wardrobe.py` and `tests/test_openai_outfit_generator.py` all remain green, and the full regression is run with `tests/run_all.py`.

## 日本語

### 理由

2026-09-02 の監査で残った四件は、原因は異なるものの結果の形は同じです。呼び出し側が受け取る値では「問題なし」と「壊れている」を区別できません。四件すべてをテスト付きで修正し、各組で「拒むべきものを拒む」ことと「通すべきものを通す」ことの両方を確かめます。

### 一、容量の走査が部分的な合計を完全な合計として扱っていた

`_directory_bytes()` はいずれかの `stat()` が失敗した時点で途中までの累計を返していました。隔離領域に実際は 6.4 GiB があるのに、800 MiB まで数えたところで同期ツールの移動や ACL 変更で一つ失敗すると 800 MiB を返し、上限を下回るため生成が書き込みを続けます。これはフェイルオープンで、ディスクを埋め尽くしかねません。修正では計測失敗時に `None` を返し、`inspect()` はそれを `storage-unmeasurable` として拒否します。上限の確認は合計が信頼できて初めて意味を持ちます。

### 二、バックグラウンド worker の失敗が「イベントなし」になっていた

`drain()` は `OSError`、`RuntimeError`、`ValueError` に対して `continue` するだけで、最後に空のリストを返していました。診断レポートが権限のせいで読めないとき、利用者には「診断上の問題なし」と表示され、しかも毎回の巡回で同じ沈黙が繰り返されます。修正では失敗を観測結果として浮上させ、同じ重複排除と冷却時間を通すので、しつこく鳴ることも消えることもありません。

### 三、衣装の監査が各姿勢の最初の層しか調べていなかった

`_audit_poses()` は `entries[0]` だけを読み込んでいました。マニフェストの契約は複数層を許しており、二層目が寸法もハッシュも正しいのにアルファが完全に不透明で顔を覆っていても、監査を通過してそのまま導入されていました。修正では全ての層が同じ検査を通ります。複数層のときは issue 識別子に層番号を付け、単層のときは元の形式を保つので、既存の利用側には影響しません。

### 四、監査記録がクリップボードの全文をそのまま保存していた

`clipboard_read` はクリップボード全体を結果に、`clipboard_write` は書き込む文字列を引数に入れ、どちらも暗号化されない JSON としてデータベースに入っていました。画面は 500 文字しか表示しないのに、データベースは最大 100,000 文字を保持し、掃除用の関数には本番の呼び出し元がありません。鍵、パスワード、私信はいずれもクリップボードに載り得ます。修正では `redact_audit_payload()` が `text` などの項目を再帰的に伏せ、長さと短い先頭部分だけを残します。監査は読めるままで、データ倉庫にはなりません。`plan_started` と `action_result` の二つの入口がともにこれを通ります。

### テスト

新しい `tests/test_silent_failures_and_audit_data.py` に十二件のテストを追加しました。既存の `tests/test_wardrobe_storage.py`、`tests/test_background_agents.py`、`tests/test_self_generating_wardrobe.py`、`tests/test_openai_outfit_generator.py` はすべて引き続き通過し、完全な回帰は `tests/run_all.py` で実行します。
