### PR TITLE
feat: 更新清單改用擁有者 Ed25519 分離簽章，用戶端只接受能以內嵌公鑰驗證的清單／更新清单改用所有者 Ed25519 分离签名，客户端只接受能以内嵌公钥验证的清单／Owner-signed update manifests: Ed25519 detached signature, client accepts only manifests verified by a pinned key／更新マニフェストを所有者の Ed25519 分離署名に切り替え、クライアントは埋め込み公開鍵で検証できるものだけを受け入れる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -674,6 +674,11 @@ jobs:
           path: release-artifacts
           merge-multiple: true
 
+      - name: Refuse to release a client with no pinned update-manifest public key
+        shell: bash
+        run: |
+          "${{ steps.runtime-python.outputs.python-path }}" -c "import sys; sys.path.insert(0, '.'); from infrastructure.update_manifest_signature import require_pinned_keys; print(len(require_pinned_keys()), 'pinned update-manifest public key(s)')"
+
       - name: Create, finalize, and validate CycloneDX 1.7 SBOMs
         run: |
           sbom_python="${{ steps.sbom-python.outputs.python-path }}"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -125,7 +125,8 @@ GitHub 自動化必須使用一條可預測的憑證路徑。Pull Request 的讀
 12. 在最小權限發布工作中重新檢查精確產物集合及每個已列入清單的 SHA-256 值；
 13. 在發布前立即重新解析標籤，若標籤已移動或遭替換便拒絕發布；
 14. 為每個發布檔案建立 GitHub 產物來源證明；
-15. 要求並發布人工整理的四語 Release 說明。
+15. 要求並發布人工整理的四語 Release 說明；
+16. 發布後由擁有者在自己的電腦上以 `tools/sign_update_manifest.py release-sign` 對更新資訊清單做 Ed25519 分離簽章並上傳 `.sig` 資產。私鑰不進儲存庫、也不進 CI Secret；用戶端只接受能以內嵌公鑰驗證的清單，中繼資料工作在沒有內嵌公鑰時拒絕發布。
 
 `vN.N.N-rc.N` 必須發布為 Pre-release，純 `vN.N.N` 必須發布為 Stable Release；工作流程會阻擋標籤與成熟度不一致。不得重複使用或移動任何已發布標籤。
 
@@ -299,7 +300,8 @@ GitHub 自动化必须使用一条可预测的凭证路径。Pull Request 的读
 12. 在最小权限发布任务中重新检查精确产物集合及每个已列入清单的 SHA-256 值；
 13. 在发布前立即重新解析标签，若标签已移动或被替换便拒绝发布；
 14. 为每个发布文件建立 GitHub 产物来源证明；
-15. 要求并发布人工整理的四语 Release 说明。
+15. 要求并发布人工整理的四语 Release 说明；
+16. 发布后由所有者在自己的电脑上以 `tools/sign_update_manifest.py release-sign` 对更新清单做 Ed25519 分离签名并上传 `.sig` 资产。私钥不进仓库、也不进 CI Secret；客户端只接受能以内嵌公钥验证的清单，元数据任务在没有内嵌公钥时拒绝发布。
 
 `vN.N.N-rc.N` 必须发布为预发布版，纯 `vN.N.N` 必须发布为正式稳定版；工作流会阻止标签与成熟度不一致。不得重复使用或移动任何已发布标签。
 
@@ -473,7 +475,8 @@ Before any platform package starts, the fast gate must confirm that the tag, ver
 12. rechecks the exact artifact set and every cataloged SHA-256 value inside a minimal publication job;
 13. re-resolves the tag immediately before publication and refuses a moved or replaced tag;
 14. creates GitHub artifact provenance attestations for every published file;
-15. requires and publishes the curated four-language Release description.
+15. requires and publishes the curated four-language Release description;
+16. after publication, the owner signs the update manifest on their own machine with `tools/sign_update_manifest.py release-sign`, producing an Ed25519 detached signature uploaded as the `.sig` asset. The private key is neither in the repository nor a CI secret; the client accepts only a manifest that verifies under a pinned public key, and the metadata job refuses to publish when no public key is pinned.
 
 Every `vN.N.N-rc.N` tag must publish as a pre-release, while a plain `vN.N.N` tag must publish as a stable release. The workflow rejects a tag/maturity mismatch. Never reuse or move any published tag.
 
@@ -648,6 +651,7 @@ GitHub 自動化では、予測可能な認証経路を一つだけ使用しま�
 13. 公開直前にタグを再解決し、移動または置換されたタグを拒否します。
 14. 公開する全ファイルに GitHub 成果物由来証明を作成します。
 15. 人手で整備した四言語 Release 説明を必須とし、その説明を公開します。
+16. 公開後、所有者が自分の端末で `tools/sign_update_manifest.py release-sign` により更新マニフェストへ Ed25519 の分離署名を付け、`.sig` 成果物としてアップロードします。秘密鍵はリポジトリにも CI Secret にも置かず、クライアントは埋め込み公開鍵で検証できるマニフェストだけを受け入れ、メタデータジョブは公開鍵が埋め込まれていなければ公開を拒否します。
 
 `vN.N.N-rc.N` は Pre-release、純粋な `vN.N.N` は Stable Release として公開し、タグと成熟度が一致しなければワークフローが拒否します。公開済みタグは再利用も移動もしません。
 

--- a/infrastructure/update_manifest_signature.py
+++ b/infrastructure/update_manifest_signature.py
@@ -1,0 +1,112 @@
+"""Ed25519 detached signatures for the GitHub update manifest.
+
+The manifest's SHA-256 values prove that a downloaded installer matches the
+manifest.  They do not prove who issued the manifest: manifest and installer
+sit in the same GitHub Release, so anyone who can write to the Release can
+replace both together and every hash still matches.  The detached signature
+moves the trust anchor from "the GitHub account" to "the owner's private
+key", which never leaves the owner's machine and is never a CI secret.
+
+Contract:
+- the signature covers the manifest asset's exact bytes, nothing canonical;
+- it is published as a separate Release asset named ``<manifest>.sig`` and
+  contains the 64-byte Ed25519 signature as 128 lowercase hex characters;
+- the client pins one or more public keys here and refuses any release whose
+  manifest lacks a signature that verifies under a pinned key (fail closed);
+- an empty pin list is a build-time error caught before release, never a
+  runtime "skip verification".
+"""
+from __future__ import annotations
+
+lazy import binascii
+lazy from collections.abc import Iterable
+
+lazy from cryptography.exceptions import InvalidSignature
+lazy from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+SIGNATURE_SUFFIX = ".sig"
+PUBLIC_KEY_HEX_LENGTH = 64
+SIGNATURE_HEX_LENGTH = 128
+MAX_SIGNATURE_BYTES = 4 * 1024
+
+# Owner-generated with `py -3.15 tools/sign_update_manifest.py keygen`.  The
+# private key stays on the owner's machine; only the public half is pinned.
+# Rotation: append the new key, ship a client release, then remove the old
+# key in a later release.  While this tuple is empty the release workflow
+# refuses to publish a client and the updater refuses every update.
+PINNED_UPDATE_MANIFEST_PUBLIC_KEYS: tuple[str, ...] = (
+    "411f1e848009b997f1d0685b271e04f560f66ec0c3260b1f3d508dba6bdb0f6f",  # owner key #1, generated 2026-09-02
+)
+
+
+class UpdateManifestSignatureError(ValueError):
+    """The manifest signature is missing, malformed or does not verify."""
+
+
+def signature_asset_name(manifest_name: str) -> str:
+    return f"{manifest_name}{SIGNATURE_SUFFIX}"
+
+
+def parse_public_key(hex_key: str) -> Ed25519PublicKey:
+    text = hex_key.strip().lower()
+    if len(text) != PUBLIC_KEY_HEX_LENGTH:
+        raise UpdateManifestSignatureError("公鑰必須是 64 個十六進位字元。")
+    try:
+        raw = binascii.unhexlify(text)
+    except (binascii.Error, ValueError):
+        raise UpdateManifestSignatureError("公鑰不是合法的十六進位字串。") from None
+    try:
+        return Ed25519PublicKey.from_public_bytes(raw)
+    except ValueError:
+        raise UpdateManifestSignatureError("公鑰不是合法的 Ed25519 公鑰。") from None
+
+
+def parse_signature(signature_text: str | bytes) -> bytes:
+    if isinstance(signature_text, bytes):
+        try:
+            signature_text = signature_text.decode("ascii")
+        except UnicodeDecodeError:
+            raise UpdateManifestSignatureError("簽章檔不是 ASCII 文字。") from None
+    text = signature_text.strip().lower()
+    if len(text) != SIGNATURE_HEX_LENGTH:
+        raise UpdateManifestSignatureError("簽章必須是 128 個十六進位字元。")
+    try:
+        return binascii.unhexlify(text)
+    except (binascii.Error, ValueError):
+        raise UpdateManifestSignatureError("簽章不是合法的十六進位字串。") from None
+
+
+def require_pinned_keys(
+    public_keys: Iterable[str] | None = None,
+) -> tuple[str, ...]:
+    """Return the pinned keys or raise; used as a release-time gate."""
+
+    keys = tuple(
+        PINNED_UPDATE_MANIFEST_PUBLIC_KEYS if public_keys is None else public_keys
+    )
+    if not keys:
+        raise UpdateManifestSignatureError(
+            "尚未內嵌任何更新清單公鑰；請先執行 tools/sign_update_manifest.py keygen "
+            "並把公鑰填入 PINNED_UPDATE_MANIFEST_PUBLIC_KEYS。"
+        )
+    for key in keys:
+        parse_public_key(key)
+    return keys
+
+
+def verify_manifest_signature(
+    manifest_bytes: bytes,
+    signature_text: str | bytes,
+    public_keys: Iterable[str] | None = None,
+) -> str:
+    """Verify and return the hex of the pinned key that signed the manifest."""
+
+    keys = require_pinned_keys(public_keys)
+    signature = parse_signature(signature_text)
+    for key_hex in keys:
+        try:
+            parse_public_key(key_hex).verify(signature, manifest_bytes)
+        except InvalidSignature:
+            continue
+        return key_hex.strip().lower()
+    raise UpdateManifestSignatureError("更新清單的簽章與任何內嵌公鑰都不符。")

--- a/infrastructure/updater.py
+++ b/infrastructure/updater.py
@@ -13,6 +13,13 @@ lazy from urllib.error import HTTPError, URLError
 lazy from urllib.parse import urlparse
 lazy from urllib.request import Request, urlopen
 
+lazy from infrastructure.update_manifest_signature import (
+    MAX_SIGNATURE_BYTES,
+    UpdateManifestSignatureError,
+    signature_asset_name,
+    verify_manifest_signature,
+)
+
 MAX_MANIFEST_BYTES = 256 * 1024
 MAX_INSTALLER_BYTES = 750 * 1024 * 1024
 HTTP_NOT_FOUND = 404
@@ -96,6 +103,7 @@ class UpdateManager:
         current_version: str,
         download_dir: Path,
         opener: Callable[..., Any] | None = None,
+        public_keys: tuple[str, ...] | None = None,
     ):
         if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
             raise ValueError("GitHub repository 格式錯誤。")
@@ -105,6 +113,8 @@ class UpdateManager:
         self.download_dir = Path(download_dir)
         self._opener = opener or urlopen
         self._ssl_context = ssl.create_default_context()
+        # None 代表用內嵌公鑰；測試才會注入臨時公鑰。
+        self._public_keys = public_keys
 
     @staticmethod
     def _validate_url(url: str) -> None:
@@ -169,15 +179,57 @@ class UpdateManager:
         return data
 
     def _request_json(self, url: str, limit: int = MAX_MANIFEST_BYTES) -> Any:
+        return self._decode_json(self._request_bytes(url, limit))
+
+    @staticmethod
+    def _decode_json(data: bytes) -> Any:
         invalid_json = False
         result: Any = None
         try:
-            result = json.loads(self._request_bytes(url, limit).decode("utf-8"))
+            result = json.loads(data.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
             invalid_json = True
         if invalid_json:
             raise UpdateError("GitHub 更新資料格式不正確。")
         return result
+
+    def _verified_manifest(
+        self,
+        manifest_asset: dict[str, Any],
+        release: dict[str, Any],
+    ) -> Any:
+        # SHA-256 只證明安裝程式與清單一致；清單與安裝程式同在一個 Release，
+        # 能改 Release 的人兩者一起換。簽章證明清單是持有擁有者私鑰的人發的。
+        # 沒有簽章、簽章驗不過、沒有內嵌公鑰，一律拒絕，不退回「只看雜湊」。
+        manifest_name = str(manifest_asset.get("name", ""))
+        expected = signature_asset_name(manifest_name)
+        signature_asset = next(
+            (
+                asset
+                for asset in release.get("assets", [])
+                if isinstance(asset, dict) and asset.get("name") == expected
+            ),
+            None,
+        )
+        if not signature_asset:
+            raise UpdateError("此版本的更新清單尚未簽章，已拒絕更新。")
+        manifest_bytes = self._request_bytes(
+            str(manifest_asset.get("browser_download_url", "")),
+            MAX_MANIFEST_BYTES,
+        )
+        signature_text = self._request_bytes(
+            str(signature_asset.get("browser_download_url", "")),
+            MAX_SIGNATURE_BYTES,
+        )
+        try:
+            verify_manifest_signature(
+                manifest_bytes,
+                signature_text,
+                self._public_keys,
+            )
+        except UpdateManifestSignatureError:
+            raise UpdateError("更新清單簽章驗證失敗，已拒絕更新。") from None
+        return self._decode_json(manifest_bytes)
 
     def _release_candidates(self, channel: str) -> list[dict[str, Any]]:
         endpoint = f"https://api.github.com/repos/{self.repository}/releases"
@@ -227,9 +279,7 @@ class UpdateManager:
             )
             if not manifest_asset:
                 continue
-            manifest = self._request_json(
-                str(manifest_asset.get("browser_download_url", ""))
-            )
+            manifest = self._verified_manifest(manifest_asset, release)
             return self._parse_manifest(manifest, release)
         return None
 

--- a/tests/test_secure_updater.py
+++ b/tests/test_secure_updater.py
@@ -12,11 +12,17 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+lazy from infrastructure.update_manifest_signature import signature_asset_name
 lazy from infrastructure.updater import (
     InstallerAsset,
     UpdateError,
     UpdateManager,
     is_newer_version,
+)
+lazy from tools.sign_update_manifest import (
+    generate_private_key,
+    load_private_key,
+    sign_manifest_bytes,
 )
 
 
@@ -51,7 +57,12 @@ def _assert_version_ordering() -> None:
     assert not is_newer_version("2.0.13", "2.0.14-rc.2")
 
 
-def _release_responses() -> tuple[str, bytes, dict[str, bytes]]:
+def _release_responses() -> tuple[str, bytes, dict[str, bytes], str]:
+    # 2026-09-02 起更新清單必須帶擁有者的 Ed25519 分離簽章；這裡用臨時金鑰
+    # 扮演擁有者，公鑰注入 UpdateManager 取代內嵌公鑰。
+    key_path = Path(tempfile.mkdtemp()) / "owner.pem"
+    public_key = generate_private_key(key_path)
+    private_key = load_private_key(key_path)
     installer_bytes = b"verified installer payload"
     digest = hashlib.sha256(installer_bytes).hexdigest()
     repo = "flameblade-studio/MoHan-PC-Desktop-Assistant"
@@ -83,15 +94,23 @@ def _release_responses() -> tuple[str, bytes, dict[str, bytes]]:
         "body": "Release notes",
         "published_at": "2026-08-01T00:00:00Z",
         "assets": [
-            {"name": manifest_name, "browser_download_url": manifest_url}
+            {"name": manifest_name, "browser_download_url": manifest_url},
+            {
+                "name": signature_asset_name(manifest_name),
+                "browser_download_url": manifest_url + ".sig",
+            },
         ],
     }
+    manifest_bytes = json.dumps(manifest).encode()
     responses = {
         f"https://api.github.com/repos/{repo}/releases/latest": json.dumps(release).encode(),
-        manifest_url: json.dumps(manifest).encode(),
+        manifest_url: manifest_bytes,
+        manifest_url + ".sig": sign_manifest_bytes(
+            manifest_bytes, private_key, pinned=(public_key,)
+        ).encode(),
         installer_url: installer_bytes,
     }
-    return repo, installer_bytes, responses
+    return repo, installer_bytes, responses, public_key
 
 
 def _response_opener(responses: dict[str, bytes]):
@@ -128,6 +147,7 @@ def _assert_verified_download(
     repo: str,
     installer_bytes: bytes,
     responses: dict[str, bytes],
+    public_key: str,
 ) -> None:
     with tempfile.TemporaryDirectory() as temp:
         manager = UpdateManager(
@@ -135,6 +155,7 @@ def _assert_verified_download(
             "2.0.14-rc.2",
             Path(temp),
             _response_opener(responses),
+            public_keys=(public_key,),
         )
         update = manager.check("stable")
         assert update is not None and update.version == "2.0.15"
@@ -160,8 +181,8 @@ def _assert_unsafe_urls_rejected() -> None:
 
 def main() -> None:
     _assert_version_ordering()
-    repo, installer_bytes, responses = _release_responses()
-    _assert_verified_download(repo, installer_bytes, responses)
+    repo, installer_bytes, responses, public_key = _release_responses()
+    _assert_verified_download(repo, installer_bytes, responses, public_key)
     _assert_unsafe_urls_rejected()
     print("SECURE_AUTO_UPDATE_OK")
 

--- a/tests/test_update_manifest_signature.py
+++ b/tests/test_update_manifest_signature.py
@@ -1,0 +1,210 @@
+"""更新清單的 Ed25519 分離簽章：模組、工具與更新器整合。
+
+安全結論只有一條：沒有能以內嵌公鑰驗證的簽章，更新器就不會把任何安裝程式
+當成可用更新，不論 SHA-256 多麼一致。
+"""
+from __future__ import annotations
+
+lazy import hashlib
+lazy import json
+lazy from email.message import Message
+lazy from pathlib import Path
+lazy from urllib.error import URLError
+
+lazy import pytest
+
+lazy from infrastructure.update_manifest_signature import (
+    UpdateManifestSignatureError,
+    parse_public_key,
+    require_pinned_keys,
+    signature_asset_name,
+    verify_manifest_signature,
+)
+lazy from infrastructure.updater import UpdateError, UpdateManager
+lazy from tools.sign_update_manifest import (
+    generate_private_key,
+    load_private_key,
+    main as tool_main,
+    public_key_hex,
+    sign_manifest_bytes,
+)
+
+REPO = "flameblade-studio/MoHan-PC-Desktop-Assistant"
+TAG = "v9.9.9"
+MANIFEST_NAME = f"MoHan-Desktop-Assistant-{TAG}-update.json"
+
+
+class _FakeResponse:
+    def __init__(self, url: str, payload: bytes) -> None:
+        self.url = url
+        self.payload = payload
+        self.offset = 0
+        self.headers = Message()
+        self.headers["Content-Length"] = str(len(payload))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def geturl(self) -> str:
+        return self.url
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self.payload) - self.offset
+        chunk = self.payload[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+
+def _opener(responses: dict[str, bytes]):
+    def open_url(request, **_kwargs):
+        if request.full_url not in responses:
+            raise URLError("unexpected URL")
+        return _FakeResponse(request.full_url, responses[request.full_url])
+
+    return open_url
+
+
+@pytest.fixture
+def owner_key(tmp_path: Path):
+    public = generate_private_key(tmp_path / "keys" / "owner.pem")
+    return load_private_key(tmp_path / "keys" / "owner.pem"), public
+
+
+def _release(manifest_bytes: bytes, signature: bytes | None) -> dict[str, bytes]:
+    base = f"https://github.com/{REPO}/releases/download/{TAG}/"
+    installer = b"installer bytes"
+    assets = [{"name": MANIFEST_NAME, "browser_download_url": base + MANIFEST_NAME}]
+    responses = {base + MANIFEST_NAME: manifest_bytes, base + "setup.exe": installer}
+    if signature is not None:
+        name = signature_asset_name(MANIFEST_NAME)
+        assets.append({"name": name, "browser_download_url": base + name})
+        responses[base + name] = signature
+    release = {
+        "tag_name": TAG, "draft": False, "prerelease": False,
+        "html_url": f"https://github.com/{REPO}/releases/tag/{TAG}",
+        "body": "", "published_at": "2026-09-02T00:00:00Z", "assets": assets,
+    }
+    responses[f"https://api.github.com/repos/{REPO}/releases/latest"] = json.dumps(
+        release
+    ).encode()
+    return responses
+
+
+def _manifest_bytes() -> bytes:
+    installer = b"installer bytes"
+    return json.dumps({
+        "schema": 1, "repository": REPO, "version": "9.9.9", "tag": TAG,
+        "installers": [{
+            "kind": "exe", "name": "setup.exe",
+            "url": f"https://github.com/{REPO}/releases/download/{TAG}/setup.exe",
+            "sha256": hashlib.sha256(installer).hexdigest(), "size": len(installer),
+        }],
+    }).encode()
+
+
+def _manager(responses, public_keys, tmp_path: Path) -> UpdateManager:
+    return UpdateManager(REPO, "1.0.0", tmp_path, _opener(responses), public_keys=public_keys)
+
+
+# ---- 模組 ----
+
+def test_signature_round_trip_and_tamper_detection(owner_key) -> None:
+    private, public = owner_key
+    payload = b'{"schema": 1}'
+    signature = sign_manifest_bytes(payload, private, pinned=(public,))
+    assert verify_manifest_signature(payload, signature, (public,)) == public
+    with pytest.raises(UpdateManifestSignatureError):
+        verify_manifest_signature(payload + b" ", signature, (public,))
+    with pytest.raises(UpdateManifestSignatureError):
+        verify_manifest_signature(payload, "0" * 128, (public,))
+    assert public_key_hex(private) == public
+
+
+def test_empty_or_malformed_pins_fail_closed() -> None:
+    with pytest.raises(UpdateManifestSignatureError, match="尚未內嵌"):
+        require_pinned_keys(())
+    with pytest.raises(UpdateManifestSignatureError):
+        require_pinned_keys(("not-hex",))
+    with pytest.raises(UpdateManifestSignatureError):
+        parse_public_key("ab" * 31)
+
+
+def test_signing_with_an_unpinned_key_is_refused(owner_key, tmp_path: Path) -> None:
+    private, _public = owner_key
+    stranger = generate_private_key(tmp_path / "stranger.pem")
+    with pytest.raises(UpdateManifestSignatureError):
+        sign_manifest_bytes(b"x", private, pinned=(stranger,))
+
+
+# ---- 更新器整合 ----
+
+def test_updater_accepts_a_manifest_signed_by_a_pinned_key(owner_key, tmp_path) -> None:
+    private, public = owner_key
+    manifest = _manifest_bytes()
+    signature = sign_manifest_bytes(manifest, private, pinned=(public,)).encode()
+    update = _manager(_release(manifest, signature), (public,), tmp_path).check("stable")
+    assert update is not None and update.version == "9.9.9"
+
+
+def test_updater_refuses_a_release_without_a_signature(owner_key, tmp_path) -> None:
+    _private, public = owner_key
+    with pytest.raises(UpdateError, match="尚未簽章"):
+        _manager(_release(_manifest_bytes(), None), (public,), tmp_path).check("stable")
+
+
+def test_updater_refuses_a_tampered_manifest_even_with_matching_hashes(
+    owner_key, tmp_path
+) -> None:
+    private, public = owner_key
+    manifest = _manifest_bytes()
+    signature = sign_manifest_bytes(manifest, private, pinned=(public,)).encode()
+    tampered = manifest.replace(b'"9.9.9"', b'"9.9.9"', 1) + b"\n"
+    with pytest.raises(UpdateError, match="簽章驗證失敗"):
+        _manager(_release(tampered, signature), (public,), tmp_path).check("stable")
+
+
+def test_updater_refuses_a_signature_from_an_unpinned_key(owner_key, tmp_path) -> None:
+    private, _public = owner_key
+    stranger = generate_private_key(tmp_path / "stranger.pem")
+    manifest = _manifest_bytes()
+    signature = sign_manifest_bytes(manifest, private, pinned=()).encode()
+    with pytest.raises(UpdateError, match="簽章驗證失敗"):
+        _manager(_release(manifest, signature), (stranger,), tmp_path).check("stable")
+
+
+def test_updater_with_no_pinned_key_refuses_every_update(owner_key, tmp_path) -> None:
+    private, public = owner_key
+    manifest = _manifest_bytes()
+    signature = sign_manifest_bytes(manifest, private, pinned=(public,)).encode()
+    with pytest.raises(UpdateError):
+        _manager(_release(manifest, signature), (), tmp_path).check("stable")
+
+
+# ---- 工具 CLI ----
+
+def test_cli_keygen_sign_verify(tmp_path: Path, capsys) -> None:
+    key_path = tmp_path / "owner.pem"
+    assert tool_main(["keygen", "--private-key", str(key_path)]) == 0
+    public = capsys.readouterr().out.split("：")[-1].strip()
+    manifest = tmp_path / MANIFEST_NAME
+    manifest.write_bytes(_manifest_bytes())
+    # 臨時金鑰沒有內嵌：CLI 的 sign 必須拒絕，避免簽出用戶端不認的簽章。
+    with pytest.raises(UpdateManifestSignatureError):
+        tool_main(["sign", str(manifest), "--private-key", str(key_path)])
+    signature = manifest.with_name(signature_asset_name(MANIFEST_NAME))
+    signature.write_text(
+        sign_manifest_bytes(manifest.read_bytes(), load_private_key(key_path), pinned=(public,))
+        + "\n",
+        encoding="ascii",
+    )
+    assert tool_main([
+        "verify", str(manifest), str(signature), "--public-key", public,
+    ]) == 0
+    with pytest.raises(UpdateManifestSignatureError):
+        tool_main(["verify", str(manifest), str(signature)])  # 內嵌公鑰不認臨時金鑰
+    with pytest.raises(FileExistsError):
+        generate_private_key(key_path)

--- a/tools/sign_update_manifest.py
+++ b/tools/sign_update_manifest.py
@@ -1,0 +1,180 @@
+"""Generate the owner's Ed25519 key, sign an update manifest, and verify it.
+
+The private key is created and kept on the owner's machine.  It is never
+committed, never a CI secret, and CI never signs: after the release workflow
+publishes ``MoHan-Desktop-Assistant-<tag>-update.json`` the owner runs
+``release-sign``, which downloads that exact asset, signs its bytes, uploads
+``<manifest>.sig`` and downloads it again to verify against the pinned keys.
+
+    py -3.15 tools/sign_update_manifest.py keygen --private-key <path outside the repo>
+    py -3.15 tools/sign_update_manifest.py release-sign --tag v4.7.0 --private-key <path>
+    py -3.15 tools/sign_update_manifest.py verify <manifest.json> <manifest.json.sig>
+"""
+from __future__ import annotations
+
+lazy import argparse
+lazy import os
+lazy import shutil
+lazy import subprocess
+lazy import sys
+lazy import tempfile
+lazy from pathlib import Path
+
+lazy from cryptography.hazmat.primitives import serialization
+lazy from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+lazy from infrastructure.update_manifest_signature import (
+    PINNED_UPDATE_MANIFEST_PUBLIC_KEYS,
+    UpdateManifestSignatureError,
+    signature_asset_name,
+    verify_manifest_signature,
+)
+
+# 讓 `py tools/sign_update_manifest.py …` 與 `py -m tools.sign_update_manifest …`
+# 都找得到 infrastructure；與 tests/ 的慣例相同。
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+DEFAULT_REPOSITORY = "flameblade-studio/MoHan-PC-Desktop-Assistant"
+MANIFEST_NAME_TEMPLATE = "MoHan-Desktop-Assistant-{tag}-update.json"
+
+
+def public_key_hex(private_key: Ed25519PrivateKey) -> str:
+    return private_key.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    ).hex()
+
+
+def generate_private_key(path: Path) -> str:
+    """Write a new PKCS#8 PEM private key; refuse to overwrite; return its public hex."""
+
+    if path.exists():
+        raise FileExistsError(f"{path} 已存在，不覆寫既有私鑰。")
+    private_key = Ed25519PrivateKey.generate()
+    pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    with os.fdopen(os.open(path, flags, 0o600), "wb") as handle:
+        handle.write(pem)
+    return public_key_hex(private_key)
+
+
+def load_private_key(path: Path) -> Ed25519PrivateKey:
+    key = serialization.load_pem_private_key(path.read_bytes(), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise UpdateManifestSignatureError(f"{path} 不是 Ed25519 私鑰。")
+    return key
+
+
+def sign_manifest_bytes(
+    manifest_bytes: bytes,
+    private_key: Ed25519PrivateKey,
+    *,
+    pinned: tuple[str, ...] = PINNED_UPDATE_MANIFEST_PUBLIC_KEYS,
+) -> str:
+    """Return the hex signature; refuse a key whose public half is not pinned."""
+
+    signature = private_key.sign(manifest_bytes).hex()
+    if pinned:
+        verify_manifest_signature(manifest_bytes, signature, pinned)
+    return signature
+
+
+def write_signature(manifest: Path, signature_hex: str, output: Path | None) -> Path:
+    target = output or manifest.with_name(signature_asset_name(manifest.name))
+    target.write_text(signature_hex + "\n", encoding="ascii")
+    return target
+
+
+def _gh(*args: str) -> None:
+    executable = shutil.which("gh")
+    if executable is None:
+        raise UpdateManifestSignatureError("找不到 gh CLI。")
+    subprocess.run([executable, *args], check=True)
+
+
+def release_sign(tag: str, repository: str, private_key_path: Path) -> str:
+    manifest_name = MANIFEST_NAME_TEMPLATE.format(tag=tag)
+    signature_name = signature_asset_name(manifest_name)
+    private_key = load_private_key(private_key_path)
+    with tempfile.TemporaryDirectory() as temporary:
+        workdir = Path(temporary)
+        _gh("release", "download", tag, "--repo", repository,
+            "--pattern", manifest_name, "--dir", str(workdir))
+        manifest = workdir / manifest_name
+        signature_hex = sign_manifest_bytes(manifest.read_bytes(), private_key)
+        signature = write_signature(manifest, signature_hex, None)
+        _gh("release", "upload", tag, str(signature), "--repo", repository, "--clobber")
+        check_dir = workdir / "check"
+        check_dir.mkdir()
+        _gh("release", "download", tag, "--repo", repository,
+            "--pattern", signature_name, "--dir", str(check_dir))
+        return verify_manifest_signature(
+            manifest.read_bytes(),
+            (check_dir / signature_name).read_text(encoding="ascii"),
+        )
+
+
+def _parse_arguments(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    keygen = commands.add_parser("keygen", help="產生擁有者私鑰並印出公鑰")
+    keygen.add_argument("--private-key", type=Path, required=True)
+
+    sign = commands.add_parser("sign", help="對本機的更新清單檔簽章")
+    sign.add_argument("manifest", type=Path)
+    sign.add_argument("--private-key", type=Path, required=True)
+    sign.add_argument("--out", type=Path, default=None)
+
+    verify = commands.add_parser("verify", help="以內嵌公鑰（或指定公鑰）驗證簽章")
+    verify.add_argument("manifest", type=Path)
+    verify.add_argument("signature", type=Path)
+    verify.add_argument("--public-key", action="append", default=None,
+                        help="十六進位公鑰；可重複。省略時用內嵌公鑰")
+
+    release = commands.add_parser(
+        "release-sign", help="下載已發布的更新清單、簽章、上傳 .sig、再下載驗證",
+    )
+    release.add_argument("--tag", required=True)
+    release.add_argument("--repo", default=DEFAULT_REPOSITORY)
+    release.add_argument("--private-key", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_arguments(argv)
+    if args.command == "keygen":
+        public = generate_private_key(args.private_key)
+        print(f"私鑰已寫入 {args.private_key}（只有這一份，請離線備份）")
+        print(f"公鑰（填入 PINNED_UPDATE_MANIFEST_PUBLIC_KEYS）：{public}")
+        return 0
+    if args.command == "sign":
+        private_key = load_private_key(args.private_key)
+        signature_hex = sign_manifest_bytes(args.manifest.read_bytes(), private_key)
+        print(write_signature(args.manifest, signature_hex, args.out))
+        return 0
+    if args.command == "verify":
+        key = verify_manifest_signature(
+            args.manifest.read_bytes(),
+            args.signature.read_text(encoding="ascii"),
+            args.public_key,
+        )
+        print(f"UPDATE_MANIFEST_SIGNATURE_OK key={key[:16]}…")
+        return 0
+    key = release_sign(args.tag, args.repo, args.private_key)
+    print(f"UPDATE_MANIFEST_SIGNED tag={args.tag} key={key[:16]}…")
+    return 0
+
+
+if __name__ == "__main__":
+    # 只在當腳本跑時改主控台編碼；被測試匯入時不能動 pytest 接管的 stdout。
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    raise SystemExit(main())


### PR DESCRIPTION
## 繁體中文

### 為什麼

更新清單裡的 SHA-256 只證明「安裝程式與清單一致」，不證明「清單是誰發的」：清單與安裝程式同在一個 GitHub Release，能寫 Release 的人可以兩者一起換，雜湊照樣全對。這是第三輪 `infrastructure/` 稽核唯一未隨 #155 修正的一項，因為它不是程式碼錯誤而是信任模型止於「GitHub 帳號」。擁有者裁定採用 Ed25519 簽章清單、公鑰內嵌用戶端，把信任錨移到只在擁有者機器上的私鑰。

### 修法

- 新模組 `infrastructure/update_manifest_signature.py`：對清單資產的**原始位元組**做分離簽章，簽章以 128 個十六進位字元存成同名 `.sig` 資產；`PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` 內嵌公鑰（tuple，支援輪替）；`require_pinned_keys()` 在公鑰為空時拋錯。
- 更新器找不到 `.sig`、驗不過、或沒有內嵌公鑰，一律拒絕更新並顯示原因；**不會退回「只看雜湊」**。
- 新工具 `tools/sign_update_manifest.py`：`keygen` 在擁有者本機產生私鑰（拒絕覆寫、0600），`release-sign` 下載已發布的清單、簽章、上傳 `.sig`、再下載一次以內嵌公鑰驗證；簽章前會拒絕公鑰未內嵌的私鑰。私鑰不進儲存庫、不進 CI Secret，CI 不簽章。
- `release.yml` 的中繼資料工作新增閘門：內嵌公鑰為空就拒絕發布任何用戶端，避免發出一個永遠拒絕更新的版本。
- `PUBLISHING.md` 四語新增第 16 步。

### 上線順序（擁有者）

1. 公鑰已在本 PR 內嵌進 `PINNED_UPDATE_MANIFEST_PUBLIC_KEYS`（擁有者授權下於 2026-09-02 在擁有者電腦上以 `keygen` 產生）；私鑰只在擁有者電腦的本機設定目錄，不在任何雲端同步目錄，請另外離線備份一份。
2. 每次 release workflow 發布完成後執行 `release-sign`。未簽章的 Release 對新用戶端等於「沒有更新」並顯示「尚未簽章」。
3. 舊用戶端沒有這段驗證碼，行為不變。

### 測試

`tests/test_update_manifest_signature.py` 九個測試：簽章往返與竄改偵測；空或格式錯的公鑰 fail closed；以未內嵌的私鑰簽章被拒；更新器接受內嵌公鑰簽過的清單、拒絕沒有 `.sig` 的版本、拒絕雜湊全對但簽章不符的清單、拒絕未內嵌公鑰的簽章、沒有內嵌公鑰時拒絕一切更新；CLI 的 `keygen`／sign／verify 往返與拒絕覆寫私鑰。`tests/test_secure_updater.py` 改為以臨時金鑰扮演擁有者。完整 `tests/run_all.py` 全綠。

## 简体中文

### 为什么

更新清单里的 SHA-256 只证明「安装程序与清单一致」，不证明「清单是谁发的」：清单与安装程序同在一个 GitHub Release，能写 Release 的人可以两者一起换，哈希照样全对。这是第三轮 `infrastructure/` 审计唯一未随 #155 修复的一项，因为它不是代码错误而是信任模型止于「GitHub 账号」。所有者裁定采用 Ed25519 签名清单、公钥内嵌客户端，把信任锚移到只在所有者机器上的私钥。

### 修复方式

- 新模块 `infrastructure/update_manifest_signature.py`：对清单资产的**原始字节**做分离签名，签名以 128 个十六进制字符存成同名 `.sig` 资产；`PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` 内嵌公钥（tuple，支持轮换）；`require_pinned_keys()` 在公钥为空时抛错。
- 更新器找不到 `.sig`、验不过、或没有内嵌公钥，一律拒绝更新并显示原因；**不会退回「只看哈希」**。
- 新工具 `tools/sign_update_manifest.py`：`keygen` 在所有者本机生成私钥（拒绝覆盖、0600），`release-sign` 下载已发布的清单、签名、上传 `.sig`、再下载一次以内嵌公钥验证；签名前会拒绝公钥未内嵌的私钥。私钥不进仓库、不进 CI Secret，CI 不签名。
- `release.yml` 的元数据任务新增闸门：内嵌公钥为空就拒绝发布任何客户端，避免发出一个永远拒绝更新的版本。
- `PUBLISHING.md` 四语新增第 16 步。

### 上线顺序（所有者）

1. 公钥已在本 PR 内嵌进 `PINNED_UPDATE_MANIFEST_PUBLIC_KEYS`（所有者授权下于 2026-09-02 在所有者电脑上以 `keygen` 生成）；私钥只在所有者电脑的本机配置目录，不在任何云端同步目录，请另外离线备份一份。
2. 每次 release workflow 发布完成后执行 `release-sign`。未签名的 Release 对新客户端等于「没有更新」并显示「尚未签名」。
3. 旧客户端没有这段验证代码，行为不变。

### 测试

`tests/test_update_manifest_signature.py` 九个测试：签名往返与篡改检测；空或格式错的公钥 fail closed；以未内嵌的私钥签名被拒；更新器接受内嵌公钥签过的清单、拒绝没有 `.sig` 的版本、拒绝哈希全对但签名不符的清单、拒绝未内嵌公钥的签名、没有内嵌公钥时拒绝一切更新；CLI 的 `keygen`／sign／verify 往返与拒绝覆盖私钥。`tests/test_secure_updater.py` 改为以临时密钥扮演所有者。完整 `tests/run_all.py` 全绿。

## English

### Why

The SHA-256 values in the update manifest prove that the installer matches the manifest, not who issued the manifest: both live in the same GitHub Release, so anyone who can write the Release can replace both together and every hash still matches. This was the one finding of the third `infrastructure/` audit not fixed with #155, because it is not a code bug but a trust model that stops at "the GitHub account". The owner decided on Ed25519-signed manifests with the public key pinned in the client, moving the trust anchor to a private key that exists only on the owner's machine.

### The fix

- New module `infrastructure/update_manifest_signature.py`: a detached signature over the manifest asset's **exact bytes**, stored as 128 hex characters in a same-named `.sig` asset; `PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` holds the pinned keys (a tuple, so rotation is possible); `require_pinned_keys()` raises when nothing is pinned.
- The updater refuses an update, with a reason, when the `.sig` is missing, does not verify, or no key is pinned; **it never falls back to hashes only**.
- New tool `tools/sign_update_manifest.py`: `keygen` creates the private key on the owner's machine (no overwrite, mode 0600); `release-sign` downloads the published manifest, signs it, uploads the `.sig`, then downloads it again and verifies against the pinned keys; signing with a key whose public half is not pinned is refused. The private key is never in the repository or a CI secret, and CI never signs.
- The metadata job in `release.yml` gains a gate: with no pinned key it refuses to publish any client, so a build that would reject every update can never ship.
- `PUBLISHING.md` gains step 16 in all four languages.

### Rollout (owner)

1. The public key is already pinned in `PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` in this PR (generated with `keygen` on the owner's machine on 2026-09-02 under the owner's authorization); the private key exists only in the owner's local settings directory, outside any cloud-synced folder, and should be backed up offline separately.
2. After every release workflow completes, run `release-sign`. To a new client an unsigned Release is "no update", reported as not yet signed.
3. Old clients do not contain this verification and behave as before.

### Tests

`tests/test_update_manifest_signature.py` adds nine tests: signature round trip and tamper detection; empty or malformed pins fail closed; signing with an unpinned key is refused; the updater accepts a manifest signed by a pinned key, refuses a release without a `.sig`, refuses a manifest whose hashes all match but whose signature does not, refuses a signature from an unpinned key, and refuses every update when nothing is pinned; the CLI `keygen`/sign/verify round trip and the refusal to overwrite a private key. `tests/test_secure_updater.py` now plays the owner with an ephemeral key. The full `tests/run_all.py` is green.

## 日本語

### 理由

更新マニフェストの SHA-256 は「インストーラーがマニフェストと一致する」ことしか証明せず、「誰がマニフェストを発行したか」は証明しません。両者は同じ GitHub Release にあり、Release を書き換えられる人は両方を一緒に差し替えられ、ハッシュはすべて一致したままです。これは第三回 `infrastructure/` 監査のうち #155 で修正しなかった唯一の項目で、コードの誤りではなく信頼モデルが「GitHub アカウント」で止まっていることが原因でした。所有者は Ed25519 でマニフェストに署名し、公開鍵をクライアントに埋め込む方式を採り、信頼の起点を所有者の端末にしか存在しない秘密鍵へ移すと決めました。

### 修正方法

- 新モジュール `infrastructure/update_manifest_signature.py`：マニフェスト成果物の**生のバイト列**に対する分離署名を、同名の `.sig` 成果物に 128 桁の十六進数として保存します。`PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` が埋め込み公開鍵（tuple なので鍵の更新が可能）を持ち、`require_pinned_keys()` は何も埋め込まれていなければ例外を送出します。
- 更新器は `.sig` が無い、検証に失敗する、公開鍵が埋め込まれていない、のいずれでも理由を示して更新を拒否し、**ハッシュだけの確認には決して退きません**。
- 新ツール `tools/sign_update_manifest.py`：`keygen` は所有者の端末で秘密鍵を生成し（上書き拒否、モード 0600）、`release-sign` は公開済みのマニフェストをダウンロードして署名し、`.sig` をアップロードしたあと再度ダウンロードして埋め込み公開鍵で検証します。公開半分が埋め込まれていない鍵での署名は拒否します。秘密鍵はリポジトリにも CI Secret にも置かず、CI は署名しません。
- `release.yml` のメタデータジョブに関門を追加し、公開鍵が埋め込まれていなければどのクライアントも公開しません。すべての更新を拒否するビルドが出荷されることはありません。
- `PUBLISHING.md` に四言語で第 16 手順を追加しました。

### 展開手順（所有者）

1. 公開鍵はこの PR で既に `PINNED_UPDATE_MANIFEST_PUBLIC_KEYS` に埋め込み済みです（所有者の許可のもと 2026-09-02 に所有者の端末で `keygen` により生成）。秘密鍵は所有者端末のローカル設定ディレクトリにのみあり、クラウド同期フォルダーの外にあります。別途オフラインでバックアップしてください。
2. リリースワークフローが完了するたびに `release-sign` を実行します。署名されていない Release は新しいクライアントにとって「更新なし」であり、未署名と表示されます。
3. 古いクライアントにはこの検証コードが無く、挙動は変わりません。

### テスト

`tests/test_update_manifest_signature.py` に九件のテストを追加しました。署名の往復と改竄検出、空または不正な埋め込み鍵の fail closed、埋め込まれていない鍵での署名拒否、更新器が埋め込み鍵で署名されたマニフェストを受け入れ、`.sig` の無いリリースを拒否し、ハッシュがすべて一致しても署名が合わないマニフェストを拒否し、埋め込まれていない鍵の署名を拒否し、何も埋め込まれていなければすべての更新を拒否すること、CLI の `keygen`／sign／verify の往復と秘密鍵の上書き拒否です。`tests/test_secure_updater.py` は一時鍵で所有者を演じるように変えました。`tests/run_all.py` 全体も緑です。
