### PR TITLE
fix: body sidecar 膝登錄點在露腿側面退回腳掌正上方／body sidecar 膝登录点在露腿侧面退回脚掌正上方／body sidecar knee landmark falls back above the foot on bare-legged profiles／body sidecar の膝登録点は脚の出た側面で足の真上へ退く

### DIFF
--- a/tests/test_body_sidecar_profile_knee.py
+++ b/tests/test_body_sidecar_profile_knee.py
@@ -1,0 +1,120 @@
+"""露腿權威在純側面時，膝登錄點不得讓整組 24 視角的建置中止。
+
+2026-09-02 以二代素體跑 build_pose_atlas_release_assets.build()：24 張只有 ±090
+兩個純側面失敗，錯誤是 alpha_registration_point_missing，落在膝（高度比例 0.78）。
+成因：膝的目標是「髖與腳掌中心的中點」，這個幾何假設穿長袍——v4 的側面把腿包住，
+中點永遠打得到 alpha；露腿的側面姿勢裡髖在腿前方一段距離、腳掌在腿正下方，
+中點落在小腿前方的空氣裡，最近 alpha 56–58 px，超過搜尋半徑 48。
+
+修正：中點找不到就退回「腳掌中心正上方」（側面時小腿在腳的正上方）；兩者都找不到
+才記為不可達的 occluded landmark，而不是中止。這裡用合成剪影，不依賴任何素材；
+剪影是兩條腿，讓 _foot_side_map 兩側都找得到腳，不會觸發既有的整側遮擋路徑。
+"""
+from __future__ import annotations
+
+lazy import hashlib
+lazy import sys
+lazy from pathlib import Path
+
+lazy import numpy as np
+lazy import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+W, H = 1024, 1536
+TOP, BOTTOM = 80, 1480
+LEG_X = (450, 590)          # 兩條腿的中心 x（左右）
+VISIBLE_SIDES = len(LEG_X)  # 兩側都可見 → 應有兩個膝登錄點
+LEG_HALF_WIDTH = 28
+FOOT_HALF_LENGTH = 40       # 腳掌以腿為中心前後各 40 px
+KNEE_TOLERANCE_PX = 40      # 膝必須落在腿寬（56 px）加上搜尋誤差之內
+SKIN = (200, 180, 170, 255)
+
+
+@pytest.fixture(scope="module")
+def module():
+    sys.path.insert(0, str(ROOT / "tools"))
+    import build_pose_atlas_release_assets as m
+
+    return m
+
+
+def _silhouette(*, hip_forward: int) -> np.ndarray:
+    """側面剪影：頭與軀幹整體向前（+x）偏移 hip_forward，兩條腿垂直，腳掌在腿正下方。
+
+    hip_forward 越大，「髖與腳掌中心的中點」離小腿越遠。
+    """
+    rgba = np.zeros((H, W, 4), np.uint8)
+    hip_y = round(TOP + (BOTTOM - TOP) * 0.56)
+    torso_center = (LEG_X[0] + LEG_X[1]) // 2 + hip_forward
+    yy, xx = np.mgrid[0:H, 0:W]
+    rgba[((xx - torso_center) ** 2 + (yy - (TOP + 60)) ** 2) < 55 ** 2] = SKIN
+    rgba[TOP + 110: hip_y + 40, torso_center - 90: torso_center + 90] = SKIN
+    for x in LEG_X:
+        rgba[hip_y: BOTTOM - 20, x - LEG_HALF_WIDTH: x + LEG_HALF_WIDTH] = SKIN
+        rgba[BOTTOM - 20: BOTTOM + 1, x - FOOT_HALF_LENGTH: x + FOOT_HALF_LENGTH] = SKIN
+    return rgba
+
+
+def _source(module, rgba: np.ndarray, view_id: str, yaw: int, tmp_path: Path):
+    import cv2
+
+    path = tmp_path / f"{view_id}.png"
+    assert cv2.imwrite(str(path), cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGRA))
+    left, top, right, bottom = module._alpha_bounds(rgba)
+    return module._SourceImage(
+        view_id, yaw, path, hashlib.sha256(path.read_bytes()).hexdigest(),
+        rgba, top, bottom, left, right,
+    )
+
+
+def _knees(sidecar):
+    return {k: v for k, v in sidecar["landmarks"].items() if k.endswith("_knee")}
+
+
+def _unreachable_knees(sidecar):
+    return [o for o in sidecar["occluded_landmarks"] if o["name"].endswith("_knee")]
+
+
+def test_forward_hip_knee_falls_back_to_above_the_foot(module, tmp_path: Path) -> None:
+    """髖前移：中點在空氣裡，膝必須退回腳掌正上方的小腿，而非中止或記為不可達。"""
+    rgba = _silhouette(hip_forward=260)
+    source = _source(module, rgba, "yaw+090-pitch+00", 90, tmp_path)
+    sidecar = module._body_sidecar(source, rgba, source.height, source.source_sha256)
+    knees = _knees(sidecar)
+    assert len(knees) == VISIBLE_SIDES, f"兩側都可見，應有兩個膝：{sorted(sidecar['landmarks'])}"
+    assert not _unreachable_knees(sidecar), "退回目標明明有 alpha，膝卻被記為不可達"
+    for name, (x, _y) in knees.items():
+        assert min(abs(x - lx) for lx in LEG_X) <= KNEE_TOLERANCE_PX, (
+            f"{name} 落在 x={x}，不在任一條腿上（腿在 x≈{LEG_X}）"
+        )
+
+
+def test_upright_hip_keeps_the_original_midpoint_target(module, tmp_path: Path) -> None:
+    """正例：髖在腿正上方時中點就在腿上，行為與修正前相同。"""
+    rgba = _silhouette(hip_forward=0)
+    source = _source(module, rgba, "yaw+090-pitch+00", 90, tmp_path)
+    sidecar = module._body_sidecar(source, rgba, source.height, source.source_sha256)
+    assert len(_knees(sidecar)) == VISIBLE_SIDES
+    assert not _unreachable_knees(sidecar)
+
+
+def test_unreachable_knee_is_recorded_not_raised(module, tmp_path: Path) -> None:
+    """兩個目標都打不到時記為不可達，整組建置不得因此中止。"""
+    rgba = _silhouette(hip_forward=260)
+    knee_y = round(TOP + (BOTTOM - TOP) * 0.78)
+    rgba[knee_y - 80: knee_y + 80, :, :] = 0      # 把膝高度一帶整列挖空
+    source = _source(module, rgba, "yaw+090-pitch+00", 90, tmp_path)
+    sidecar = module._body_sidecar(source, rgba, source.height, source.source_sha256)
+    unreachable = _unreachable_knees(sidecar)
+    assert len(unreachable) == VISIBLE_SIDES, f"兩個目標都找不到卻沒有記為不可達：{unreachable}"
+    assert all(o["occluder_id"] == "knee-target-unreachable" for o in unreachable)
+
+
+def test_registration_error_names_the_target(module) -> None:
+    """錯誤訊息必須帶座標：整組失敗時才知道是哪一張、哪個點。"""
+    mask = np.zeros((H, W), bool)
+    mask[100:200, 100:200] = True
+    with pytest.raises(
+        module.BuildError, match=r"alpha_registration_point_missing:target=\(900,1400\)"
+    ):
+        module._alpha_point(mask, 900, 1400, 0, 0, W - 1, H - 1)

--- a/tools/build_pose_atlas_release_assets.py
+++ b/tools/build_pose_atlas_release_assets.py
@@ -270,7 +270,29 @@ def _body_sidecar(
         hip_target = body_center - hip_offset if side == "right" else body_center + hip_offset
         knee_target = (hip_target + run.center) / 2.0
         landmarks[f"{side}_hip"] = _alpha_point(mask, hip_target, hip_y, left, top, right, bottom)
-        landmarks[f"{side}_knee"] = _alpha_point(mask, knee_target, knee_y, left, top, right, bottom)
+        # 膝的第一目標是髖與腳掌中心的中點。這個幾何假設穿長袍：v4 的側面把腿包住，
+        # 中點永遠打得到 alpha。露腿的權威在純側面（|yaw|=90）時腳掌很長，中點落在
+        # 小腿前方的空氣裡（2026-09-02 實測 ±090 最近 alpha 56–58 px，超過搜尋半徑 48）。
+        # 退回第二目標：腳掌中心正上方——側面時小腿就在腳的正上方。兩者都找不到才
+        # 記為不可達，而不是讓整組 24 視角的建置中止。
+        try:
+            landmarks[f"{side}_knee"] = _alpha_point(
+                mask, knee_target, knee_y, left, top, right, bottom
+            )
+        except BuildError:
+            try:
+                landmarks[f"{side}_knee"] = _alpha_point(
+                    mask, run.center, knee_y, left, top, right, bottom
+                )
+            except BuildError:
+                occluded_landmarks.append(
+                    {
+                        "name": f"{side}_knee",
+                        "reason": "No alpha within the search radius of either knee target "
+                        "(hip-to-foot midpoint, or directly above the foot run).",
+                        "occluder_id": "knee-target-unreachable",
+                    }
+                )
         landmarks[f"{side}_ankle"] = _alpha_point(mask, run.center, ankle_y, left, top, right, bottom)
         landmarks[f"{side}_heel"] = _alpha_point(
             mask,
@@ -371,7 +393,11 @@ def _alpha_point(
             distances = (xs + x0 - target_x) ** 2 + (ys + y0 - target_y) ** 2
             index = int(numpy.argmin(distances))
             return [int(xs[index] + x0), int(ys[index] + y0)]
-    raise BuildError("alpha_registration_point_missing")
+    # 帶上目標座標：原本只有一個代碼，24 視角的整組建置失敗時連是哪一張、哪個點
+    # 都看不出來（2026-09-02 為此逐視角重現才定位到 ±090 的膝）。
+    raise BuildError(
+        f"alpha_registration_point_missing:target=({round(target_x)},{round(target_y)})"
+    )
 
 
 def _hand_sidecar(


### PR DESCRIPTION
## 繁體中文

### 為什麼

`tools/build_pose_atlas_release_assets.py` 的 `_body_sidecar()` 為每個視角算膝登錄點時，目標是「髖與腳掌中心的中點」。這個幾何假設穿長袍：v4 的側面把腿包住，中點永遠打得到 alpha。2026-09-02 以露腿的二代素體跑整組 `build()`，24 張只有 `±090` 兩個純側面失敗——側面姿勢裡髖在腿前方、腳掌在腿正下方，中點落在小腿前方的空氣裡，最近 alpha 56 與 58 px，超過搜尋半徑 48。一個登錄點打不到就讓整組 24 視角的建置中止，錯誤還不帶視角與座標，逐視角重現才定位得到。

### 修法

膝的目標找不到時退回第二目標「腳掌中心正上方」——側面時小腿就在腳的正上方；兩個目標都找不到才記為不可達的 `occluded_landmarks`（`occluder_id` 為 `knee-target-unreachable`），沿用既有「不為被遮擋的一側捏造座標」的契約，而不是中止。`_alpha_point()` 的錯誤訊息改為帶目標座標。以真實二代來源重跑，24 視角全部通過；`±090` 的近側膝落在小腿上，遠側膝依真實遮擋記為不可達。

### 測試

新增 `tests/test_body_sidecar_profile_knee.py` 四個測試，用合成剪影、不依賴素材：髖前移的雙腿側面剪影斷言膝退回到腿上；髖在腿正上方時行為與修正前相同；膝高度整列挖空時記為不可達而非拋錯；錯誤訊息帶座標。剪影畫成兩條腿，讓 `_foot_side_map` 兩側都找得到腳，不會誤觸既有的整側遮擋路徑。預設行為不變，v4 的 24 視角建置結果相同。

## 简体中文

### 为什么

`tools/build_pose_atlas_release_assets.py` 的 `_body_sidecar()` 为每个视角算膝登录点时，目标是「髋与脚掌中心的中点」。这个几何假设穿长袍：v4 的侧面把腿包住，中点永远打得到 alpha。2026-09-02 以露腿的二代素体跑整组 `build()`，24 张只有 `±090` 两个纯侧面失败——侧面姿势里髋在腿前方、脚掌在腿正下方，中点落在小腿前方的空气里，最近 alpha 56 与 58 px，超过搜索半径 48。一个登录点打不到就让整组 24 视角的构建中止，错误还不带视角与坐标，逐视角重现才定位得到。

### 修复方式

膝的目标找不到时退回第二目标「脚掌中心正上方」——侧面时小腿就在脚的正上方；两个目标都找不到才记为不可达的 `occluded_landmarks`（`occluder_id` 为 `knee-target-unreachable`），沿用既有「不为被遮挡的一侧捏造坐标」的契约，而不是中止。`_alpha_point()` 的错误信息改为带目标坐标。以真实二代来源重跑，24 视角全部通过；`±090` 的近侧膝落在小腿上，远侧膝依真实遮挡记为不可达。

### 测试

新增 `tests/test_body_sidecar_profile_knee.py` 四个测试，用合成剪影、不依赖素材：髋前移的双腿侧面剪影断言膝退回到腿上；髋在腿正上方时行为与修复前相同；膝高度整行挖空时记为不可达而非抛错；错误信息带坐标。剪影画成两条腿，让 `_foot_side_map` 两侧都找得到脚，不会误触既有的整侧遮挡路径。默认行为不变，v4 的 24 视角构建结果相同。

## English

### Why

When `_body_sidecar()` in `tools/build_pose_atlas_release_assets.py` places each view's knee landmark, its target is the midpoint between the hip and the centre of the foot run. That geometry assumes a long robe: v4's profiles wrap the legs, so the midpoint always lands on alpha. Running the whole-set `build()` on the bare-legged second-generation body on 2026-09-02, exactly two of 24 views failed — the pure profiles at `±090` — because in profile the hip sits ahead of the leg and the foot sits directly below it, so the midpoint falls in the air in front of the shin, with the nearest alpha 56 and 58 px away against a search radius of 48. One unreachable landmark aborted the build of all 24 views, and the error carried neither the view nor the coordinates, so it took a per-view reproduction to locate.

### The fix

When the knee target is unreachable, fall back to a second target directly above the foot run — in profile the shin is straight above the foot. Only when both fail is the knee recorded in `occluded_landmarks` (with `occluder_id` set to `knee-target-unreachable`), following the existing contract of never inventing coordinates for an occluded side, rather than aborting. `_alpha_point()` now reports the target coordinates in its error. Rerun on the real second-generation sources, all 24 views pass; at `±090` the near knee lands on the shin and the far knee is recorded as unreachable, which matches the true occlusion.

### Tests

`tests/test_body_sidecar_profile_knee.py` adds four tests on synthetic silhouettes with no asset dependency: a two-legged profile with the hip shifted forward asserts the knee falls back onto the leg; an upright hip behaves as before; hollowing out the whole knee row records the knee as unreachable instead of raising; and the error message carries coordinates. The silhouette has two legs so `_foot_side_map` finds a foot on each side and the existing whole-side occlusion path is not triggered by accident. Default behaviour is unchanged and the v4 24-view build produces the same result.

## 日本語

### 理由

`tools/build_pose_atlas_release_assets.py` の `_body_sidecar()` は各視点の膝の登録点を、腰と足裏の走査中心との中点に置きます。この幾何は長い衣を前提にしています。v4 の側面は脚を包んでいるため、中点は必ずアルファに当たります。2026-09-02 に脚の出た第二世代の素体で全体の `build()` を走らせたところ、24 枚のうち失敗したのは純粋な側面の `±090` の二枚だけでした。側面では腰が脚より前にあり、足はその真下にあるため、中点は脛の前の空中に落ち、最も近いアルファまで 56 px と 58 px で、探索半径 48 を超えていました。登録点が一つ届かないだけで 24 視点全体の構築が中止され、しかもエラーには視点も座標も無く、視点ごとの再現でようやく特定できました。

### 修正方法

膝の目標に届かない場合は、足の走査中心の真上という第二の目標へ退きます。側面では脛は足の真上にあります。両方とも届かないときに初めて膝を `occluded_landmarks` に記録し（`occluder_id` は `knee-target-unreachable`）、遮られた側の座標を捏造しないという既存の契約に従い、中止はしません。`_alpha_point()` のエラーには目標座標を含めました。実際の第二世代の素材で再実行すると 24 視点すべてが通り、`±090` では手前の膝が脛の上に置かれ、奥の膝は実際の遮蔽どおりに到達不能として記録されます。

### テスト

`tests/test_body_sidecar_profile_knee.py` に合成シルエットによる四件のテストを追加し、素材には依存しません。腰を前にずらした両脚の側面シルエットで膝が脚の上へ退くこと、腰が脚の真上なら従来どおりであること、膝の高さの行を全て空にすると例外ではなく到達不能として記録されること、エラー文が座標を含むことを確かめます。シルエットは両脚を持たせ、`_foot_side_map` が両側で足を見つけられるようにして、既存の片側遮蔽の経路を誤って踏まないようにしています。既定の挙動は変わらず、v4 の 24 視点の構築結果も同一です。
