### PR TITLE
docs: 新增上游貢獻紀錄頁並自 README 連結／新增上游贡献记录页并自 README 链接／Add the upstream contributions record and link it from the README／上流への貢献記録ページを追加し README からリンク

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責�
 - **架構分層落實：** 一百七十五個根目錄相容殼檔全數退役，根目錄由 239 項瘦身至 64 項，二百零一個呼叫端改用正式分層路徑，「退役別名不得復活」已入契約。
 - **四語、四平台治理：** 軟體與主要文件同步支援繁體中文、簡體中文、英文與日文；Windows 為正式支援，macOS Apple Silicon／Intel 與 Linux 同步提供功能受限 Preview。
 - **多感知與角色表現：** 可明確授權與隨時撤銷的本機視覺感知、21 點手部資料、468／478 點 Face Mesh、語音活動偵測與安全的非阻塞融合；缺少模型、裝置、網路或額度時只停用受影響路徑，不損及既有功能。
-- **授權純淨與開源回饋：** 產線的工具與權重只採用 MIT／Apache 2.0／CC0／CC BY 授權（見[授權純淨承諾](docs/LICENSE-PURITY.md)）；開發期間並向上游 ai-toolkit 回饋兩顆缺陷修復。
+- **授權純淨與開源回饋：** 產線的工具與權重只採用 MIT／Apache 2.0／CC0／CC BY 授權（見[授權純淨承諾](docs/LICENSE-PURITY.md)）；開發期間並向上游 ai-toolkit 回饋兩顆缺陷修復，完整清單見[上游貢獻紀錄](docs/UPSTREAM-CONTRIBUTIONS.md)。
 - **可稽核的工程基線：** 734 個 Python 檔、184,534 行，其中產品本體 87,565 行、測試 74,174 行、開發工具 22,795 行。
 
 ### 專案特色
@@ -633,7 +633,7 @@ Codex 协助我把想法转译成程序架构与代码；而我始终负责决�
 - **架构分层落实：** 一百七十五个根目录兼容壳文件全数退役，根目录由 239 项瘦身至 64 项，二百零一个调用端改用正式分层路径，「退役别名不得复活」已入契约。
 - **四语、四平台治理：** 软件与主要文档同步支持繁体中文、简体中文、英文与日文；Windows 为正式支持，macOS Apple Silicon／Intel 与 Linux 同步提供功能受限 Preview。
 - **多感知与角色表现：** 可明确授权与随时撤销的本机视觉感知、21 点手部数据、468／478 点 Face Mesh、语音活动检测与安全的非阻塞融合；缺少模型、设备、网络或额度时只停用受影响路径，不损及既有功能。
-- **授权纯净与开源回馈：** 产线的工具与权重只采用 MIT／Apache 2.0／CC0／CC BY 授权（见[授权纯净承诺](docs/LICENSE-PURITY.md)）；开发期间并向上游 ai-toolkit 回馈两颗缺陷修复。
+- **授权纯净与开源回馈：** 产线的工具与权重只采用 MIT／Apache 2.0／CC0／CC BY 授权（见[授权纯净承诺](docs/LICENSE-PURITY.md)）；开发期间并向上游 ai-toolkit 回馈两颗缺陷修复，完整清单见[上游贡献记录](docs/UPSTREAM-CONTRIBUTIONS.md)。
 - **可稽核的工程基线：** 734 个 Python 文件、184,534 行，其中产品本体 87,565 行、测试 74,174 行、开发工具 22,795 行。
 
 ### 主要功能
@@ -1064,7 +1064,7 @@ The current release is `v4.6.0`; see [Releases](https://github.com/flameblade-st
 - **Layered architecture enforced.** All one hundred and seventy-five root compatibility facades are retired, the root directory falls from 239 entries to 64, two hundred and one call sites now use formal layered paths, and "retired aliases must not return" is written into a contract.
 - **Four languages, four platforms.** The software and its principal documents carry Traditional Chinese, Simplified Chinese, English and Japanese. Windows is formally supported, while macOS Apple Silicon and Intel, plus Linux, ship as limited Previews.
 - **Multi-sensory perception and character expression.** Explicitly consented and revocable local vision, 21-point hand data, a 468/478-point face mesh, voice activity detection and a safe non-blocking fusion path. A missing model, device, network or quota disables only the affected route and leaves everything else intact.
-- **License purity and upstream contribution.** The pipeline's tools and weights admit only MIT, Apache 2.0, CC0 and CC BY material — see the [License Purity Commitment](docs/LICENSE-PURITY.md) — and two defect fixes went upstream to ai-toolkit during development.
+- **License purity and upstream contribution.** The pipeline's tools and weights admit only MIT, Apache 2.0, CC0 and CC BY material — see the [License Purity Commitment](docs/LICENSE-PURITY.md) — and two defect fixes went upstream to ai-toolkit during development; the full list is in the [upstream contributions record](docs/UPSTREAM-CONTRIBUTIONS.md).
 - **An auditable engineering baseline.** 734 Python files and 184,534 lines: 87,565 in the product itself, 74,174 in tests, and 22,795 in development tooling.
 
 ### Key capabilities
@@ -1495,7 +1495,7 @@ Codex は私の思いをアーキテクチャとコードへ翻訳する手助�
 - **階層アーキテクチャの徹底。** ルート直下の互換ファサード百七十五件をすべて退役させ、ルートの項目数は 239 から 64 へ、呼び出し側二百一箇所を正式な階層パスへ移行し、「退役した別名を復活させない」ことを契約に明記しました。
 - **四言語・四プラットフォーム。** ソフトウェアと主要文書は繁体中文・簡体中文・英語・日本語に対応します。Windows が正式対応、macOS Apple Silicon／Intel と Linux は機能限定 Preview です。
 - **多感覚知覚とキャラクター表現。** 明示的な同意といつでも撤回できるローカル視覚、21 点の手指データ、468／478 点フェイスメッシュ、音声区間検出、そして安全な非ブロッキング統合。モデル・機器・ネットワーク・利用枠のいずれかが欠けても、影響を受けた経路のみを停止し、他の機能は損ないません。
-- **ライセンス純度と上流への還元。** パイプラインの道具と重みには MIT／Apache 2.0／CC0／CC BY のみを受け入れます（[ライセンス純度に関する約束](docs/LICENSE-PURITY.md)）。開発期間中には上流の ai-toolkit へ二件の修正を還元しました。
+- **ライセンス純度と上流への還元。** パイプラインの道具と重みには MIT／Apache 2.0／CC0／CC BY のみを受け入れます（[ライセンス純度に関する約束](docs/LICENSE-PURITY.md)）。開発期間中には上流の ai-toolkit へ二件の修正を還元しました。一覧は[上流への貢献記録](docs/UPSTREAM-CONTRIBUTIONS.md)を参照してください。
 - **監査可能なエンジニアリング基準値。** Python ファイル 734 件、184,534 行。内訳は製品本体 87,565 行、テスト 74,174 行、開発ツール 22,795 行です。
 
 ### 主な機能

--- a/docs/UPSTREAM-CONTRIBUTIONS.md
+++ b/docs/UPSTREAM-CONTRIBUTIONS.md
@@ -1,0 +1,105 @@
+# 上游貢獻紀錄／上游贡献记录／Upstream contributions／上流への貢献記録
+
+## 繁體中文
+
+### 為什麼有這一頁
+
+墨寒的產線踩到第三方套件的真缺陷時，修好之後多花半小時送回上游，是成本最低、也最誠實的能見度：在別人的場子裡被別人需要。這一頁是唯一的權威清單，每送出一個上游 PR 就在這裡加一列，狀態以上游頁面為準。
+
+### 紀錄
+
+| 日期 | 上游專案 | PR | 內容 | 狀態（2026-09-02） |
+|---|---|---|---|---|
+| 2026-08-28 | ostris/ai-toolkit | [#1021](https://github.com/ostris/ai-toolkit/pull/1021) | `cache_text_encoder` 缺少裝置預設分支，導致 `BaseModel` 在快取文字編碼器時失敗 | 開啟中 |
+| 2026-08-29 | ostris/ai-toolkit | [#1023](https://github.com/ostris/ai-toolkit/pull/1023) | `cache_text_embeddings` 以假文字編碼器取代後，取樣階段直接崩潰；改為略過取樣 | 開啟中 |
+
+### 流程
+
+1. 在第三方套件遇到真缺陷，先在墨寒這邊修好並附迴歸測試。
+2. 評估是否可上游：與墨寒無關、上游仍在維護、修法不綁墨寒的假設。
+3. 送 PR 時附最小重現與測試，說明踩到的情境。
+4. 在本頁加一列；上游合併或關閉時更新狀態。
+
+### 閘門
+
+- 每月至少送出一個上游 PR。
+- 每個 PR 都附最小重現。
+- 本頁列出全部上游貢獻，沒有例外。
+
+## 简体中文
+
+### 为什么有这一页
+
+墨寒的产线踩到第三方软件包的真缺陷时，修好之后多花半小时送回上游，是成本最低、也最诚实的能见度：在别人的场子里被别人需要。这一页是唯一的权威清单，每送出一个上游 PR 就在这里加一行，状态以上游页面为准。
+
+### 记录
+
+| 日期 | 上游项目 | PR | 内容 | 状态（2026-09-02） |
+|---|---|---|---|---|
+| 2026-08-28 | ostris/ai-toolkit | [#1021](https://github.com/ostris/ai-toolkit/pull/1021) | `cache_text_encoder` 缺少设备预设分支，导致 `BaseModel` 在缓存文本编码器时失败 | 开启中 |
+| 2026-08-29 | ostris/ai-toolkit | [#1023](https://github.com/ostris/ai-toolkit/pull/1023) | `cache_text_embeddings` 以假文本编码器替换后，采样阶段直接崩溃；改为跳过采样 | 开启中 |
+
+### 流程
+
+1. 在第三方软件包遇到真缺陷，先在墨寒这边修好并附回归测试。
+2. 评估是否可上游：与墨寒无关、上游仍在维护、修法不绑墨寒的假设。
+3. 送 PR 时附最小重现与测试，说明踩到的情境。
+4. 在本页加一行；上游合并或关闭时更新状态。
+
+### 闸门
+
+- 每月至少送出一个上游 PR。
+- 每个 PR 都附最小重现。
+- 本页列出全部上游贡献，没有例外。
+
+## English
+
+### Why this page exists
+
+When MoHan's pipeline hits a real defect in a third-party package, spending half an hour after the fix to send it upstream is the cheapest and most honest form of visibility: being needed in someone else's space. This page is the single authoritative list; every upstream PR gets a row here, and the upstream page is the source of truth for its status.
+
+### Record
+
+| Date | Upstream project | PR | What | Status (2026-09-02) |
+|---|---|---|---|---|
+| 2026-08-28 | ostris/ai-toolkit | [#1021](https://github.com/ostris/ai-toolkit/pull/1021) | `cache_text_encoder` lacked a device-preset branch, so `BaseModel` failed while caching the text encoder | Open |
+| 2026-08-29 | ostris/ai-toolkit | [#1023](https://github.com/ostris/ai-toolkit/pull/1023) | after `cache_text_embeddings` swapped in a fake text encoder, sampling crashed outright; now sampling is skipped | Open |
+
+### Process
+
+1. Hit a real defect in a third-party package, fix it on MoHan's side first with a regression test.
+2. Decide whether it can go upstream: unrelated to MoHan, upstream still maintained, fix not tied to MoHan's assumptions.
+3. Send the PR with a minimal reproduction and a test, and describe the situation that triggered it.
+4. Add a row here; update the status when upstream merges or closes it.
+
+### Gates
+
+- At least one upstream PR per month.
+- Every PR carries a minimal reproduction.
+- This page lists every upstream contribution, without exception.
+
+## 日本語
+
+### このページがある理由
+
+墨寒のパイプラインがサードパーティ製パッケージの本物の欠陥を踏んだとき、修正後に三十分だけ余分に使って上流へ送ることは、最も安く最も誠実な可視性です。他人の場で他人に必要とされることだからです。このページが唯一の権威ある一覧であり、上流へ PR を送るたびに一行を追加し、状態は上流のページを正とします。
+
+### 記録
+
+| 日付 | 上流プロジェクト | PR | 内容 | 状態（2026-09-02） |
+|---|---|---|---|---|
+| 2026-08-28 | ostris/ai-toolkit | [#1021](https://github.com/ostris/ai-toolkit/pull/1021) | `cache_text_encoder` にデバイス既定の分岐が無く、`BaseModel` がテキストエンコーダーのキャッシュ時に失敗していた | オープン |
+| 2026-08-29 | ostris/ai-toolkit | [#1023](https://github.com/ostris/ai-toolkit/pull/1023) | `cache_text_embeddings` が偽のテキストエンコーダーに差し替えた後、サンプリングがそのままクラッシュしていた。サンプリングを飛ばすように修正 | オープン |
+
+### 手順
+
+1. サードパーティ製パッケージで本物の欠陥を踏んだら、まず墨寒側で回帰テスト付きで修正する。
+2. 上流へ送れるか判断する。墨寒に固有でないこと、上流が保守中であること、修正が墨寒の前提に縛られていないこと。
+3. PR には最小再現とテストを添え、踏んだ状況を説明する。
+4. このページに一行を追加し、上流で取り込みまたは却下されたら状態を更新する。
+
+### 関門
+
+- 毎月少なくとも一件の上流 PR を送る。
+- すべての PR に最小再現を添える。
+- このページに上流への貢献をすべて列挙し、例外を作らない。


### PR DESCRIPTION
## 繁體中文

### 為什麼

能見度工單 #125 的第三個閘門是「repo 內有一頁列出所有上游貢獻紀錄」。README 只寫了一句「向上游 ai-toolkit 回饋兩顆缺陷修復」，沒有連結、沒有狀態，也沒有把「踩到第三方缺陷就送上游」寫成流程。

### 內容

- 新增 `docs/UPSTREAM-CONTRIBUTIONS.md`：四語，含紀錄表（目前兩筆：ai-toolkit #1021、#1023，建立日期與 2026-09-02 的狀態皆以上游頁面核對）、四步流程、三條閘門。
- `README.md` 四語的「授權純淨與開源回饋」條目各加一個連結指向該頁；其餘不動。

### 測試

純文件變更。`tools/check_four_language_docs.py` 通過；完整 `tests/run_all.py` 全綠。

## 简体中文

### 为什么

能见度工单 #125 的第三个闸门是「repo 内有一页列出所有上游贡献记录」。README 只写了一句「向上游 ai-toolkit 回馈两颗缺陷修复」，没有链接、没有状态，也没有把「踩到第三方缺陷就送上游」写成流程。

### 内容

- 新增 `docs/UPSTREAM-CONTRIBUTIONS.md`：四语，含记录表（目前两条：ai-toolkit #1021、#1023，创建日期与 2026-09-02 的状态皆以上游页面核对）、四步流程、三条闸门。
- `README.md` 四语的「授权纯净与开源回馈」条目各加一个链接指向该页；其余不动。

### 测试

纯文档变更。`tools/check_four_language_docs.py` 通过；完整 `tests/run_all.py` 全绿。

## English

### Why

The third gate of visibility issue #125 is "a page in this repo lists all upstream contributions". The README only said that two defect fixes went upstream to ai-toolkit, with no links, no status, and no written process for "hit a third-party defect, send it upstream".

### Contents

- New `docs/UPSTREAM-CONTRIBUTIONS.md`: four languages, with the record table (currently two rows, ai-toolkit #1021 and #1023, creation dates and 2026-09-02 status both checked against the upstream pages), the four-step process and the three gates.
- The "license purity and upstream contribution" bullet in each of the four `README.md` languages gains one link to that page; nothing else changes.

### Tests

Documentation only. `tools/check_four_language_docs.py` passes; the full `tests/run_all.py` is green.

## 日本語

### 理由

可視性の課題 #125 の三つ目の関門は「リポジトリ内に上流への貢献をすべて列挙するページがある」ことです。README には上流の ai-toolkit へ二件の修正を還元したと一文あるだけで、リンクも状態も無く、「サードパーティの欠陥を踏んだら上流へ送る」という手順も書かれていませんでした。

### 内容

- `docs/UPSTREAM-CONTRIBUTIONS.md` を新設：四言語で、記録表（現在二件、ai-toolkit #1021 と #1023。作成日と 2026-09-02 時点の状態はいずれも上流ページで確認）、四段階の手順、三つの関門を含みます。
- `README.md` の四言語それぞれの「ライセンス純度と上流への還元」項目に、そのページへのリンクを一つずつ追加。他は変更しません。

### テスト

文書のみの変更です。`tools/check_four_language_docs.py` を通過し、`tests/run_all.py` 全体も緑です。
