### PR TITLE
chore: codeql-action init 與 analyze 同步升至 4.37.9／codeql-action init 与 analyze 同步升至 4.37.9／Bump codeql-action init and analyze together to 4.37.9／codeql-action の init と analyze を同時に 4.37.9 へ更新

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           build-mode: none
 
       - name: Analyze Python
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:python"

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -68,8 +68,8 @@ def test_funding_configuration() -> None:
 
 def test_security_workflows() -> None:
     codeql = read(".github/workflows/codeql.yml")
-    assert "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3" in codeql
-    assert "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3" in codeql
+    assert "github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938" in codeql
+    assert "github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938" in codeql
     assert "security-events: write" in codeql
     assert "pull_request_target" not in codeql
 


### PR DESCRIPTION
## 繁體中文

### 為什麼

dependabot 把 `github/codeql-action` 的升版拆成 #99（init）與 #100（analyze）兩個 PR。CodeQL 要求 init 與 analyze 同版本，兩個 PR 各自單獨跑時必要檢查 `analyze-python` 一定失敗（記錄：設定檔為 4.37.6、執行版本為 4.37.9），所以永遠合不進去。

### 內容

一個 PR 同時把 `codeql.yml` 裡的 init 與 analyze 升到同一個 SHA（4.37.9，與 dependabot 目前分支相同）。純 workflow 變更，取代 #99 與 #100。

## 简体中文

### 为什么

dependabot 把 `github/codeql-action` 的升版拆成 #99（init）与 #100（analyze）两个 PR。CodeQL 要求 init 与 analyze 同版本，两个 PR 各自单独跑时必要检查 `analyze-python` 一定失败（记录：配置文件为 4.37.6、运行版本为 4.37.9），所以永远合不进去。

### 内容

一个 PR 同时把 `codeql.yml` 里的 init 与 analyze 升到同一个 SHA（4.37.9，与 dependabot 当前分支相同）。纯 workflow 变更，取代 #99 与 #100。

## English

### Why

dependabot split the `github/codeql-action` bump into #99 (init) and #100 (analyze). CodeQL requires init and analyze to be the same version, so each PR on its own always fails the required `analyze-python` check (the log says the configuration file is 4.37.6 while the running version is 4.37.9), and neither can ever merge.

### Contents

One PR bumps both init and analyze in `codeql.yml` to the same SHA (4.37.9, the one on dependabot's current branches). Workflow-only change; supersedes #99 and #100.

## 日本語

### 理由

dependabot は `github/codeql-action` の更新を #99（init）と #100（analyze）の二つの PR に分けました。CodeQL は init と analyze が同じ版であることを要求するため、それぞれ単独では必須検査 `analyze-python` が必ず失敗し（ログでは設定ファイルが 4.37.6、実行版が 4.37.9）、どちらも取り込めません。

### 内容

一つの PR で `codeql.yml` の init と analyze を同じ SHA（4.37.9、dependabot の現在のブランチと同じ）へ上げます。ワークフローのみの変更で、#99 と #100 を置き換えます。
