### PR TITLE
fix: integrations 第二輪重驗的九項缺口——包裝逾時不重送、取消再查、個資不進稽核、靜音不出聲、合約變動不偽裝／integrations 第二轮复验的九项缺口／Close the nine gaps from the second integrations re-verification／integrations 第二回再検証で見つかった九件の隙間を閉じる

### DIFF
--- a/application/flagship_action_runtime.py
+++ b/application/flagship_action_runtime.py
@@ -40,6 +40,15 @@ Audit = Callable[[str, dict[str, Any]], None]
 REDACTED_AUDIT_KEYS = frozenset(
     {"text", "content", "body", "password", "token", "secret"}
 )
+# 2026-09-02 第 2 發重驗：郵件預覽、主旨、寄件者與 Home Assistant 的
+# state.attributes（GPS、friendly_name）原樣進了稽核 payload。這些是個資，
+# 連 64 字預覽都不留，只記長度或筆數。
+PII_AUDIT_KEYS = frozenset(
+    {
+        "bodyPreview", "snippet", "subject", "from", "sender", "toRecipients",
+        "attributes", "latitude", "longitude", "friendly_name",
+    }
+)
 AUDIT_PREVIEW_CHARS = 64
 
 
@@ -48,7 +57,10 @@ def redact_audit_payload(value: object) -> object:
     if isinstance(value, dict):
         redacted: dict[str, object] = {}
         for key, item in value.items():
-            if key in REDACTED_AUDIT_KEYS and isinstance(item, str):
+            if key in PII_AUDIT_KEYS and not isinstance(item, bool) and isinstance(item, (str, int, float, dict, list)):
+                size = len(item) if isinstance(item, (str, dict, list)) else 1
+                redacted[key] = f"<redacted {type(item).__name__} ({size})>"
+            elif key in REDACTED_AUDIT_KEYS and isinstance(item, str):
                 preview = item[:AUDIT_PREVIEW_CHARS]
                 more = "..." if len(item) > AUDIT_PREVIEW_CHARS else ""
                 redacted[key] = f"<redacted {len(item)} chars: {preview}{more}>"

--- a/domain/outfit_generation.py
+++ b/domain/outfit_generation.py
@@ -16,3 +16,28 @@ class OutfitGenerationCancelled(RuntimeError):
     分辨「這次沒做成」與「使用者按了緊急停止」。混在一起的後果是退避計時器
     把停手記成一次失敗嘗試，接著封鎖使用者下一次真正想要的生成。
     """
+
+
+class OutfitImageGenerationError(RuntimeError):
+    """A sanitized, user-displayable image-provider failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "provider-error",
+        http_status: int = 0,
+        request_id: str = "",
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.code = str(code or "provider-error")
+        self.http_status = int(http_status or 0)
+        self.request_id = str(request_id or "")
+        self.retryable = bool(retryable)
+
+    @property
+    def public_status(self) -> str:
+        """Return a stable, secret-free status suitable for UI and audit."""
+
+        return f"failed:{self.code}"

--- a/integrations/cloud_connectors.py
+++ b/integrations/cloud_connectors.py
@@ -150,11 +150,20 @@ def _require_identified(result: object, action: str, *keys: str) -> dict[str, An
     """
     if not isinstance(result, dict):
         raise OAuthError(f"{action}失敗：回應格式不符")
-    if keys and not any(str(result.get(key, "")).strip() for key in keys):
+    if keys and not any(_is_identifier(result.get(key)) for key in keys):
         raise OAuthError(
             f"{action}的回應缺少識別欄位（{'、'.join(keys)}），無法確認確實完成"
         )
     return result
+
+
+def _is_identifier(value: object) -> bool:
+    """只有非空字串或整數算識別值；str(value).strip() 會放行 None／False／{}／[]。"""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    return isinstance(value, str) and bool(value.strip())
 
 
 def _require_collection(
@@ -179,7 +188,10 @@ def _require_collection(
     rows = result[key]
     if not isinstance(rows, list):
         raise OAuthError(f"{action}的「{key}」欄位不是清單")
-    return [row for row in rows if isinstance(row, dict)]
+    if any(not isinstance(row, dict) for row in rows):
+        # 無聲濾掉非物件元素會讓「schema 改了」再次偽裝成「找到 0 筆」。
+        raise OAuthError(f"{action}的「{key}」清單含有非物件元素，回應合約已改變")
+    return rows
 
 
 

--- a/integrations/home_assistant.py
+++ b/integrations/home_assistant.py
@@ -147,6 +147,10 @@ class HomeAssistantClient:
         response = self._request("GET", f"/api/states/{entity_id}")
         if not isinstance(response, dict):
             raise HomeAssistantError("找不到裝置狀態")
+        # 代理或損壞的 API 回 200 + {} 時，原本會被包成 success=True、
+        # 訊息「light.office：unknown」，與真的讀到 unknown 狀態無法區分。
+        if "entity_id" not in response or "state" not in response:
+            raise HomeAssistantError("裝置狀態回應不完整，無法判讀")
         return response
 
     @staticmethod

--- a/integrations/openai_outfit_generator.py
+++ b/integrations/openai_outfit_generator.py
@@ -28,7 +28,10 @@ lazy from application.self_generating_wardrobe import (
     OutfitCreationRequest,
 )
 lazy from domain.outfit_pack import POSE_ATLAS_SILHOUETTES
-lazy from domain.outfit_generation import OutfitGenerationCancelled
+lazy from domain.outfit_generation import (
+    OutfitGenerationCancelled,
+    OutfitImageGenerationError,
+)
 
 OPENAI_IMAGE_EDITS_URL = "https://api.openai.com/v1/images/edits"
 OPENAI_IMAGE_MODEL = "gpt-image-2"
@@ -52,31 +55,6 @@ HTTP_TOO_MANY_REQUESTS = 429
 HTTP_SERVER_ERROR_MINIMUM = 500
 
 
-class OutfitImageGenerationError(RuntimeError):
-    """A sanitized, user-displayable image-provider failure."""
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        code: str = "provider-error",
-        http_status: int = 0,
-        request_id: str = "",
-        retryable: bool = False,
-    ) -> None:
-        super().__init__(message)
-        self.code = str(code or "provider-error")
-        self.http_status = int(http_status or 0)
-        self.request_id = str(request_id or "")
-        self.retryable = bool(retryable)
-
-    @property
-    def public_status(self) -> str:
-        """Return a stable, secret-free status suitable for UI and audit."""
-
-        return f"failed:{self.code}"
-
-
 class OutfitImageEditTransport(Protocol):
     def edit(
         self,
@@ -92,6 +70,26 @@ class OpenAIImageEditOptions:
     timeout_seconds: float = 180.0
     quality: str = "medium"
     endpoint: str = OPENAI_IMAGE_EDITS_URL
+
+
+def _timeout_failure() -> "OutfitImageGenerationError":
+    return OutfitImageGenerationError(
+        "GPT Image request timed out; not retried because the "
+        "provider may already have processed and billed it.",
+        code="timeout-ambiguous",
+        retryable=False,
+    )
+
+
+def _is_wrapped_timeout(error: BaseException) -> bool:
+    return isinstance(getattr(error, "reason", None), (TimeoutError, socket.timeout))
+
+
+def _raise_if_cancelled(cancelled: "Callable[[], bool]") -> None:
+    if cancelled():
+        raise OutfitGenerationCancelled(
+            "使用者在生成途中要求停手；已完成的視角保留在暫存區。"
+        )
 
 
 class OpenAIImageEditTransport:
@@ -164,25 +162,20 @@ class OpenAIImageEditTransport:
                     return response.read(MAX_RESPONSE_BYTES + 1)
             except urllib_error.HTTPError as error:
                 failure = self._http_failure(error)
-            except (TimeoutError, socket.timeout) as error:
-                # Timeout 的語意是「不知道對方做了沒」，不是「沒做」。這是
-                # 付費且非冪等的請求：若服務已經處理完、只是回應沒回來，
-                # 重試就是再付一次錢，而且會產生重複的服裝。31 視角的工作
-                # 最壞可送出 93 次。在沒有冪等鍵可用之前，timeout 一律不重試。
-                failure = OutfitImageGenerationError(
-                    "GPT Image request timed out; not retried because the "
-                    "provider may already have processed and billed it.",
-                    code="timeout-ambiguous",
-                    retryable=False,
-                )
-                del error
-            except (OSError, urllib_error.URLError):
-                # 連線根本沒建立起來，可以安全重試。
-                failure = OutfitImageGenerationError(
-                    "GPT Image request could not reach the provider.",
-                    code="network-unavailable",
-                    retryable=True,
-                )
+            except (TimeoutError, socket.timeout):
+                # 不知道對方做了沒：付費且非冪等，重試等於再付一次。一律不重試。
+                failure = _timeout_failure()
+            except (OSError, urllib_error.URLError) as error:
+                if _is_wrapped_timeout(error):
+                    # urllib 把讀取逾時包成 URLError(reason=TimeoutError)，語意同上。
+                    failure = _timeout_failure()
+                else:
+                    # 連線根本沒建立起來，可以安全重試。
+                    failure = OutfitImageGenerationError(
+                        "GPT Image request could not reach the provider.",
+                        code="network-unavailable",
+                        retryable=True,
+                    )
             last_error = failure
             if not failure.retryable or attempt >= MAX_TRANSIENT_ATTEMPTS - 1:
                 raise failure from None
@@ -424,13 +417,8 @@ class OpenAIOutfitDraftGenerator:
         hair_poses: dict[str, list[dict[str, object]]] = {}
         reference_hashes: dict[str, str] = {}
         for view_id in required_views:
-            # 每個視角都是一次付費呼叫，所以取消要檢查在呼叫之前而不是之後。
-            # 沒有這一行時，使用者按下緊急停止之後剩餘視角仍會逐張扣款——
-            # 介面卻已經宣告「所有工具均已中止」。
-            if cancelled():
-                raise OutfitGenerationCancelled(
-                    "使用者在生成途中要求停手；已完成的視角保留在暫存區。"
-                )
+            # 每個視角都是一次付費呼叫：取消要檢查在呼叫之前，不是之後。
+            _raise_if_cancelled(cancelled)
             reference_path = _reference_path(self._root, view_id)
             if not reference_path.is_file():
                 raise OutfitImageGenerationError(
@@ -454,6 +442,8 @@ class OpenAIOutfitDraftGenerator:
             garment_poses[view_id] = [_asset(garment_path, "outerwear", 10)]
 
             if "handheld" in request.requested_categories:
+                # 同一視角的第二次付費呼叫，停手後不得再扣一次款。
+                _raise_if_cancelled(cancelled)
                 normalized_handheld = self._checkpointed_edit(
                     request,
                     view_id,

--- a/integrations/realtime_session.py
+++ b/integrations/realtime_session.py
@@ -284,17 +284,23 @@ class RealtimeSessionMethods:
                 return
             try:
                 event = json.loads(message)
-            except (TypeError, json.JSONDecodeError):
+            except (TypeError, ValueError):
+                # ValueError 涵蓋 JSONDecodeError 與 UnicodeDecodeError：截斷的
+                # 二進位 frame 會讓 json.loads 在解碼階段就丟 UnicodeDecodeError，
+                # 只接 JSONDecodeError 時 callback 直接崩潰、連線不會被關掉。
                 # 無聲丟棄會讓使用者一直看到「正在聆聽」，而 session 其實
                 # 已經在收無法解讀的內容。二進位、截斷或非 JSON frame 代表
                 # 協定層出了問題，不是一個可以忽略的事件。
-                self.signals.failed.emit(
-                    "Realtime 連線收到無法解讀的資料，已中止本次語音工作階段。"
-                )
+                # RealtimeVoiceClient 直接定義 failed Signal，沒有 self.signals；
+                # 原本這裡會先拋 AttributeError，後面的 close() 永遠跑不到。
                 try:
-                    _ws.close()
-                except Exception:
-                    pass
+                    self.failed.emit(
+                        "Realtime 連線收到無法解讀的資料，已中止本次語音工作階段。"
+                    )
+                finally:
+                    # 不論通知是否成功，連線都必須真的關掉。
+                    with suppress(Exception):
+                        _ws.close()
                 return
             self._handle_server_event(event)
 

--- a/integrations/speech_audio.py
+++ b/integrations/speech_audio.py
@@ -76,6 +76,13 @@ def apply_wav_volume(
         with wave.open(io.BytesIO(audio), "rb") as source:
             params = source.getparams()
             if params.sampwidth != PCM16_SAMPLE_WIDTH:
+                # 非 16-bit PCM 無法套用增益。原本直接原音回傳，等於繞過下面
+                # 「靜音／降音量失敗必須中止」的契約：使用者按了靜音，8-bit
+                # 的回應仍以原音量播出。無法套用就是失敗，不是例外。
+                if muted or gain < 1.0:
+                    raise PcmAudioError(
+                        "音訊不是 16-bit PCM，無法套用靜音或降音量，為避免以非預期音量播放而中止本次播放"
+                    )
                 return audio
             frame_chunks = []
             while chunk := source.readframes(4096):

--- a/integrations/speech_voice_catalog.py
+++ b/integrations/speech_voice_catalog.py
@@ -144,9 +144,18 @@ def windows_voice_catalog() -> list[WindowsVoiceInfo]:
         ),
         (r"SOFTWARE\Microsoft\Speech\Voices\Tokens", ""),
     )
-    return [
-        *_registry_voices(registry_path, prefix) for registry_path, prefix in locations
-    ]
+    voices: list[WindowsVoiceInfo] = []
+    skipped = 0
+    for registry_path, prefix in locations:
+        voices.extend(_registry_voices(registry_path, prefix))
+        skipped += int(getattr(_registry_voices, "last_skipped", 0))
+    if not voices and skipped:
+        # last_skipped 原本只被寫入、從未被讀取：唯一的語音 token 因 ACL 讀不到
+        # 時，函式回傳 []，上層判成「未安裝語音」而不是「查詢部分失敗」。
+        raise WindowsVoiceCatalogError(
+            f"Windows 語音登錄檔有 {skipped} 個項目無法讀取，且沒有任何可用語音"
+        )
+    return voices
 
 
 def windows_voices() -> list[tuple[str, str]]:

--- a/tests/test_cancellation_semantics.py
+++ b/tests/test_cancellation_semantics.py
@@ -77,15 +77,30 @@ def test_default_cancellation_query_never_cancels() -> None:
 
 def test_generation_checks_cancellation_before_each_paid_view() -> None:
     """取消必須檢查在付費呼叫之前，否則停手也已經扣過款。"""
-    from integrations import openai_outfit_generator
+    # 2026-09-02 第 2 發重驗後改成行為測試：數實際的付費呼叫次數，
+    # 而不是搜尋原始碼字串。一開始就已取消 → 零次付費呼叫。
+    import types
 
-    source = inspect.getsource(openai_outfit_generator)
-    loop = source.split("for view_id in required_views:", 1)[1]
-    before_reference = loop.split("_reference_path(", 1)[0]
-    assert "cancelled()" in before_reference, (
-        "取消檢查沒有排在讀取參考圖與發出付費請求之前"
-    )
-    assert "OutfitGenerationCancelled" in before_reference
+    import pytest
+
+    from integrations import openai_outfit_generator as gen
+
+    generator = object.__new__(gen.OpenAIOutfitDraftGenerator)
+    generator._root = None
+    paid = {"n": 0}
+
+    def fake_edit(self, *_edit_arguments):
+        paid["n"] += 1
+        return b"image"
+
+    generator._checkpointed_edit = types.MethodType(fake_edit, generator)
+    generator._design_prompt = lambda request, trends: "design"
+    generator._view_prompt = lambda design, view_id, target: "view"
+    generator._handheld_prompt = lambda request, view_id, target: "handheld"
+    request = types.SimpleNamespace(requested_categories=frozenset({"garment"}))
+    with pytest.raises(gen.OutfitGenerationCancelled):
+        generator.create(request, (), ("yaw+000-pitch+00",), cancelled=lambda: True)
+    assert paid["n"] == 0, "已取消仍送出了付費呼叫"
 
 
 def test_emergency_stop_is_connected_to_the_generation_controller() -> None:

--- a/tests/test_integrations_audit2_gaps.py
+++ b/tests/test_integrations_audit2_gaps.py
@@ -1,0 +1,210 @@
+"""第 2 發 integrations 重驗（2026-09-02）找到的九項缺口，全部以行為測試釘住。
+
+重驗明講：不可再用原始碼字串搜尋替代付費呼叫次數、socket 關閉與稽核持久化
+結果的驗證。這裡每一條都數實際發生的事。
+"""
+from __future__ import annotations
+
+lazy import io
+lazy import os
+lazy import types
+lazy import wave
+lazy from pathlib import Path
+lazy from urllib import error as urllib_error
+
+lazy import pytest
+
+lazy from application.flagship_action_runtime import redact_audit_payload
+lazy from integrations import openai_outfit_generator as gen
+lazy from integrations import speech_voice_catalog as catalog
+lazy from integrations.cloud_connectors import OAuthError, _require_identified
+lazy from integrations.home_assistant import HomeAssistantClient, HomeAssistantError
+lazy from integrations.realtime_session import RealtimeSessionMethods
+lazy from integrations.speech_audio import PcmAudioError, apply_wav_volume
+
+
+# ---- 1. 被 URLError 包裝的 timeout 不得重送付費請求 ----
+
+
+def test_wrapped_timeout_is_not_retried(monkeypatch) -> None:
+    calls = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        calls["n"] += 1
+        raise urllib_error.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(gen.urllib_request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(gen.time, "sleep", lambda _s: None)
+    transport = object.__new__(gen.OpenAIImageEditTransport)
+    transport._options = gen.OpenAIImageEditOptions(api_key="test-key")
+    with pytest.raises(gen.OutfitImageGenerationError) as failure:
+        transport._open_with_retry(object())
+    assert calls["n"] == 1
+    assert failure.value.retryable is False
+    assert failure.value.code == "timeout-ambiguous"
+
+
+def test_plain_connection_failure_is_still_retried(monkeypatch) -> None:
+    calls = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        calls["n"] += 1
+        raise urllib_error.URLError(ConnectionRefusedError("refused"))
+
+    monkeypatch.setattr(gen.urllib_request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(gen.time, "sleep", lambda _s: None)
+    transport = object.__new__(gen.OpenAIImageEditTransport)
+    transport._options = gen.OpenAIImageEditOptions(api_key="test-key")
+    with pytest.raises(gen.OutfitImageGenerationError):
+        transport._open_with_retry(object())
+    assert calls["n"] == gen.MAX_TRANSIENT_ATTEMPTS
+
+
+# ---- 2. 同一視角的第二次付費呼叫（handheld）前也要檢查取消 ----
+
+
+def test_cancel_between_garment_and_handheld_stops_before_second_paid_call(
+    monkeypatch, tmp_path: Path
+) -> None:
+    reference = tmp_path / "ref.png"
+    reference.write_bytes(b"png")
+    monkeypatch.setattr(gen, "_reference_path", lambda _root, _view: reference)
+    generator = object.__new__(gen.OpenAIOutfitDraftGenerator)
+    generator._root = tmp_path
+    paid = {"n": 0}
+
+    def fake_edit(self, *_edit_arguments):
+        paid["n"] += 1
+        return b"image"
+
+    generator._checkpointed_edit = types.MethodType(fake_edit, generator)
+    generator._design_prompt = lambda request, trends: "design"
+    generator._view_prompt = lambda design, view_id, target: "view"
+    generator._handheld_prompt = lambda request, view_id, target: "handheld"
+    request = types.SimpleNamespace(requested_categories=frozenset({"garment", "handheld"}))
+    with pytest.raises(gen.OutfitGenerationCancelled):
+        generator.create(
+            request,
+            (),
+            ("yaw+000-pitch+00",),
+            cancelled=lambda: paid["n"] >= 1,  # garment 回來後立刻按停手
+        )
+    assert paid["n"] == 1, f"停手後仍送出了 {paid['n'] - 1} 次 handheld 付費呼叫"
+
+
+# ---- 3. 郵件預覽與 Home Assistant 個資不得原樣進稽核 ----
+
+
+def test_audit_redaction_covers_mail_preview_and_home_assistant_attributes() -> None:
+    payload = {
+        "messages": [{"id": "m1", "subject": "診斷結果", "bodyPreview": "醫師說……", "from": {"emailAddress": {"address": "a@b"}}}],
+        "state": {"entity_id": "person.owner", "state": "home", "attributes": {"latitude": 25.03, "longitude": 121.5, "friendly_name": "明樺"}},
+    }
+    redacted = redact_audit_payload(payload)
+    text = str(redacted)
+    for secret in ("診斷結果", "醫師說", "a@b", "25.03", "121.5", "明樺"):
+        assert secret not in text, f"稽核 payload 仍含 {secret!r}"
+    assert redacted["messages"][0]["id"] == "m1"
+    assert redacted["state"]["entity_id"] == "person.owner"
+    assert redacted["state"]["state"] == "home"
+
+
+# ---- 4. 非 16-bit WAV 在靜音時不得原音播出 ----
+
+
+def _wav(sampwidth: int) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as target:
+        target.setnchannels(1)
+        target.setsampwidth(sampwidth)
+        target.setframerate(8000)
+        target.writeframes(bytes(range(256)) * 4 if sampwidth == 1 else b"\x00\x10" * 512)
+    return buffer.getvalue()
+
+
+def test_muted_non_pcm16_audio_is_a_failure_not_full_volume() -> None:
+    eight_bit = _wav(1)
+    with pytest.raises(PcmAudioError):
+        apply_wav_volume(eight_bit, 100, muted=True)
+    with pytest.raises(PcmAudioError):
+        apply_wav_volume(eight_bit, 30, muted=False)
+    assert apply_wav_volume(eight_bit, 100, muted=False) == eight_bit  # 原音量：不需處理
+
+
+# ---- 5. null／容器型 ID 不算已識別 ----
+
+
+@pytest.mark.parametrize("value", [None, False, {}, [], "", "   "])
+def test_non_identifying_values_are_rejected(value) -> None:
+    with pytest.raises(OAuthError):
+        _require_identified({"id": value}, "Gmail 寄送", "id")
+
+
+@pytest.mark.parametrize("value", ["abc", 7])
+def test_real_identifiers_pass(value) -> None:
+    assert _require_identified({"id": value}, "Gmail 寄送", "id") == {"id": value}
+
+
+# ---- 6. Realtime 非 JSON frame：通知走對的 Signal，且連線一定關閉 ----
+
+
+class _Signal:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def emit(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class _Ws:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_non_json_realtime_frame_emits_failed_and_closes_socket() -> None:
+    fake = types.SimpleNamespace(failed=_Signal(), running=True)
+    fake._handle_server_event = lambda event: (_ for _ in ()).throw(AssertionError("不該處理"))
+    fake._emit_failure = lambda message: None
+    callbacks = RealtimeSessionMethods._websocket_callbacks(fake, object(), lambda: True)
+    ws = _Ws()
+    callbacks["on_message"](ws, b"\x00\x01 not json")
+    assert fake.failed.messages, "failed Signal 沒有被通知"
+    assert ws.closed, "非 JSON frame 之後 websocket 沒有被關閉"
+
+
+# ---- 7. Home Assistant 空物件不是成功讀取 ----
+
+
+def test_home_assistant_empty_state_object_is_an_error() -> None:
+    client = object.__new__(HomeAssistantClient)
+    client._request = lambda *args, **kwargs: {}
+    with pytest.raises(HomeAssistantError):
+        client.state("light.office")
+    client._request = lambda *args, **kwargs: {"entity_id": "light.office", "state": "unknown"}
+    assert client.state("light.office")["state"] == "unknown"
+
+
+# ---- 9. 登錄檔項目讀不到且沒有任何語音，必須是查詢失敗而非「未安裝」 ----
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows 語音登錄檔只在 Windows 上")
+def test_all_voice_tokens_unreadable_is_a_catalog_error(monkeypatch) -> None:
+    def fake_registry_voices(registry_path, prefix):
+        fake_registry_voices.last_skipped = 1
+        return []
+
+    fake_registry_voices.last_skipped = 0
+    monkeypatch.setattr(catalog, "_registry_voices", fake_registry_voices)
+    with pytest.raises(catalog.WindowsVoiceCatalogError):
+        catalog.windows_voice_catalog()
+
+    def fake_registry_voices_ok(registry_path, prefix):
+        fake_registry_voices_ok.last_skipped = 0
+        return []
+
+    fake_registry_voices_ok.last_skipped = 0
+    monkeypatch.setattr(catalog, "_registry_voices", fake_registry_voices_ok)
+    assert catalog.windows_voice_catalog() == []  # 真的沒有語音：正常的空清單

--- a/tests/test_integrations_silent_failures.py
+++ b/tests/test_integrations_silent_failures.py
@@ -71,12 +71,16 @@ def test_missing_collection_key_is_an_error_not_zero_results() -> None:
 def test_present_but_empty_collection_is_genuinely_zero_results() -> None:
     """欄位存在而為空陣列，才是真正的「找到 0 筆」。"""
     assert _require_collection({"messages": []}, "Gmail 搜尋", "messages") == []
-    rows = _require_collection(
-        {"messages": [{"id": "1"}, "junk", {"id": "2"}]},
-        "Gmail 搜尋",
-        "messages",
-    )
-    assert rows == [{"id": "1"}, {"id": "2"}]
+    assert _require_collection(
+        {"messages": [{"id": "1"}, {"id": "2"}]}, "Gmail 搜尋", "messages"
+    ) == [{"id": "1"}, {"id": "2"}]
+    # 2026-09-02 第 2 發重驗：非物件元素代表合約已變，不能無聲丟掉再回報 0 筆。
+    with pytest.raises(OAuthError):
+        _require_collection(
+            {"messages": [{"id": "1"}, "junk", {"id": "2"}]},
+            "Gmail 搜尋",
+            "messages",
+        )
 
 
 def test_home_assistant_without_expected_state_is_not_verified() -> None:


### PR DESCRIPTION
## 繁體中文

### 為什麼

2026-09-02 對 `integrations/` 做修後重驗：第一輪六項修補中 F2、F3 完整關閉，F1、F4、F5、F6 各留缺口，另有一項新發現，合計九項可重現問題。重驗特別指出先前的回歸測試有些只比對原始碼字串，沒有數實際發生的事。

### 修法

- `openai_outfit_generator.py`：`URLError(reason=TimeoutError)` 與裸 `TimeoutError` 同樣是「不知道對方做了沒」，一律不重試（付費且非冪等）；同一視角 garment 回來之後、handheld 之前再查一次取消，停手後不再送出第二次付費呼叫。
- `flagship_action_runtime.py`：新增 `PII_AUDIT_KEYS`（郵件預覽、主旨、寄件者、收件者、Home Assistant 的 `attributes`、GPS、`friendly_name`），這些欄位連 64 字預覽都不留，只記型別與長度。
- `speech_audio.py`：非 16-bit PCM 在靜音或降音量時無法套用增益，改為中止而非原音播出。
- `cloud_connectors.py`：`_require_identified()` 只接受非空字串或整數，`None`／`False`／`{}`／`[]` 不算識別；`_require_collection()` 遇到非物件元素直接報合約已變，不再無聲濾掉後回報 0 筆。
- `realtime_session.py`：壞 frame 的通知改走 client 實際存在的 `failed` Signal（原本引用不存在的 `self.signals` 先拋 `AttributeError`），例外種類擴到 `ValueError` 以涵蓋 `UnicodeDecodeError`，並用 try/finally 保證 websocket 一定關閉。
- `home_assistant.py`：`state()` 缺 `entity_id` 或 `state` 的回應視為不完整而報錯，不再包成成功。
- `speech_voice_catalog.py`：`last_skipped` 真的被讀取——全部 token 讀不到且沒有任何語音時拋 `WindowsVoiceCatalogError`。
- 行數棘輪：`OutfitImageGenerationError` 搬到 `domain/outfit_generation.py`（與 `OutfitGenerationCancelled` 同屬生成生命週期），`test_cancellation_semantics.py` 裡的原始碼字串測試改為數付費呼叫次數的行為測試。

### 測試

新增 `tests/test_integrations_audit2_gaps.py` 十六個行為測試：數付費呼叫次數（包裝逾時 1 次、連線被拒重試到上限、停手後 handheld 0 次）、讀遮罩後的 payload 確認個資字串不存在、8-bit WAV 靜音時拋錯、六種非識別值被拒、壞 frame 後 `failed` 被通知且 socket 已關、HA 空物件報錯、語音登錄全部讀不到時報錯。既有 `tests/test_integrations_silent_failures.py` 的「靜默濾掉 junk」斷言改為預期報錯。完整 `tests/run_all.py` 全綠。

## 简体中文

### 为什么

2026-09-02 对 `integrations/` 做修后复验：第一轮六项修补中 F2、F3 完整关闭，F1、F4、F5、F6 各留缺口，另有一项新发现，合计九项可重现问题。复验特别指出先前的回归测试有些只比对源代码字符串，没有数实际发生的事。

### 修复方式

- `openai_outfit_generator.py`：`URLError(reason=TimeoutError)` 与裸 `TimeoutError` 同样是「不知道对方做了没」，一律不重试（付费且非幂等）；同一视角 garment 回来之后、handheld 之前再查一次取消，停手后不再送出第二次付费调用。
- `flagship_action_runtime.py`：新增 `PII_AUDIT_KEYS`（邮件预览、主题、发件人、收件人、Home Assistant 的 `attributes`、GPS、`friendly_name`），这些字段连 64 字预览都不留，只记类型与长度。
- `speech_audio.py`：非 16-bit PCM 在静音或降音量时无法套用增益，改为中止而非原音播出。
- `cloud_connectors.py`：`_require_identified()` 只接受非空字符串或整数，`None`／`False`／`{}`／`[]` 不算识别；`_require_collection()` 遇到非对象元素直接报合约已变，不再无声滤掉后报告 0 条。
- `realtime_session.py`：坏 frame 的通知改走 client 实际存在的 `failed` Signal（原本引用不存在的 `self.signals` 先抛 `AttributeError`），异常种类扩到 `ValueError` 以涵盖 `UnicodeDecodeError`，并用 try/finally 保证 websocket 一定关闭。
- `home_assistant.py`：`state()` 缺 `entity_id` 或 `state` 的响应视为不完整而报错，不再包成成功。
- `speech_voice_catalog.py`：`last_skipped` 真的被读取——全部 token 读不到且没有任何语音时抛 `WindowsVoiceCatalogError`。
- 行数棘轮：`OutfitImageGenerationError` 搬到 `domain/outfit_generation.py`（与 `OutfitGenerationCancelled` 同属生成生命周期），`test_cancellation_semantics.py` 里的源代码字符串测试改为数付费调用次数的行为测试。

### 测试

新增 `tests/test_integrations_audit2_gaps.py` 十六个行为测试：数付费调用次数（包装超时 1 次、连接被拒重试到上限、停手后 handheld 0 次）、读遮罩后的 payload 确认个资字符串不存在、8-bit WAV 静音时抛错、六种非识别值被拒、坏 frame 后 `failed` 被通知且 socket 已关、HA 空对象报错、语音注册表全部读不到时报错。既有 `tests/test_integrations_silent_failures.py` 的「静默滤掉 junk」断言改为预期报错。完整 `tests/run_all.py` 全绿。

## English

### Why

A post-fix re-verification of `integrations/` on 2026-09-02 found that of the first round's six fixes, F2 and F3 are fully closed while F1, F4, F5 and F6 each left a gap, plus one new finding: nine reproducible problems in total. The re-verification also pointed out that some earlier regression tests only matched source text instead of counting what actually happened.

### The fix

- `openai_outfit_generator.py`: a `URLError(reason=TimeoutError)` means "unknown whether the provider acted" exactly like a bare `TimeoutError`, so it is never retried (paid, non-idempotent); cancellation is checked again after the garment call and before the handheld call of the same view, so a stop no longer lets a second paid call go out.
- `flagship_action_runtime.py`: new `PII_AUDIT_KEYS` (mail preview, subject, sender, recipients, Home Assistant `attributes`, GPS, `friendly_name`); these keep no 64-character preview at all, only type and length.
- `speech_audio.py`: non-16-bit PCM cannot take gain, so under mute or reduced volume playback is aborted instead of playing at full volume.
- `cloud_connectors.py`: `_require_identified()` accepts only a non-empty string or an integer, so `None`, `False`, `{}` and `[]` no longer count as identifiers; `_require_collection()` reports a changed contract when a non-object element appears instead of silently dropping it and reporting zero results.
- `realtime_session.py`: the bad-frame notification uses the `failed` Signal that actually exists on the client (the old code referenced a non-existent `self.signals` and raised `AttributeError` first), the caught exception widens to `ValueError` to cover `UnicodeDecodeError`, and a try/finally guarantees the websocket is closed.
- `home_assistant.py`: a `state()` response missing `entity_id` or `state` is an incomplete response and an error, no longer wrapped as success.
- `speech_voice_catalog.py`: `last_skipped` is finally read; when every token is unreadable and no voice was found, `WindowsVoiceCatalogError` is raised.
- Line-count ratchet: `OutfitImageGenerationError` moves to `domain/outfit_generation.py` (it belongs to the generation lifecycle next to `OutfitGenerationCancelled`), and the source-string test in `test_cancellation_semantics.py` becomes a behavioural test that counts paid calls.

### Tests

New `tests/test_integrations_audit2_gaps.py` with sixteen behavioural tests: paid-call counts (wrapped timeout once, connection refused retried to the limit, zero handheld calls after a stop), the redacted payload checked for the absence of the personal strings, an 8-bit WAV raising under mute, six non-identifying values rejected, `failed` notified and the socket closed after a bad frame, an empty Home Assistant object raising, and a catalog error when every voice token is unreadable. The "silently drop junk" assertion in the existing `tests/test_integrations_silent_failures.py` now expects an error. The full `tests/run_all.py` is green.

## 日本語

### 理由

2026-09-02 に `integrations/` の修正後再検証を行ったところ、第一回の六件の修正のうち F2 と F3 は完全に閉じ、F1、F4、F5、F6 にはそれぞれ隙間が残り、さらに新規一件、合計九件の再現可能な問題が見つかりました。再検証は、以前の回帰テストの一部がソース文字列の照合だけで、実際に起きたことを数えていなかった点も指摘しています。

### 修正方法

- `openai_outfit_generator.py`：`URLError(reason=TimeoutError)` は素の `TimeoutError` と同じく「相手が処理したか不明」なので再送しません（有料かつ非冪等）。同じ視角で garment の応答後、handheld の前にもう一度取り消しを確認し、停止後に二回目の有料呼び出しが出ないようにしました。
- `flagship_action_runtime.py`：`PII_AUDIT_KEYS` を新設（メールのプレビュー、件名、送信者、受信者、Home Assistant の `attributes`、GPS、`friendly_name`）。これらは 64 文字のプレビューすら残さず、型と長さだけを記録します。
- `speech_audio.py`：16-bit PCM 以外にはゲインを適用できないため、ミュートまたは音量低下の場合は原音で鳴らさず再生を中止します。
- `cloud_connectors.py`：`_require_identified()` は空でない文字列か整数だけを受け入れ、`None`／`False`／`{}`／`[]` は識別子と見なしません。`_require_collection()` はオブジェクトでない要素があれば契約変更として報告し、黙って捨てて 0 件と報告することをやめました。
- `realtime_session.py`：不正フレームの通知はクライアントに実在する `failed` Signal を使い（旧コードは存在しない `self.signals` を参照して先に `AttributeError` を投げていた）、捕捉する例外を `ValueError` に広げて `UnicodeDecodeError` を含め、try/finally で websocket を必ず閉じます。
- `home_assistant.py`：`state()` の応答に `entity_id` か `state` が無ければ不完全な応答としてエラーにし、成功として包みません。
- `speech_voice_catalog.py`：`last_skipped` をようやく読み取り、すべてのトークンが読めず音声が一つも無い場合は `WindowsVoiceCatalogError` を送出します。
- 行数ラチェット：`OutfitImageGenerationError` を `domain/outfit_generation.py` へ移し（`OutfitGenerationCancelled` と同じ生成ライフサイクルに属する）、`test_cancellation_semantics.py` のソース文字列テストは有料呼び出し回数を数える振る舞いテストに改めました。

### テスト

`tests/test_integrations_audit2_gaps.py` に十六件の振る舞いテストを追加しました。有料呼び出し回数（包装されたタイムアウトは一回、接続拒否は上限まで再試行、停止後の handheld は零回）、マスク後のペイロードに個人情報の文字列が無いこと、8-bit WAV がミュート時に例外になること、六種類の非識別値が拒否されること、不正フレーム後に `failed` が通知されソケットが閉じること、Home Assistant の空オブジェクトがエラーになること、音声トークンがすべて読めないときにカタログエラーになることです。既存の `tests/test_integrations_silent_failures.py` の「junk を黙って捨てる」断言はエラーを期待するように変えました。`tests/run_all.py` 全体も緑です。
