### PR TITLE
fix: golden 建置器對另一代權威的三個契約／golden 构建器对另一代权威的三个契约／Three contracts for the golden builder against a different-generation authority／別世代の権威に対するゴールデン構築器の三つの契約

### DIFF
--- a/tests/test_golden_base_body_contracts.py
+++ b/tests/test_golden_base_body_contracts.py
@@ -1,0 +1,115 @@
+"""golden 建置器對「另一代素體」必須守住的兩個契約。
+
+2026-09-02 用二代素體重切圖層時發現：
+
+1. 背面視角的臉部層依賴「YuNet 偵測不到臉」才留空。v4 的背面剛好偵測不到；
+   二代素體 yaw+120 的耳朵／下顎一小片被判成臉（信心 ≥ 0.75），半身正面遮罩
+   就被貼上去（虹膜 24 px、上唇 107 px）。契約應以 |yaw| 為準，與語意稽核的
+   背面裁決一致。
+2. 遮罩轉貼不知道權威沒有袖子。無袖素體的手臂皮膚被切進 sleeve_*，而渲染器的
+   _sleeve_lift 會隨手勢把袖層獨立平移——皮膚跟著離開身體。`empty_layers`
+   讓呼叫端宣告權威沒有的實體層，像素交還 body。
+
+兩個測試都只用 v4 的既有資產，不依賴任何新素體檔案。
+"""
+from __future__ import annotations
+
+lazy import sys
+lazy from pathlib import Path
+
+lazy import numpy as np
+lazy import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONT = "yaw+000-pitch+00"
+REAR = "yaw+120-pitch+00"
+SLEEVES = ("sleeve_left", "sleeve_right")
+
+
+def _alpha(path: Path) -> np.ndarray:
+    import cv2
+
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    assert image is not None, path
+    return image[:, :, 3]
+
+
+@pytest.fixture(scope="module")
+def builder():
+    sys.path.insert(0, str(ROOT))
+    from tools import build_yaw000_golden_template as module
+
+    return module
+
+
+def test_rear_view_face_layers_are_empty_even_when_a_face_is_detectable(
+    builder, tmp_path: Path
+) -> None:
+    """背面視角以 |yaw| 為準留空，不賭偵測器。
+
+    權威故意用正面圖（臉一定偵測得到）配上背面視角 id：舊行為會把臉貼上去，
+    契約行為必須留空。
+    """
+    face_bearing_authority = ROOT / "assets/pose-atlas/v4" / f"{FRONT}.png"
+    out = tmp_path / "rear"
+    builder.build(ROOT, out, view=REAR, authority_path=face_bearing_authority)
+    for layer in builder.FACE_REMAP_LAYERS:
+        count = int((_alpha(out / f"{REAR}_{layer}.png") > 0).sum())
+        assert count == 0, f"背面視角的 {layer} 仍有 {count} px——臉部層沒有依契約留空"
+
+
+def test_front_view_face_layers_still_populate(builder, tmp_path: Path) -> None:
+    """正例：契約只針對背面；正面的臉部層必須仍有像素。"""
+    out = tmp_path / "front"
+    builder.build(ROOT, out, view=FRONT)
+    for layer in ("iris_left", "iris_right", "lip_upper", "brow_left"):
+        assert int((_alpha(out / f"{FRONT}_{layer}.png") > 0).sum()) > 0, f"{layer} 變空了"
+
+
+def test_empty_layers_return_pixels_to_body_losslessly(builder, tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline"
+    sleeveless = tmp_path / "sleeveless"
+    builder.build(ROOT, baseline, view=FRONT)
+    builder.build(ROOT, sleeveless, view=FRONT, empty_layers=SLEEVES)
+
+    baseline_sleeves = sum(int((_alpha(baseline / f"{FRONT}_{s}.png") > 0).sum()) for s in SLEEVES)
+    assert baseline_sleeves > 0, "基線的袖層本來就是空的，這個測試證明不了任何事"
+    for s in SLEEVES:
+        assert int((_alpha(sleeveless / f"{FRONT}_{s}.png") > 0).sum()) == 0, f"{s} 未歸零"
+
+    def gain(layer: str) -> int:
+        return int((_alpha(sleeveless / f"{FRONT}_{layer}.png") > 0).sum()) - int(
+            (_alpha(baseline / f"{FRONT}_{layer}.png") > 0).sum()
+        )
+
+    body_gain, hair_back_gain = gain("body"), gain("hair_back")
+    # 無主像素依 _exclusive_ownership 的規則：HAIR_BODY_SPLIT_Y 以上交 hair_back、
+    # 以下交 body。實測 v4 yaw+000 的袖層有 61 px 落在肩頸交界的分割線之上。
+    # 兩者都是不會隨手勢平移的層，所以這個分配是可接受的；不可接受的是像素
+    # 消失、或流進會動的層／臉部層。
+    assert body_gain + hair_back_gain == baseline_sleeves, (
+        f"袖層釋出 {baseline_sleeves} px，但 body +{body_gain}、hair_back +{hair_back_gain}"
+        "——有像素流向別處或消失"
+    )
+    assert body_gain >= baseline_sleeves * 0.95, f"大部分袖像素應回到 body，實際只有 {body_gain}"
+    untouched = [
+        layer for layer in builder.LAYERS
+        if layer not in (*SLEEVES, "body", "hair_back") and gain(layer) != 0
+    ]
+    assert not untouched, f"袖層歸零不該影響這些層：{untouched}"
+
+    # 無損重組：25 層 alpha 的聯集必須等於權威的 alpha（一個像素都不能掉、不能重複）。
+    authority = _alpha(ROOT / "assets/pose-atlas/v4-working" / f"{FRONT}.user-approved-generated-alpha-clean-v3-20260823.png") > 0
+    union = np.zeros_like(authority)
+    total = 0
+    for layer in builder.LAYERS:
+        mask = _alpha(sleeveless / f"{FRONT}_{layer}.png") > 0
+        union |= mask
+        total += int(mask.sum())
+    assert bool((union == authority).all()), "圖層聯集與權威 alpha 不一致——重組有損"
+    assert total == int(authority.sum()), "圖層之間有重疊像素——歸屬不再互斥"
+
+
+def test_unknown_empty_layer_fails_closed(builder, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown layer"):
+        builder.build(ROOT, tmp_path / "bad", view=FRONT, empty_layers=("sleeve_middle",))

--- a/tests/test_golden_face_target_follows_authority.py
+++ b/tests/test_golden_face_target_follows_authority.py
@@ -1,0 +1,105 @@
+"""golden 建置器的臉部目標必須解在權威圖上，而不是寫死的 v4 canonical。
+
+2026-09-02 為二代素體重切圖層時發現：`_remap_face_candidates()` 的目標臉框
+一律讀 `assets/pose-atlas/v4/{view}.png`，與 `--authority` 傳進來的圖無關。
+兩代素體的臉位置不同（實測 yaw+045 的 y 差 36 px、眼睛 landmark 差約 20 px），
+五點仿射會對著 v4 的臉解、再把遮罩貼到新權威上——虹膜與嘴唇落在新臉之外，
+或被臉部區域裁成空。
+
+這裡不依賴任何新素體檔案：把 v4 canonical 平移一個已知位移當作「另一個權威」，
+斷言重建出的虹膜層跟著位移走。沒給權威時行為必須與原本相同。
+"""
+from __future__ import annotations
+
+lazy import inspect
+lazy import sys
+lazy from pathlib import Path
+
+lazy import numpy as np
+lazy import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+VIEW = "yaw+000-pitch+00"
+RGBA_CHANNELS = 4
+SHIFT = (40, 30)          # (dx, dy) 像素；canonical 四周邊距足夠容納
+# 位移後 YuNet 會在新圖上重新偵測，landmark 有幾 px 抖動，再經 warpAffine 取樣；
+# 嘴唇層之後還過 oral-clamp／skin-reclaim 對權威像素重切，實測 lip_upper 殘差 7.5 px
+# （虹膜 ≤ 3.5 px）。判別的重點不在絕對精度，而在「Δ 是否跟著位移走」——若目標
+# 仍解在 v4 上，Δ 會是 0；下面另有 residual < moved/3 的判別式守住這一點。
+FOLLOW_TOLERANCE_PX = 10.0
+V4_FRONT_LEFT_EYE = (492, 216)   # v4 canonical yaw+000 的 YuNet 左眼 landmark 實測
+DEFAULT_CENTROID_TOLERANCE_PX = 12
+
+
+def _load_rgba(path: Path) -> np.ndarray:
+    import cv2
+
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    assert image is not None and image.shape[2] == RGBA_CHANNELS, path
+    return image
+
+
+def _alpha_centroid(path: Path) -> tuple[float, float]:
+    alpha = _load_rgba(path)[:, :, 3]
+    ys, xs = np.nonzero(alpha)
+    assert len(xs) > 0, f"{path.name} 的 alpha 全空"
+    weights = alpha[ys, xs].astype(np.float64)
+    return float((xs * weights).sum() / weights.sum()), float((ys * weights).sum() / weights.sum())
+
+
+@pytest.fixture(scope="module")
+def builder():
+    sys.path.insert(0, str(ROOT))
+    from tools import build_yaw000_golden_template as module
+
+    return module
+
+
+def test_face_layers_follow_a_shifted_authority(builder, tmp_path: Path) -> None:
+    import cv2
+
+    canonical = _load_rgba(ROOT / "assets/pose-atlas/v4" / f"{VIEW}.png")
+    dx, dy = SHIFT
+    shifted = np.zeros_like(canonical)
+    shifted[dy:, dx:] = canonical[: canonical.shape[0] - dy, : canonical.shape[1] - dx]
+    authority = tmp_path / "shifted-authority.png"
+    assert cv2.imwrite(str(authority), shifted)
+
+    baseline_dir = tmp_path / "baseline"
+    shifted_dir = tmp_path / "shifted"
+    builder.build(ROOT, baseline_dir, view=VIEW)
+    builder.build(ROOT, shifted_dir, view=VIEW, authority_path=authority)
+
+    for layer in ("iris_left", "iris_right", "lip_upper"):
+        bx, by = _alpha_centroid(baseline_dir / f"{VIEW}_{layer}.png")
+        sx, sy = _alpha_centroid(shifted_dir / f"{VIEW}_{layer}.png")
+        moved = np.hypot(sx - bx, sy - by)
+        residual = np.hypot((sx - bx) - dx, (sy - by) - dy)
+        assert residual <= FOLLOW_TOLERANCE_PX, (
+            f"{layer} 未跟著權威位移：基線 ({bx:.1f},{by:.1f}) → 位移後 ({sx:.1f},{sy:.1f})，"
+            f"期望位移 {SHIFT}，殘差 {residual:.1f} px"
+        )
+        # 判別式：跟著走的 Δ 必須遠比「沒動」更接近期望位移，否則只是抖動碰巧過關。
+        assert residual < moved / 3, (
+            f"{layer} 的位移 {moved:.1f} px 與期望位移的殘差 {residual:.1f} px 不成比例；"
+            "臉部目標可能仍解在 v4 canonical 上"
+        )
+
+
+def test_default_authority_path_is_unchanged(builder, tmp_path: Path) -> None:
+    """沒給權威時必須走原本的 v4 路徑，v4 重建結果位元不變。"""
+    parameters = inspect.signature(builder._remap_face_candidates).parameters
+    assert "authority_path" in parameters
+    assert parameters["authority_path"].default is None, "預設必須是 None（退回 v4 路徑）"
+    source = inspect.getsource(builder._remap_face_candidates)
+    assert 'repo / "assets/pose-atlas/v4" / f"{view}.png"' in source
+
+    out = tmp_path / "default"
+    builder.build(ROOT, out, view=VIEW)
+    iris = out / f"{VIEW}_iris_left.png"
+    assert iris.is_file()
+    x, y = _alpha_centroid(iris)
+    ex, ey = V4_FRONT_LEFT_EYE
+    assert abs(x - ex) < DEFAULT_CENTROID_TOLERANCE_PX and abs(y - ey) < DEFAULT_CENTROID_TOLERANCE_PX, (
+        f"預設路徑的虹膜質心異常 ({x:.1f},{y:.1f})，應在 v4 左眼 landmark {V4_FRONT_LEFT_EYE} 附近"
+    )

--- a/tools/build_yaw000_golden_template.py
+++ b/tools/build_yaw000_golden_template.py
@@ -105,6 +105,8 @@ FACE_REMAP_LAYERS = (
     "eyelid_left", "eyelid_right", "eyeliner_left", "eyeliner_right",
     "brow_left", "brow_right",
 )
+# |yaw| 超過此值即為背面視角，臉部細節層依契約留空（與語意稽核的背面裁決一致）。
+REAR_VIEW_MIN_ABS_YAW = 90
 
 
 def _face_evidence(image_path: Path):
@@ -179,6 +181,7 @@ def _remap_face_candidates(
     layer_dir: Path,
     view: str,
     foreground: np.ndarray,
+    authority_path: Path | None = None,
 ) -> None:
     """Replace mirrored face-detail candidates with front-anchored warps."""
 
@@ -188,8 +191,28 @@ def _remap_face_candidates(
     # the offset defect on EVERY view, including the front.
     source_dir = repo / "assets/expressions/layered"
     front = _face_evidence(repo / "assets/expressions/idle_front.png")
+    # 目標臉框必須解在「像素要被切出來的那張圖」上。原本寫死讀 v4 canonical：
+    # 權威若是另一代素體，臉的位置不同（2026-09-02 實測 yaw+045 兩代 y 差 36 px、
+    # 眼睛 landmark 差約 20 px），仿射會對著 v4 的臉解、再貼到新權威上——虹膜與
+    # 嘴唇遮罩落在新臉之外，或被臉部區域裁成空。沒給權威時維持 v4 路徑，
+    # v4 的重建結果位元不變。
+    target_source = (
+        authority_path
+        if authority_path is not None
+        else repo / "assets/pose-atlas/v4" / f"{view}.png"
+    )
+    # 背面視角（|yaw| > 90）的臉部層依契約留空，不賭偵測器抓不到臉：語意稽核的
+    # BACK_VIEW_EMPTY_MOUTH_LAYERS 與背面裁決都以 |yaw| 為準。v4 的背面剛好偵測不到
+    # 臉所以走到 except 分支；二代素體 yaw+120 的耳朵／下顎一小片被 YuNet 以 0.75 以上
+    # 的信心判成臉，前面的半身正面遮罩就被貼上去（虹膜 24 px、上唇 107 px）。
+    yaw_match = re.prefixmatch(r"yaw([+-]\d{3})-pitch", view)
+    if yaw_match is not None and abs(int(yaw_match.group(1))) > REAR_VIEW_MIN_ABS_YAW:
+        h, w = foreground.shape
+        for layer in FACE_REMAP_LAYERS:
+            candidates[layer] = np.zeros((h, w), bool)
+        return
     try:
-        target = _face_evidence(repo / "assets/pose-atlas/v4" / f"{view}.png")
+        target = _face_evidence(target_source)
     except ValueError:
         # Rear views have no detectable face; their face-detail layers are
         # licensed empty (speech-mouth and back-view rulings).
@@ -396,6 +419,7 @@ def build(
     output: Path,
     view: str = VIEW,
     authority_path: Path | None = None,
+    empty_layers: tuple[str, ...] = (),
 ) -> dict:
     canonical_path = repo / "assets/pose-atlas/v4" / f"{view}.png"
     if authority_path is None:
@@ -417,7 +441,16 @@ def build(
     # Every view is remapped — the legacy full-body feature masks carried
     # the offset defect on the front view too (iris on the cheekbones, lip
     # on the neck; only the x-symmetry hid it from centroid checks).
-    _remap_face_candidates(candidates, repo, layer_dir, view, foreground)
+    _remap_face_candidates(
+        candidates, repo, layer_dir, view, foreground, authority_path=authority_path
+    )
+    # 權威若沒有某些實體層（二代素體無袖），把那些候選歸零：_exclusive_ownership
+    # 會把無主的前景像素交還 body。否則 v4 的袖遮罩會把手臂皮膚切進 sleeve_*，
+    # 而渲染器的 _sleeve_lift 會隨手勢把袖層獨立平移——皮膚跟著離開身體。
+    for layer in empty_layers:
+        if layer not in candidates:
+            raise ValueError(f"unknown layer in empty_layers: {layer}")
+        candidates[layer] = np.zeros_like(candidates[layer])
 
     # Legacy eye masks overlap exactly.  Assign every authority pixel once so
     # blink and gaze layers remain independently addressable at runtime.
@@ -502,13 +535,21 @@ def main() -> int:
     parser.add_argument("--output", type=Path)
     parser.add_argument("--view", default=VIEW)
     parser.add_argument("--authority", type=Path)
+    parser.add_argument(
+        "--empty-layers",
+        default="",
+        help="逗號分隔；權威沒有的實體層（例如無袖素體的 sleeve_left,sleeve_right），"
+        "其候選歸零並把像素交還 body",
+    )
     args = parser.parse_args()
     output = args.output or args.repo / "work/full-body-yaw000-golden/layers"
+    empty_layers = tuple(name.strip() for name in args.empty_layers.split(",") if name.strip())
     manifest = build(
         args.repo.resolve(),
         output.resolve(),
         view=args.view,
         authority_path=args.authority,
+        empty_layers=empty_layers,
     )
     print(json.dumps({"output": manifest["output"], "layers": len(manifest["records"])}, ensure_ascii=False))
     return 0


### PR DESCRIPTION
## 繁體中文

### 為什麼

`tools/build_yaw000_golden_template.py` 把既有的 v4 圖層遮罩轉貼到一張「權威」圖上重切像素。2026-09-02 用二代素體當權威時，三個原本隱含「權威就是 v4」的假設同時失效。

### 一、臉部目標寫死讀 v4 canonical

臉部細節層用 YuNet 五點 landmark 仿射從半身正面層映射到目標視角，但目標臉框一律讀 `assets/pose-atlas/v4/{view}.png`，與 `--authority` 無關。兩代的臉位置不同：實測 `yaw+045` 臉框 y 差 36 px、眼睛 landmark 差約 20 px。仿射對著 v4 的臉解、遮罩貼到新權威上，虹膜與嘴唇落在新臉之外。修正後有給權威就以權威圖解臉框，沒給維持 v4 路徑。以真實二代 `yaw+000` 重跑，虹膜質心距權威的眼睛 landmark 3.3 與 3.7 px。

### 二、背面視角靠「偵測不到臉」才留空

v4 的背面剛好偵測不到臉，所以走到留空分支；二代 `yaw+120` 的耳朵與下顎一小片被判成臉，半身正面遮罩就被貼上去（虹膜 24 px、上唇 107 px）。修正後 `|yaw|` 超過 90 的視角依契約留空，與語意稽核的背面裁決一致，不再賭偵測器。

### 三、遮罩轉貼不知道權威沒有袖子

無袖素體的手臂皮膚被切進 `sleeve_left` 與 `sleeve_right`，而渲染器的 `_sleeve_lift` 會隨手勢把袖層獨立平移——皮膚跟著離開身體。新增 `--empty-layers`：呼叫端宣告權威沒有的實體層，其候選歸零，像素依 `_exclusive_ownership` 的規則交還 `body`（分割線以上的少數交還 `hair_back`）。實測 11,727 px 全數歸位，25 層聯集仍等於權威 alpha 且互斥。

### 驗證

新增 `tests/test_golden_face_target_follows_authority.py` 與 `tests/test_golden_base_body_contracts.py` 共六個測試，只用 v4 既有資產：平移權威斷言臉部層跟著走（含殘差遠小於位移量的判別式）；正面圖配背面視角 id 斷言臉部層仍留空；`empty_layers` 斷言袖層歸零、像素全數交還且重組無損；未知層名 fail-closed。以真實二代權威重跑 `yaw+000` 與 `yaw+120`，三支稽核對該視角自身皆為語意 0、layer-pack 僅 1 個已知 C、不對稱 0，與 v4 基準一致。預設行為不變，v4 重建結果位元相同。

## 简体中文

### 为什么

`tools/build_yaw000_golden_template.py` 把既有的 v4 图层遮罩转贴到一张「权威」图上重切像素。2026-09-02 用二代素体当权威时，三个原本隐含「权威就是 v4」的假设同时失效。

### 一、脸部目标写死读 v4 canonical

脸部细节层用 YuNet 五点 landmark 仿射从半身正面层映射到目标视角，但目标脸框一律读 `assets/pose-atlas/v4/{view}.png`，与 `--authority` 无关。两代的脸位置不同：实测 `yaw+045` 脸框 y 差 36 px、眼睛 landmark 差约 20 px。仿射对着 v4 的脸解、遮罩贴到新权威上，虹膜与嘴唇落在新脸之外。修复后有给权威就以权威图解脸框，没给维持 v4 路径。以真实二代 `yaw+000` 重跑，虹膜质心距权威的眼睛 landmark 3.3 与 3.7 px。

### 二、背面视角靠「检测不到脸」才留空

v4 的背面刚好检测不到脸，所以走到留空分支；二代 `yaw+120` 的耳朵与下颌一小片被判成脸，半身正面遮罩就被贴上去（虹膜 24 px、上唇 107 px）。修复后 `|yaw|` 超过 90 的视角依契约留空，与语义审计的背面裁决一致，不再赌检测器。

### 三、遮罩转贴不知道权威没有袖子

无袖素体的手臂皮肤被切进 `sleeve_left` 与 `sleeve_right`，而渲染器的 `_sleeve_lift` 会随手势把袖层独立平移——皮肤跟着离开身体。新增 `--empty-layers`：调用端声明权威没有的实体层，其候选归零，像素依 `_exclusive_ownership` 的规则交还 `body`（分割线以上的少数交还 `hair_back`）。实测 11,727 px 全数归位，25 层并集仍等于权威 alpha 且互斥。

### 验证

新增 `tests/test_golden_face_target_follows_authority.py` 与 `tests/test_golden_base_body_contracts.py` 共六个测试，只用 v4 既有资产：平移权威断言脸部层跟着走（含残差远小于位移量的判别式）；正面图配背面视角 id 断言脸部层仍留空；`empty_layers` 断言袖层归零、像素全数交还且重组无损；未知层名 fail-closed。以真实二代权威重跑 `yaw+000` 与 `yaw+120`，三支审计对该视角自身皆为语义 0、layer-pack 仅 1 个已知 C、不对称 0，与 v4 基线一致。默认行为不变，v4 重建结果字节相同。

## English

### Why

`tools/build_yaw000_golden_template.py` transfers the existing v4 layer masks onto an "authority" image and re-cuts its pixels. When a second-generation base body was used as the authority on 2026-09-02, three assumptions that silently equated the authority with v4 failed at once.

### 1. The face target was hard-wired to the v4 canonical

Face-detail layers are remapped from the half-body front layers with a five-point YuNet landmark affine, but the target face box was always read from `assets/pose-atlas/v4/{view}.png`, regardless of `--authority`. The two generations place the face differently: measured on `yaw+045`, the face box differs by 36 px in y and the eye landmarks by about 20 px. The affine was solved against the v4 face and the masks pasted onto the new authority, leaving irises and lips off the new face. The face box is now solved on the authority when one is given, and on the v4 path otherwise. Rebuilt against a real second-generation `yaw+000`, the iris centroids sit 3.3 and 3.7 px from the authority's eye landmarks.

### 2. Rear views were empty only because no face happened to be detected

v4's rear views happen to yield no detection, so they reached the empty branch; on the second-generation `yaw+120` a sliver of ear and jaw was classified as a face and the half-body front masks were pasted onto it (24 px of iris, 107 px of upper lip). Views with `|yaw|` above 90 are now left empty by contract, matching the semantic audit's rear-view ruling, instead of betting on the detector.

### 3. Mask transfer did not know the authority has no sleeves

On a sleeveless base body the arm skin was cut into `sleeve_left` and `sleeve_right`, and the renderer's `_sleeve_lift` translates the sleeve layers independently with gestures — the skin would leave the body. A new `--empty-layers` option lets the caller declare physical layers the authority lacks; their candidates are zeroed and the pixels return to `body` under the `_exclusive_ownership` rules (the few above the split line go to `hair_back`). Measured: all 11,727 px were reassigned, and the union of the 25 layers still equals the authority alpha with no overlap.

### Verification

`tests/test_golden_face_target_follows_authority.py` and `tests/test_golden_base_body_contracts.py` add six tests using only existing v4 assets: shifting the authority asserts the face layers follow (with a discriminating check that the residual is far smaller than the movement); a front image paired with a rear view id asserts the face layers stay empty; `empty_layers` asserts the sleeves are zeroed, every pixel is returned and recomposition is lossless; an unknown layer name fails closed. Rebuilding `yaw+000` and `yaw+120` from a real second-generation authority, all three audits report for the view itself zero semantic issues, one known class-C finding in the layer pack, and zero asymmetry issues — identical to the v4 baseline. Default behaviour is unchanged and v4 rebuilds are byte-identical.

## 日本語

### 理由

`tools/build_yaw000_golden_template.py` は既存の v4 レイヤーマスクを「権威」画像に写して画素を切り直します。2026-09-02 に第二世代の素体を権威として使ったところ、権威を暗黙に v4 と同一視していた三つの前提が同時に崩れました。

### 一、顔の対象が v4 の canonical に固定されていた

顔細部レイヤーは半身正面レイヤーから YuNet 五点 landmark のアフィンで対象視点へ写像されますが、対象の顔枠は常に `assets/pose-atlas/v4/{view}.png` から読まれ、`--authority` とは無関係でした。二世代で顔の位置は異なります。`yaw+045` の実測で顔枠 y は 36 px、目の landmark は約 20 px ずれています。アフィンは v4 の顔に対して解かれ、マスクは新しい権威に貼られ、虹彩と唇が新しい顔から外れました。修正後は権威が与えられればその画像で顔枠を解き、無ければ従来の v4 経路を使います。実際の第二世代 `yaw+000` で再構築すると、虹彩の重心は権威の目の landmark から 3.3 px と 3.7 px です。

### 二、背面視点が「顔が検出されない」ことに頼って空になっていた

v4 の背面はたまたま検出されないため空の分岐に入っていました。第二世代の `yaw+120` では耳と顎の一部が顔と判定され、半身正面マスクがそこへ貼られました（虹彩 24 px、上唇 107 px）。修正後は `|yaw|` が 90 を超える視点を契約として空にし、意味監査の背面裁定と一致させ、検出器に賭けません。

### 三、マスクの転写は権威に袖が無いことを知らなかった

袖の無い素体では腕の皮膚が `sleeve_left` と `sleeve_right` に切り出され、描画側の `_sleeve_lift` は仕草に応じて袖レイヤーだけを平行移動するため、皮膚が体から離れてしまいます。新しい `--empty-layers` で、権威に存在しない実体レイヤーを呼び出し側が宣言できます。その候補は零になり、画素は `_exclusive_ownership` の規則に従って `body` へ戻ります（分割線より上のわずかな画素は `hair_back` へ）。実測では 11,727 px がすべて再配分され、25 レイヤーの和集合は権威のアルファと一致し重なりもありません。

### 検証

`tests/test_golden_face_target_follows_authority.py` と `tests/test_golden_base_body_contracts.py` に六件のテストを追加し、既存の v4 資産だけを使います。権威を平行移動して顔レイヤーが追従すること（残差が移動量よりはるかに小さいという判別付き）、正面画像に背面の視点 id を組み合わせても顔レイヤーが空のままであること、`empty_layers` で袖が零になり全画素が戻り再構成が無損失であること、未知のレイヤー名がフェイルクローズすることを確かめます。実際の第二世代の権威で `yaw+000` と `yaw+120` を再構築すると、三つの監査はいずれもその視点について意味の問題 0、レイヤーパックの既知のクラス C が 1、非対称 0 と、v4 の基準と同一でした。既定の挙動は変わらず、v4 の再構築はバイト単位で同一です。
