### PR TITLE
fix: 手部稽核的 extra-digit 皮膚啟發式改由 skin_background 宣告決定，跳過必列為 skipped／手部审计的 extra-digit 皮肤启发式改由 skin_background 声明决定，跳过必列为 skipped／Hand audit: the extra-digit skin heuristic is gated by a skin_background declaration and any skip is reported／手の監査の extra-digit 肌経験則は skin_background 宣言で制御し、スキップは必ず報告する

### DIFF
--- a/domain/hand_asset_audit.py
+++ b/domain/hand_asset_audit.py
@@ -131,6 +131,12 @@ class HandAuditReport:
     passed: bool
     issues: tuple[AuditIssue, ...]
     fingers: tuple[FingerEvidence, ...]
+    # Checks that were deliberately not run for this asset, with the reason.
+    # A skipped check is reported, never silently counted as a pass.
+    skipped_checks: tuple[str, ...] = ()
+
+
+EXTRA_DIGIT_SKIPPED_SKIN_BACKGROUND = "extra-digit:skin-background"
 
 
 @dataclass(frozen=True, slots=True)
@@ -291,7 +297,19 @@ def audit_hand_asset(
     projections: tuple[HandProjection, ...],
     occluders: tuple[Occluder, ...] = (),
     allow_occluded_sides: frozenset[str] = frozenset(),
+    skin_background: bool = False,
 ) -> HandAuditReport:
+    """Audit one hand canvas.
+
+    ``skin_background`` declares that the pixels around the hand are
+    legitimately skin (bare forearm, bare thigh behind a hanging hand).  The
+    extra-digit heuristic counts skin inside the hand ROI that no skeleton
+    bone explains; it was calibrated on a long-sleeved body where that skin
+    could only be a sixth finger.  Against a bare body it flags the forearm
+    and thigh on most views, so under the declaration it is not run and the
+    skip is reported in ``skipped_checks`` for a human to cover.
+    """
+
     try:
         image = _png(png)
     except HandAuditError:
@@ -311,10 +329,13 @@ def audit_hand_asset(
             continue
         valid_point_sets.append(projection.landmarks)
         fingers.extend(_audit_projection(image, projection, allowlist, issues))
-    if valid_point_sets and _unexpected_skin_pixels(image, valid_point_sets) > MAX_UNEXPECTED_SKIN_PIXELS:
+    skipped: tuple[str, ...] = ()
+    if skin_background:
+        skipped = (EXTRA_DIGIT_SKIPPED_SKIN_BACKGROUND,)
+    elif valid_point_sets and _unexpected_skin_pixels(image, valid_point_sets) > MAX_UNEXPECTED_SKIN_PIXELS:
         issues.append(AuditIssue(IssueCode.EXTRA_DIGIT, None, None, None))
     unique = tuple(dict.fromkeys(issues))
-    return HandAuditReport(not unique, unique, tuple(fingers))
+    return HandAuditReport(not unique, unique, tuple(fingers), skipped)
 
 
 def _audit_hand_counts(

--- a/domain/hand_asset_evidence.py
+++ b/domain/hand_asset_evidence.py
@@ -74,6 +74,7 @@ class HandAssetEvidenceResult:
     issues: tuple[HandAssetEvidenceIssue, ...]
     visible_sides: frozenset[str] = frozenset()
     occluded_sides: frozenset[str] = frozenset()
+    skipped_checks: tuple[str, ...] = ()
 
     @property
     def problems(self) -> tuple[str, ...]:
@@ -97,6 +98,7 @@ class HandAssetEvidenceResult:
             ],
             "visible_sides": sorted(self.visible_sides),
             "occluded_sides": sorted(self.occluded_sides),
+            "skipped_checks": list(self.skipped_checks),
         }
         return json.dumps(
             payload,
@@ -143,6 +145,7 @@ def build_hand_asset_evidence(
             height,
         )
         occluders = _occluders(payload)
+        skin_background = _skin_background(payload)
     except (UnicodeError, json.JSONDecodeError, TypeError, ValueError, zlib.error):
         return _failure("sidecar_invalid", manifest.view_id, files.png_sha256, files.sidecar_sha256)
     report = audit_hand_asset(
@@ -150,6 +153,7 @@ def build_hand_asset_evidence(
         projections,
         occluders,
         allow_occluded_sides=occluded_sides,
+        skin_background=skin_background,
     )
     issues = tuple(
         HandAssetEvidenceIssue(
@@ -170,7 +174,16 @@ def build_hand_asset_evidence(
         tuple(dict.fromkeys(issues)),
         visible_sides,
         occluded_sides,
+        report.skipped_checks,
     )
+
+
+def _skin_background(payload: dict[str, object]) -> bool:
+    # 素體裸臂裸腿時由建置器宣告；沒有宣告就是 False，不從像素推斷。
+    value = payload.get("skin_background", False)
+    if type(value) is not bool:
+        raise TypeError("invalid_skin_background")
+    return value
 
 
 class _EvidenceFailure(RuntimeError):

--- a/tests/test_hand_asset_evidence.py
+++ b/tests/test_hand_asset_evidence.py
@@ -116,6 +116,7 @@ def chunk(kind: bytes, payload: bytes) -> bytes:
 def sidecar(
     *,
     hands: list[dict[str, object]] | None = None,
+    skin_background: object = None,
     occluded_hands: list[dict[str, object]] | None = None,
 ) -> bytes:
     configured = [
@@ -142,6 +143,7 @@ def sidecar(
             {"label": "face", "rect": [62, 2, 8, 14]},
             {"label": "body", "rect": [62, 20, 8, 47]},
         ],
+        **({} if skin_background is None else {"skin_background": skin_background}),
     }, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
@@ -322,8 +324,45 @@ def assert_missing_or_unsafe_roi_fails_closed() -> None:
         assert build_hand_asset_evidence(root, manifest).problems == ("sidecar_invalid",)
 
 
+def assert_skin_background_declaration_skips_extra_digit_and_reports_it() -> None:
+    # 裸臂裸腿的素體：手部 ROI 內合法有皮膚。extra-digit 的皮膚啟發式是在長袖 v4 上
+    # 校準的，對裸體 24 視角誤報 19 個。宣告後不跑該檢查，但必須列在 skipped_checks，
+    # 其他檢查照跑，非布林宣告 fail closed，沒有宣告時行為與以前完全相同。
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        manifest = write_fixture(
+            root,
+            png_data=png(inside_extra_finger=True),
+            sidecar_data=sidecar(skin_background=True),
+        )
+        result = build_hand_asset_evidence(root, manifest)
+        assert result.passed
+        assert "hand_extra_digit" not in result.problems
+        assert result.skipped_checks == ("extra-digit:skin-background",)
+        assert b'"skipped_checks":["extra-digit:skin-background"]' in result.to_json_bytes()
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        manifest = write_fixture(
+            root, png_data=png(fused=True), sidecar_data=sidecar(skin_background=True)
+        )
+        result = build_hand_asset_evidence(root, manifest)
+        assert not result.passed
+        assert "hand_fused_digits" in result.problems
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        manifest = write_fixture(root, sidecar_data=sidecar(skin_background="yes"))
+        assert build_hand_asset_evidence(root, manifest).problems == ("sidecar_invalid",)
+    with TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        manifest = write_fixture(root, png_data=png(inside_extra_finger=True))
+        result = build_hand_asset_evidence(root, manifest)
+        assert result.skipped_checks == ()
+        assert "hand_extra_digit" in result.problems
+
+
 def run() -> None:
     assert_valid_evidence_is_release_compatible_and_deterministic()
+    assert_skin_background_declaration_skips_extra_digit_and_reports_it()
     assert_missing_digit_wrong_thumb_and_fusion_fail()
     assert_body_occlusion_is_explicit_without_inventing_hidden_landmarks()
     assert_fully_occluded_hands_are_explicit_and_safe()

--- a/tools/audit_pose_atlas_working.py
+++ b/tools/audit_pose_atlas_working.py
@@ -65,6 +65,7 @@ def audit(root: Path) -> dict[str, object]:
                 ],
                 "visible_sides": sorted(result.visible_sides),
                 "occluded_sides": sorted(result.occluded_sides),
+                "skipped_checks": list(result.skipped_checks),
             }
         )
     failed = [item for item in views if not item["passed"]]

--- a/tools/build_pose_atlas_release_assets.py
+++ b/tools/build_pose_atlas_release_assets.py
@@ -91,7 +91,21 @@ class BuildError(RuntimeError):
     pass
 
 
-def build(source_root: Path, output_root: Path) -> dict[str, object]:
+def build(
+    source_root: Path,
+    output_root: Path,
+    *,
+    skin_background: bool = False,
+) -> dict[str, object]:
+    """Build the working atlas.
+
+    ``skin_background`` declares a bare-limbed body: the hand ROIs legitimately
+    contain forearm and thigh skin, so the hand audit's extra-digit skin
+    heuristic (calibrated on the long-sleeved v4) is not applicable.  The
+    declaration is written into every hands sidecar; the audit reports the
+    skipped check instead of silently passing or falsely failing.
+    """
+
     source = source_root.resolve()
     output = output_root.resolve()
     if source == output:
@@ -136,6 +150,7 @@ def build(source_root: Path, output_root: Path) -> dict[str, object]:
             runner,
             palm_net,
             hand_net,
+            skin_background=skin_background,
         )
         (normalized / f"{item.view_id}.hands.json").write_text(
             json.dumps(hands, ensure_ascii=False, sort_keys=True, indent=2) + "\n",
@@ -407,6 +422,8 @@ def _hand_sidecar(
     runner: OpenCVZooHandRunner,
     palm_net: object,
     hand_net: object,
+    *,
+    skin_background: bool = False,
 ) -> tuple[dict[str, object], dict[str, object]]:
     mapped = []
     for augmentation in _augmentations(rgb):
@@ -488,6 +505,7 @@ def _hand_sidecar(
         "occluded_hands": occluded,
         "protected_regions": protected,
         "occluders": occluders,
+        "skin_background": skin_background,
         "inference": {
             "pipeline": "OpenCV Zoo MediaPipe PalmDet + HandPose FP32 ONNX",
             "palm_threshold": HAND_PALM_THRESHOLD,
@@ -903,9 +921,18 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source-root", type=Path, required=True)
     parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument(
+        "--skin-background",
+        action="store_true",
+        help="素體裸臂裸腿：手部 ROI 內合法有皮膚，宣告後 extra-digit 皮膚啟發式不跑並列為 skipped",
+    )
     args = parser.parse_args(argv)
     try:
-        report = build(args.source_root, args.output_root)
+        report = build(
+            args.source_root,
+            args.output_root,
+            skin_background=args.skin_background,
+        )
     except (BuildError, OSError, ValueError, RuntimeError) as error:
         print(json.dumps({"status": "blocked", "error": str(error)}, ensure_ascii=False, sort_keys=True))
         return 1


### PR DESCRIPTION
## 繁體中文

### 為什麼

手部稽核的 extra-digit 判定是「手部 ROI 內、離任何骨架線都超過容許值的皮膚像素超過 28 個」。這個啟發式在長袖的 v4 上成立：ROI 裡除了手，其餘是衣料，多出來的皮膚只可能是第六根手指。二代素體裸臂裸腿，手垂在大腿旁，ROI 裡有前臂與大腿的皮膚，2026-09-02 對 24 視角跑 `tools/audit_pose_atlas_working.py` 有 19 個視角被判 `hand_extra_digit`，手部裁圖目視每隻都是五指。這是繼 golden 建置器與 body sidecar 之後，第三個把 v4 服裝當成前提的工具。

### 修法

不調門檻、不改皮膚判定。改為由建置器**宣告**背景是皮膚：`build_pose_atlas_release_assets.py` 新增 `--skin-background`，把 `skin_background` 寫進每個 hands sidecar；`hand_asset_evidence.py` 讀取這個布林（非布林即 `sidecar_invalid`）傳給 `audit_hand_asset()`；宣告成立時不跑 extra-digit 的皮膚啟發式，並在 `HandAuditReport` 與證據 JSON 新增的 `skipped_checks` 欄位明列 `extra-digit:skin-background`。其他檢查（缺指、黏指、拇指方向、比例、覆蓋、遮擋）照跑。沒有宣告時行為與以前完全相同。

**明講的限制**：宣告之後，第六根手指要靠人眼在接觸表上抓，不再靠這條啟發式。這與專案既有做法一致：身份與美術缺陷本來就以擁有者目視為閘門，稽核只負責不偽裝成通過。

### 測試

`tests/test_hand_asset_evidence.py` 新增一組斷言：夾具內含額外手指且宣告 `skin_background` 時不報 `hand_extra_digit`、`skipped_checks` 記錄且進入 JSON；宣告下黏指仍被抓；非布林宣告 fail closed；無宣告時仍報 `hand_extra_digit` 且 `skipped_checks` 為空。完整 `tests/run_all.py` 全綠。

## 简体中文

### 为什么

手部审计的 extra-digit 判定是「手部 ROI 内、离任何骨架线都超过容许值的皮肤像素超过 28 个」。这个启发式在长袖的 v4 上成立：ROI 里除了手，其余是衣料，多出来的皮肤只可能是第六根手指。二代素体裸臂裸腿，手垂在大腿旁，ROI 里有前臂与大腿的皮肤，2026-09-02 对 24 视角跑 `tools/audit_pose_atlas_working.py` 有 19 个视角被判 `hand_extra_digit`，手部裁图目视每只都是五指。这是继 golden 构建器与 body sidecar 之后，第三个把 v4 服装当成前提的工具。

### 修复方式

不调阈值、不改皮肤判定。改为由构建器**声明**背景是皮肤：`build_pose_atlas_release_assets.py` 新增 `--skin-background`，把 `skin_background` 写进每个 hands sidecar；`hand_asset_evidence.py` 读取这个布尔值（非布尔即 `sidecar_invalid`）传给 `audit_hand_asset()`；声明成立时不跑 extra-digit 的皮肤启发式，并在 `HandAuditReport` 与证据 JSON 新增的 `skipped_checks` 字段明列 `extra-digit:skin-background`。其他检查（缺指、粘指、拇指方向、比例、覆盖、遮挡）照跑。没有声明时行为与以前完全相同。

**明说的限制**：声明之后，第六根手指要靠人眼在接触表上抓，不再靠这条启发式。这与项目既有做法一致：身份与美术缺陷本来就以所有者目视为闸门，审计只负责不伪装成通过。

### 测试

`tests/test_hand_asset_evidence.py` 新增一组断言：夹具内含额外手指且声明 `skin_background` 时不报 `hand_extra_digit`、`skipped_checks` 记录且进入 JSON；声明下粘指仍被抓；非布尔声明 fail closed；无声明时仍报 `hand_extra_digit` 且 `skipped_checks` 为空。完整 `tests/run_all.py` 全绿。

## English

### Why

The hand audit's extra-digit rule is "more than 28 skin pixels inside the hand ROI that are farther than the allowance from every skeleton bone". That heuristic held on the long-sleeved v4: apart from the hand, the ROI contained fabric, so any extra skin could only be a sixth finger. The second-generation body has bare arms and legs and its hands hang beside the thighs, so the ROI contains forearm and thigh skin; running `tools/audit_pose_atlas_working.py` on the 24 views on 2026-09-02 flagged `hand_extra_digit` on 19 of them, while every hand crop shows five fingers. After the golden builder and the body sidecar, this is the third tool that had the v4 outfit baked in as a premise.

### The fix

No threshold tuning and no change to the skin classifier. The builder now **declares** that the background is skin: `build_pose_atlas_release_assets.py` gains `--skin-background`, which writes `skin_background` into every hands sidecar; `hand_asset_evidence.py` reads that boolean (anything else is `sidecar_invalid`) and passes it to `audit_hand_asset()`; under the declaration the extra-digit skin heuristic is not run, and the new `skipped_checks` field on `HandAuditReport` and in the evidence JSON lists `extra-digit:skin-background`. Every other check (missing digit, fused digits, thumb side, proportion, coverage, occlusion) still runs. Without the declaration the behaviour is unchanged.

**Stated limitation**: under the declaration a sixth finger has to be caught by a human on the contact sheet, not by this heuristic. That matches how the project already works: identity and art defects are gated by the owner's eye, and the audit's job is to never pose as a pass.

### Tests

`tests/test_hand_asset_evidence.py` adds one group of assertions: a fixture with an extra finger and `skin_background` declared does not report `hand_extra_digit`, records `skipped_checks` and carries it into the JSON; fused digits are still caught under the declaration; a non-boolean declaration fails closed; without the declaration `hand_extra_digit` is still reported and `skipped_checks` is empty. The full `tests/run_all.py` is green.

## 日本語

### 理由

手の監査の extra-digit 判定は「手の ROI 内で、どの骨格線からも許容値より離れた肌の画素が 28 を超える」というものです。この経験則は長袖の v4 では成り立ちました。ROI の中は手以外が衣服なので、余分な肌は第六の指しかあり得なかったからです。第二世代の素体は腕も脚も露出し、手は太腿の横に垂れているため、ROI には前腕と太腿の肌が入ります。2026-09-02 に 24 視角へ `tools/audit_pose_atlas_working.py` を走らせると 19 視角が `hand_extra_digit` と判定されましたが、手の切り出しを目視するとどれも五本指でした。golden ビルダーと body sidecar に続き、v4 の衣装を前提に焼き込んでいた三つ目のツールです。

### 修正方法

閾値も肌判定も変えません。ビルダーが背景は肌であると**宣言**する方式にしました。`build_pose_atlas_release_assets.py` に `--skin-background` を追加し、各 hands サイドカーへ `skin_background` を書き込みます。`hand_asset_evidence.py` はその真偽値を読み（真偽値以外は `sidecar_invalid`）`audit_hand_asset()` へ渡し、宣言があるときは extra-digit の肌経験則を実行せず、`HandAuditReport` と証拠 JSON に新設した `skipped_checks` に `extra-digit:skin-background` を明記します。それ以外の検査（指の欠落、指の癒着、親指の向き、比率、被覆、遮蔽）はすべて従来どおり動きます。宣言が無ければ挙動は変わりません。

**明記する制限**：宣言下では第六の指はこの経験則ではなく、人がコンタクトシートで見つける必要があります。これはプロジェクトの既存のやり方と一致します。同一性と美術上の欠陥はもともと所有者の目視が関門であり、監査の役目は合格を装わないことです。

### テスト

`tests/test_hand_asset_evidence.py` に一組の検証を追加しました。余分な指を含む素材で `skin_background` を宣言すると `hand_extra_digit` を報告せず、`skipped_checks` に記録され JSON にも入ること、宣言下でも指の癒着は検出されること、真偽値でない宣言は fail closed になること、宣言が無ければ従来どおり `hand_extra_digit` を報告し `skipped_checks` が空であることです。`tests/run_all.py` 全体も緑です。
