### PR TITLE
fix: infrastructure 第三輪稽核六項——匯出白名單、DPAPI 解密失敗出錯、備份只採計可驗證檔、匯入補驗證、偏好 store 讀取失敗不回預設、Win32 回傳值／infrastructure 第三轮审计六项——导出白名单、DPAPI 解密失败报错、备份只采计可验证文件、导入补验证、偏好 store 读取失败不回默认、Win32 返回值／Third infrastructure audit, six fixes: export allowlist, DPAPI decrypt failure raises, only verified backups count, import validation, preference stores raise on read failure, Win32 return values／infrastructure 第三回監査の六件——エクスポート許可リスト、DPAPI 復号失敗はエラー、検証済みバックアップのみ採用、インポート検証、設定 store は読み取り失敗で例外、Win32 戻り値

### DIFF
--- a/infrastructure/backup_manager.py
+++ b/infrastructure/backup_manager.py
@@ -57,13 +57,27 @@ class BackupManager:
         finally:
             connection.close()
 
+    def _verified_backups(self) -> list[Path]:
+        """Backups that pass verify(), newest first.
+
+        A .db without its manifest (power loss between the two writes), with a
+        mismatched hash or failing integrity_check is not a backup: it must not
+        satisfy "recent backup exists" and must not outrank a real one in prune.
+        Such files are left alone rather than deleted.
+        """
+        return sorted(
+            (
+                path
+                for path in self.backup_dir.glob("mohan-*.db")
+                if self.verify(path)
+            ),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+
     def automatic_if_due(self, hours: int = 24) -> Path | None:
         self.backup_dir.mkdir(parents=True, exist_ok=True)
-        newest = max(
-            self.backup_dir.glob("mohan-*.db"),
-            key=lambda path: path.stat().st_mtime,
-            default=None,
-        )
+        newest = next(iter(self._verified_backups()), None)
         if newest is not None:
             age = local_wall_time() - local_wall_time_from_timestamp(
                 newest.stat().st_mtime
@@ -75,11 +89,7 @@ class BackupManager:
         return created
 
     def prune(self, keep_daily: int = 14, keep_monthly: int = 6) -> None:
-        backups = sorted(
-            self.backup_dir.glob("mohan-*.db"),
-            key=lambda path: path.stat().st_mtime,
-            reverse=True,
-        )
+        backups = self._verified_backups()
         keep: set[Path] = set(backups[: max(1, keep_daily)])
         months: set[str] = set()
         for backup in backups:

--- a/infrastructure/framing_preferences_store.py
+++ b/infrastructure/framing_preferences_store.py
@@ -86,7 +86,10 @@ class FramingPreferencesStore[SnapshotT]:
         try:
             raw = self._settings.read(_ALL_READ_KEYS)
         except _BOUNDARY_ERRORS:
-            return FramingPreferences()
+            # 後端讀不到不是「從未保存」，比照其他偏好 store 拋型別化錯誤。
+            raise FramingPreferencesStoreError(
+                "Framing preferences could not be read."
+            ) from None
         if not isinstance(raw, Mapping):
             return FramingPreferences()
         version = raw.get(STORE_SCHEMA_KEY)

--- a/infrastructure/gesture_configuration_store.py
+++ b/infrastructure/gesture_configuration_store.py
@@ -98,7 +98,12 @@ class GestureConfigurationStore[SnapshotT]:
         try:
             raw = self._settings.read(PORTABLE_GESTURE_SETTING_KEYS)
         except Exception:
-            return GestureConfiguration()
+        # 後端讀不到不是「從未保存」：回預設值會讓排程端把已送達的提醒再送一次，
+        # 偏好編輯器也會拿預設值開啟、一存就覆蓋掉原有設定。寫入路徑早就拋
+        # 型別化錯誤，讀取路徑比照。
+            raise GestureConfigurationStoreError(
+                "Gesture configuration could not be read."
+            ) from None
         if not isinstance(raw, Mapping):
             return GestureConfiguration()
         configuration = import_gesture_configuration(

--- a/infrastructure/openai_vision_preferences_store.py
+++ b/infrastructure/openai_vision_preferences_store.py
@@ -72,7 +72,12 @@ class OpenAIVisionPreferencesStore[SnapshotT]:
         try:
             raw = self._settings.read(PORTABLE_SETTING_KEYS)
         except _BOUNDARY_ERRORS:
-            return OpenAIVisionPreferences()
+        # 後端讀不到不是「從未保存」：回預設值會讓排程端把已送達的提醒再送一次，
+        # 偏好編輯器也會拿預設值開啟、一存就覆蓋掉原有設定。寫入路徑早就拋
+        # 型別化錯誤，讀取路徑比照。
+            raise OpenAIVisionPreferencesStoreError(
+                "OpenAI vision preferences could not be read."
+            ) from None
         if not isinstance(raw, Mapping):
             return OpenAIVisionPreferences()
         version = raw.get(STORE_SCHEMA_KEY)

--- a/infrastructure/performance_preferences_store.py
+++ b/infrastructure/performance_preferences_store.py
@@ -136,7 +136,12 @@ class PerformancePreferencesStore[SnapshotT]:
         try:
             raw = self._settings.read((STORE_SCHEMA_KEY,))
         except _BOUNDARY_ERRORS:
-            return -1
+        # 後端讀不到不是「從未保存」：回預設值會讓排程端把已送達的提醒再送一次，
+        # 偏好編輯器也會拿預設值開啟、一存就覆蓋掉原有設定。寫入路徑早就拋
+        # 型別化錯誤，讀取路徑比照。
+            raise PerformancePreferencesStoreError(
+                "Performance preferences could not be read."
+            ) from None
         if not isinstance(raw, Mapping) or STORE_SCHEMA_KEY not in raw:
             return None
         version = raw[STORE_SCHEMA_KEY]

--- a/infrastructure/portable_import_checks.py
+++ b/infrastructure/portable_import_checks.py
@@ -1,0 +1,52 @@
+"""Row-level checks a portable-profile import must pass before any write.
+
+The import path writes rows with executemany and never goes through the
+normal write APIs, so a profile whose hashes and row counts are all
+consistent could still carry content those APIs reject: a workflow with an
+empty name or a non-JSON definition, or a settings value that is not JSON
+(set_setting always stores json.dumps output).  These checks apply the same
+rules up front and reject the whole import through the caller's error type.
+"""
+from __future__ import annotations
+
+lazy import json
+lazy import sqlite3
+lazy from collections.abc import Callable
+
+
+def validate_portable_rows(
+    table: str,
+    columns: tuple[str, ...],
+    rows: tuple[tuple[object, ...], ...],
+    *,
+    error: Callable[[str], Exception],
+) -> None:
+    if table != "workflows":
+        return
+    for index, row in enumerate(rows, start=1):
+        record = dict(zip(columns, row, strict=True))
+        if not str(record.get("name") or "").strip():
+            raise error(f"workflows 第 {index} 列的名稱留空。")
+        try:
+            json.loads(str(record.get("definition") or ""))
+        except json.JSONDecodeError:
+            raise error(f"workflows 第 {index} 列的定義不是合法 JSON。") from None
+
+
+def read_portable_settings(
+    incoming: sqlite3.Connection,
+    *,
+    is_portable: Callable[[str], bool],
+    error: Callable[[str], Exception],
+) -> tuple[tuple[str, str], ...]:
+    settings = tuple(
+        (str(row["key"]), str(row["value"]))
+        for row in incoming.execute("SELECT key,value FROM settings")
+        if is_portable(str(row["key"]))
+    )
+    for key, value in settings:
+        try:
+            json.loads(value)
+        except json.JSONDecodeError:
+            raise error(f"設定 {key} 的值不是合法 JSON。") from None
+    return settings

--- a/infrastructure/profile_transfer.py
+++ b/infrastructure/profile_transfer.py
@@ -43,6 +43,10 @@ lazy from infrastructure.openai_vision_preferences_store import (
     STORE_SCHEMA_KEY as OPENAI_VISION_STORE_SCHEMA_KEY,
 )
 lazy from infrastructure.performance_preferences_store import STORE_SCHEMA_KEY
+lazy from infrastructure.portable_import_checks import (
+    read_portable_settings,
+    validate_portable_rows,
+)
 lazy from infrastructure.portable_secrets import (
     PortableSecretsError,
     PortableSecretsPayload,
@@ -367,10 +371,12 @@ class PortableProfileManager:
         self,
         snapshot: sqlite3.Connection,
     ) -> None:
-        available_tables = self._table_names(snapshot)
-        for table in MACHINE_BOUND_TABLES:
-            if table in available_tables:
-                snapshot.execute(f'DELETE FROM "{table}"')
+        # 白名單：PORTABLE_TABLES 與 settings（另有鍵過濾）以外的表一律不出這台電腦。
+        portable = set(PORTABLE_TABLES) | {"settings"}
+        for table in sorted(self._table_names(snapshot)):
+            if table in portable or table.startswith("sqlite_"):
+                continue
+            snapshot.execute(f'DELETE FROM "{table}"')
 
     @staticmethod
     def _profile_identity(
@@ -843,19 +849,8 @@ class PortableProfileManager:
                 f'SELECT {quoted} FROM "{table}"'
             )
         )
+        validate_portable_rows(table, columns, rows, error=ProfileTransferError)
         return PortableTablePayload(columns=columns, rows=rows)
-
-    @staticmethod
-    def _read_portable_settings(
-        incoming: sqlite3.Connection,
-    ) -> tuple[tuple[str, str], ...]:
-        return tuple(
-            (str(row["key"]), str(row["value"]))
-            for row in incoming.execute(
-                "SELECT key,value FROM settings"
-            )
-            if is_portable_setting(str(row["key"]))
-        )
 
     def _load_profile_payload(
         self,
@@ -871,7 +866,11 @@ class PortableProfileManager:
                 for table in PORTABLE_TABLES
             )
             return PortableProfilePayload(
-                settings=self._read_portable_settings(incoming),
+                settings=read_portable_settings(
+                    incoming,
+                    is_portable=is_portable_setting,
+                    error=ProfileTransferError,
+                ),
                 tables=tables,
             )
         finally:

--- a/infrastructure/secret_store.py
+++ b/infrastructure/secret_store.py
@@ -18,6 +18,10 @@ def _blob(data: bytes) -> tuple[DATA_BLOB, object]:
     return DATA_BLOB(len(data), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_byte))), buffer
 
 
+class SecretDecryptError(OSError):
+    """The protected blob exists but cannot be decrypted in this context."""
+
+
 class SecretStore:
     """Store secrets encrypted for the current Windows user with DPAPI."""
 
@@ -67,10 +71,15 @@ class SecretStore:
             ctypes.windll.kernel32.LocalFree(output.pbData)
 
     def load(self) -> str:
+        # 只有「檔案不存在」才是空字串。blob 在但解不開（換了 Windows 帳號或
+        # 機器、非 Windows 平台）必須出錯：回空字串會讓上層把它當成尚未設定，
+        # 例如臉部身份回報零個 profile，接著重新註冊就直接覆蓋掉舊資料。
         if not self.path.exists():
             return ""
         if os.name != "nt":
-            return ""
+            raise SecretDecryptError(
+                f"{self.path.name} 只能在保存它的 Windows 帳號下解密。"
+            )
         source, source_buffer = _blob(self.path.read_bytes())
         output = DATA_BLOB()
         ok = ctypes.windll.crypt32.CryptUnprotectData(
@@ -84,7 +93,11 @@ class SecretStore:
         )
         _ = source_buffer
         if not ok:
-            return ""
+            code = ctypes.GetLastError()
+            raise SecretDecryptError(
+                f"{self.path.name} 無法解密（Win32 錯誤 {code}）；"
+                "保存它的 Windows 帳號或機器可能不同。"
+            )
         try:
             return ctypes.string_at(output.pbData, output.cbData).decode("utf-8")
         finally:

--- a/infrastructure/special_occasion_store.py
+++ b/infrastructure/special_occasion_store.py
@@ -63,7 +63,12 @@ class SpecialOccasionStore[SnapshotT]:
         try:
             raw = self._settings.read(PORTABLE_SETTING_KEYS)
         except _BOUNDARY_ERRORS:
-            return default_special_occasion_state(now.date())
+        # 後端讀不到不是「從未保存」：回預設值會讓排程端把已送達的提醒再送一次，
+        # 偏好編輯器也會拿預設值開啟、一存就覆蓋掉原有設定。寫入路徑早就拋
+        # 型別化錯誤，讀取路徑比照。
+            raise SpecialOccasionStoreError(
+                "Special occasion state could not be read."
+            ) from None
         payload = (
             raw.get(SPECIAL_OCCASION_STATE_KEY) if isinstance(raw, Mapping) else None
         )

--- a/infrastructure/wellbeing_reminder_store.py
+++ b/infrastructure/wellbeing_reminder_store.py
@@ -120,7 +120,12 @@ class WellbeingReminderStore[SnapshotT]:
         try:
             raw = self._settings.read(PORTABLE_SETTING_KEYS)
         except _BOUNDARY_ERRORS:
-            return default_wellbeing_state(now.date())
+        # 後端讀不到不是「從未保存」：回預設值會讓排程端把已送達的提醒再送一次，
+        # 偏好編輯器也會拿預設值開啟、一存就覆蓋掉原有設定。寫入路徑早就拋
+        # 型別化錯誤，讀取路徑比照。
+            raise WellbeingReminderStoreError(
+                "Wellbeing reminder state could not be read."
+            ) from None
         payload = raw.get(WELLBEING_STATE_KEY) if isinstance(raw, Mapping) else None
         state = _decode_state(payload, now.date())
         return _rollover(state, now)

--- a/infrastructure/windows_tools.py
+++ b/infrastructure/windows_tools.py
@@ -30,12 +30,15 @@ def visible_windows() -> list[dict[str, Any]]:
         if length <= 0:
             return True
         buffer = ctypes.create_unicode_buffer(length + 1)
-        user32.GetWindowTextW(hwnd, buffer, length + 1)
+        if user32.GetWindowTextW(hwnd, buffer, length + 1) <= 0:
+            return True
         title = buffer.value.strip()
         if not title:
             return True
         rect = wintypes.RECT()
-        user32.GetWindowRect(hwnd, ctypes.byref(rect))
+        # 視窗可能在取標題與取矩形之間關閉；失敗就略過，不記一個 [0,0,0,0]。
+        if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            return True
         rows.append(
             {
                 "hwnd": int(hwnd),
@@ -50,7 +53,10 @@ def visible_windows() -> list[dict[str, Any]]:
         )
         return True
 
-    user32.EnumWindows(callback_type(callback), 0)
+    if not user32.EnumWindows(callback_type(callback), 0):
+        raise OSError(
+            f"Windows 視窗列舉失敗（Win32 錯誤 {ctypes.GetLastError()}）"
+        )
     return rows
 
 

--- a/tests/test_infrastructure_audit3.py
+++ b/tests/test_infrastructure_audit3.py
@@ -1,0 +1,275 @@
+"""第 3 發 infrastructure 稽核（2026-09-02）的回歸。
+
+七項裡的六項在這裡有測試；第 1 項（更新清單與安裝程式同源、沒有獨立發布者
+簽章）是發行流程與金鑰託管的決策，不是程式碼修補。
+"""
+from __future__ import annotations
+
+lazy import os
+lazy import sqlite3
+lazy import zipfile
+lazy from datetime import UTC, datetime
+lazy from pathlib import Path
+
+lazy import pytest
+
+lazy from infrastructure import windows_tools
+lazy from infrastructure.backup_manager import BackupManager
+lazy from infrastructure.db import StudioDB
+lazy from infrastructure.framing_preferences_store import (
+    FramingPreferencesStore,
+    FramingPreferencesStoreError,
+)
+lazy from infrastructure.portable_import_checks import read_portable_settings
+lazy from infrastructure.profile_transfer import (
+    PortableProfileManager,
+    ProfileTransferError,
+    is_portable_setting,
+)
+lazy from infrastructure.gesture_configuration_store import (
+    GestureConfigurationStore,
+    GestureConfigurationStoreError,
+)
+lazy from infrastructure.openai_vision_preferences_store import (
+    OpenAIVisionPreferencesStore,
+    OpenAIVisionPreferencesStoreError,
+)
+lazy from infrastructure.performance_preferences_store import (
+    PerformancePreferencesStore,
+    PerformancePreferencesStoreError,
+)
+lazy from infrastructure.secret_store import SecretDecryptError, SecretStore
+lazy from infrastructure.special_occasion_store import (
+    SpecialOccasionStore,
+    SpecialOccasionStoreError,
+)
+lazy from infrastructure.wellbeing_reminder_store import (
+    WellbeingReminderStore,
+    WellbeingReminderStoreError,
+)
+
+windows_only = pytest.mark.skipif(
+    os.name != "nt", reason="DPAPI 與 user32 只在 Windows 上"
+)
+NOW = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+
+
+# ---- #3 DPAPI：沒有 blob 是空字串；有 blob 解不開必須出錯 ----
+
+
+def test_secret_store_missing_blob_is_empty(tmp_path: Path) -> None:
+    assert SecretStore(tmp_path / "none.dpapi", "test").load() == ""
+
+
+@windows_only
+def test_secret_store_undecryptable_blob_raises(tmp_path: Path) -> None:
+    store = SecretStore(tmp_path / "key.dpapi", "test")
+    store.save("secret-value")
+    assert store.load() == "secret-value"
+    blob = store.path.read_bytes()
+    store.path.write_bytes(bytes(len(blob)))  # 同長度的全零：DPAPI 必然拒絕
+    with pytest.raises(SecretDecryptError) as failure:
+        store.load()
+    assert isinstance(failure.value, OSError)
+    assert "key.dpapi" in str(failure.value)
+
+
+# ---- #5 備份：只有 verify() 通過的檔案算備份 ----
+
+
+class _FakeDB:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.conn = sqlite3.connect(":memory:")
+        self.conn.execute("CREATE TABLE t(x)")
+        self.conn.commit()
+
+
+def test_unverifiable_backup_neither_satisfies_recent_nor_outranks_real(
+    tmp_path: Path,
+) -> None:
+    manager = BackupManager(_FakeDB(tmp_path / "main.db"), tmp_path / "backups")
+    real = manager.create("manual")
+    assert manager.verify(real)
+    two_days_ago = real.stat().st_mtime - 2 * 86400
+    os.utime(real, (two_days_ago, two_days_ago))  # 真備份已過期，該再備份
+    bogus = tmp_path / "backups" / "mohan-29991231-235959-000000.db"
+    bogus.write_bytes(b"")  # 斷電情境：有 .db、沒 manifest，mtime 是「剛剛」
+    assert not manager.verify(bogus)
+
+    created = manager.automatic_if_due(hours=24)
+    assert created is not None and manager.verify(created)
+
+    manager.prune(keep_daily=1, keep_monthly=0)
+    assert created.exists()  # 最新的真備份留下
+    assert not real.exists()  # 較舊的真備份依保留數被清
+    assert bogus.exists()  # 無法驗證的檔案不參與排名、也不動它
+
+
+# ---- #7 Win32 回傳值 ----
+
+
+class _FakeUser32:
+    def __init__(
+        self, *, rect_fail_hwnd: int | None = None, enum_ok: bool = True
+    ) -> None:
+        self.rect_fail_hwnd = rect_fail_hwnd
+        self.enum_ok = enum_ok
+
+    def IsWindowVisible(self, hwnd):  # noqa: N802 - Win32 名稱
+        return 1
+
+    def GetWindowTextLengthW(self, hwnd):  # noqa: N802
+        return 9
+
+    def GetWindowTextW(self, hwnd, buffer, size):  # noqa: N802
+        buffer.value = f"window-{hwnd}"
+        return len(buffer.value)
+
+    def GetWindowRect(self, hwnd, rect_ref):  # noqa: N802
+        if hwnd == self.rect_fail_hwnd:
+            return 0
+        rect = rect_ref._obj
+        rect.left, rect.top, rect.right, rect.bottom = 1, 2, 3, 4
+        return 1
+
+    def EnumWindows(self, callback, lparam):  # noqa: N802
+        if not self.enum_ok:
+            return 0
+        for hwnd in (11, 22, 33):
+            callback(hwnd, lparam)
+        return 1
+
+
+@windows_only
+def test_window_closed_between_calls_is_skipped_not_zero_rect(monkeypatch) -> None:
+    monkeypatch.setattr(
+        windows_tools, "_user32", lambda: _FakeUser32(rect_fail_hwnd=22)
+    )
+    rows = windows_tools.visible_windows()
+    assert [row["hwnd"] for row in rows] == [11, 33]
+    assert all(row["rect"] == [1, 2, 3, 4] for row in rows)
+
+
+@windows_only
+def test_enum_windows_failure_is_an_error_not_an_empty_success(monkeypatch) -> None:
+    monkeypatch.setattr(windows_tools, "_user32", lambda: _FakeUser32(enum_ok=False))
+    with pytest.raises(OSError):
+        windows_tools.visible_windows()
+
+
+# ---- #6 五個 store：後端讀取失敗要拋型別化錯誤，不回預設值 ----
+
+
+class _BrokenSettings:
+    def read(self, keys):
+        raise sqlite3.OperationalError("disk I/O error")
+
+
+class _EmptySettings:
+    def read(self, keys):
+        return {}
+
+
+@pytest.mark.parametrize(
+    ("factory", "error", "call"),
+    [
+        (WellbeingReminderStore, WellbeingReminderStoreError, lambda s: s.load(NOW)),
+        (SpecialOccasionStore, SpecialOccasionStoreError, lambda s: s.load(NOW)),
+        (
+            OpenAIVisionPreferencesStore,
+            OpenAIVisionPreferencesStoreError,
+            lambda s: s.load(),
+        ),
+        (
+            PerformancePreferencesStore,
+            PerformancePreferencesStoreError,
+            lambda s: s.load(),
+        ),
+        (GestureConfigurationStore, GestureConfigurationStoreError, lambda s: s.load()),
+        (FramingPreferencesStore, FramingPreferencesStoreError, lambda s: s.load()),
+    ],
+    ids=["wellbeing", "occasion", "vision", "performance", "gesture", "framing"],
+)
+def test_backend_read_failure_raises_typed_error(factory, error, call) -> None:
+    with pytest.raises(error):
+        call(factory(_BrokenSettings()))
+    # 「從未保存」仍然是預設值，不是錯誤。
+    assert call(factory(_EmptySettings())) is not None
+
+
+# ---- #2 匯出白名單：不可攜的表不能夾帶出去 ----
+
+
+def test_export_clears_every_table_outside_the_portable_allowlist(
+    tmp_path: Path,
+) -> None:
+    db = StudioDB(tmp_path / "source" / "mohan.db")
+    db.add_todo("帶傘")
+    db.conn.execute(
+        "INSERT INTO memory_archive(original_id,snapshot,reason,archived_at) "
+        "VALUES(1,'我的身分證字號是 A123456789','test','2026-09-02T00:00:00')"
+    )
+    db.conn.commit()
+    manager = PortableProfileManager(db, tmp_path / "source" / "backups")
+    bundle, _manifest = manager.export_profile(tmp_path / "out")
+    with zipfile.ZipFile(bundle) as archive:
+        profile_bytes = archive.read("profile.db")
+    assert b"A123456789" not in profile_bytes
+    exported = tmp_path / "exported.db"
+    exported.write_bytes(profile_bytes)
+    connection = sqlite3.connect(exported)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM memory_archive").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM todos").fetchone()[0] == 1
+    finally:
+        connection.close()
+
+
+# ---- #4 匯入不得繞過正常寫入路徑的驗證 ----
+
+
+def _incoming_like(db: StudioDB, table: str) -> sqlite3.Connection:
+    incoming = sqlite3.connect(":memory:")
+    incoming.row_factory = sqlite3.Row
+    schema = db.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()[0]
+    incoming.execute(schema)
+    return incoming
+
+
+@pytest.mark.parametrize(
+    ("name", "definition", "message"),
+    [
+        ("", '{"steps": []}', "名稱留空"),
+        ("夜間備份", "not-json", "不是合法 JSON"),
+    ],
+)
+def test_import_rejects_workflow_rows_save_workflow_would_reject(
+    tmp_path: Path, name: str, definition: str, message: str
+) -> None:
+    db = StudioDB(tmp_path / "mohan.db")
+    manager = PortableProfileManager(db, tmp_path / "backups")
+    incoming = _incoming_like(db, "workflows")
+    incoming.execute(
+        "INSERT INTO workflows(name,definition,enabled,created_at,updated_at) "
+        "VALUES(?,?,1,'2026-09-02T00:00:00','2026-09-02T00:00:00')",
+        (name, definition),
+    )
+    with pytest.raises(ProfileTransferError, match=message):
+        manager._read_table_payload(incoming, "workflows")
+
+
+def test_import_rejects_setting_values_that_are_not_json(tmp_path: Path) -> None:
+    db = StudioDB(tmp_path / "mohan.db")
+    manager = PortableProfileManager(db, tmp_path / "backups")
+    incoming = _incoming_like(db, "settings")
+    incoming.execute(
+        "INSERT INTO settings(key,value) VALUES('assistant_name','not-json')"
+    )
+    assert manager is not None  # 目標資料庫存在，與正式匯入同一前提
+    with pytest.raises(ProfileTransferError, match="assistant_name"):
+        read_portable_settings(
+            incoming, is_portable=is_portable_setting, error=ProfileTransferError
+        )

--- a/tests/test_layered_facade_cycles.py
+++ b/tests/test_layered_facade_cycles.py
@@ -44,7 +44,7 @@ LAYER_MODULE_LINE_BASELINE = {
     "application.presentation_ports": 1_063,
     "domain.outfit_pack": 974,
     "infrastructure.db": 1_195,
-    "infrastructure.profile_transfer": 1_071,
+    "infrastructure.profile_transfer": 1_070,
     "integrations.azure_speech": 864,
     "integrations.realtime_voice": 878,
     "integrations.speech": 1_195,


### PR DESCRIPTION
## 繁體中文

### 為什麼

2026-09-02 對 `infrastructure/` 的第三輪獨立稽核追出七項缺陷，六項在此修正；第七項（更新清單與安裝程式同源、沒有獨立發布者簽章）是發行流程與金鑰託管的決策，另案處理。六項都是同一種病：失敗被偽裝成成功，或保護的範圍比宣稱的窄。

- `profile_transfer.py`：匯出只清 `MACHINE_BOUND_TABLES` 四張表，`memory_archive`、`companion_affection` 這類既不可攜也不在拒絕名單的表原樣夾帶進 `profile.db`，匯入端卻不讀它們。
- `secret_store.py`：檔案不存在、非 Windows、`CryptUnprotectData` 失敗都回傳空字串，上層無法區分「沒有秘密」與「解不開」——臉部身份會回報零個 profile，重新註冊就直接覆蓋舊資料。
- `backup_manager.py`：`automatic_if_due()` 與 `prune()` 只看檔名與 mtime，沒呼叫同類別的 `verify()`；缺 manifest 的斷電殘檔會讓「近期已備份」成立，也會在保留排名裡擠掉真備份。
- `profile_transfer.py`：匯入直接 `executemany`，沒有 `save_workflow()` 的非空名稱與 JSON 定義驗證，settings 值也不驗證是不是 JSON。
- 六個偏好／狀態 store 的 `load()` 在後端讀取失敗時回傳全新預設值：排程端會把已送達的提醒再送一次，偏好編輯器會拿預設值開啟、一存就覆蓋原有設定。
- `windows_tools.py`：`GetWindowTextW`、`GetWindowRect`、`EnumWindows` 的回傳值都沒檢查，視窗在兩次呼叫間關閉會記一個 `[0,0,0,0]`，列舉失敗仍回報成功。

### 修法

- 匯出改白名單：不在 `PORTABLE_TABLES` 的表一律清空（`settings` 另有鍵過濾），之後新增的表預設也不外流。
- 只有檔案不存在才是空字串；blob 在但解不開拋 `SecretDecryptError`（`OSError` 子類，帶 Win32 錯誤碼），既有呼叫端都已接 `OSError`。
- 新增 `_verified_backups()`，`automatic_if_due()` 與 `prune()` 都只採計 `verify()` 通過的檔案；無法驗證的檔案不參與排名、也不動它。
- 匯入在任何寫入前用 `save_workflow()` 同一套規則拒絕整個匯入，`ProfileTransferError` 帶列號或鍵名。驗證抽成新模組 `infrastructure/portable_import_checks.py`，`profile_transfer.py` 留在行數棘輪內，基準同步下調為 `1_070`。
- 六個 store（wellbeing、special occasion、OpenAI vision、performance、gesture、framing）比照各自的寫入路徑拋型別化 `StoreError`；「從未保存」仍是預設值。framing 不在稽核清單上，但同一缺陷、同一修法。
- `GetWindowRect` 失敗的視窗略過，`EnumWindows` 失敗拋 `OSError`。

### 測試

新增 `tests/test_infrastructure_audit3.py` 十五個測試：匯出檔的 `memory_archive` 為空且位元組裡找不到誘餌；真實 DPAPI 全零 blob 拋 `SecretDecryptError`；斷電殘檔既不滿足近期備份也不擠掉真備份；workflows 空名稱／非 JSON 定義與非 JSON 設定值在寫入前被拒；六個 store 後端失敗拋各自錯誤、空後端仍回預設；user32 假件驗證略過與拋錯。既有的六個 store 測試與 `test_profile_transfer.py` 未改、全過；完整 `tests/run_all.py` 全綠。

## 简体中文

### 为什么

2026-09-02 对 `infrastructure/` 的第三轮独立审计追出七项缺陷，六项在此修复；第七项（更新清单与安装程序同源、没有独立发布者签名）是发布流程与密钥托管的决策，另案处理。六项都是同一种病：失败被伪装成成功，或保护的范围比宣称的窄。

- `profile_transfer.py`：导出只清 `MACHINE_BOUND_TABLES` 四张表，`memory_archive`、`companion_affection` 这类既不可携也不在拒绝名单的表原样夹带进 `profile.db`，导入端却不读它们。
- `secret_store.py`：文件不存在、非 Windows、`CryptUnprotectData` 失败都返回空字符串，上层无法区分「没有秘密」与「解不开」——人脸身份会报告零个 profile，重新注册就直接覆盖旧数据。
- `backup_manager.py`：`automatic_if_due()` 与 `prune()` 只看文件名与 mtime，没调用同类的 `verify()`；缺 manifest 的断电残留文件会让「近期已备份」成立，也会在保留排名里挤掉真备份。
- `profile_transfer.py`：导入直接 `executemany`，没有 `save_workflow()` 的非空名称与 JSON 定义验证，settings 值也不验证是不是 JSON。
- 六个偏好／状态 store 的 `load()` 在后端读取失败时返回全新默认值：调度端会把已送达的提醒再送一次，偏好编辑器会拿默认值打开、一存就覆盖原有设置。
- `windows_tools.py`：`GetWindowTextW`、`GetWindowRect`、`EnumWindows` 的返回值都没检查，窗口在两次调用间关闭会记一个 `[0,0,0,0]`，枚举失败仍报告成功。

### 修复方式

- 导出改白名单：不在 `PORTABLE_TABLES` 的表一律清空（`settings` 另有键过滤），之后新增的表默认也不外流。
- 只有文件不存在才是空字符串；blob 在但解不开抛 `SecretDecryptError`（`OSError` 子类，带 Win32 错误码），既有调用端都已接 `OSError`。
- 新增 `_verified_backups()`，`automatic_if_due()` 与 `prune()` 都只采计 `verify()` 通过的文件；无法验证的文件不参与排名、也不动它。
- 导入在任何写入前用 `save_workflow()` 同一套规则拒绝整个导入，`ProfileTransferError` 带行号或键名。验证抽成新模块 `infrastructure/portable_import_checks.py`，`profile_transfer.py` 留在行数棘轮内，基线同步下调为 `1_070`。
- 六个 store（wellbeing、special occasion、OpenAI vision、performance、gesture、framing）比照各自的写入路径抛类型化 `StoreError`；「从未保存」仍是默认值。framing 不在审计清单上，但同一缺陷、同一修法。
- `GetWindowRect` 失败的窗口跳过，`EnumWindows` 失败抛 `OSError`。

### 测试

新增 `tests/test_infrastructure_audit3.py` 十五个测试：导出文件的 `memory_archive` 为空且字节里找不到诱饵；真实 DPAPI 全零 blob 抛 `SecretDecryptError`；断电残留文件既不满足近期备份也不挤掉真备份；workflows 空名称／非 JSON 定义与非 JSON 设置值在写入前被拒；六个 store 后端失败抛各自错误、空后端仍回默认；user32 假件验证跳过与抛错。既有的六个 store 测试与 `test_profile_transfer.py` 未改、全过；完整 `tests/run_all.py` 全绿。

## English

### Why

The third independent audit of `infrastructure/` on 2026-09-02 traced seven defects; six are fixed here. The seventh (the update manifest and the installer come from the same mutable source with no independent publisher signature) is a release-process and key-custody decision and is handled separately. All six share one disease: a failure dressed up as success, or a guard narrower than what it claims.

- `profile_transfer.py`: the export cleared only the four `MACHINE_BOUND_TABLES`, so tables that are neither portable nor on the denylist — `memory_archive`, `companion_affection` — shipped verbatim inside `profile.db`, while the importer never reads them.
- `secret_store.py`: a missing file, a non-Windows platform and a failed `CryptUnprotectData` all returned the empty string, so callers could not tell "no secret" from "cannot decrypt" — face identity reported zero profiles, and re-enrolling simply overwrote the old data.
- `backup_manager.py`: `automatic_if_due()` and `prune()` looked only at file names and mtimes and never called the class's own `verify()`; a power-loss remnant without its manifest satisfied "recent backup exists" and could outrank a real backup in retention.
- `profile_transfer.py`: the import ran `executemany` directly, skipping the non-empty-name and JSON-definition checks of `save_workflow()`, and never checked that settings values are JSON.
- `load()` in six preference/state stores returned fresh defaults on a backend read failure: the scheduler would re-deliver a reminder already delivered, and the preference editor would open on defaults and overwrite the real settings on the first save.
- `windows_tools.py`: the return values of `GetWindowTextW`, `GetWindowRect` and `EnumWindows` were never checked; a window closed between the two calls was recorded as `[0,0,0,0]`, and a failed enumeration still reported success.

### The fix

- The export is now an allowlist: every table outside `PORTABLE_TABLES` is cleared (`settings` keeps its key filter), so tables added later stay local by default.
- Only a missing file is the empty string; a blob that exists but cannot be decrypted raises `SecretDecryptError` (an `OSError` subclass carrying the Win32 error code), which every existing caller already catches as `OSError`.
- A new `_verified_backups()` feeds both `automatic_if_due()` and `prune()` with only the files that pass `verify()`; unverifiable files take no part in ranking and are left alone.
- The import applies the same rules as `save_workflow()` before any write and rejects the whole import with a `ProfileTransferError` naming the row or key. The checks live in the new module `infrastructure/portable_import_checks.py`, which keeps `profile_transfer.py` inside the line-count ratchet; its baseline is lowered to `1_070` in step.
- The six stores (wellbeing, special occasion, OpenAI vision, performance, gesture, framing) now raise their typed `StoreError` on a backend read failure, matching their write paths; "never saved" is still the default. framing was not on the audit list, but it is the same defect and the same fix.
- A window whose `GetWindowRect` fails is skipped, and a failed `EnumWindows` raises `OSError`.

### Tests

`tests/test_infrastructure_audit3.py` adds fifteen tests: the exported `memory_archive` is empty and the bait is absent from the bytes; a real DPAPI all-zero blob raises `SecretDecryptError`; a power-loss remnant neither satisfies "recent backup" nor outranks a real one; workflow rows with an empty name or a non-JSON definition and non-JSON settings values are rejected before any write; the six stores raise their own error on backend failure and still return defaults on an empty backend; a fake user32 verifies the skip and the raise. The existing six store tests and `test_profile_transfer.py` are unchanged and pass; the full `tests/run_all.py` is green.

## 日本語

### 理由

2026-09-02 の `infrastructure/` に対する第三回の独立監査で七件の欠陥が見つかり、六件をここで修正します。七件目（更新マニフェストとインストーラーが同じ可変の出所から来ていて、独立した発行者署名が無い）はリリース手順と鍵管理の判断であり、別途扱います。六件は同じ病です。失敗が成功に見せかけられているか、守っている範囲が宣言より狭いかのどちらかです。

- `profile_transfer.py`：エクスポートは `MACHINE_BOUND_TABLES` の四表しか消さず、`memory_archive` や `companion_affection` のように持ち出し対象でも拒否名簿でもない表がそのまま `profile.db` に同梱されていました。インポート側はそれらを読みません。
- `secret_store.py`：ファイルが無い、Windows でない、`CryptUnprotectData` が失敗した、のすべてが空文字列を返し、上位層は「秘密が無い」と「復号できない」を区別できませんでした。顔識別はプロファイル零件と報告し、再登録すると古いデータをそのまま上書きします。
- `backup_manager.py`：`automatic_if_due()` と `prune()` はファイル名と mtime しか見ず、同じクラスの `verify()` を呼びません。manifest の無い停電の残骸が「最近のバックアップあり」を成立させ、保持順位でも本物のバックアップを押し出せました。
- `profile_transfer.py`：インポートは `executemany` を直接実行し、`save_workflow()` の空でない名前と JSON 定義の検査を通らず、settings の値が JSON かどうかも確かめませんでした。
- 六つの設定／状態 store の `load()` は、バックエンドの読み取りに失敗すると新品の既定値を返していました。スケジューラーは配信済みの通知をもう一度送り、設定エディターは既定値で開いて最初の保存で本来の設定を上書きします。
- `windows_tools.py`：`GetWindowTextW`、`GetWindowRect`、`EnumWindows` の戻り値を確認せず、二回の呼び出しの間に閉じたウィンドウが `[0,0,0,0]` として記録され、列挙が失敗しても成功と報告していました。

### 修正方法

- エクスポートを許可リストにしました。`PORTABLE_TABLES` に無い表はすべて空にし（`settings` は従来どおりキーで絞る）、後から追加される表も既定でローカルに留まります。
- 空文字列になるのはファイルが無いときだけです。blob はあるのに復号できない場合は `SecretDecryptError`（Win32 エラーコードを持つ `OSError` の派生）を送出し、既存の呼び出し元はすべて `OSError` として受け止めます。
- 新しい `_verified_backups()` が `automatic_if_due()` と `prune()` の両方に `verify()` を通ったファイルだけを渡します。検証できないファイルは順位付けに関与せず、手も触れません。
- インポートはどの書き込みよりも前に `save_workflow()` と同じ規則を適用し、行番号かキー名を含む `ProfileTransferError` でインポート全体を拒否します。検査は新しいモジュール `infrastructure/portable_import_checks.py` に置き、`profile_transfer.py` を行数ラチェットの内側に保ち、基準値も合わせて `1_070` に下げました。
- 六つの store（wellbeing、special occasion、OpenAI vision、performance、gesture、framing）はバックエンドの読み取り失敗で各自の型付き `StoreError` を送出し、書き込み経路と揃えました。「一度も保存していない」は従来どおり既定値です。framing は監査一覧に無いものの、同じ欠陥で同じ修正です。
- `GetWindowRect` が失敗したウィンドウは飛ばし、`EnumWindows` の失敗は `OSError` を送出します。

### テスト

`tests/test_infrastructure_audit3.py` に十五件のテストを追加しました。エクスポートされた `memory_archive` が空で、バイト列に囮が無いこと。実際の DPAPI で全零の blob が `SecretDecryptError` を送出すること。停電の残骸が「最近のバックアップ」を満たさず、本物を押し出しもしないこと。名前が空か定義が JSON でない workflows 行と、JSON でない設定値が書き込み前に拒否されること。六つの store がバックエンド失敗で各自のエラーを送出し、空のバックエンドでは既定値を返すこと。偽の user32 でスキップと送出を確かめること。既存の六つの store テストと `test_profile_transfer.py` は変更なしで通り、`tests/run_all.py` 全体も緑です。
