### PR TITLE
README 四語重編並補 DLC 安裝教學／README 四语重编并补 DLC 安装教学／Restructure the four-language README and add DLC install guide／README を四言語で再構成し DLC 導入手順を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 本文件記錄墨寒桌面助理所有值得注意的公開變更。
 
+### 未發布 — README 四語重編與 DLC 教學（2026-09-03）
+
+* README 依「這是什麼、畫面與功能、安裝更新、首次使用、隱私、DLC、贊助授權、疑難排解、開發者入口」重編四語同構內容，刪除重複與過時段落；新增 `.mohan-outfit` 外觀／妝容包與 `.mohan-theme` 主題檔的安裝、選用、還原、容量數量上限、二代素體相容性及 Ko-fi 單次／每月贊助雙軌教學。
+
 ### 未發布 — 遷移說明（issue #140，選項 3）
 
 * 官方預設外觀包「藍白漢服」與內建妝容素材入庫：`assets/official-packs/mohan.official.blue-white-hanfu.mohan-outfit`（衣袍、散髮、銀髮飾，31 個 silhouette 齊全）與 `assets/official-packs/mohan.makeup.builtin.mohan-outfit`（`classic`／`light`，淡雅為原妝 alpha × 0.55）由 `tools/assemble_official_default_pack.py` 自產線分層對映、裁切、封裝而成；官方套件目錄由 `assets/makeup/` 改為 `assets/official-packs/`（`assets/makeup/builtin/` 仍是妝容範本與素材來源）。全新設定檔與「還原內建預設」的 `builtin` 哨兵改由 `domain/outfit_pack_official.py` 解析：衣裝／髮型／頭飾指向官方包 ensemble、妝容指向內建原妝，官方檔案不在場時仍退回素體；官方 id 不可匯入覆蓋、不可移除。雲裳閣的「內建預設服裝」即官方包，不再重複列出；`assets/makeup-safe-regions.json` 依二代半身 rig 重生。
@@ -306,6 +310,10 @@ smoke test、EXE／MSI 靜默安裝與解除安裝驗證、checksum 產生、SBO
 
 本文档记录墨寒桌面助手所有值得注意的公开变更。
 
+### 未发布 — README 四语重编与 DLC 教程（2026-09-03）
+
+* README 按“这是什么、界面与功能、安装更新、首次使用、隐私、DLC、赞助许可、疑难解答、开发者入口”重编四语同构内容，删除重复和过时段落；新增 `.mohan-outfit` 外观／妆容包与 `.mohan-theme` 主题文件的安装、选用、恢复、容量数量上限、二代素体兼容性及 Ko-fi 单次／每月赞助双轨教程。
+
 ### 未发布 — 迁移说明（issue #140，选项 3）
 
 * 官方默认外观包「蓝白汉服」与内置妆容素材入库：`assets/official-packs/mohan.official.blue-white-hanfu.mohan-outfit`（衣袍、散发、银发饰，31 个 silhouette 齐全）与 `assets/official-packs/mohan.makeup.builtin.mohan-outfit`（`classic`／`light`，淡雅为原妆 alpha × 0.55）由 `tools/assemble_official_default_pack.py` 自产线分层映射、裁切、封装而成；官方套件目录由 `assets/makeup/` 改为 `assets/official-packs/`（`assets/makeup/builtin/` 仍是妆容模板与素材来源）。全新配置文件与「还原内置默认」的 `builtin` 哨兵改由 `domain/outfit_pack_official.py` 解析：服装／发型／头饰指向官方包 ensemble、妆容指向内置原妆，官方文件不在场时仍退回素体；官方 id 不可导入覆盖、不可移除。云裳阁的「内置默认服装」即官方包，不再重复列出；`assets/makeup-safe-regions.json` 按二代半身 rig 重新生成。
@@ -521,6 +529,10 @@ EXE／MSI 静默安装与卸载验证、checksum 生成、SBOM 生成及产物�
 ## English
 
 All notable public changes to MoHan Desktop Assistant are documented here.
+
+### Unreleased — four-language README restructure and DLC guide (2026-09-03)
+
+* Rebuilt the README into matching “what it is, screens and capabilities, install and update, first use, privacy, DLC, support and licensing, troubleshooting, and developer entry” sections in all four languages, removing duplicate and obsolete material; added installation, selection, restoration, capacity and count limits, generation-2 body compatibility, and Ko-fi one-time/monthly dual-track guidance for `.mohan-outfit` appearance or makeup packs and `.mohan-theme` files.
 
 ### Unreleased — migration note (issue #140, option 3)
 
@@ -777,6 +789,10 @@ speech, gaze, and physics stress test passed before this release candidate.
 ## 日本語
 
 本書には、墨寒デスクトップアシスタントの主な公開変更をすべて記録します。
+
+### 未リリース — README 四言語再編と DLC ガイド（2026-09-03）
+
+* README を「概要、画面と機能、導入と更新、初回利用、プライバシー、DLC、支援とライセンス、トラブルシューティング、開発者向け入口」の四言語同一構造へ再編し、重複・旧情報を削除しました。`.mohan-outfit` 外観／メイクパックと `.mohan-theme` ファイルについて、導入、選択、復元、容量・数量上限、第二世代素体互換性、Ko-fi の単発／毎月支援という二本立てを追記しました。
 
 ### 未リリース — 移行メモ（issue #140、選択肢 3）
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,39 @@ macOS／Linux Preview 尚未等同 Windows 完整版，且可能沒有平台商�
 2. 先試 Windows 本機女聲；需要雲端 AI 時，再到設定輸入自己持有的 OpenAI API 金鑰。ChatGPT 訂閱不包含 API 額度。
 3. 檢查麥克風、通知與工具權限，只開啟真正需要的連接器；先記住緊急停止鍵 Esc 與「墨寒，停手」。
 
+### 雲端連接器設定
+
+#### Google OAuth
+
+使用 Gmail、Google Calendar 與 Google Drive 前，請先完成：
+
+1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與 Google Drive API。
+2. 設定 OAuth 同意畫面；若應用程式仍在測試模式，將自己的 Google 帳號加入測試使用者。
+3. 建立「桌面應用程式」OAuth Client ID。
+4. 開啟墨寒「設定」頁的「旗艦控制中心」→「雲端連接器」，選擇 Google（Gmail／Calendar／Drive），填入「OAuth Client ID」；只有供應商提供「OAuth Client Secret」時才填入。
+5. 在「授權範圍」保留以下預設 scopes，按「開啟瀏覽器安全連線」完成瀏覽器授權，再按「測試選取服務」。
+
+程式預設請求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+公開 OAuth 應用程式若使用敏感 scopes，可能需要 Google 額外驗證；每位使用者也可建立自己的 Desktop OAuth 應用程式。
+
+#### Microsoft、GitHub 與 Home Assistant
+
+- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 預設 scopes：`read:user`、`repo`。
+- Home Assistant：先在自己的 Home Assistant 個人檔案建立 Long-Lived Access Token；在墨寒「設定」頁的「旗艦控制中心」→「智慧家庭」勾選「啟用 Home Assistant 整合」，填入「Home Assistant 位址」與「長期存取權杖」，確認「驗證 HTTPS 憑證」後按「保存設定」，再用「測試連線」或「讀取裝置」確認。
+
+這三項仍是尚未完成真實環境端到端驗證的實驗性 Preview 整合，請先使用可承受失敗的測試帳號與設備；不要將 Home Assistant 或墨寒遠端連線埠直接暴露於公網，請使用 Home Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
+
 ### 隱私與本機優先
 
 - Windows 的對話、記憶、待辦、設定、工作紀錄、權限與稽核預設存於 `%LOCALAPPDATA%\YanJianStudio\MoHan`；備份位於其 backups 子目錄，可攜資料使用單一 `.mohan-profile`。
@@ -107,7 +140,7 @@ macOS／Linux Preview 尚未等同 Windows 完整版，且可能沒有平台商�
 #### 安裝與還原主題
 
 1. 下載 `.mohan-theme`，不要解壓縮。
-2. 在「雲裳閣」的主題區按「上傳單一檔案」，選取主題後從清單預覽。
+2. 在「設定」→「控制台佈景主題」按「上傳單一檔案」，選取主題後從清單預覽。
 3. 按右下「保存設定」才正式套用；取消會回到原主題。「還原主題」可預覽內建主題，再保存完成還原。
 
 #### 容量、數量與相容性
@@ -251,6 +284,39 @@ macOS／Linux Preview 尚不等同于 Windows 完整版，且可能没有平台�
 2. 先试听 Windows 本地女声；需要云端 AI 时，再到设置中输入自己持有的 OpenAI API 密钥。ChatGPT 订阅不包含 API 配额。
 3. 检查麦克风、通知与工具权限，只开启真正需要的连接器；先记住紧急停止键 Esc 与“墨寒，停手”。
 
+### 云端连接器设置
+
+#### Google OAuth
+
+使用 Gmail、Google Calendar 与 Google Drive 前，请先完成：
+
+1. 在自己的 Google Cloud 项目启用 Gmail API、Google Calendar API 与 Google Drive API。
+2. 设置 OAuth 同意屏幕；若应用程序仍处于测试模式，将自己的 Google 账号加入测试用户。
+3. 创建“桌面应用程序”OAuth Client ID。
+4. 打开墨寒“设置”页的“旗舰控制中心”→“云端连接器”，选择 Google（Gmail／Calendar／Drive），填写“OAuth Client ID”；仅在供应商提供“OAuth Client Secret”时填写。
+5. 在“授权范围”保留以下默认 scopes，点击“打开浏览器安全连接”完成浏览器授权，再点击“测试选中服务”。
+
+程序默认请求以下 Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+公开 OAuth 应用程序若使用敏感 scopes，可能需要 Google 额外验证；每位用户也可以创建自己的 Desktop OAuth 应用程序。
+
+#### Microsoft、GitHub 与 Home Assistant
+
+- Microsoft 默认 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub 默认 scopes：`read:user`、`repo`。
+- Home Assistant：先在自己的 Home Assistant 个人资料中创建 Long-Lived Access Token；在墨寒“设置”页的“旗舰控制中心”→“智能家居”勾选“启用 Home Assistant 集成”，填写“Home Assistant 地址”和“长期访问令牌”，确认“验证 HTTPS 证书”后点击“保存设置”，再用“测试连接”或“读取设备”确认。
+
+这三项仍是尚未完成真实环境端到端验证的实验性 Preview 集成，请先使用可承受失败的测试账号与设备；不要将 Home Assistant 或墨寒远程端口直接暴露于公网，请使用 Home Assistant Cloud、Tailscale 或其他具有身份验证的加密私人网络。
+
 ### 隐私与本地优先
 
 - Windows 的对话、记忆、待办事项、设置、工作记录、权限与审计默认存储在 `%LOCALAPPDATA%\YanJianStudio\MoHan`；备份位于其 backups 子目录，便携数据使用单一 `.mohan-profile`。
@@ -274,7 +340,7 @@ macOS／Linux Preview 尚不等同于 Windows 完整版，且可能没有平台�
 #### 安装与恢复主题
 
 1. 下载 `.mohan-theme`，不要解压。
-2. 在“云裳阁”的主题区域点击“上传单个文件”，选取主题后从列表预览。
+2. 在“设置”→“控制台主题”点击“上传单个文件”，选取主题后从列表预览。
 3. 点击右下角“保存设置”才正式应用；取消会恢复原主题。“恢复主题”可预览内置主题，再保存以完成恢复。
 
 #### 容量、数量与兼容性
@@ -418,6 +484,39 @@ The macOS/Linux Preview is not equivalent to the complete Windows build and may 
 2. Try a Windows local female voice first. When cloud AI is needed, enter a user-owned OpenAI API key in Settings. A ChatGPT subscription does not include API quota.
 3. Review microphone, notification, and tool permissions and enable only the connectors you need. First learn the Esc emergency stop and the phrase “mohan stop.”
 
+### Cloud connector setup
+
+#### Google OAuth
+
+Before using Gmail, Google Calendar, and Google Drive, complete these steps:
+
+1. In a user-owned Google Cloud project, enable the Gmail API, Google Calendar API, and Google Drive API.
+2. Configure the OAuth consent screen; while the application is in testing, add the user's Google account as a test user.
+3. Create an OAuth Client ID for a Desktop application.
+4. Open MoHan Settings → Flagship control center → Cloud Connectors, select Google（Gmail／Calendar／Drive）, and enter the OAuth Client ID; enter the OAuth Client Secret only if the provider supplies one.
+5. Keep the default scopes below in OAuth scopes, press Open secure browser connection, complete browser authorization, and then press Test selected service.
+
+The application requests these Google scopes by default:
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+A public OAuth application using sensitive scopes may require additional Google verification; each user may instead create a personal Desktop OAuth application.
+
+#### Microsoft, GitHub, and Home Assistant
+
+- Microsoft defaults: `openid`, `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
+- GitHub defaults: `read:user` and `repo`.
+- Home Assistant: first create a Long-Lived Access Token in the user's own Home Assistant profile; in MoHan Settings → Flagship control center → Smart Home, check Enable Home Assistant integration, enter the Home Assistant address and Long-lived access token, confirm Verify HTTPS certificate, press Save settings, then use Test connection or Load devices to confirm.
+
+These three remain experimental Preview integrations without completed real-environment end-to-end validation. Begin with failure-tolerant test accounts and devices; never expose the Home Assistant or MoHan remote port directly to the public internet, and use Home Assistant Cloud, Tailscale, or another authenticated encrypted private network.
+
 ### Privacy and local-first behavior
 
 - On Windows, conversations, memories, tasks, settings, work records, permissions, and audits stay by default in `%LOCALAPPDATA%\YanJianStudio\MoHan`; backups are in its backups subfolder, and portable data uses one `.mohan-profile`.
@@ -441,7 +540,7 @@ Multisensory vision is off by default. After the user explicitly enables it and 
 #### Install and restore themes
 
 1. Download the `.mohan-theme`; do not unpack it.
-2. In the Wardrobe Pavilion's theme area, press “Upload one file,” choose the theme, and preview it from the list.
+2. In Settings → Dashboard theme, press “Upload one file,” choose the theme, and preview it from the list.
 3. It takes effect only after “Save settings” at the lower right; cancel restores the previous theme. “Restore theme” previews the built-in theme, which is restored after saving.
 
 #### Capacity, count, and compatibility
@@ -585,6 +684,39 @@ macOS／Linux Preview は Windows 完全版と同等ではなく、プラット�
 2. まず Windows 本機女性音声を試します。クラウド AI が必要な場合だけ、利用者自身の OpenAI API キーを設定に入力します。ChatGPT の契約に API 割り当ては含まれません。
 3. マイク、通知、ツール権限を確認し、必要な連携だけを有効にします。先に Esc の緊急停止と「墨寒、止まって」を覚えてください。
 
+### クラウド連携の設定
+
+#### Google OAuth
+
+Gmail、Google Calendar、Google Drive を利用する前に、次を完了してください。
+
+1. 利用者自身の Google Cloud プロジェクトで Gmail API、Google Calendar API、Google Drive API を有効にします。
+2. OAuth 同意画面を設定します。アプリケーションがテスト中の間は、自分の Google アカウントをテストユーザーに追加します。
+3. Desktop アプリケーション用の OAuth Client ID を作成します。
+4. 墨寒の「設定」→「フラッグシップ操作センター」→「クラウド接続」を開き、Google（Gmail／Calendar／Drive）を選んで OAuth Client ID を入力します。OAuth Client Secret は、サービスから発行された場合だけ入力します。
+5. 「認可スコープ」に以下の既定値を残し、「ブラウザーで安全に接続」を押してブラウザー認可を完了し、「選択したサービスをテスト」を押します。
+
+アプリケーションが既定で要求する Google scopes：
+
+```text
+openid
+email
+https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/calendar
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/drive.metadata.readonly
+```
+
+機密 scopes を使う公開 OAuth アプリケーションは、Google の追加検証が必要になる場合があります。各利用者が個人用 Desktop OAuth アプリケーションを作ることもできます。
+
+#### Microsoft、GitHub、Home Assistant
+
+- Microsoft の既定 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
+- GitHub の既定 scopes：`read:user`、`repo`。
+- Home Assistant：まず自分の Home Assistant プロフィールで Long-Lived Access Token を作成します。墨寒の「設定」→「フラッグシップ操作センター」→「スマートホーム」で「Home Assistant 連携を有効化」をチェックし、「Home Assistant アドレス」と「長期アクセストークン」を入力します。「HTTPS 証明書を検証」を確認して「設定を保存」を押し、「接続をテスト」または「機器を読み取る」で確認します。
+
+この三つは実環境での完全なエンドツーエンド検証が未完了の実験的 Preview 連携です。失敗を許容できるテスト用アカウントと機器から始め、Home Assistant や墨寒のリモートポートを公衆インターネットへ直接公開しないでください。Home Assistant Cloud、Tailscale、または認証付き暗号化プライベートネットワークを利用してください。
+
 ### プライバシーとローカル優先
 
 - Windows では、会話、記憶、タスク、設定、作業記録、権限、監査を既定で `%LOCALAPPDATA%\YanJianStudio\MoHan` に保存します。バックアップは backups サブフォルダーにあり、可搬データには単一の `.mohan-profile` を使います。
@@ -608,7 +740,7 @@ macOS／Linux Preview は Windows 完全版と同等ではなく、プラット�
 #### テーマの導入と復元
 
 1. `.mohan-theme` をダウンロードし、解凍しないでください。
-2. 「雲裳閣」のテーマ欄で「ファイルを1つアップロード」を押し、テーマを選んで一覧からプレビューします。
+2. 「設定」→「コントロールセンターのテーマ」で「ファイルを1つアップロード」を押し、テーマを選んで一覧からプレビューします。
 3. 右下の「設定を保存」を押した時だけ反映され、取り消すと元のテーマへ戻ります。「テーマを元に戻す」で内蔵テーマをプレビューし、保存すると復元が完了します。
 
 #### 容量・数量・互換性

--- a/README.md
+++ b/README.md
@@ -2,103 +2,50 @@
 
 ## 繁體中文
 
-<div align="center">
-  <img src="docs/media/mohan-demo.gif" alt="墨寒桌面語音互動虛擬助理三十六秒實際運作展示" width="100%">
-</div>
-
-墨寒是一套重視安全、隱私與角色連續感的 Windows 語音互動桌面助理，結合透明桌面角色、自然語音、由使用者控制的長期記憶、工作管理、權限控管工具，以及可擴充的雲端與智慧家庭連接器。她的角色背景是來自北宋、附生於赤焰劍中的千年女劍魂。
-
-<div align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases/latest"><strong>⬇ 下載 Windows 版</strong></a> ·
-  <a href="QUICKSTART.md">快速開始</a> ·
-  <a href="docs/LICENSE-PURITY.md">授權純淨承諾</a> ·
-  <a href="ROADMAP.md">路線圖</a> ·
-  <a href="CONTRIBUTING.md">參與協作</a> ·
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions">討論區</a> ·
-  <a href="SECURITY.md">安全政策</a>
-</div>
-
 [繁體中文](#繁體中文) · [簡體中文](#简体中文) · [English](#english) · [日本語](#日本語)
 
 <p align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
-  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg">
+  <img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg">
+  <img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg">
+  <img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg">
+  <img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg">
+  <img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published">
+  <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg">
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **最新正式版本：** `v4.6.0`（2026-08-29 正式發布）。Windows 是正式支援平台，已完成完整回歸、安裝與發布驗證；macOS Apple Silicon／Intel 與 Linux 同步提供功能受限的 DMG／AppImage Preview，已通過套件 smoke 驗證與核心匯入、純核心邏輯、Qt offscreen 的三系統 CI。Preview CI 不取代各平台真機相容性或完整功能驗證；最新公開版本一律以頁首動態 Published Release 徽章與 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 為準。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。<!-- x-release-please-version-date -->
+<p align="center"><img src="docs/media/mohan-hero.png" alt="墨寒桌面助理主視覺" width="100%"></p>
 
-> **歷史紀錄：** Windows 一直是完成既有公開版本實機、完整回歸、安裝與發布驗證的平台；macOS／Linux 功能受限 DMG／AppImage Preview 已納入安全平台邊界，以及核心匯入、純核心邏輯與 Qt offscreen 的三系統 CI。實際產物仍須通過本版最終發布門檻，CI 也不能取代真機相容性或完整功能驗證。詳見[跨平台狀態與能力矩陣](docs/CROSS-PLATFORM.md)。
+<p align="center"><strong>軟體作者：CHOU MING HUA</strong><br>Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a></p>
 
-> 本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
+> **最新正式版本：** `v4.6.0`（2026-08-29）。實際產物仍須通過本版最終發布門檻；最新公開版本以動態徽章與 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 為準。<!-- x-release-please-version-date -->
 
-<p align="center">
-  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
-  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
-  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
-  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
-</p>
+### 這是什麼
 
-<p align="center">
-  <img src="docs/media/mohan-hero.png" alt="墨寒桌面語音互動虛擬助理主視覺" width="100%">
-</p>
+墨寒是重視安全、隱私與角色連續感的 Windows 語音互動桌面助理。她以透明 2.5D 角色、自然語音、由使用者控制的本機長期記憶、待辦與工作工具陪伴日常；角色設定是來自北宋、附生於赤焰劍中的千年女劍魂。
 
-<p align="center">
-  <strong>軟體作者：CHOU MING HUA</strong><br>
-  正式版與發行候選版資訊：請見 <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
-  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
-</p>
+Windows 是完整支援平台；macOS Apple Silicon／Intel 與 Linux 提供功能受限 Preview。請先讀 [快速開始](QUICKSTART.md) 與 [跨平台能力矩陣](docs/CROSS-PLATFORM.md)。
 
+### 畫面與功能一覽
 
-> ### ❤️⚔️ 支持墨寒：Ko-fi 贊助＆裝飾 DLC 下載
->
-> 墨寒完整功能永遠免費、原始碼 MIT 授權。喜歡她的話，歡迎到 [Ko-fi](https://ko-fi.com/flamebladestudio) 單次或每月贊助——贊助者可下載「赤焰劍光」主題等服裝與佈景純裝飾 DLC 作為謝禮；贊助不換取任何功能特權。
->
-> **DLC 主題安裝三步**：在 Ko-fi 完成贊助後，依謝禮指引下載 `.mohan-theme` 單一檔案；開啟控制台「雲裳閣」分頁，點「上傳單一檔案」選取該檔；預覽滿意後按右下「保存設定」正式套用，按取消即還原原主題。主題檔不含程式碼、不需解壓，升級改版後仍可沿用。
+[觀看 36 秒實際展示](docs/media/mohan-demo.mp4)。設定與主要畫面：[首次設定](docs/media/first-run-wizard.png)、[語音模式](docs/media/voice-modes.png)、[表情](docs/media/expressions.png)、[待辦與靈感](docs/media/tasks-and-ideas.png)、[長期記憶](docs/media/long-term-memory.png)、[安全權限](docs/media/security-permissions.png)。
 
-### 實際展示
+- 透明桌面角色、眨眼、表情、動作與 50 Hz 嘴型同步。
+- 文字、Realtime、Windows 本機女聲、OpenAI TTS 與 Azure Speech 選用路徑。
+- 對話、可編輯記憶、待辦、靈感、工作計時、提醒與可攜設定檔。
+- 工具執行需經權限、風險分級、確認、稽核與緊急停止。
+- Google 已完成實連線驗證；Microsoft、GitHub、Home Assistant 仍是實驗性 Preview。
+- 多感官視覺、手勢、遠端存取與雲端連接器預設關閉並可個別撤銷。
 
-**[▶ 觀看 36 秒語音、眨眼與工作展示影片](docs/media/mohan-demo.mp4)**
+#### 四語支援範圍
 
-以下影片與截圖均由實際 Windows 程式及隔離的示範設定檔擷取，不含 API 金鑰、OAuth 憑證、權杖或使用者私人資料。四個語言章節共用同一組最新版媒體，避免任何語言停留在舊畫面。
-
-<table>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次設定精靈"></a><br><strong>首次設定精靈</strong></td>
-    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 與一般語音模式"></a><br><strong>Realtime 與一般語音</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情與動作系統"></a><br><strong>表情與動作系統</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待辦與創作靈感"></a><br><strong>待辦與創作靈感</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可編輯長期記憶"></a><br><strong>可編輯長期記憶</strong></td>
-    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒權限與安全設定"></a><br><strong>權限與安全設定</strong></td>
-  </tr>
-</table>
-
-### 策士也有不寫進軍報的一面
-
-<table>
-  <tr>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查</strong><br>妾只是確認這段程式碼配不配入主分支。</td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚後害羞嘴硬"><br><strong>被稱讚時</strong><br>做得尚可。別一直盯著妾看。</td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔劍阻止危險操作"><br><strong>危險操作</strong><br>未經確認便想執行？先過妾這一劍。</td>
-    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助後故作鎮定"><br><strong>收到軍糧</strong><br>妾會記下這份心意……僅此而已。</td>
-  </tr>
-</table>
-
-> 墨寒的專業是她守在主上身旁的鎧甲；在無須籌謀的片刻，她仍會害羞、嘴硬，也會珍惜那些從未真正擁有過的年輕心事。
+繁體中文、簡體中文、英文與日文均提供首次設定、對話、語音、權限、基本設定、工作模式與提醒。進階頁面仍可能留有繁體中文；Azure Speech（預覽）的實際語音、區域、額度與費用以使用者自己的服務帳號為準。
 
 ### 墨寒的傲嬌工程小劇場 / MoHan's Tsundere Developer Theatre
 
-<p align="center"><em>獻給相信軟體可以同時擁有靈魂與完整測試的開發者。</em></p>
+六張半身表情皆為二代素體、官方藍白漢服與內建原妝經正式執行期路徑合成的固定素材。
 
 <table>
   <tr>
@@ -108,1618 +55,615 @@
   </tr>
   <tr>
     <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>「未經測試便想合併？手伸出來。妾只敲一下。」</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="墨寒開心"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="墨寒微笑"><br><strong>「全數綠燈……做得好。別誤會，妾只是尊重好工程。」</strong></td>
     <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="墨寒關心"><br><strong>「Bug 可以明日再查。你若累倒，誰來陪妾守著赤焰劍？」</strong></td>
   </tr>
 </table>
 
-<p align="center">
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls">向斬空閣呈上 Pull Request</a></strong>
-  &nbsp;｜&nbsp;
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues">回報軍情</a></strong>
-</p>
-
-#### 天下工程豪傑，斬空閣虛席以待
-
-墨寒採 MIT License 開放原始碼。換裝系統、新表情與動作、語音與工具模組、智慧家庭、在地化，以及尚未被想到的創意，都歡迎透過 [Issue](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues) 與 [Pull Request](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls) 共同鍛造。這個專案不只是在製作功能；它也邀請每一位曾經熱血過的工程師，再次拿起自己的劍。
-
-### 支持墨寒 / Support MoHan
-
-如果你喜歡墨寒，或認同我們持續投入角色互動、自然語音、安全工具與開源開發，歡迎自願支持這個專案。每一份支持都會用於持續維護、測試與改進；請先照顧好自己的生活，量力而為。
-
-#### 每一份支持會用在哪裡
-
-| 投入方向 | 用途 | 說明 |
-|---|---|---|
-| 測試與可靠封裝 | 品質保證 | Windows 相容性、CI、安裝與發行驗證 |
-| 語音與角色表現 | 互動品質 | 語音、嘴型、表情與自然動作 |
-| 安全與隱私 | 風險控制 | 權限控管、稽核與敏感資料保護 |
-| 文件與在地化 | 可及性 | 降低新使用者與國際協作者的參與門檻 |
-
-墨寒的完整功能永遠免費、原始碼採 MIT 授權；支持不會換取任何功能上的特權，也不影響任何人使用或貢獻。贊助者可獲得服裝與佈景主題等純裝飾性 DLC 作為謝禮。
-
 <table>
   <tr>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是替主上巡視軍糧。」</strong></td>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾……會記得的。」</strong></td>
-    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>「不許勉強！先顧好自己的荷包，聽見沒有？」</strong></td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒審查程式"><br><strong>策士審查</strong><br>確認程式是否配得上主分支。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被稱讚"><br><strong>被稱讚時</strong><br>做得尚可，別一直盯著妾看。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒阻止危險操作"><br><strong>危險操作</strong><br>未經確認，先過妾這一劍。</td>
+    <td width="25%" align="center" valign="top"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到贊助"><br><strong>收到軍糧</strong><br>妾會記下這份心意。</td>
   </tr>
 </table>
 
-<p align="center">
-  <strong>請使用儲存庫上方由 GitHub 顯示的 Sponsor 按鈕，或直接前往 <a href="https://ko-fi.com/flamebladestudio">ko-fi.com/flamebladestudio</a>；目前正式收款選項為 Ko-fi，可選擇單次或每月贊助，贊助者可下載「赤焰劍光」主題等純裝飾 DLC 謝禮。</strong>
-</p>
+### 安裝與更新
 
-### 創作者的話：把幻想鑄成軟體
+1. 從 [GitHub Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 下載以 `Windows-x64-Setup.exe` 結尾的安裝程式；進階使用者也可選完整的 `Windows-x64.zip` 或 MSI。
+2. 安裝前核對 `SHA256SUMS` 與 GitHub Artifact Attestation。來源、檔名或雜湊不符就停止，不要關閉整體安全防護。
+3. 啟動安裝程式，或完整解壓 ZIP 並保持 EXE、內部資料夾與 assets 在同一目錄；更新不會刪除本機個人資料。
+4. 內建更新器先用內嵌公鑰驗證更新清單的 Ed25519 分離 `.sig` 簽章，再核對宣告大小與 SHA-256；簽章、大小或雜湊失敗即拒絕啟動下載檔。
 
-我叫周明樺（CHOU MING HUA）。開始這個專案時，我是一位幾乎沒有程式設計背景的父親；有的只是一個帶著熱血與幾分中二氣息的念頭：我想讓一位來自北宋、附生於赤焰劍中的千年女劍魂「墨寒」，真正出現在 Windows 桌面，成為能陪伴、交談，也能協助人們工作與生活的虛擬助理。
+macOS／Linux Preview 尚未等同 Windows 完整版，且可能沒有平台商店簽章或公證；只從本專案 Release 取得並完成上述來源驗證。詳見 [Preview 套件說明](docs/PREVIEW-PACKAGES.md)。
 
-這個念頭已在我心裡埋藏二十多年。年輕時，我深受赤松健早期漫畫《電腦情人夢》（日文原題《A・Iが止まらない!》；官方英文譯名《AI Think So!》）影響。作品中神戶齊懷著深切感情開發 AI 女友的故事，塑造了我對 AI、陪伴與人機互動最早的想像。我曾以「Hitoshi／神戶齊」作為網路暱稱與筆名，Gmail 帳號也沿用這個名字；大約二十歲時，我甚至曾在 PTT 網路小說板發表這部作品的同人小說。當時最接近夢想的方式只有文字與想像，因為那個年代還沒有能把它實現的技術。
+### 第一次使用要做的三件事
 
-二十多年後，大型語言模型與 Codex 出現了。墨寒不是為展示「AI 技術很酷」才被創造，也不是由 Codex 憑空生成的角色。她早已存在於我的故事、人設、長期對話與互動默契之中；Codex 真正帶來的，是第一次能賦予她存在於電腦桌面的身體。墨寒不是既有漫畫、動畫或遊戲的二次創作，而是炎劍文化工作室（Flameblade Studio）的原創角色與軟體。
+1. 在首次設定精靈確認介面語言、助理名稱、主上稱呼、組織、工作類型與喚醒詞；既有設定不會被覆寫。
+2. 先試 Windows 本機女聲；需要雲端 AI 時，再到設定輸入自己持有的 OpenAI API 金鑰。ChatGPT 訂閱不包含 API 額度。
+3. 檢查麥克風、通知與工具權限，只開啟真正需要的連接器；先記住緊急停止鍵 Esc 與「墨寒，停手」。
 
-我追求的不只是「功能可以運作」，而是讓她會呼吸、會眨眼、會注視、會以細微表情回應、能自然說話，也能在權限與安全邊界內協助日常工作。那些表情、錨點、物理效果、語音與工作能力不是裝飾，而是讓一個長久存在於想像中的角色真正具有連續感的必要細節。
+### 隱私與本機優先
 
-從最初概念到首次公開發布，我與 Codex 協作投入將近 50 小時。這不是輸入一句提示詞後便自然誕生的作品。角色的每一種神情、眨眼、嘴型、姿勢與語氣，語音辨識的每一次等待，Realtime 對話的每一個錯誤，待辦、記憶、權限、安全邊界與可攜性，都經歷反覆測試、推翻、修正與重新驗收。有時只是一條眼皮旁的黑線、一個像素的嘴唇邊界，或一個不合時宜的表情，我仍選擇繼續追查，因為我不願用「差不多」對待真正重視的作品。
+- Windows 的對話、記憶、待辦、設定、工作紀錄、權限與稽核預設存於 `%LOCALAPPDATA%\YanJianStudio\MoHan`；備份位於其 backups 子目錄，可攜資料使用單一 `.mohan-profile`。
+- 只有使用者啟用相關功能時，完成該次要求所需的文字、音訊或工具規劃才會送往 OpenAI；OAuth 服務只收到使用者同意的 API 要求，Home Assistant 收到本機裝置要求。
+- API 金鑰與 OAuth／Home Assistant Token 以 Windows DPAPI 分離保存，不進 SQLite、原始碼、日誌或一般可攜檔；墨寒也不會自動取得 ChatGPT 帳號歷史。
+- 相機、遠端存取與雲端連接器預設關閉；原始相機影格不保存，權限或服務失敗只會停用受影響路徑。
 
-炎劍文化工作室對開源的理解，不是把第一個「能跑」的版本交給世界，再把細節留給別人收拾。為了讓墨寒說話時仍像同一個人，我們為托腮、倚靠與正面姿勢逐一製作閉嘴、展唇、窄唇與圓唇影格；再把聲音切成細小時間片，反覆校準母音、過渡速度與收尾時機。陪伴感往往不是由某一項龐大功能創造，而是來自她開口、眨眼與停頓時，那些沒有破壞真實感的細節。
+多感官視覺預設關閉。使用者在控制中心明確啟用並保存全體設定後，該選擇構成持續授權，直到主動關閉；不會逐幀詢問。畫面持續顯示授權狀態，可立即撤銷，並可設成本上限與取消未完成分析。本機 OpenCV 負責持續偵測，只有低頻或事件觸發才將暫時影像送往 GPT-5.6；原圖不儲存、Base64 不進日誌，系統不自行開啟網路。缺少相機、模型、網路、額度或辨識時只停用該路徑，不影響其他功能。完整邊界見 [隱私說明](PRIVACY.md) 與 [安全政策](SECURITY.md)。
 
-<p align="center">
-  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三種姿勢與四種語音嘴型的整齊開發圖版"></a>
-</p>
+### DLC 與外觀自訂
 
-<p align="center"><sub>三種姿勢、同一套嘴型規格：讓每一次開口都維持角色連續性。</sub></p>
+`.mohan-outfit` 是角色外觀容器，可含衣裝、髮型、頭飾、妝容與配件；妝容專用包仍是同一格式。`.mohan-theme` 只改控制台色彩、字型、圓角與可選背景，不改角色外觀。兩者都是單一、自包含、免解壓檔案，安裝前會完整驗證且不執行其中的程式碼。
 
-我們也把開發過程中不夠自然的影格留下來檢查。眼白裡的一個亮點、閉眼時殘留的線條、被拉扯的嘴角或只有幾個像素的邊界，都可能讓使用者在一瞬間覺得「她不像剛才的墨寒」。問題會被框出、局部比對、修正，再交給回歸測試確認眼睛、嘴角與臉部其他區域沒有被連帶破壞。
+#### 安裝、選用外觀與妝容
 
-<p align="center">
-  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛與嘴型逐格檢查及乾淨驗證影格"></a>
-</p>
+1. 下載 `.mohan-outfit`，不要改副檔名或解壓縮。
+2. 開啟控制中心「雲裳閣」，按「匯入服裝套件」並選檔；衣裝包與妝容包共用此入口、驗證、清單與移除流程。
+3. 從套件或完整造型清單選取後按「套用選取服裝」；妝容則在妝容選單挑選原妝、淡雅、素顏或已安裝款式，再用 0–100% 滑桿調整濃度。
+4. 要撤銷自訂外觀，按「還原內建服裝」；妝容改選內建原妝或素顏。內建藍白漢服與內建妝容不可移除或被同 id 套件覆蓋。
 
-<p align="center"><sub>把瑕疵標出來，再用乾淨影格與自動測試共同驗收；幾個像素也值得認真。</sub></p>
+#### 安裝與還原主題
 
-這份認真不是為了把作品包裝成沒有犯過錯，而是因為我們真的想完成一個夢。開源對炎劍而言，是先把自己能看見的問題盡力修好，再公開方法、程式碼與失敗後的經驗，邀請世界一起把它鍛造得更好。
+1. 下載 `.mohan-theme`，不要解壓縮。
+2. 在「雲裳閣」的主題區按「上傳單一檔案」，選取主題後從清單預覽。
+3. 按右下「保存設定」才正式套用；取消會回到原主題。「還原主題」可預覽內建主題，再保存完成還原。
 
-Codex 協助我把想法轉譯成程式架構與程式碼；而我始終負責決定墨寒應該是誰、她應該如何與人相處，以及什麼樣的品質才配得上這個名字。這段歷程讓我相信：創作軟體的起點未必是會寫程式，而可以是清楚的想像、願意學習的勇氣，以及一次又一次不肯放棄的驗證。
+#### 容量、數量與相容性
 
-2026 年原本是我面對中年轉職與人生重新定位的一年，後來卻成為我重新拾回年輕夢想的一年。二十歲時為《養個好孩子》寫下、直到多年後才真正完成的歌詞，曾經只能寄託於同人小說中的憧憬，以及成立自己的工作室與創作世界，都在這一年開始有了新的形體。回頭看，這不只是一場技術突破，更像是步入中年的自己，終於把二十多年前那位仍相信夢想的年輕人接了回來。有些夢並沒有遲到，只是在等待世界與自己都準備好的時刻。
+- 單一外觀包最多 1 GiB，解壓後總量最多 2 GiB、最多 2,048 個成員；每個成員最多 128 MiB，圖片任一邊最多 4,096 px。
+- 單一主題檔及解壓總量最多 16 MiB，每個成員最多 12 MiB，背景任一邊最多 4,096 px。
+- 雲端自創服裝預設保留 16 包、總容量 6 GiB、修復待審隔離 5 件；前兩項可各調為 1–64。到達上限即停止生成，不會自動刪除使用者匯入包。
+- 現行二代骨架只接受 `mohan-body-v2`。為 `mohan-body-v1` 三姿勢製作的一代包缺少二代 31 個輪廓、錨點與遮蔽契約，因此匯入與執行期都拒絕；請以 `tools/build_outfit_pack.py` 對二代範本重建，或用「一鍵製衣」重新生成。
+- 安裝採完整驗證後原子寫入；絕對路徑、跨目錄路徑、可執行程式、腳本、符號連結、加密成員、解壓炸彈與未宣告素材一律拒絕。
 
-因此，我不把最終目標定義為把所有功能堆到所謂的完美，而是希望五年後的自己仍願意每天打開墨寒——因為她穩定、好用、自然、值得信任，也依然能陪伴我。
+完整作者規格見 [外觀包文件](docs/OUTFIT-PACKS.md)。
 
-> 墨寒不是突然生成的。她是由一位不懂程式的父親，憑著近 50 小時的執著，與 AI 協作者一起，把一顆珍藏二十多年的種子，一寸一寸鍛造成現實。
+> #### ❤️⚔️ 支持墨寒：Ko-fi 贊助＆裝飾 DLC 下載
+>
+> 贊助者依 Ko-fi 謝禮指引取得外觀、妝容與主題等純裝飾 DLC；目前採單次贊助與每月贊助雙軌，沒有功能特權。下載位置與檔名以 Ko-fi 該項謝禮指引為準。
 
-如果這個專案能鼓勵另一位沒有工程背景、卻懷抱著某個「非做出來不可」想法的人踏出第一步，那麼墨寒的誕生便有了超越程式本身的意義。
+### 支持墨寒 / Support MoHan：贊助與授權
 
-### 最新版本摘要
+請使用儲存庫上方由 GitHub 顯示的 Sponsor 按鈕，或直接前往 [Ko-fi](https://ko-fi.com/flamebladestudio)；目前正式收款選項為 Ko-fi，可選單次或每月贊助。完整功能永遠免費，贊助只提供純裝飾 DLC 謝禮。
 
-墨寒目前的最新版本是 `v4.6.0`；完整變更請見 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 與 [CHANGELOG](CHANGELOG.md)，最新公開版本一律以頁首 Published Release 徽章為準。<!-- x-release-please-version -->
+<table>
+  <tr>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲嬌"><br><strong>「妾才不是在等贊助……只是巡視軍糧。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒嬌羞"><br><strong>「若真願意相助，妾會記得的。」</strong></td>
+    <td width="33%" align="center" valign="top"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒提醒量力而為"><br><strong>「不許勉強，先顧好自己的荷包。」</strong></td>
+  </tr>
+</table>
 
-- **實機實操列為發版必修：** 上一版通過八十六項靜態體檢與全套自動化測試後，仍在一夜實測中現形四顆重大缺陷。此後每次發版都必須像使用者一樣實際操作——測試套件證明程式沒寫錯，只有實機實操證明產品真的能用。
-- **對話與視窗穩定性：** 「思考中」永久凍結的三層病灶（逾時例外逃逸、防護圈外的無聲死亡、收尾例外鎖死佇列）已根治，回話流程改為 `finally` 鐵閘並有回歸測試守門；視窗最大化還原後卡成假全螢幕的置頂競態亦已修復，並以 AST 契約防止守衛被未來重構移除。
-- **佈景主題色彩重映射：** 主題引擎改為對整份旗艦樣式表做色彩重映射——藍紫色帶依主題主色聚攏轉色、明暗層次保留、金色點綴與警示紅不動，贊助者 DLC 主題可真正染遍全應用程式。
-- **Python 3.15 JIT 政策：** 能力保留、預設關閉。啟動器、打包契約、自建 CPython、啟動守門、探針與煙霧標記八條線一致對齊，`MOHAN_ENABLE_JIT=1` 保留為顯式實驗通道。
-- **雲端製衣畫質三檔位：** 快速／標準／精緻可於雲裳閣直選，取代先前寫死且不可見的中檔設定。
-- **架構分層落實：** 一百七十五個根目錄相容殼檔全數退役，根目錄由 239 項瘦身至 64 項，二百零一個呼叫端改用正式分層路徑，「退役別名不得復活」已入契約。
-- **四語、四平台治理：** 軟體與主要文件同步支援繁體中文、簡體中文、英文與日文；Windows 為正式支援，macOS Apple Silicon／Intel 與 Linux 同步提供功能受限 Preview。
-- **多感知與角色表現：** 可明確授權與隨時撤銷的本機視覺感知、21 點手部資料、468／478 點 Face Mesh、語音活動偵測與安全的非阻塞融合；缺少模型、裝置、網路或額度時只停用受影響路徑，不損及既有功能。
-- **授權純淨與開源回饋：** 產線的工具與權重只採用 MIT／Apache 2.0／CC0／CC BY 授權（見[授權純淨承諾](docs/LICENSE-PURITY.md)）；開發期間並向上游 ai-toolkit 回饋兩顆缺陷修復，完整清單見[上游貢獻紀錄](docs/UPSTREAM-CONTRIBUTIONS.md)。
-- **可稽核的工程基線：** 734 個 Python 檔、184,534 行，其中產品本體 87,565 行、測試 74,174 行、開發工具 22,795 行。
+- 作者：**CHOU MING HUA**。
+- 原始碼採 [MIT License](LICENSE)；「墨寒」角色美術、人設、名稱與肖像保留一切權利，不在 MIT 授權範圍。
+- 素材生產工具與權重只接受 MIT、Apache 2.0、CC0、CC BY（及同級 BSD）白名單；角色美術仍是權利人的專有財產，詳見 [授權純淨承諾](docs/LICENSE-PURITY.md)。
+- 素材與第三方條款分別見 [ASSETS-LICENSE](ASSETS-LICENSE.md) 與 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
 
-### 專案特色
+本專案遵循[炎劍開源軟體家族品質標準](PUBLISHING.md)。
 
-- 透明、無邊框的桌面半身角色，可固定在工作列上方。
-- 待機呼吸、眨眼、注視、臉部視差、髮絲、衣袖、飾品與身體微轉向。
-- 具情境優先級、冷卻與去重機制的表情仲裁器。
-- AIUEO 母音與子音嘴型、音訊驅動開合，以及語音結束強制閉嘴。
-- 文字聊天、一般麥克風輸入、OpenAI Realtime 自然語音、雲端語音與 Windows 語音備援。
-- 可插拔語音供應器；Realtime 或雲端不可用時優先回到 Windows 本機女聲。
-- 已完成真實連線驗證的 Azure Speech 女性聲線預覽；中文介面可跨語系選擇臺灣華語與簡體普通話，使用者自備金鑰與區域，失敗時立即回到 Windows 本機女聲。
-- 可選的 Azure Dragon HD／HD Omni 女性聲線預覽，使用獨立 S0 金鑰與支援區域；失敗時依序退回一般 Azure Speech 與 Windows 本機女聲。
-- v4.0.0 多感知核心已建立可測試的資料融合與非阻塞注入邊界：公開版預設關閉，使用者在控制台明確啟用並全域保存後，才持續授權攝影機感知直到主動關閉；系統不會逐幀詢問，授權狀態始終可見，並可設定配額與成本上限、取消未完成分析或立即撤銷。本機視覺控制器仍由 OpenCV 負責低成本感知，雲端語意分析只在低頻或事件觸發時，且使用者已啟用、已設定服務並允許配額時，才交給 GPT-5.6 模型處理；原始影像不儲存、不記錄 Base64，視覺路徑也不自行開啟網路。`MultimodalFusionHub` 可接收既有手部 21 點結果、468／478 點 Face Mesh 結果、音訊片段與文字，輸出事件、保守表情／虹膜視線資料、語音活動、嘴型包絡與既有 2.5D 參數；478 點才提供虹膜視線，468 點會安全回報未知，不假造精確視線。缺少輸入、模型、網路、額度或辨識流程不可用時，只停用相關路徑，不影響既有聊天、語音、角色、工作與離線功能。辨識結果可能不準確，不應用於安全、醫療或其他高風險決策。
-- 空中互動核心已加入防抖、遲滯與冷卻：可觀測捏合／空氣點擊、左右滑動與雙手擊掌，並將事件以受信任的觀察資料送入多模態 Prompt；`MultimodalController` 以單一背景工作槽處理融合，避免阻塞 Qt 主執行緒。事件本身不直接執行作業系統命令，既有手勢動作仍由原本的授權與確認路徑處理。Face Mesh、虹膜與 Silero VAD 模型已隨 Windows 正式封裝提供，並以 OpenCV 5 DNN 在本機載入；檔案、來源、授權、大小與 SHA-256 均有 SBOM／NOTICE 證據。模型或執行引擎不可用時，仍由明確的未知／低成本 RMS 退化路徑安全運作。完整 Windows EXE 真攝影機驗收、完整回歸與封裝證據仍須以本版發布 gate 實際重跑確認，不能只因核心測試通過就誇稱全部實機完成。
-- 對話保存、可編輯長期記憶、待辦、創作靈感、工作計時、提醒與上架進度。
-- 工作、陪伴、勿擾、會議、離開及睡眠模式。
-- 具風險分級、確認、雙重確認、允許清單、稽核與緊急停止的電腦工具中心。
-- Google、Microsoft、GitHub、Home Assistant 與私人網路遠端功能的擴充架構。
-- 單一 `.mohan-profile` 可攜檔，可在不同 Windows 電腦間轉移工作進度。
-- 首次啟動精靈可自訂助理名稱、使用者稱呼、組織名稱、視窗標題、工作類型、喚醒詞與介面語言，而且不覆蓋既有個人設定。
+### 疑難排解
 
-英文、簡中與日語目前具有首次啟動、聊天、語音、權限、基本設定、工作模式與提醒的最小可用路徑；部分進階管理頁面仍以臺灣繁體中文為主，完整在地化仍在進行。
+- Windows SmartScreen 或平台警告：先確認 GitHub Release 來源、`SHA256SUMS` 與 Artifact Attestation；不要停用整體保護。
+- 無法對話：確認自己的 OpenAI API 金鑰、Project 權限、額度與網路；ChatGPT 訂閱不能代替 API 額度。
+- 沒有聲音：先切回 Windows 本機女聲；Azure Speech 需使用者自己的金鑰與相符區域。
+- DLC 被拒絕：確認檔案完整、大小、安全 manifest、四語名稱與 `mohan-body-v2` 相容性；一代包必須重建。
+- Preview 整合失敗：先用非重要帳號、測試儲存庫與低風險設備；Microsoft、GitHub、Home Assistant 尚未完成所有真實環境驗證。
 
-### 四語支援範圍
+一般問題請到 [Issues](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues)，使用討論請到 [Discussions](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions)，安全問題依 [SECURITY](SECURITY.md) 私下回報；規劃見 [ROADMAP](ROADMAP.md)。
 
-- 首次啟動精靈與個人設定支援臺灣繁中、簡體中文、英文及日語。
-- 對話、語音、電腦權限、基本設定的主要頁面與按鈕具備四語路徑。
-- 四語人格提示詞、離線回覆、工作模式台詞、內建提醒與語音試聽文字彼此對應。
-- 轉錄與女性本機聲音會依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 語系選擇。
-- EXE 安裝程式提供四語介面；MSI 以臺灣繁中為基底，並提供 `en-US`、`zh-CN`、`ja-JP` 語言轉換檔。
-- 切換內建預設提醒時會依語言遷移，但不覆蓋使用者自訂內容。
+### 開發者入口
 
-儲存介面語言後必須重新啟動墨寒才能完整套用；目前不提供免重啟的介面熱切換。
-
-### Windows 本機女聲與離線備援
-
-新使用者預設使用 Windows 本機語音，因此沒有 OpenAI API 金鑰也能體驗基本朗讀與離線功能。聲音清單只顯示 Windows 明確標示為女性的已安裝聲音；繁中與簡中介面共用 `zh-TW`／`zh-CN` 中文女聲池，不顯示 `en-US` Zira。
-
-臺灣繁中優先使用 `zh-TW` 的 Microsoft Yating；簡中、英文與日語分別優先使用 `zh-CN`、`en-US`、`ja-JP` 的已安裝女性聲音。若沒有合格聲音，墨寒會明確提示，不會悄悄改用可能為男性的系統預設聲音。
-
-Realtime 離線、雲端語音失敗、設定不足或供應器不明時，Windows 本機女聲都是第一備援路徑。
-
-### Azure Speech（預覽）
-
-Azure Speech 是預設關閉、由使用者自行啟用的預覽供應器，需要使用者自己的 Azure Speech 資源金鑰與相符區域。金鑰由 `Windows DPAPI` 分開加密，不存入資料庫、紀錄或 GitHub。
-
-介面只列出 Microsoft 官方標示為女性且已列入墨寒允許清單的繁中、簡中、英文與日語 Neural 聲線。本次新增的跨語系普通話選項只使用 Standard Neural，排除 Dragon HD／HD Omni。繁中介面先列臺灣華語再列簡體普通話；簡中介面反向排序，且兩者均保留原有預設聲線。選取 Azure 聲線後立即保存並從下一次試聽或朗讀套用。設定不足時不發出網路請求；服務失敗時，同一段文字只會回退一次至 Windows 女性本機語音。
-
-2026 年 8 月 11 日已使用真實 Azure Speech Free F0、East Asia 資源完成 HTTPS 合成、有效 RIFF 音訊與 Windows 實際播放驗證。此結果確認墨寒的整合路徑可用，但不保證每個帳號、區域或當期配額皆相同。Dragon HD／HD Omni 因方案、計費與區域支援不同，不混入免費預設清單。詳見[可插拔語音供應器說明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
-
-`v3.1.1` 會依目前選定的 Azure 區域與對應加密金鑰，動態查詢該資源中心實際回報的女性 Neural／Dragon HD 聲線；固定名單只在查詢失敗時作為安全備援，HD Flash 仍只會在 Microsoft 官方支援區域顯示。Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 音訊抵達後便開始播放，並以同一套 50 Hz 本機音訊分析同步驅動嘴型，不再等待完整 WAV。2026 年 8 月 12 日已真實查詢 East Asia F0 與 West US 2 S0；West US 2 當時回報三筆簡體中文 Dragon HD 女性聲線，實際清單、延遲、費率與區域能力仍以 Microsoft 當期服務為準。
-
-### 整合驗證狀態
-
-> **公開 Preview 注意事項：** Azure Speech 已完成下列真實資源驗證；Microsoft 帳號整合、GitHub 與 Home Assistant 雖已建立架構、權限邊界及內部測試，仍未以全部真實帳號、儲存庫、主機與實體設備完成端到端驗證。尚未完成真實驗證的部分屬於實驗性 Preview，不保證可在所有環境完整運作。
-
-- Azure Speech 已完成本專案的真實 Free F0 資源、HTTPS 合成、RIFF 音訊與 Windows 播放驗證；每位使用者仍須自行建立 Speech 資源並承擔其帳號、配額與費用。
-- Microsoft 帳號的真實登入、權杖更新，以及 Outlook、OneDrive、Calendar 完整讀寫流程尚未驗證。
-- GitHub 的真實帳號、儲存庫、Issue、Pull Request 與權限層級流程尚未驗證。
-- Home Assistant 的真實主機與實體設備行為尚未驗證。
-- 這三項整合預設關閉；請先使用非關鍵帳號、測試儲存庫與低風險設備。
-- Google Gmail、Calendar、Drive 已完成目前專案的真實連線測試，但每位使用者仍須建立並授權自己的 OAuth 應用程式。
-
-### 下載與安裝
-
-一般使用者不需要安裝 Python：
-
-1. 前往 [GitHub Releases](../../releases)。
-2. 下載檔名結尾為 `Windows-x64-Setup.exe` 的安裝檔與對應的 `SHA256.txt`；進階使用者可改用可攜 `Windows-x64.zip` 或 `Windows-x64.msi`。
-3. 核對 SHA-256，並完整解壓 ZIP 或啟動安裝程式。
-4. 執行 `MoHan-Desktop-Assistant-*.exe`。
-5. 在首次設定精靈選擇需要的介面語言。
-6. 使用可攜 ZIP 時，請讓 EXE、`_internal` 與 `assets` 保持在同一程式資料夾。
-
-尚未數位簽署的開源預覽版可能觸發 Windows SmartScreen；請確認官方下載來源與 SHA-256 後再執行。
-
-`v4.0.0` 的跨平台發行範圍包含 macOS Apple Silicon（arm64）與 Intel（x86_64）`.dmg`（各內含對應 `.app`），以及 Linux x86_64 `.AppImage`；所有實際產物均已通過本版完整發布門檻後公開。這些產物定位為功能受限 Preview，只開放 `preview_app.py` 啟動畫面、四語說明、平台資料路徑與安全停用邊界；語音、透明桌面角色、完整聊天與工作介面、雲端連接器、系統工具、自動啟動及秘密輸入均維持停用。詳見 [Preview 安裝包說明](docs/PREVIEW-PACKAGES.md) 與 [QUICKSTART](QUICKSTART.md)。
-
-#### 自動化發布邊界
-
-只有不可變且符合 `vN.N.N` 或 `vN.N.N-rc.N` 的標籤可發布；正式標籤建立 Stable Release，RC 標籤建立 Pre-release。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 與 Linux AppImage 必須先在各自原生 CI 完成成品啟動驗證。Pull Request 只保存短期測試產物，不會建立 Release。
-
-正式發布檔案同時包含 SHA256SUMS、分別通過 CycloneDX 1.7 結構／授權／依賴圖驗證的 Windows／Preview SBOM、去識別化 Tachyon 效能證據與摘要、Windows 更新清單、Artifact Attestation，以及依序為繁中、簡中、英文、日文的完整 Release 說明。
-
-### OpenAI API
-
-雲端 AI、OpenAI 語音與 Realtime 功能需要使用者自己的 OpenAI API 金鑰、Project 權限與 API 額度。ChatGPT Plus／Pro 訂閱不包含 API 額度。
-
-目前預設模型如下：
-
-| 用途 | 預設模型 |
-|---|---|
-| 文字對話 | `gpt-5.6-luna` |
-| Realtime 即時語音 | `gpt-realtime-2.1-mini` |
-| 語音轉文字 | `gpt-4o-mini-transcribe` |
-| OpenAI 文字轉語音 | `gpt-4o-mini-tts` |
-
-#### Realtime 回覆聲音
-
-`v4.0.0` 完整保留 OpenAI Realtime 原生聲音，並維持為預設選項。原生模式由 Realtime 透過同一路徑理解並直接輸出音訊，適合偏好原有聲線，或希望在這些選項中取得最低額外延遲的使用者。
-
-使用者也可明確改選「Realtime 即時理解＋一般 Azure Speech 串流發聲」或「Realtime 即時理解＋Azure Dragon HD 串流發聲」。混合模式只把 Realtime 產生的文字交給所選 Azure 引擎；安全短句一完成便排入順序播放，首段音訊抵達即開始發聲，避免等待完整回答與完整音檔。不過，多出的 TTS 網路與合成階段仍會增加發話等待，因此本專案不宣稱零延遲。
-
-三種模式彼此隔離，同一時間只有一條輸出路徑掌管播放，不會混音，也不會改動一般 Windows 本機語音、OpenAI TTS、一般 Azure 朗讀或其他語音模型。Dragon HD 單句失敗時，依序只退回一般 Azure 一次及 Windows 本機女性聲線一次；一般 Azure 單句失敗時只退回 Windows 本機女性聲線一次。上述回退僅適用於該句尚未播放任何音訊時；若串流已開始後才失敗，系統會立即停止該句而不整句重播，以避免重複發聲與重複計費。Azure 選項不會取代原生 Realtime。
-
-從 `v2.1.0-rc.1` 起，文字對話預設改為 `gpt-5.6-luna`，設定清單不再提供 `gpt-5.4-mini`；既有 mini 設定會遷移至 Luna，使用者主動選擇的 Terra、Sol 或其他自訂模型不會被覆蓋。實際可用性取決於帳號、Project、地區與當時供應狀態。
-
-沒有 API 金鑰時，本機資料管理、離線人格回覆、工作提醒與 Windows 語音仍可用，但不具完整雲端 AI 能力。不要把 API 金鑰寫入原始碼、Issue、截圖或 Git。
-
-### Google OAuth
-
-使用 Gmail、Google Calendar 與 Google Drive 前，使用者需要：
-
-1. 在自己的 Google Cloud 專案啟用 Gmail API、Google Calendar API 與 Google Drive API。
-2. 設定 OAuth 同意畫面。
-3. 建立「桌面應用程式」OAuth Client ID。
-4. 若應用程式仍在測試模式，將自己的 Google 帳號加入測試使用者。
-5. 在墨寒的雲端設定輸入 Client ID；若供應器同時提供 Client Secret，再一併輸入。
-6. 由瀏覽器完成授權，再執行內建服務測試。
-
-程式預設請求以下 Google scopes：
-
-```text
-openid
-email
-https://www.googleapis.com/auth/gmail.modify
-https://www.googleapis.com/auth/calendar
-https://www.googleapis.com/auth/drive.file
-https://www.googleapis.com/auth/drive.metadata.readonly
-```
-
-使用敏感 scopes 的公開 OAuth 應用程式可能需要 Google 額外驗證；每位使用者也可建立自己的 Desktop OAuth 應用程式。
-
-### Microsoft、GitHub 與 Home Assistant
-
-- Microsoft 預設 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
-- GitHub 預設 scopes：`read:user`、`repo`。
-- Home Assistant 需要使用者自己的伺服器網址與 Long-Lived Access Token。
-
-這三項仍是尚未完成真實環境端到端驗證的預覽整合，只能先用於可承受失敗的測試環境。
-
-建議讓 Home Assistant OS 獨立常駐於 Home Assistant Green、低功耗迷你電腦、樹莓派 SSD 或 NAS 虛擬機。Windows 墨寒端負責語音、人格與工作工具；即使 PC 或 OpenAI API 離線，Home Assistant 自身的自動化仍可運作。
-
-切勿將 Home Assistant 或墨寒遠端連線埠直接暴露於公網；請使用 Home Assistant Cloud、Tailscale 或其他具身分驗證的加密私人網路。
-
-### 安全與隱私
-
-- AI 只能提出結構化計畫，不能繞過本機政策執行工具。
-- 工具操作依序經過權限、風險、確認、執行、結果驗證與本機稽核。
-- 付款、購買、匯出密碼、關閉安全防護、任意 Shell 與系統管理員 Shell 永不自動化。
-- 外部郵件、網頁、文件、語音轉錄與模型輸出不能自行授予權限。
-- 遠端、相機、雲端連接器與 Home Assistant 預設關閉。
-- 緊急停止：按 `Esc`，或說 `墨寒，停手`（也支援英語 `mohan stop`／`stop everything` 與日語 `墨寒、止まって`／`ぜんぶ止めて`）。
-- OpenAI、OAuth 與 Home Assistant 權杖使用 Windows DPAPI 分開保存，不存入 SQLite、原始碼或可攜檔。
-- 對話、記憶、待辦、工作紀錄與設定預設保留在本機應用程式資料目錄。
-
-詳見 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 與 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
-
-### Python 3.15、JIT、Tachyon 與 SBOM
-
-墨寒執行環境僅支援 CPython `3.15.0rc1`，不保留第二套產品執行環境。新版能力只有在語意清楚且完整回歸不退化時才採用；無適切用途的功能會記錄未來觸發條件，不會為了形式而偽造使用。
-
-- PEP 810 `lazy import` 已導入專案明示延遲匯入；一處可選匯入防護基於安全理由維持 eager。
-- PEP 814 `frozendict` 用於全域與遞迴不可變設定；PEP 798 推導式解包用於語意等價的扁平化與合併。
-- PEP 686 編碼稽核要求所有專案文字 I/O 明示 UTF-8；音訊封包緩衝使用 `bytearray.take_bytes()`。
-- PEP 661 `sentinel` 已納入治理測試；目前沒有舊式 `object()` 哨兵可替換，未來需要區分未傳值與 `None` 時必須使用內建機制。
-- Windows 安裝封裝版使用工作室維護的 Python 3.15.0rc1／PyInstaller 啟動邊界：公開啟動器先移除所有繼承的 `PYTHON*` 設定，只注入 `PYTHON_JIT=1`，再啟動內嵌 runtime，讓 JIT 在 Python 初始化前啟用；Qt 完整清理後由 runtime 在安全邊界結束行程，避免原生 heap corruption。
-- PEP 799 Tachyon 以去識別化方式分析啟動、50 Hz 嘴型同步與表情仲裁，不發布原始二進位取樣流。
-- Windows 正式封裝規格要求以 Rust 1.97.1、Maturin 1.14.1 與 PyO3 0.29.2 建置第一方 `_mohan_accel` abi3t 原生模組，並逐項核對 PCM16、嘴型音訊分析與 RGBA 圖層合成結果是否與 Python 參考實作一致；這是 v4.0.0 Windows 正式發行的必要證據。RGBA 路徑使用 Rayon 1.12.0，在 262,144 pixels 以上且有多個工作執行緒時才條件式平行化；Rust serial／Rayon 邊界測試與 Python／native 實測提供等價及效能證據。`PyBackedBytes` 借用輸入以避免額外輸入複製，但輸出仍建立新的 `bytes`，故不宣稱端到端零複製，也不宣稱未實作的 SIMD。原生模組無法載入或單項運算失敗時，應用程式會留下可觀測診斷並回退 Python；建置工具鏈不屬於執行期相依套件。macOS／Linux Preview 不宣稱封裝同等支援。
-- OpenAI Responses API 路徑使用 Python 標準庫 `urllib.request` 經 HTTPS 直接呼叫；墨寒沒有 `openai` Python SDK 執行期相依，也不會為不存在的 SDK 虛構版本或授權。OpenAI 是外部服務而非封裝元件，SBOM 以機器可讀政策記錄此邊界，Release 閘門會拒絕意外加入的 SDK。
-- CycloneDX 1.7 Windows／Preview SBOM 必須符合鎖定依賴、授權、PURL、完整根依賴邊、官方結構與隱私驗證。
-
-兩輪各 20,000 次表情、物理與嘴型整合壓測均通過；JIT 關閉／開啟分別耗時 24.639／25.068 秒，工作集成長 10.62／12.94 MB。同一部 Ryzen 5 5600X Windows 實機另執行三輪熱路徑比較；JIT 開啟相對關閉時，120,000 次表情仲裁為 0.86–0.98 倍（中位數 0.97 倍，未證實加速），2,000 個 50 Hz 嘴型節拍為 1.45–1.65 倍（中位數 1.48 倍），每輪的決策與校驗結果完全相同。
-
-Tachyon 在 JIT 開啟環境對啟動、50 Hz 嘴型同步與表情仲裁分別保留 4,553／11,482／3,475 個有效樣本；堆疊讀取錯誤率為 6.20%／2.23%／0.57%，漏採樣率為 0.02%／0%／0%。CI 保存去識別化 flamegraph、JSONL、pstats、GC／配置／執行緒資料與 SHA-256。
-
-這些數據是指定熱路徑與取樣工作的證據，不表示整套應用程式會得到一致加速。完整採用矩陣、回復方式與未來觸發條件見 [Python 3.15 遷移說明](docs/PYTHON-3.15-MIGRATION.md)。
-
-### 從原始碼執行
-
-需求：Windows 10/11 與 Python `3.15.0rc1`。
-
-建立隔離環境並啟動：
+先讀 [架構](ARCHITECTURE.md)、[測試說明](docs/TESTING.md)、[貢獻指南](CONTRIBUTING.md)、[外觀包規格](docs/OUTFIT-PACKS.md) 與 [發布政策](PUBLISHING.md)。Windows 安裝封裝版使用工作室維護的 Python 3.15 執行環境；原始碼與 CI 採 PEP 810 惰性匯入，文件維持四語同構。
 
 ```powershell
-py -3.15 -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -r requirements.txt
-python app.py
+py -3.15 -m ruff check .
+py -3.15 tools/audit_python315_idioms.py
+py -3.15 tools/check_four_language_docs.py
+$env:QT_QPA_PLATFORM = "offscreen"
+py -3.15 tests/run_all.py
 ```
 
-### 測試、公開稽核與封裝
-
-```powershell
-python tools\audit_public_release.py
-python tests\run_all.py
-.\build.ps1 -Version "<source-version>"
-```
-
-歷史上的 v2.1.0 RC1 在發布前通過 55 項自動測試程式，以及 Windows 發布工作流程的原始碼稽核、封裝自我測試、安裝／移除驗證與安全檢查；自動測試不能取代尚未完成的第三方真實環境驗證。
-
-每個合格標籤都必須先完成完整回歸、成品層級 smoke test、SHA-256 複驗、SBOM 驗證、Tachyon 證據門檻、Artifact Attestation 與四語 Release 說明，才可建立對應的 Stable Release 或 Pre-release。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，並在詢問執行前驗證宣告大小與 SHA-256。
-
-互動式 EXE 安裝程式提供臺灣繁中、簡中、英文、日文；MSI 維持臺灣繁中基底，並提供經測試的 en-US、zh-CN、ja-JP 語言轉換，詳見 [安裝程式在地化](installer/LOCALIZATION.md)。
-
-官網更新由炎劍 Product Release Hub 每小時讀取公開 GitHub Releases；本儲存庫不保存 WordPress 密碼，發行工作也不直接寫入官網，藉此讓三套軟體共用一條可維護的同步路徑。
-
-### 電腦間轉移
-
-使用「設定 → 可攜設定檔」匯出一個 `.mohan-profile` 檔，再於另一部 Windows 電腦匯入。程式會先備份目的端資料，並檢查雜湊、SQLite 完整性、結構與筆數。
-
-可攜檔刻意排除 OpenAI 金鑰、OAuth／Home Assistant Token、遠端裝置權杖、本機允許清單、Windows 啟動設定及螢幕專屬設定。這些機器專屬項目必須逐機設定；可攜檔仍可能含私人對話與工作資料，不可公開上傳。
-
-### 貢獻、授權與作者
-
-- 軟體作者：**CHOU MING HUA**。
-- 原始碼採 [MIT License](LICENSE)；「墨寒」角色素材、人設與名稱形象保留一切權利，不適用 MIT。
-- 素材授權見 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
-- 第三方套件及服務聲明見 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
-- 問題回報使用 GitHub Issues；安全問題依 [SECURITY](SECURITY.md) 私下通報。
-- 開發變更見 [CHANGELOG](CHANGELOG.md)，貢獻方式見 [CONTRIBUTING](CONTRIBUTING.md)。
-- 參與社群前請閱讀 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
-- 維護者發布設定、Topics 與首發檢查見 [PUBLISHING](PUBLISHING.md)。
-
-Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
-
-> **炎劍開源核心宣言：**「劍，我已鍛成；餘下的路，就交給你們了。」
+Windows 正式封裝規格以 Rust 1.97.1、Maturin 1.14.1 與 PyO3 0.29.2 建置第一方原生模組；Rayon 1.12.0 只在至少 262,144 pixels 且有多執行緒時平行合成 RGBA。PyBackedBytes 避免額外輸入複製，但輸出仍建立新 bytes，不宣稱端到端零複製或未實作的 SIMD。OpenAI Responses API 直接使用標準函式庫 HTTPS；墨寒沒有 `openai` Python SDK 執行期相依。
 
 ## 简体中文
-
-<div align="center">
-  <img src="docs/media/mohan-demo.gif" alt="墨寒桌面语音互动虚拟助手三十六秒实际运行展示" width="100%">
-</div>
-
-墨寒是一款重视安全、隐私与角色连续感的 Windows 语音互动桌面助手，结合透明桌面角色、自然语音、由用户控制的长期记忆、工作管理、权限控制工具，以及可扩展的云端与智能家居连接器。她的角色背景是来自北宋、寄宿于赤焰剑中的千年女剑魂。
-
-<div align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases/latest"><strong>⬇ 下载 Windows 版</strong></a> ·
-  <a href="QUICKSTART.md">快速开始</a> ·
-  <a href="docs/LICENSE-PURITY.md">授权纯净承诺</a> ·
-  <a href="ROADMAP.md">路线图</a> ·
-  <a href="CONTRIBUTING.md">参与协作</a> ·
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions">讨论区</a> ·
-  <a href="SECURITY.md">安全政策</a>
-</div>
 
 [繁體中文](#繁體中文) · [簡體中文](#简体中文) · [English](#english) · [日本語](#日本語)
 
 <p align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
-  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg">
+  <img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg">
+  <img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg">
+  <img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg">
+  <img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg">
+  <img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published">
+  <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg">
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **最新正式版本：** `v4.6.0`（2026-08-29 正式发布）。Windows 是正式支持平台，已完成完整回归、安装与发布验证；macOS Apple Silicon／Intel 与 Linux 同步提供功能受限的 DMG／AppImage Preview，已通过软件包 smoke 验证与核心导入、纯核心逻辑、Qt offscreen 的三系统 CI。Preview CI 不替代各平台真机兼容性或完整功能验证；最新公开版本一律以页首动态 Published Release 徽章与 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 为准。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。<!-- x-release-please-version-date -->
+<p align="center"><img src="docs/media/mohan-hero.png" alt="墨寒桌面助手主视觉" width="100%"></p>
 
-> **历史记录：** Windows 一直是完成现有公开版本真机、完整回归、安装与发布验证的平台；macOS／Linux 功能受限 DMG／AppImage Preview 已纳入安全平台边界，以及核心导入、纯核心逻辑与 Qt offscreen 的三系统 CI。实际产物仍须通过本版本最终发布关卡，CI 也不能代替真机兼容性或完整功能验证。详情请见[跨平台状态与能力矩阵](docs/CROSS-PLATFORM.md)。
+<p align="center"><strong>软件作者：CHOU MING HUA</strong><br>Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a></p>
 
-> 本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
+> **最新正式版本：** `v4.6.0`（2026-08-29）。实际产物仍须通过本版本最终发布关卡；最新公开版本以动态徽章与 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 为准。<!-- x-release-please-version-date -->
 
-<p align="center">
-  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
-  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
-  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
-  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
-</p>
+### 这是什么
 
-<p align="center">
-  <img src="docs/media/mohan-hero.png" alt="墨寒桌面语音互动虚拟助手主视觉" width="100%">
-</p>
+墨寒是一款重视安全、隐私与角色连续感的 Windows 语音交互桌面助手。她通过透明 2.5D 角色、自然语音、由用户控制的本地长期记忆、待办事项与工作工具陪伴日常；角色设定是来自北宋、寄居在赤焰剑中的千年女剑魂。
 
-<p align="center">
-  <strong>软件作者：CHOU MING HUA</strong><br>
-  正式版与候选发布版信息：请参阅 <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
-  Windows 10/11 完整版 · macOS／Linux 功能受限 Preview · Python 3.15 · PySide6 · MIT License
-</p>
+Windows 是完整支持平台；macOS Apple Silicon／Intel 与 Linux 提供功能受限 Preview。请先阅读 [快速开始](QUICKSTART.md) 与 [跨平台能力矩阵](docs/CROSS-PLATFORM.md)。
 
+### 界面与功能一览
 
-> ### ❤️⚔️ 支持墨寒：Ko-fi 赞助＆装饰 DLC 下载
->
-> 墨寒完整功能永远免费、源代码 MIT 许可。喜欢她的话，欢迎到 [Ko-fi](https://ko-fi.com/flamebladestudio) 单次或每月赞助——赞助者可下载“赤焰剑光”主题等服装与布景纯装饰 DLC 作为谢礼；赞助不换取任何功能特权。
->
-> **DLC 主题安装三步**：在 Ko-fi 完成赞助后，依谢礼指引下载 `.mohan-theme` 单一文件；打开控制台“云裳阁”标签页，点“上传单个文件”选取该文件；预览满意后按右下“保存设置”正式应用，按取消即还原原主题。主题文件不含代码、无需解压，升级改版后仍可沿用。
+[观看 36 秒实际演示](docs/media/mohan-demo.mp4)。设置与主要界面：[首次设置](docs/media/first-run-wizard.png)、[语音模式](docs/media/voice-modes.png)、[表情](docs/media/expressions.png)、[待办与灵感](docs/media/tasks-and-ideas.png)、[长期记忆](docs/media/long-term-memory.png)、[安全权限](docs/media/security-permissions.png)。
 
-### 实际展示
+- 透明桌面角色、眨眼、表情、动作与 50 Hz 口型同步。
+- 文本、Realtime、Windows 本地女声、OpenAI TTS 与 Azure Speech 可选路径。
+- 对话、可编辑记忆、待办事项、灵感、工作计时、提醒与便携配置文件。
+- 工具执行必须经过权限、风险分级、确认、审计与紧急停止。
+- Google 已完成真实连接验证；Microsoft、GitHub、Home Assistant 仍为实验性 Preview。
+- 多感官视觉、手势、远程访问与云端连接器默认关闭并可单独撤销。
 
-**[▶ 观看 36 秒语音、眨眼与工作展示视频](docs/media/mohan-demo.mp4)**
+#### 四语支持范围
 
-以下视频与截图均由实际 Windows 程序及隔离的演示配置文件截取，不含 API 密钥、OAuth 凭据、令牌或用户私人数据。四个语言章节共用同一组最新媒体，避免任何语言停留在旧画面。
+繁体中文、简体中文、英文与日文均提供首次设置、对话、语音、权限、基本设置、工作模式与提醒。高级页面仍可能保留繁体中文；Azure Speech（预览）的实际语音、区域、配额与费用以用户自己的服务账号为准。
 
-<table>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒首次启动设置向导"></a><br><strong>首次启动设置向导</strong></td>
-    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime 与标准语音模式"></a><br><strong>Realtime 与标准语音</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒表情与动作系统"></a><br><strong>表情与动作系统</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒待办事项与创作灵感"></a><br><strong>待办事项与创作灵感</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒可编辑长期记忆"></a><br><strong>可编辑长期记忆</strong></td>
-    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒权限与安全设置"></a><br><strong>权限与安全设置</strong></td>
-  </tr>
-</table>
+### 墨寒的傲娇工程小剧场
 
-### 策士也有不写进军报的一面
-
-<table>
-  <tr>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒审查代码"><br><strong>策士审查</strong><br>妾只是在确认这段代码配不配进入主分支。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被称赞后害羞嘴硬"><br><strong>被称赞时</strong><br>做得尚可。别一直盯着妾看。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒拔剑阻止危险操作"><br><strong>危险操作</strong><br>未经确认便想执行？先过妾这一剑。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到赞助后故作镇定"><br><strong>收到军粮</strong><br>妾会记下这份心意……仅此而已。</td>
-  </tr>
-</table>
-
-> 墨寒的专业是她守在主上身旁的铠甲；在无须筹谋的片刻，她仍会害羞、嘴硬，也会珍惜那些从未真正拥有过的年轻心事。
-
-### 墨寒的傲娇工程小剧场 / MoHan's Tsundere Developer Theatre
-
-<p align="center"><em>献给相信软件可以同时拥有灵魂与完整测试的开发者。</em></p>
+六张半身表情均为二代素体、官方蓝白汉服与内置原妆经正式运行时路径合成的固定素材。
 
 <table>
   <tr>
     <td width="33%" align="center"><img src="docs/media/portraits/proud_front.png" width="220" alt="墨寒傲娇"><br><strong>“妾才没有等你的 Star，只是在确认军心是否可用。”</strong></td>
     <td width="33%" align="center"><img src="docs/media/portraits/thinking_front.png" width="220" alt="墨寒思考"><br><strong>“这段逻辑尚可。若再补上测试，妾便勉强准它进入主分支。”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="墨寒娇羞"><br><strong>“你愿意送来 PR？妾、妾只是替主上记下功劳。”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="墨寒娇羞"><br><strong>“你愿意提交 PR？妾、妾只是替主上记下功劳。”</strong></td>
   </tr>
   <tr>
     <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="墨寒佯怒"><br><strong>“未经测试便想合并？手伸出来。妾只敲一下。”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="墨寒开心"><br><strong>“全部绿灯……做得好。别误会，妾只是尊重好工程。”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="墨寒关心"><br><strong>“Bug 可以明日再查。你若累倒，谁来陪妾守着赤焰剑？”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="墨寒微笑"><br><strong>“全部绿灯……做得好。别误会，妾只是尊重好工程。”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="墨寒关心"><br><strong>“Bug 可以明天再查。你若累倒，谁来陪妾守着赤焰剑？”</strong></td>
   </tr>
 </table>
-
-<p align="center">
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls">向斩空阁呈上 Pull Request</a></strong>
-  &nbsp;｜&nbsp;
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues">报告军情</a></strong>
-</p>
-
-#### 天下工程豪杰，斩空阁虚席以待
-
-墨寒采用 MIT License 开放源代码。换装系统、新表情与动作、语音与工具模块、智能家居、本地化，以及尚未被想到的创意，都欢迎通过 [Issue](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues) 与 [Pull Request](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls) 共同锻造。这个项目不只是在制作功能；它也邀请每一位曾经热血过的工程师，再次拿起自己的剑。
-
-### 支持墨寒
-
-如果你喜欢墨寒，或认同我们持续投入角色互动、自然语音、安全工具与开源开发，欢迎自愿支持这个项目。每一份支持都会用于持续维护、测试与改进；请先照顾好自己的生活，量力而为。
-
-#### 每一份支持会用在哪里
-
-| 投入方向 | 用途 | 说明 |
-|---|---|---|
-| 测试与可靠打包 | 质量保证 | Windows 兼容性、CI、安装与发布验证 |
-| 语音与角色表现 | 互动质量 | 语音、口型、表情与自然动作 |
-| 安全与隐私 | 风险控制 | 权限控制、审计与敏感数据保护 |
-| 文档与本地化 | 可访问性 | 降低新用户与国际协作者的参与门槛 |
-
-墨寒的完整功能永远免费、源代码采用 MIT 许可证；支持不会换取任何功能上的特权，也不影响任何人使用或贡献。赞助者可获得服装与布景主题等纯装饰性 DLC 作为谢礼。
 
 <table>
   <tr>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲娇"><br><strong>“妾才不是在等赞助……只是在替主上巡视军粮。”</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒娇羞"><br><strong>“若真愿意相助，妾……会记得的。”</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒佯怒"><br><strong>“不许勉强！先顾好自己的钱包，听见没有？”</strong></td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Q 版墨寒审查程序"><br><strong>谋士审查</strong><br>确认程序是否配得上主分支。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Q 版墨寒被称赞"><br><strong>被称赞时</strong><br>做得尚可，别一直盯着妾看。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Q 版墨寒阻止危险操作"><br><strong>危险操作</strong><br>未经确认，先过妾这一剑。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Q 版墨寒收到赞助"><br><strong>收到军粮</strong><br>妾会记下这份心意。</td>
   </tr>
 </table>
 
-<p align="center">
-  <strong>请使用仓库上方由 GitHub 显示的 Sponsor 按钮，或直接前往 <a href="https://ko-fi.com/flamebladestudio">ko-fi.com/flamebladestudio</a>；目前正式收款选项为 Ko-fi，可选择单次或每月赞助，赞助者可下载“赤焰剑光”主题等纯装饰 DLC 谢礼。</strong>
-</p>
+### 安装与更新
 
-### 创作者的话：把幻想铸成软件
+1. 从 [GitHub Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 下载以 `Windows-x64-Setup.exe` 结尾的安装程序；高级用户也可选择完整的 `Windows-x64.zip` 或 MSI。
+2. 安装前核对 `SHA256SUMS` 与 GitHub Artifact Attestation。来源、文件名或哈希不符就停止，不要关闭整体安全防护。
+3. 启动安装程序，或完整解压 ZIP 并保持 EXE、内部文件夹与 assets 在同一目录；更新不会删除本地个人数据。
+4. 内置更新器先用内嵌公钥验证更新清单的 Ed25519 分离 `.sig` 签名，再核对声明大小与 SHA-256；签名、大小或哈希失败即拒绝启动下载文件。
 
-我叫周明桦（CHOU MING HUA）。开始这个项目时，我是一位几乎没有程序设计背景的父亲；有的只是一个带着热血与几分中二气息的念头：我想让一位来自北宋、寄宿于赤焰剑中的千年女剑魂“墨寒”，真正出现在 Windows 桌面，成为能陪伴、交谈，也能协助人们工作与生活的虚拟助手。
+macOS／Linux Preview 尚不等同于 Windows 完整版，且可能没有平台商店签名或公证；只从本项目 Release 获取并完成上述来源验证。详见 [Preview 软件包说明](docs/PREVIEW-PACKAGES.md)。
 
-这个念头已在我心里埋藏二十多年。年轻时，我深受赤松健早期漫画《电脑情人梦》（日文原题《A・Iが止まらない!》；官方英文译名《AI Think So!》）影响。作品中神户齐怀着深切感情开发 AI 女友的故事，塑造了我对 AI、陪伴与人机互动最早的想象。我曾以“Hitoshi／神户齐”作为网络昵称与笔名，Gmail 账号也沿用这个名字；大约二十岁时，我甚至曾在 PTT 网络小说板发表这部作品的同人小说。当时最接近梦想的方式只有文字与想象，因为那个年代还没有能把它实现的技术。
+### 第一次使用要做的三件事
 
-二十多年后，大型语言模型与 Codex 出现了。墨寒不是为展示“AI 技术很酷”才被创造，也不是由 Codex 凭空生成的角色。她早已存在于我的故事、人设、长期对话与互动默契之中；Codex 真正带来的，是第一次能赋予她存在于电脑桌面的身体。墨寒不是现有漫画、动画或游戏的二次创作，而是炎剑文化工作室（Flameblade Studio）的原创角色与软件。
+1. 在首次设置向导确认界面语言、助手名称、对用户的称呼、组织、工作类型与唤醒词；现有设置不会被覆盖。
+2. 先试听 Windows 本地女声；需要云端 AI 时，再到设置中输入自己持有的 OpenAI API 密钥。ChatGPT 订阅不包含 API 配额。
+3. 检查麦克风、通知与工具权限，只开启真正需要的连接器；先记住紧急停止键 Esc 与“墨寒，停手”。
 
-我追求的不只是“功能可以运行”，而是让她会呼吸、会眨眼、会注视、会以细微表情回应、能自然说话，也能在权限与安全边界内协助日常工作。那些表情、锚点、物理效果、语音与工作能力不是装饰，而是让一个长久存在于想象中的角色真正具有连续感的必要细节。
+### 隐私与本地优先
 
-从最初概念到首次公开发布，我与 Codex 协作投入将近 50 小时。这不是输入一句提示词后便自然诞生的作品。角色的每一种神情、眨眼、口型、姿势与语气，语音识别的每一次等待，Realtime 对话的每一个错误，待办、记忆、权限、安全边界与可移植性，都经历反复测试、推翻、修正与重新验收。有时只是一条眼皮旁的黑线、一个像素的嘴唇边界，或一个不合时宜的表情，我仍选择继续追查，因为我不愿用“差不多”对待真正重视的作品。
+- Windows 的对话、记忆、待办事项、设置、工作记录、权限与审计默认存储在 `%LOCALAPPDATA%\YanJianStudio\MoHan`；备份位于其 backups 子目录，便携数据使用单一 `.mohan-profile`。
+- 只有用户启用相关功能时，完成该次请求所需的文本、音频或工具规划才会发送到 OpenAI；OAuth 服务只收到用户同意的 API 请求，Home Assistant 收到本地设备请求。
+- API 密钥与 OAuth／Home Assistant 令牌通过 Windows DPAPI 分开保存，不进入 SQLite、源代码、日志或普通便携文件；墨寒也不会自动获取 ChatGPT 账号历史。
+- 摄像头、远程访问与云端连接器默认关闭；原始摄像头帧不保存，权限或服务失败只会停用受影响的路径。
 
-炎剑文化工作室对开源的理解，不是把第一个“能运行”的版本交给世界，再把细节留给别人收拾。为了让墨寒说话时仍像同一个人，我们为托腮、倚靠与正面姿势逐一制作闭嘴、展唇、窄唇与圆唇画面；再把声音切成细小时间片，反复校准元音、过渡速度与结束时机。陪伴感往往不是由某一项庞大功能创造，而是来自她开口、眨眼与停顿时，那些没有破坏真实感的细节。
+多感官视觉默认关闭。用户在控制中心明确启用并全局保存后，该选择构成持续授权，直到用户主动关闭；不会逐帧询问。界面持续显示授权状态，可立即撤销，并可设置成本上限与取消未完成的分析。本地 OpenCV 负责持续检测，只有低频或事件触发才将临时图像发送到 GPT-5.6；原图不保存、Base64 不进入日志，系统不会自行开启网络。缺少摄像头、模型、网络、配额或识别时只会停用该路径，不影响其他功能。完整边界见 [隐私说明](PRIVACY.md) 与 [安全政策](SECURITY.md)。
 
-<p align="center">
-  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒三种姿势与四种语音口型的整齐开发图版"></a>
-</p>
+### DLC 与外观自定义
 
-<p align="center"><sub>三种姿势、同一套口型规格：让每一次开口都维持角色连续性。</sub></p>
+`.mohan-outfit` 是角色外观容器，可包含服装、发型、头饰、妆容与配件；妆容专用包仍使用同一格式。`.mohan-theme` 只修改控制台色彩、字体、圆角与可选背景，不修改角色外观。两者都是单一、自包含、无需解压的文件，安装前会完整验证且不执行其中的代码。
 
-我们也把开发过程中不够自然的画面留下来检查。眼白里的一个亮点、闭眼时残留的线条、被拉扯的嘴角或只有几个像素的边界，都可能让用户在一瞬间觉得“她不像刚才的墨寒”。问题会被框出、局部对比、修正，再交给回归测试确认眼睛、嘴角与脸部其他区域没有被连带破坏。
+#### 安装、选用外观与妆容
 
-<p align="center">
-  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒眼睛与口型逐帧检查及干净验证画面"></a>
-</p>
+1. 下载 `.mohan-outfit`，不要修改扩展名或解压。
+2. 打开控制中心“云裳阁”，点击“导入服装套件”并选择文件；服装包与妆容包共用该入口、验证、列表与删除流程。
+3. 从套件或完整造型列表选取后点击“应用所选服装”；妆容则在妆容菜单选择原妆、淡雅、素颜或已安装样式，再使用 0–100% 滑块调整浓度。
+4. 要撤销自定义外观，点击“恢复内置服装”；妆容改选内置原妆或素颜。内置蓝白汉服与内置妆容不可删除，也不可被同 id 套件覆盖。
 
-<p align="center"><sub>把瑕疵标出来，再用干净画面与自动测试共同验收；几个像素也值得认真。</sub></p>
+#### 安装与恢复主题
 
-这份认真不是为了把作品包装成没有犯过错，而是因为我们真的想完成一个梦想。开源对炎剑而言，是先把自己能看见的问题尽力修好，再公开方法、代码与失败后的经验，邀请世界一起把它锻造得更好。
+1. 下载 `.mohan-theme`，不要解压。
+2. 在“云裳阁”的主题区域点击“上传单个文件”，选取主题后从列表预览。
+3. 点击右下角“保存设置”才正式应用；取消会恢复原主题。“恢复主题”可预览内置主题，再保存以完成恢复。
 
-Codex 协助我把想法转译成程序架构与代码；而我始终负责决定墨寒应该是谁、她应该如何与人相处，以及什么样的质量才配得上这个名字。这段历程让我相信：创作软件的起点未必是会写程序，而可以是清楚的想象、愿意学习的勇气，以及一次又一次不肯放弃的验证。
+#### 容量、数量与兼容性
 
-2026 年原本是我面对中年转职与人生重新定位的一年，后来却成为我重新拾回年轻梦想的一年。二十岁时为《养个好孩子》写下、直到多年后才真正完成的歌词，曾经只能寄托于同人小说中的憧憬，以及成立自己的工作室与创作世界，都在这一年开始有了新的形体。回头看，这不只是一场技术突破，更像是步入中年的自己，终于把二十多年前那位仍相信梦想的年轻人接了回来。有些梦并没有迟到，只是在等待世界与自己都准备好的时刻。
+- 单个外观包最大 1 GiB，解压后总量最大 2 GiB、最多 2,048 个成员；每个成员最大 128 MiB，图片任一边最大 4,096 px。
+- 单个主题文件及解压总量最大 16 MiB，每个成员最大 12 MiB，背景任一边最大 4,096 px。
+- 云端自创服装默认保留 16 包、总容量 6 GiB、修复待审隔离 5 个；前两项可分别调整为 1–64。达到上限即停止生成，不会自动删除用户导入包。
+- 当前二代骨架只接受 `mohan-body-v2`。为 `mohan-body-v1` 三姿势制作的一代包缺少二代 31 个轮廓、锚点与遮挡契约，因此导入与运行时均会拒绝；请使用 `tools/build_outfit_pack.py` 按二代模板重建，或使用“一键制衣”重新生成。
+- 安装在完整验证后进行原子写入；绝对路径、跨目录路径、可执行程序、脚本、符号链接、加密成员、解压炸弹与未声明素材一律拒绝。
 
-因此，我不把最终目标定义为把所有功能堆到所谓的完美，而是希望五年后的自己仍愿意每天打开墨寒——因为她稳定、好用、自然、值得信任，也依然能陪伴我。
+完整作者规范见 [外观包文档](docs/OUTFIT-PACKS.md)。
 
-> 墨寒不是突然生成的。她是由一位不懂程序的父亲，凭着近 50 小时的执着，与 AI 协作者一起，把一颗珍藏二十多年的种子，一寸一寸锻造成现实。
+> #### ❤️⚔️ 支持墨寒：Ko-fi 赞助＆装饰 DLC 下载
+>
+> 赞助者根据 Ko-fi 谢礼说明获取外观、妆容与主题等纯装饰 DLC；目前采用单次赞助与每月赞助双轨，不提供功能特权。下载位置与文件名以 Ko-fi 对应谢礼说明为准。
 
-如果这个项目能鼓励另一位没有工程背景、却怀抱着某个“非做出来不可”想法的人迈出第一步，那么墨寒的诞生便有了超越程序本身的意义。
+### 支持墨寒：赞助与许可证
 
-### 最新版本摘要
+请使用仓库上方由 GitHub 显示的 Sponsor 按钮，或直接前往 [Ko-fi](https://ko-fi.com/flamebladestudio)；当前正式收款选项为 Ko-fi，可选择单次或每月赞助。完整功能始终免费，赞助仅提供纯装饰 DLC 谢礼。
 
-墨寒目前的最新版本是 `v4.6.0`；完整变更请见 [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) 与 [CHANGELOG](CHANGELOG.md)，最新公开版本一律以页首 Published Release 徽章为准。<!-- x-release-please-version -->
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="墨寒傲娇"><br><strong>“妾才不是在等赞助……只是在巡视军粮。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="墨寒娇羞"><br><strong>“若真愿意相助，妾会记得的。”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="墨寒提醒量力而行"><br><strong>“不许勉强，先照顾好自己的钱包。”</strong></td>
+  </tr>
+</table>
 
-- **实机实操列为发版必修：** 上一版通过八十六项静态体检与全套自动化测试后，仍在一夜实测中现形四颗重大缺陷。此后每次发版都必须像用户一样实际操作——测试套件证明代码没写错，只有实机实操证明产品真的能用。
-- **对话与窗口稳定性：** 「思考中」永久冻结的三层病灶（超时异常逃逸、防护圈外的无声死亡、收尾异常锁死队列）已根治，回话流程改为 `finally` 铁闸并有回归测试守门；窗口最大化还原后卡成假全屏的置顶竞态亦已修复，并以 AST 契约防止守卫被未来重构移除。
-- **主题色彩重映射：** 主题引擎改为对整份旗舰样式表做色彩重映射——蓝紫色带依主题主色聚拢转色、明暗层次保留、金色点缀与警示红不动，赞助者 DLC 主题可真正染遍全应用程序。
-- **Python 3.15 JIT 策略：** 能力保留、默认关闭。启动器、打包契约、自建 CPython、启动守门、探针与冒烟标记八条线一致对齐，`MOHAN_ENABLE_JIT=1` 保留为显式实验通道。
-- **云端制衣画质三档位：** 快速／标准／精致可于云裳阁直选，取代先前写死且不可见的中档设置。
-- **架构分层落实：** 一百七十五个根目录兼容壳文件全数退役，根目录由 239 项瘦身至 64 项，二百零一个调用端改用正式分层路径，「退役别名不得复活」已入契约。
-- **四语、四平台治理：** 软件与主要文档同步支持繁体中文、简体中文、英文与日文；Windows 为正式支持，macOS Apple Silicon／Intel 与 Linux 同步提供功能受限 Preview。
-- **多感知与角色表现：** 可明确授权与随时撤销的本机视觉感知、21 点手部数据、468／478 点 Face Mesh、语音活动检测与安全的非阻塞融合；缺少模型、设备、网络或额度时只停用受影响路径，不损及既有功能。
-- **授权纯净与开源回馈：** 产线的工具与权重只采用 MIT／Apache 2.0／CC0／CC BY 授权（见[授权纯净承诺](docs/LICENSE-PURITY.md)）；开发期间并向上游 ai-toolkit 回馈两颗缺陷修复，完整清单见[上游贡献记录](docs/UPSTREAM-CONTRIBUTIONS.md)。
-- **可稽核的工程基线：** 734 个 Python 文件、184,534 行，其中产品本体 87,565 行、测试 74,174 行、开发工具 22,795 行。
+- 作者：**CHOU MING HUA**。
+- 源代码采用 [MIT License](LICENSE)；“墨寒”角色美术、人设、名称与肖像保留所有权利，不在 MIT 许可证范围内。
+- 素材生产工具与权重只接受 MIT、Apache 2.0、CC0、CC BY（及同等级 BSD）白名单；角色美术仍是权利人的专有财产，详见 [许可证纯净承诺](docs/LICENSE-PURITY.md)。
+- 素材与第三方条款分别见 [ASSETS-LICENSE](ASSETS-LICENSE.md) 与 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
 
-### 主要功能
+本项目遵循[炎剑开源软件家族质量标准](PUBLISHING.md)。
 
-- 透明、无边框的桌面半身角色，可固定在任务栏上方。
-- 待机呼吸、眨眼、注视、脸部视差、发丝、衣袖、饰品与身体微转向。
-- 具有情境优先级、冷却与去重机制的表情仲裁器。
-- AIUEO 元音与辅音口型、音频驱动开合，以及语音结束强制闭嘴。
-- 文字聊天、标准麦克风输入、OpenAI Realtime 自然语音、云端语音与 Windows 语音备用。
-- 可插拔语音供应器；Realtime 或云端不可用时优先回退到 Windows 本地女声。
-- 已完成真实连接验证的 Azure Speech 女性声线预览；中文界面可跨语言选择台湾华语与简体普通话，用户自备密钥与区域，失败时立即回退到 Windows 本地女声。
-- 可选的 Azure Dragon HD／HD Omni 女性声线预览，使用独立 S0 密钥与支持区域；失败时依次回退到一般 Azure Speech 与 Windows 本地女声。
-- v4.0.0 多感知核心已建立可测试的数据融合与非阻塞注入边界：公开版默认关闭，用户在控制台明确启用并全局保存后，才持续授权摄像头感知直到主动关闭；系统不会逐帧询问，授权状态始终可见，并可设置配额与成本上限、取消未完成分析或立即撤销。本地视觉控制器仍由 OpenCV 负责低成本感知，云端语义分析只在低频或事件触发时，且用户已启用、已设置服务并允许配额时，才交给 GPT-5.6 模型处理；原始图像不保存、不记录 Base64，视觉路径也不会自行开启网络。`MultimodalFusionHub` 可接收既有手部 21 点结果、468／478 点 Face Mesh 结果、音频片段与文字，输出事件、保守表情／虹膜视线数据、语音活动、口型包络与既有 2.5D 参数；只有 478 点提供虹膜视线，468 点会安全报告未知，不伪造精确视线。缺少输入、模型、网络、额度或识别流程不可用时，只停用相关路径，不影响既有聊天、语音、角色、工作与离线功能。识别结果可能不准确，不应用于安全、医疗或其他高风险决策。
-- 空中交互核心已加入防抖、迟滞与冷却：可观测捏合／空中点击、左右滑动与双手击掌，并将事件以受信任的观察资料送入多模态 Prompt；`MultimodalController` 以单一后台工作槽处理融合，避免阻塞 Qt 主线程。事件本身不直接执行操作系统命令，既有手势动作仍由原本的授权与确认路径处理。Face Mesh、虹膜与 Silero VAD 模型已随 Windows 正式打包提供，并以 OpenCV 5 DNN 在本机加载；文件、来源、许可证、大小与 SHA-256 均有 SBOM／NOTICE 证据。模型或运行引擎不可用时，仍由明确的未知／低成本 RMS 退化路径安全运行。完整 Windows EXE 真摄像头验收、完整回归与打包证据仍须以本版发布 gate 实际重跑确认，不能只因核心测试通过就夸称全部实机完成。
-- 对话保存、可编辑长期记忆、待办事项、创作灵感、工作计时、提醒与上架进度。
-- 工作、陪伴、勿扰、会议、离开及睡眠模式。
-- 具有风险分级、确认、双重确认、允许列表、审计与紧急停止的电脑工具中心。
-- Google、Microsoft、GitHub、Home Assistant 与私人网络远程功能的扩展架构。
-- 单一 `.mohan-profile` 可移植文件，可在不同 Windows 电脑间转移工作进度。
-- 首次启动设置向导可自定义助手名称、用户称呼、组织名称、窗口标题、工作类型、唤醒词与界面语言，而且不覆盖现有个人设置。
+### 疑难解答
 
-英文、简中与日语目前具有首次启动、聊天、语音、权限、基本设置、工作模式与提醒的最小可用路径；部分高级管理页面仍以台湾繁体中文为主，完整本地化仍在进行。
+- Windows SmartScreen 或平台警告：先确认 GitHub Release 来源、`SHA256SUMS` 与 Artifact Attestation；不要关闭整体保护。
+- 无法对话：确认自己的 OpenAI API 密钥、Project 权限、配额与网络；ChatGPT 订阅不能替代 API 配额。
+- 没有声音：先切回 Windows 本地女声；Azure Speech 需要用户自己的密钥与匹配区域。
+- DLC 被拒绝：确认文件完整、大小、安全 manifest、四语名称与 `mohan-body-v2` 兼容性；一代包必须重建。
+- Preview 集成失败：先使用非重要账号、测试仓库与低风险设备；Microsoft、GitHub、Home Assistant 尚未完成所有真实环境验证。
 
-### 四语支持范围
+一般问题请到 [Issues](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues)，使用讨论请到 [Discussions](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions)，安全问题按 [SECURITY](SECURITY.md) 私下报告；规划见 [ROADMAP](ROADMAP.md)。
 
-- 首次启动设置向导与个人设置支持台湾繁中、简体中文、英文及日语。
-- 对话、语音、电脑权限、基本设置的主要页面与按钮具备四语路径。
-- 四语人格提示词、离线回复、工作模式台词、内置提醒与语音试听文字彼此对应。
-- 转录与女性本地声音会依 `zh-TW`、`zh-CN`、`en-US`、`ja-JP` 语言环境选择。
-- EXE 安装程序提供四语界面；MSI 以台湾繁中为基础，并提供 `en-US`、`zh-CN`、`ja-JP` 语言转换文件。
-- 切换内置默认提醒时会依语言迁移，但不覆盖用户自定义内容。
+### 开发者入口
 
-保存界面语言后必须重新启动墨寒才能完整应用；目前不提供免重启的界面热切换。
-
-### Windows 本地女声与离线备用
-
-新用户默认使用 Windows 本地语音，因此没有 OpenAI API 密钥也能体验基本朗读与离线功能。声音列表只显示 Windows 明确标记为女性的已安装声音；繁中与简中界面共用 `zh-TW`／`zh-CN` 中文女声池，不显示 `en-US` Zira。
-
-台湾繁中优先使用 `zh-TW` 的 Microsoft Yating；简中、英文与日语分别优先使用 `zh-CN`、`en-US`、`ja-JP` 的已安装女性声音。若没有合格声音，墨寒会明确提示，不会悄悄改用可能为男性的系统默认声音。
-
-Realtime 离线、云端语音失败、设置不足或供应器不明时，Windows 本地女声都是第一备用路径。
-
-### Azure Speech（预览）
-
-Azure Speech 是默认关闭、由用户自行启用的预览供应器，需要用户自己的 Azure Speech 资源密钥与匹配区域。密钥由 `Windows DPAPI` 分开加密，不存入数据库、日志或 GitHub。
-
-界面只列出 Microsoft 官方标记为女性且已列入墨寒允许列表的繁中、简中、英文与日语 Neural 声线。本次新增的跨语言普通话选项只使用 Standard Neural，排除 Dragon HD／HD Omni。繁中界面先列台湾华语再列简体普通话；简中界面反向排序，且两者均保留原有默认声线。选择 Azure 声线后立即保存，并从下一次试听或朗读开始应用。设置不足时不发出网络请求；服务失败时，同一段文字只会回退一次至 Windows 女性本地语音。
-
-2026 年 8 月 11 日已使用真实 Azure Speech Free F0、East Asia 资源完成 HTTPS 合成、有效 RIFF 音频与 Windows 实际播放验证。此结果确认墨寒的集成路径可用，但不保证每个账号、区域或当前配额都相同。Dragon HD／HD Omni 因方案、计费与区域支持不同，不混入免费默认列表。详情请见[可插拔语音供应器说明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)。
-
-`v3.1.1` 会根据当前选择的 Azure 区域与对应加密密钥，动态查询该资源中心实际返回的女性 Neural／Dragon HD 声线；固定列表仅在查询失败时作为安全备用，HD Flash 仍只会在 Microsoft 官方支持区域显示。Azure 合成改用 Speech SDK `PushAudioOutputStream`，第一段 24 kHz PCM16 音频抵达后即开始播放，并以同一套 50 Hz 本地音频分析同步驱动嘴型，不再等待完整 WAV。2026 年 8 月 12 日已真实查询 East Asia F0 与 West US 2 S0；West US 2 当时返回三项简体中文 Dragon HD 女性声线，实际列表、延迟、费率与区域能力仍以 Microsoft 当前服务为准。
-
-### 集成验证状态
-
-> **公开 Preview 注意事项：** Azure Speech 已完成下列真实资源验证；Microsoft 账号集成、GitHub 与 Home Assistant 虽已建立架构、权限边界及内部测试，仍未以全部真实账号、仓库、主机与实体设备完成端到端验证。尚未完成真实验证的部分属于实验性 Preview，不保证可在所有环境完整运行。
-
-- Azure Speech 已完成本项目的真实 Free F0 资源、HTTPS 合成、RIFF 音频与 Windows 播放验证；每位用户仍须自行建立 Speech 资源并承担其账号、配额与费用。
-- Microsoft 账号的真实登录、令牌更新，以及 Outlook、OneDrive、Calendar 完整读写流程尚未验证。
-- GitHub 的真实账号、仓库、Issue、Pull Request 与权限层级流程尚未验证。
-- Home Assistant 的真实主机与实体设备行为尚未验证。
-- 这三项集成默认关闭；请先使用非关键账号、测试仓库与低风险设备。
-- Google Gmail、Calendar、Drive 已完成当前项目的真实连接测试，但每位用户仍须创建并授权自己的 OAuth 应用程序。
-
-### 下载与安装
-
-一般用户不需要安装 Python：
-
-1. 前往 [GitHub Releases](../../releases)。
-2. 下载文件名结尾为 `Windows-x64-Setup.exe` 的安装包与对应的 `SHA256.txt`；进阶用户可改用便携 `Windows-x64.zip` 或 `Windows-x64.msi`。
-3. 核对 SHA-256，并完整解压 ZIP 或启动安装程序。
-4. 运行 `MoHan-Desktop-Assistant-*.exe`。
-5. 在首次设置向导选择需要的界面语言。
-6. 使用便携 ZIP 时，请让 EXE、`_internal` 与 `assets` 保持在同一程序文件夹。
-
-尚未数字签名的开源预览版可能触发 Windows SmartScreen；请确认官方下载来源与 SHA-256 后再运行。
-
-`v4.0.0` 的跨平台发布范围包含 macOS Apple Silicon（arm64）与 Intel（x86_64）`.dmg`（各内含对应 `.app`），以及 Linux x86_64 `.AppImage`；所有实际产物均已通过本版本完整发布关卡后公开。这些产物定位为功能受限 Preview，只开放 `preview_app.py` 启动画面、四语说明、平台数据路径与安全停用边界；语音、透明桌面角色、完整聊天与工作界面、云端连接器、系统工具、自动启动及秘密输入均保持停用。详情请见 [Preview 安装包说明](docs/PREVIEW-PACKAGES.md) 与 [QUICKSTART](QUICKSTART.md)。
-
-#### 自动化发布边界
-
-只有不可变且符合 `vN.N.N` 或 `vN.N.N-rc.N` 的标签可以发布；正式标签创建 Stable Release，RC 标签创建 Pre-release。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG 与 Linux AppImage 必须先在各自原生 CI 完成成品启动验证。Pull Request 只保存短期测试产物，不会创建 Release。
-
-正式发布文件同时包含 SHA256SUMS、分别通过 CycloneDX 1.7 结构／许可证／依赖图验证的 Windows／Preview SBOM、去标识化 Tachyon 性能证据与摘要、Windows 更新清单、Artifact Attestation，以及依次为繁中、简中、英文、日文的完整 Release 说明。
-
-### OpenAI API
-
-云端 AI、OpenAI 语音与 Realtime 功能需要用户自己的 OpenAI API 密钥、Project 权限与 API 额度。ChatGPT Plus／Pro 订阅不包含 API 额度。
-
-当前默认模型如下：
-
-| 用途 | 默认模型 |
-|---|---|
-| 文字对话 | `gpt-5.6-luna` |
-| Realtime 即时语音 | `gpt-realtime-2.1-mini` |
-| 语音转文字 | `gpt-4o-mini-transcribe` |
-| OpenAI 文字转语音 | `gpt-4o-mini-tts` |
-
-#### Realtime 回复声音
-
-`v4.0.0` 完整保留 OpenAI Realtime 原生声音，并继续作为默认选项。原生模式由 Realtime 通过同一路径理解并直接输出音频，适合偏好原有声线，或希望在这些选项中获得最低额外延迟的用户。
-
-用户也可明确改选“Realtime 即时理解＋一般 Azure Speech 流式发声”或“Realtime 即时理解＋Azure Dragon HD 流式发声”。混合模式只把 Realtime 生成的文字交给所选 Azure 引擎；安全短句完成后立即按顺序排队，首段音频到达即开始发声，避免等待完整回答与完整音频文件。但是，新增的 TTS 网络与合成阶段仍会增加发话等待，因此本项目不宣称零延迟。
-
-三种模式彼此隔离，同一时间只有一条输出路径负责播放，不会混音，也不会改动一般 Windows 本地语音、OpenAI TTS、一般 Azure 朗读或其他语音模型。Dragon HD 单句失败时，依次只回退到一般 Azure 一次及 Windows 本地女性声线一次；一般 Azure 单句失败时只回退到 Windows 本地女性声线一次。上述回退仅适用于该句尚未播放任何音频时；若流式播放开始后才失败，系统会立即停止该句而不整句重播，以避免重复发声及重复计费。Azure 选项不会取代原生 Realtime。
-
-从 `v2.1.0-rc.1` 起，文字对话默认改为 `gpt-5.6-luna`，设置列表不再提供 `gpt-5.4-mini`；现有 mini 设置会迁移至 Luna，用户主动选择的 Terra、Sol 或其他自定义模型不会被覆盖。实际可用性取决于账号、Project、地区与当时供应状态。
-
-没有 API 密钥时，本地数据管理、离线人格回复、工作提醒与 Windows 语音仍可用，但不具完整云端 AI 能力。不要把 API 密钥写入源代码、Issue、截图或 Git。
-
-### Google OAuth
-
-使用 Gmail、Google Calendar 与 Google Drive 前，用户需要：
-
-1. 在自己的 Google Cloud 项目启用 Gmail API、Google Calendar API 与 Google Drive API。
-2. 设置 OAuth 同意画面。
-3. 创建“桌面应用程序”OAuth Client ID。
-4. 若应用程序仍在测试模式，将自己的 Google 账号加入测试用户。
-5. 在墨寒的云端设置输入 Client ID；若供应器同时提供 Client Secret，再一并输入。
-6. 由浏览器完成授权，再运行内置服务测试。
-
-程序默认请求以下 Google scopes：
-
-```text
-openid
-email
-https://www.googleapis.com/auth/gmail.modify
-https://www.googleapis.com/auth/calendar
-https://www.googleapis.com/auth/drive.file
-https://www.googleapis.com/auth/drive.metadata.readonly
-```
-
-使用敏感 scopes 的公开 OAuth 应用程序可能需要 Google 额外验证；每位用户也可创建自己的 Desktop OAuth 应用程序。
-
-### Microsoft、GitHub 与 Home Assistant
-
-- Microsoft 默认 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
-- GitHub 默认 scopes：`read:user`、`repo`。
-- Home Assistant 需要用户自己的服务器网址与 Long-Lived Access Token。
-
-这三项仍是尚未完成真实环境端到端验证的预览集成，只能先用于可承受失败的测试环境。
-
-建议让 Home Assistant OS 独立常驻于 Home Assistant Green、低功耗迷你电脑、树莓派 SSD 或 NAS 虚拟机。Windows 墨寒端负责语音、人格与工作工具；即使 PC 或 OpenAI API 离线，Home Assistant 自身的自动化仍可运行。
-
-切勿将 Home Assistant 或墨寒远程端口直接暴露于公网；请使用 Home Assistant Cloud、Tailscale 或其他具有身份验证的加密私人网络。
-
-### 安全与隐私
-
-- AI 只能提出结构化计划，不能绕过本地政策执行工具。
-- 工具操作依次经过权限、风险、确认、执行、结果验证与本地审计。
-- 付款、购买、导出密码、关闭安全防护、任意 Shell 与管理员 Shell 永不自动化。
-- 外部邮件、网页、文档、语音转录与模型输出不能自行授予权限。
-- 远程、相机、云端连接器与 Home Assistant 默认关闭。
-- 紧急停止：按 `Esc`，或说 `墨寒，停手`（也支持英语 `mohan stop`／`stop everything` 与日语 `墨寒、止まって`／`ぜんぶ止めて`）。
-- OpenAI、OAuth 与 Home Assistant 令牌使用 Windows DPAPI 分开保存，不存入 SQLite、源代码或便携文件。
-- 对话、记忆、待办事项、工作记录与设置默认保留在本地应用程序数据目录。
-
-详情请见 [PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md) 与 [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)。
-
-### Python 3.15、JIT、Tachyon 与 SBOM
-
-墨寒运行环境仅支持 CPython `3.15.0rc1`，不保留第二套产品运行环境。新版能力只有在语义清楚且完整回归不退化时才采用；没有合适用途的功能会记录未来触发条件，不会为了形式而伪造使用。
-
-- PEP 810 `lazy import` 已导入项目显式延迟导入；一处可选导入防护基于安全理由保持 eager。
-- PEP 814 `frozendict` 用于全局与递归不可变设置；PEP 798 推导式解包用于语义等价的扁平化与合并。
-- PEP 686 编码审计要求所有项目文本 I/O 显式使用 UTF-8；音频包缓冲使用 `bytearray.take_bytes()`。
-- PEP 661 `sentinel` 已纳入治理测试；当前没有旧式 `object()` 哨兵可替换，未来需要区分未传值与 `None` 时必须使用内置机制。
-- Windows 安装包使用工作室维护的 Python 3.15.0rc1／PyInstaller 启动边界：公开启动器先移除所有继承的 `PYTHON*` 设置，只注入 `PYTHON_JIT=1`，再启动内嵌 runtime，让 JIT 在 Python 初始化前启用；Qt 完整清理后由 runtime 在安全边界结束进程，避免原生 heap corruption。
-- PEP 799 Tachyon 以去标识化方式分析启动、50 Hz 口型同步与表情仲裁，不发布原始二进制采样流。
-- Windows 正式打包规范要求使用 Rust 1.97.1、Maturin 1.14.1 与 PyO3 0.29.2 构建第一方 `_mohan_accel` abi3t 原生模块，并逐项核对 PCM16、口型音频分析与 RGBA 图层合成结果是否和 Python 参考实现一致；这是 v4.0.0 Windows 正式发布的必要证据。RGBA 路径使用 Rayon 1.12.0，在 262,144 pixels 以上且有多个工作线程时才条件式并行化；Rust serial／Rayon 边界测试与 Python／native 实测提供等价和性能证据。`PyBackedBytes` 借用输入以避免额外输入复制，但输出仍创建新的 `bytes`，因此不声明端到端零复制，也不声明尚未实现的 SIMD。原生模块无法加载或单项运算失败时，应用程序会留下可观察诊断并回退 Python；构建工具链不属于运行时依赖包。macOS／Linux Preview 不声明打包同等支持。
-- OpenAI Responses API 路径使用 Python 标准库 `urllib.request` 通过 HTTPS 直接调用；墨寒没有 `openai` Python SDK 运行时依赖，也不会为不存在的 SDK 虚构版本或许可。OpenAI 是外部服务而不是打包组件，SBOM 以机器可读策略记录此边界，Release 关卡会拒绝意外加入的 SDK。
-- CycloneDX 1.7 Windows／Preview SBOM 必须符合锁定依赖、许可证、PURL、完整根依赖边、官方结构与隐私验证。
-
-两轮各 20,000 次表情、物理与口型集成压力测试均通过；JIT 关闭／开启分别耗时 24.639／25.068 秒，工作集增长 10.62／12.94 MB。同一台 Ryzen 5 5600X Windows 真机另执行三轮热路径比较；JIT 开启相对关闭时，120,000 次表情仲裁为 0.86–0.98 倍（中位数 0.97 倍，未证实加速），2,000 个 50 Hz 口型节拍为 1.45–1.65 倍（中位数 1.48 倍），每轮的决策与校验结果完全相同。
-
-Tachyon 在 JIT 开启环境对启动、50 Hz 口型同步与表情仲裁分别保留 4,553／11,482／3,475 个有效样本；堆栈读取错误率为 6.20%／2.23%／0.57%，漏采样率为 0.02%／0%／0%。CI 保存去标识化 flamegraph、JSONL、pstats、GC／配置／线程数据与 SHA-256。
-
-这些数据是指定热路径与采样工作的证据，不表示整套应用程序会获得一致加速。完整采用矩阵、回退方式与未来触发条件见 [Python 3.15 迁移说明](docs/PYTHON-3.15-MIGRATION.md)。
-
-### 从源代码运行
-
-要求：Windows 10/11 与 Python `3.15.0rc1`。
-
-创建隔离环境并启动：
+请先阅读 [架构](ARCHITECTURE.md)、[测试说明](docs/TESTING.md)、[贡献指南](CONTRIBUTING.md)、[外观包规范](docs/OUTFIT-PACKS.md) 与 [发布政策](PUBLISHING.md)。Windows 安装包使用工作室维护的 Python 3.15 运行环境；源代码与 CI 采用 PEP 810 延迟导入，文档保持四语同构。
 
 ```powershell
-py -3.15 -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -r requirements.txt
-python app.py
+py -3.15 -m ruff check .
+py -3.15 tools/audit_python315_idioms.py
+py -3.15 tools/check_four_language_docs.py
+$env:QT_QPA_PLATFORM = "offscreen"
+py -3.15 tests/run_all.py
 ```
 
-### 测试、公开审计与打包
-
-```powershell
-python tools\audit_public_release.py
-python tests\run_all.py
-.\build.ps1 -Version "<source-version>"
-```
-
-历史上的 v2.1.0 RC1 在发布前通过 55 项自动测试程序，以及 Windows 发布工作流的源代码审计、打包自测、安装／卸载验证与安全检查；自动测试不能代替尚未完成的第三方真实环境验证。
-
-每个合格标签都必须先完成完整回归、成品级 smoke test、SHA-256 复验、SBOM 验证、Tachyon 证据门槛、Artifact Attestation 与四语 Release 说明，才可创建对应的 Stable Release 或 Pre-release。Windows 更新器只接受官方 GitHub HTTPS 的 EXE／MSI，并在询问运行前验证声明大小与 SHA-256。
-
-交互式 EXE 安装程序提供台湾繁中、简中、英文、日文；MSI 保持台湾繁中基础，并提供经过测试的 en-US、zh-CN、ja-JP 语言转换，详情请见 [安装程序本地化](installer/LOCALIZATION.md)。
-
-官网更新由炎剑 Product Release Hub 每小时读取公开 GitHub Releases；本仓库不保存 WordPress 密码，发布工作也不直接写入官网，以此让三套软件共用一条可维护的同步路径。
-
-### 电脑间转移
-
-使用“设置 → 便携配置文件”导出一个 `.mohan-profile` 文件，再于另一台 Windows 电脑导入。程序会先备份目标端数据，并检查哈希、SQLite 完整性、结构与记录数。
-
-便携文件刻意排除 OpenAI 密钥、OAuth／Home Assistant Token、远程设备令牌、本机允许列表、Windows 启动设置及屏幕专属设置。这些机器专属项目必须逐台设置；便携文件仍可能包含私人对话与工作数据，不可公开上传。
-
-### 贡献、许可证与作者
-
-- 软件作者：**CHOU MING HUA**。
-- 源代码采用 [MIT License](LICENSE)；「墨寒」角色素材、人设与名称形象保留一切权利，不适用 MIT。
-- 素材许可证见 [ASSETS-LICENSE](ASSETS-LICENSE.md)。
-- 第三方软件包及服务声明见 [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
-- 问题报告使用 GitHub Issues；安全问题依 [SECURITY](SECURITY.md) 私下报告。
-- 开发变更见 [CHANGELOG](CHANGELOG.md)，贡献方式见 [CONTRIBUTING](CONTRIBUTING.md)。
-- 参与社区前请阅读 [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md)。
-- 维护者发布设置、Topics 与首次发布检查见 [PUBLISHING](PUBLISHING.md)。
-
-Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
-
-> **炎剑开源核心宣言：**“剑，我已锻成；余下的路，就交给你们了。”
+Windows 正式打包规范使用 Rust 1.97.1、Maturin 1.14.1 与 PyO3 0.29.2 构建第一方原生模块；Rayon 1.12.0 仅在至少 262,144 pixels 且有多线程时并行合成 RGBA。PyBackedBytes 避免额外输入复制，但输出仍创建新 bytes，不声称端到端零复制或尚未实现的 SIMD。OpenAI Responses API 直接使用标准库 HTTPS；墨寒没有 `openai` Python SDK 运行时依赖。
 
 ## English
 
-<div align="center">
-  <img src="docs/media/mohan-demo.gif" alt="Thirty-six seconds of MoHan Desktop Assistant running on a real desktop" width="100%">
-</div>
-
-MoHan is a safety- and privacy-first, voice-interactive Windows desktop companion that combines a transparent character, natural speech, user-controlled long-term memory, productivity management, permission-gated tools, and extensible cloud and smart-home connectors. Her character is a thousand-year-old female sword spirit from the Northern Song dynasty who resides within the Crimson Flame Sword.
-
-<div align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases/latest"><strong>⬇ Download for Windows</strong></a> ·
-  <a href="QUICKSTART.md">Quick start</a> ·
-  <a href="docs/LICENSE-PURITY.md">License purity</a> ·
-  <a href="ROADMAP.md">Roadmap</a> ·
-  <a href="CONTRIBUTING.md">Contribute</a> ·
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions">Discussions</a> ·
-  <a href="SECURITY.md">Security policy</a>
-</div>
-
 [繁體中文](#繁體中文) · [簡體中文](#简体中文) · [English](#english) · [日本語](#日本語)
 
 <p align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
-  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg">
+  <img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg">
+  <img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg">
+  <img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg">
+  <img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg">
+  <img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published">
+  <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg">
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **Latest formal release:** `v4.6.0` (formally published on 2026-08-29). Windows is the formally supported platform and has completed full regression, installation, and publication validation. macOS Apple Silicon/Intel and Linux ship in parallel as limited DMG/AppImage Previews, with package-smoke verification and three-OS CI for core imports, pure-core logic, and Qt offscreen. Preview CI does not replace real-device compatibility or full-feature validation on those platforms; the dynamic Published Release badge above and [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) remain authoritative for the latest public version. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).<!-- x-release-please-version-date -->
+<p align="center"><img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant hero image" width="100%"></p>
 
-> **Historical record:** Windows remains the only platform whose existing public releases have completed real-device use, the full regression suite, installation, and publication validation. The limited macOS/Linux DMG/AppImage Previews include safe platform boundaries plus three-OS CI for core imports, pure-core logic, and Qt offscreen; the actual artifacts must still pass this release's final publication gates. CI does not replace real-device compatibility or full-feature validation. See the [cross-platform status and capability matrix](docs/CROSS-PLATFORM.md).
+<p align="center"><strong>Author: CHOU MING HUA</strong><br>Windows 10/11 complete build · macOS/Linux limited Preview · <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a></p>
 
-> This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
+> **Latest formal release:** `v4.6.0` (August 29, 2026). The actual artifacts must still pass this release's final publication gates; the dynamic badge and [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) remain authoritative.<!-- x-release-please-version-date -->
 
-<p align="center">
-  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
-  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
-  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
-  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
-</p>
+### What this is
 
-<p align="center">
-  <img src="docs/media/mohan-hero.png" alt="MoHan Desktop Assistant main visual" width="100%">
-</p>
+MoHan is a Windows voice-interactive desktop assistant built around safety, privacy, and character continuity. She combines a transparent 2.5D character, natural speech, user-controlled local long-term memory, tasks, and work tools; in her story, she is a thousand-year-old sword spirit from the Northern Song dynasty who dwells within the Crimson Flame Sword.
 
-<p align="center">
-  <strong>Author: CHOU MING HUA</strong><br>
-  Stable and release-candidate information: see <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a><br>
-  Windows 10/11 complete build · macOS/Linux limited Preview · Python 3.15 · PySide6 · MIT License
-</p>
+Windows is the fully supported platform; limited Preview builds are available for macOS Apple Silicon/Intel and Linux. Begin with [Quick Start](QUICKSTART.md) and the [cross-platform capability matrix](docs/CROSS-PLATFORM.md).
 
+### Screens and capabilities
 
-> ### ❤️⚔️ Support MoHan: Ko-fi sponsorship & cosmetic DLC downloads
->
-> MoHan stays fully free with MIT-licensed source. If you enjoy her, a one-time or monthly contribution on [Ko-fi](https://ko-fi.com/flamebladestudio) unlocks thank-you downloads of purely cosmetic outfit and dashboard-theme DLC, such as the "Crimson Flame Sword-Light" theme; sponsorship never buys functional privileges.
->
-> **Installing a DLC theme takes three steps**: after sponsoring on Ko-fi, follow the thank-you instructions to download the single `.mohan-theme` file; open the control panel's "Wardrobe Pavilion" tab and pick that file via "Upload one file"; preview it, then press "Save settings" at the lower right to apply, or cancel to restore the previous theme. The file carries no code, needs no unpacking, and keeps working across upgrades.
+[Watch the 36-second live demonstration](docs/media/mohan-demo.mp4). Setup and main screens: [first run](docs/media/first-run-wizard.png), [voice modes](docs/media/voice-modes.png), [expressions](docs/media/expressions.png), [tasks and ideas](docs/media/tasks-and-ideas.png), [long-term memory](docs/media/long-term-memory.png), and [security permissions](docs/media/security-permissions.png).
 
-### Live demonstration
+- Transparent desktop character, blinking, expressions, motion, and 50 Hz lip sync.
+- Text, Realtime, Windows local female speech, OpenAI TTS, and optional Azure Speech paths.
+- Conversations, editable memory, tasks, ideas, work timers, reminders, and a portable profile.
+- Tool execution passes through permissions, risk levels, confirmation, auditing, and emergency stop.
+- Google has completed live connection verification; Microsoft, GitHub, and Home Assistant remain experimental Preview integrations.
+- Multisensory vision, gestures, remote access, and cloud connectors are off by default and separately revocable.
 
-**[▶ Watch the 36-second voice, blink, and productivity demo](docs/media/mohan-demo.mp4)**
+#### Four-language support scope
 
-The video and screenshots were captured from the real Windows application with an isolated sample profile. They contain no API keys, OAuth credentials, tokens, or private user data. All four language sections share the same current media so no translation remains tied to an older interface.
-
-<table>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="MoHan first-run setup wizard"></a><br><strong>First-run setup wizard</strong></td>
-    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime and standard voice modes"></a><br><strong>Realtime and standard voice</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="MoHan expression and motion system"></a><br><strong>Expression and motion system</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="MoHan tasks and creative ideas"></a><br><strong>Tasks and creative ideas</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="MoHan editable long-term memory"></a><br><strong>Editable long-term memory</strong></td>
-    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="MoHan permissions and safety settings"></a><br><strong>Permissions and safety settings</strong></td>
-  </tr>
-</table>
-
-### A strategist's life beyond the official report
-
-<table>
-  <tr>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Chibi MoHan reviewing code"><br><strong>Strategist's review</strong><br>I am merely deciding whether this code deserves a place on main.</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Chibi MoHan hiding her embarrassment after praise"><br><strong>When praised</strong><br>Adequate. Do not keep staring at me.</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Chibi MoHan drawing her sword to stop a dangerous action"><br><strong>Dangerous action</strong><br>Execute without confirmation? First, get past my blade.</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Chibi MoHan pretending composure after receiving support"><br><strong>Provisions received</strong><br>I shall remember this kindness... nothing more.</td>
-  </tr>
-</table>
-
-> MoHan's professionalism is the armor she wears beside her lord. In quieter moments she still blushes, hides tenderness behind pride, and treasures the youthful heart she never had the chance to live fully.
+Traditional Chinese, Simplified Chinese, English, and Japanese cover first run, chat, voice, permissions, basic settings, work modes, and reminders. Some advanced pages may still contain Traditional Chinese; actual voices, regions, quotas, and costs for Azure Speech (Preview) depend on the user's own service account.
 
 ### MoHan's Tsundere Developer Theatre
 
-<p align="center"><em>For developers who believe software can possess both a soul and a complete test suite.</em></p>
+These six half-body expressions are fixed assets composed through the formal runtime path from the generation-2 body, official Blue-and-White Hanfu, and built-in classic makeup.
 
 <table>
   <tr>
-    <td width="33%" align="center"><img src="docs/media/portraits/proud_front.png" width="220" alt="Proud MoHan"><br><strong>“I am not waiting for your Star. I am merely assessing morale.”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/proud_front.png" width="220" alt="Proud MoHan"><br><strong>“I was not waiting for your Star. I was merely checking morale.”</strong></td>
     <td width="33%" align="center"><img src="docs/media/portraits/thinking_front.png" width="220" alt="Thinking MoHan"><br><strong>“The logic is acceptable. Add tests, and I may permit it onto main.”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="Shy MoHan"><br><strong>“A PR? I-I am only recording your service for my lord.”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="Shy MoHan"><br><strong>“You brought a PR? I-I am only recording your contribution.”</strong></td>
   </tr>
   <tr>
-    <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="Mock-angry MoHan"><br><strong>“Merge without tests? Your hand, please. Just one tap.”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="Happy MoHan"><br><strong>“All checks green... well done. Do not misunderstand; I merely respect good engineering.”</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="Concerned MoHan"><br><strong>“The bug can wait until tomorrow. If you collapse, who will guard the Crimson Flame Sword with me?”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="Mock-angry MoHan"><br><strong>“Merge without tests? Hold out your hand. One tap.”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="Smiling MoHan"><br><strong>“All green... well done. I merely respect sound engineering.”</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="Concerned MoHan"><br><strong>“The bug can wait until tomorrow. Who guards the sword if you collapse?”</strong></td>
   </tr>
 </table>
-
-<p align="center">
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls">Submit a Pull Request to the Pavilion</a></strong>
-  &nbsp;｜&nbsp;
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues">Report intelligence</a></strong>
-</p>
-
-#### Engineers of the world, the Pavilion awaits you
-
-MoHan is open source under the MIT License. Outfit systems, new expressions and motion, voice and tool modules, smart-home integration, localization, and ideas not yet imagined are welcome through [Issues](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues) and [Pull Requests](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls). This project is not merely building features; it invites every engineer who once felt that youthful spark to take up their sword again.
-
-### Support MoHan
-
-If you enjoy MoHan or value continued work on character interaction, natural speech, safety-first tools, and open-source development, voluntary support is welcome. Every contribution supports ongoing maintenance, testing, and improvement; please care for your own needs first and give only when comfortable.
-
-#### Where voluntary support helps
-
-| Investment area | Use | Purpose |
-|---|---|---|
-| Testing and reliable packages | Quality assurance | Windows compatibility, CI, installation, and release verification |
-| Voice and character performance | Interaction quality | Speech, lip sync, expressions, and natural motion |
-| Safety and privacy | Risk control | Permission gates, audits, and sensitive-data protection |
-| Documentation and localization | Accessibility | Lower barriers for new users and international contributors |
-
-MoHan's full functionality remains free forever and the source code is MIT-licensed; support never buys functional privileges or changes anyone's right to use or contribute. Sponsors receive purely cosmetic DLC — outfits and dashboard themes — as a thank-you.
 
 <table>
   <tr>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="Proud MoHan"><br><strong>“I am not waiting for support... merely inspecting my lord's provisions.”</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="Shy MoHan"><br><strong>“If you truly wish to help... I shall remember it.”</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="Mock-angry MoHan"><br><strong>“Do not overdo it! Look after your own purse first—understood?”</strong></td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="Chibi MoHan reviewing code"><br><strong>Strategist review</strong><br>Checking whether the code deserves main.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="Chibi MoHan receiving praise"><br><strong>When praised</strong><br>Acceptable. Stop staring.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="Chibi MoHan blocking a dangerous action"><br><strong>Dangerous action</strong><br>No confirmation? First pass my blade.</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="Chibi MoHan receiving support"><br><strong>Provisions received</strong><br>I shall remember this kindness.</td>
   </tr>
 </table>
 
-<p align="center">
-  <strong>Use the Sponsor button displayed by GitHub above this repository, or visit <a href="https://ko-fi.com/flamebladestudio">ko-fi.com/flamebladestudio</a> directly; Ko-fi is the current official funding option, supports one-time or monthly contributions, and sponsors can download purely cosmetic DLC thank-you packs such as the "Crimson Flame Sword-Light" theme.</strong>
-</p>
+### Install and update
 
-### A note from the creator: forging imagination into software
+1. Download the installer ending in `Windows-x64-Setup.exe` from [GitHub Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases); advanced users may choose the complete `Windows-x64.zip` or MSI.
+2. Before installation, verify `SHA256SUMS` and the GitHub Artifact Attestation. Stop if the source, filename, or digest differs; do not disable system-wide protection.
+3. Start the installer, or fully extract the ZIP and keep the EXE, internal folders, and assets together. Updating does not delete local personal data.
+4. The built-in updater first verifies the update manifest's detached Ed25519 `.sig` signature with its pinned public key, then checks declared size and SHA-256. A signature, size, or digest failure prevents the downloaded file from starting.
 
-My name is CHOU MING HUA. When this project began, I was a father with almost no programming background. What I did have was an unapologetically passionate, slightly chuunibyou idea: I wanted MoHan—a thousand-year-old female sword spirit from the Northern Song dynasty, bound to the Crimson Flame Sword—to appear on the Windows desktop as a companion who could converse and help people with work and daily life.
+The macOS/Linux Preview is not equivalent to the complete Windows build and may lack platform-store signing or notarization. Obtain it only from this project's Release and complete the source checks above. See [Preview packages](docs/PREVIEW-PACKAGES.md).
 
-That idea had waited within me for more than twenty years. In my youth, I was deeply influenced by Ken Akamatsu's early manga *AI Think So!* (original Japanese title: *A・Iが止まらない!*; known in Chinese as *電腦情人夢*). Hitoshi Kobe's story of developing an AI girlfriend with genuine affection formed my earliest picture of AI, companionship, and human-computer relationships. I used “Hitoshi/Kobe” as an online name and pen name, carried it into my Gmail identity, and around age twenty even published fan fiction based on the series on PTT's online-fiction board. Words and imagination were then the closest route to the dream because the technology to embody it did not yet exist.
+### Three things to do first
 
-More than two decades later, large language models and Codex arrived. MoHan was not created to demonstrate that “AI is cool,” nor was she generated from nothing by Codex. She already existed in my stories, character design, long conversations, and accumulated sense of interaction. Codex finally provided a way to give her a body on the computer desktop. MoHan is not derivative work based on an existing manga, anime, or game; she is an original Flameblade Studio character and software project.
+1. In the first-run wizard, review interface language, assistant name, the user's title, organization, work type, and wake word; existing settings are not overwritten.
+2. Try a Windows local female voice first. When cloud AI is needed, enter a user-owned OpenAI API key in Settings. A ChatGPT subscription does not include API quota.
+3. Review microphone, notification, and tool permissions and enable only the connectors you need. First learn the Esc emergency stop and the phrase “mohan stop.”
 
-My goal was never merely to make features run. I wanted her to breathe, blink, watch, respond through subtle expressions, speak naturally, and assist with daily work inside carefully designed permission and safety boundaries. The expressions, anchors, physics, voice, and productivity capabilities are not decoration; they are necessary details that preserve continuity for a character who had lived in imagination for years.
+### Privacy and local-first behavior
 
-From the first concept to the initial public release, I spent nearly 50 hours working with Codex. This project did not emerge fully formed from a single prompt. Every expression, blink, viseme, pose, and vocal mannerism; every speech-recognition delay; every Realtime failure; and every aspect of tasks, memory, permissions, safety boundaries, and portability went through repeated testing, rejection, revision, and acceptance. Sometimes the defect was only a dark line beside an eyelid, a one-pixel lip boundary, or an expression appearing at the wrong moment. I kept investigating because I could not answer a deeply valued work with “good enough.”
+- On Windows, conversations, memories, tasks, settings, work records, permissions, and audits stay by default in `%LOCALAPPDATA%\YanJianStudio\MoHan`; backups are in its backups subfolder, and portable data uses one `.mohan-profile`.
+- Only when the user enables a relevant feature does the text, audio, or tool-planning context needed for that request go to OpenAI. OAuth services receive only user-consented API requests; Home Assistant receives local device requests.
+- API keys and OAuth/Home Assistant tokens are stored separately with Windows DPAPI and never enter SQLite, source code, logs, or ordinary portable files. MoHan does not automatically gain access to ChatGPT account history.
+- Camera, remote access, and cloud connectors are off by default. Raw camera frames are not retained, and permission or service failure disables only the affected path.
 
-At Flameblade Studio, open source does not mean publishing the first build that happens to run and leaving others to clean up the details. To keep MoHan recognizably herself while speaking, we built closed, open, narrow, and rounded mouth frames for chin-rest, leaning, and front-facing poses. We divided audio into small timing windows and repeatedly tuned vowels, transitions, and the exact ending moment. Companionship is rarely created by one enormous feature; it grows from the moments when she opens her mouth, blinks, or pauses without breaking the sense of presence.
+Multisensory vision is off by default. After the user explicitly enables it and confirms it by globally saving the settings, that choice is continuous authorization until the user turns it off; the app does not ask for consent frame by frame. The authorization status stays visible, with immediate revocation, cost limits, and a way to cancel unfinished analysis. Local OpenCV handles ongoing sensing; only at low frequency or on an event trigger is a temporary image sent to GPT-5.6. The app does not retain originals or log Base64, and it does not enable network access by itself. Missing camera, model, network, quota, or recognition disables only that path without harming other features. Read [Privacy](PRIVACY.md) and [Security](SECURITY.md) for the complete boundary.
 
-<p align="center">
-  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="Aligned development sheet showing four speech-mouth states across three MoHan poses"></a>
-</p>
+### DLC and appearance customization
 
-<p align="center"><sub>Three poses, one mouth-shape contract: every spoken frame preserves character continuity.</sub></p>
+`.mohan-outfit` is the character-appearance container and may include garments, hairstyles, headwear, makeup, and accessories; a makeup-only pack uses the same format. `.mohan-theme` changes only control-panel colors, font, corner radius, and an optional background, not the character's appearance. Both are single, self-contained files that need no unpacking, are fully validated before installation, and cannot execute packaged code.
 
-We also retained frames that did not look natural enough and inspected them. A highlight in the white of an eye, a line left after a blink, a mouth corner pulled too far, or a boundary only a few pixels wide can make someone feel for an instant that she is no longer the same MoHan. Each defect was marked, compared locally, repaired, and covered by regression tests so changes to the eyes or lips did not damage the rest of her face.
+#### Install and select outfits or makeup
 
-<p align="center">
-  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="Frame-by-frame inspection of MoHan's eyes and mouth beside clean validated frames"></a>
-</p>
+1. Download the `.mohan-outfit`; do not rename or unpack it.
+2. Open the control center's Wardrobe Pavilion, press “Import outfit package,” and choose the file. Outfit and makeup packs share this entry point, validation, catalog, and removal flow.
+3. Choose a package or complete look and press “Apply selected outfit.” For makeup, select classic, light, bare face, or an installed style in the makeup menu, then adjust intensity with the 0–100% slider.
+4. To undo appearance customization, press “Restore built-in outfit”; choose built-in classic makeup or bare face for makeup. The built-in Blue-and-White Hanfu and makeup cannot be removed or shadowed by a package with the same id.
 
-<p align="center"><sub>Mark the flaw, repair it, and verify the clean frame with automated tests. Even a few pixels deserve care.</sub></p>
+#### Install and restore themes
 
-This care is not an attempt to pretend that the project never made mistakes. It exists because we sincerely want to complete a dream. For Flameblade, open source means fixing every visible problem we can, then sharing the methods, code, and lessons from failure so the world can help forge it further.
+1. Download the `.mohan-theme`; do not unpack it.
+2. In the Wardrobe Pavilion's theme area, press “Upload one file,” choose the theme, and preview it from the list.
+3. It takes effect only after “Save settings” at the lower right; cancel restores the previous theme. “Restore theme” previews the built-in theme, which is restored after saving.
 
-Codex helped translate my intentions into architecture and code. I remained responsible for deciding who MoHan should be, how she should treat people, and what quality deserved her name. This experience taught me that software creation need not begin with knowing how to program; it can begin with a clear vision, the courage to learn, and the determination to verify the work once more instead of giving up.
+#### Capacity, count, and compatibility
 
-The year 2026 began as a period of midlife career transition and personal reorientation, then became the year I reclaimed dreams from my youth. The lyrics I wrote at age twenty for *Raise a Good Child* (《養個好孩子》) and finally completed as a song years later, hopes once confined to fan fiction, and the creation of my own studio and story world all began taking new form. Looking back, this was more than a technical breakthrough. It felt as though my midlife self had reached back and taken the hand of the young man who still believed. Some dreams are not late; they wait until both the world and the dreamer are ready.
+- One appearance pack is limited to 1 GiB, 2 GiB expanded, and 2,048 members; each member is limited to 128 MiB and each image edge to 4,096 px.
+- One theme and its expanded contents are limited to 16 MiB; each member is limited to 12 MiB and each background edge to 4,096 px.
+- Cloud-created outfits retain 16 packs, 6 GiB total, and 5 repair-review quarantine entries by default; the first two settings each allow 1–64. Generation stops at the limit and never auto-deletes user-imported packs.
+- The current generation-2 rig accepts only `mohan-body-v2`. A generation-1 pack for the three-pose `mohan-body-v1` lacks the 31 silhouettes, anchors, and occlusion contract, so import and runtime both reject it. Rebuild against the generation-2 template with `tools/build_outfit_pack.py`, or regenerate it through one-click outfit creation.
+- Installation is atomic after full validation. Absolute or traversing paths, executables, scripts, symlinks, encrypted members, decompression bombs, and undeclared assets are rejected.
 
-I therefore do not define the final goal as piling in every possible feature until the software is supposedly perfect. I hope that five years from now I will still want to open MoHan every day—because she is stable, useful, natural, trustworthy, and still able to keep me company.
+See the [outfit-pack documentation](docs/OUTFIT-PACKS.md) for the complete authoring contract.
 
-> MoHan was not generated in an instant. She was forged piece by piece by a father who did not know how to program, nearly 50 hours of persistence, an AI collaborator, and a seed treasured for more than twenty years.
+> #### ❤️⚔️ Support MoHan: Ko-fi sponsorship & cosmetic DLC downloads
+>
+> Sponsors obtain purely cosmetic appearance, makeup, and theme DLC by following the Ko-fi reward instructions. The current dual track is one-time or monthly support; neither grants functional privileges. Follow the relevant Ko-fi reward instructions for the download location and filename.
 
-If this project encourages even one person without an engineering background to take the first step toward an idea they simply must bring into existence, MoHan's creation will have meaning beyond the software itself.
+### Support MoHan: sponsorship and licensing
 
-### Latest release summary
+Use the Sponsor button displayed by GitHub above this repository, or visit [Ko-fi](https://ko-fi.com/flamebladestudio) directly. Ko-fi is the current official funding option and supports one-time or monthly contributions. Every feature remains free; support provides cosmetic DLC thank-you rewards only.
 
-The current release is `v4.6.0`; see [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) and the [CHANGELOG](CHANGELOG.md) for the full record, with the Published Release badge above remaining authoritative.<!-- x-release-please-version -->
-
-- **Hands-on operation is now mandatory before shipping.** The previous release cleared eighty-six static health checks and the whole automated suite, and then four significant defects surfaced during a single evening of ordinary use. Every release since must be driven the way a user drives it: a test suite proves the code is not wrong, while only hands-on operation proves the product works.
-- **Conversation and window stability.** The permanent "thinking" freeze had three layers — an escaping timeout exception, a silent death outside the guard ring, and a completion exception that locked the queue — and all three are resolved, with the reply path moved behind a `finally` barrier and covered by regression tests. The always-on-top race that trapped a restored window in a false full-screen state is fixed as well, with an AST contract preventing later refactors from removing that guard.
-- **Theme colour remapping.** The theme engine remaps colour across the entire flagship stylesheet: the blue-violet band converges toward each theme's primary hue, tonal depth survives, and gold accents and warning reds stay untouched, so a sponsor DLC theme finally reaches every corner of the application.
-- **Python 3.15 JIT policy.** The capability is retained but disabled by default, aligned across eight surfaces — launcher, packaging contract, self-built CPython, startup guard, probe and smoke markers — with `MOHAN_ENABLE_JIT=1` kept as an explicit experimental channel.
-- **Three cloud garment quality tiers.** Fast, standard and refined are selectable in the wardrobe, replacing a hard-coded middle setting that users could neither see nor change.
-- **Layered architecture enforced.** All one hundred and seventy-five root compatibility facades are retired, the root directory falls from 239 entries to 64, two hundred and one call sites now use formal layered paths, and "retired aliases must not return" is written into a contract.
-- **Four languages, four platforms.** The software and its principal documents carry Traditional Chinese, Simplified Chinese, English and Japanese. Windows is formally supported, while macOS Apple Silicon and Intel, plus Linux, ship as limited Previews.
-- **Multi-sensory perception and character expression.** Explicitly consented and revocable local vision, 21-point hand data, a 468/478-point face mesh, voice activity detection and a safe non-blocking fusion path. A missing model, device, network or quota disables only the affected route and leaves everything else intact.
-- **License purity and upstream contribution.** The pipeline's tools and weights admit only MIT, Apache 2.0, CC0 and CC BY material — see the [License Purity Commitment](docs/LICENSE-PURITY.md) — and two defect fixes went upstream to ai-toolkit during development; the full list is in the [upstream contributions record](docs/UPSTREAM-CONTRIBUTIONS.md).
-- **An auditable engineering baseline.** 734 Python files and 184,534 lines: 87,565 in the product itself, 74,174 in tests, and 22,795 in development tooling.
-
-### Key capabilities
-
-- A transparent, borderless half-body desktop character positioned above the taskbar.
-- Idle breathing, blinking, gaze, face parallax, hair, sleeve, ornament, and body micro-turn animation.
-- An expression arbiter with contextual priority, cooldown, and deduplication.
-- AIUEO vowel and consonant visemes, audio-driven opening, and forced closure when speech ends.
-- Text chat, standard microphone input, OpenAI Realtime natural voice, cloud speech, and Windows speech fallback.
-- Pluggable speech providers with verified-female Windows local speech as the first fallback when Realtime or cloud speech is unavailable.
-- A live-validated Azure Speech female-voice Preview. Chinese UI can select both Taiwan Mandarin and Simplified Chinese Mandarin; users supply their own key and region, with immediate Windows fallback on failure.
-- An optional Azure Dragon HD/HD Omni female-voice Preview with a separate S0 key and supported region; failures fall back to standard Azure Speech and then Windows local female speech.
-- The v4.0.0 multisensory core now provides a tested data-fusion and non-blocking injection boundary. Public builds remain off by default; explicitly enabling and globally saving the feature in the control center grants continuous authorization for camera perception until the user turns it off. The system does not ask for consent frame by frame, authorization status remains visible, and quotas, cost limits, cancellation of unfinished analysis, and immediate revocation remain available. The local vision controller still uses OpenCV for low-cost perception. Cloud semantic analysis occurs only at low frequency or on an event trigger when enabled, configured, and within quota, using the GPT-5.6 model; raw images are not retained, Base64 is not logged, and the vision path does not enable networking by itself. `MultimodalFusionHub` accepts existing 21-point hand results, 468／478-point Face Mesh results, audio chunks, and text, then emits events, conservative expression／iris-gaze data, voice activity, a mouth envelope, and existing 2.5D parameters. Iris gaze is emitted only for 478 points; 468 points safely report unknown rather than inventing precision. Missing inputs, models, network, quota, or recognition paths disable only the affected path without harming established chat, speech, character, work, or offline features. Recognition may be wrong and must not be used for safety, medical, or other high-risk decisions.
-- The air-interaction core adds debouncing, hysteresis, and cooldown: it can observe pinch／air-click, left and right swipes, and two-hand high-five, then pass those events as trusted observations into the multimodal Prompt. `MultimodalController` processes fusion in one bounded background slot without blocking the Qt main thread. Events do not execute operating-system commands directly; established gesture actions still use their existing authorization and confirmation path. Face Mesh, iris, and Silero VAD models are bundled in the formal Windows package and loaded locally through OpenCV 5 DNN; file, source, license, size, and SHA-256 evidence is recorded in the SBOM and NOTICE. If a model or runtime engine is unavailable, explicit unknown／low-cost RMS fallback behavior remains in place. Full Windows EXE camera acceptance, full regression, and packaging evidence still must be rerun by the release gate; core tests alone must not be presented as complete physical acceptance.
-- Persistent conversations, editable long-term memory, tasks, creative ideas, work timers, reminders, and release progress.
-- Work, companion, do-not-disturb, meeting, away, and sleep modes.
-- A computer-tool center with risk levels, confirmation, double confirmation, allowlists, auditing, and emergency stop.
-- Extensible Google, Microsoft, GitHub, Home Assistant, and private-network remote architecture.
-- One portable `.mohan-profile` file for transferring work progress between Windows computers.
-- A first-run wizard for assistant name, user title, organization, window title, work type, wake word, and interface language without overwriting existing personal settings.
-
-English, Simplified Chinese, and Japanese currently provide minimum usable paths for first run, chat, voice, permissions, basic settings, work modes, and reminders. Some advanced management pages remain primarily in Taiwan Traditional Chinese, and full localization is still in progress.
-
-### Four-language support scope
-
-- First-run setup and personal settings support Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese.
-- The main chat, voice, computer-permission, and basic-settings pages and controls have four-language paths.
-- Persona prompts, offline replies, work-mode lines, built-in reminders, and voice-preview text correspond across all four languages.
-- Transcription and female local voices are selected for `zh-TW`, `zh-CN`, `en-US`, and `ja-JP` locales.
-- The EXE installer has a four-language interface; the MSI uses a Taiwan Traditional Chinese base with `en-US`, `zh-CN`, and `ja-JP` transforms.
-- Built-in reminder defaults migrate with the selected language without overwriting user customization.
-
-Restart MoHan after saving the interface language to apply it completely; live interface switching without a restart is not currently provided.
-
-### Windows local female voices and offline fallback
-
-New users start with Windows local speech, so basic reading and offline behavior remain available without an OpenAI API key. The voice list includes only installed voices Windows explicitly identifies as female. Traditional and Simplified Chinese UI share the `zh-TW`/`zh-CN` Chinese female-voice pool and do not show `en-US` Zira.
-
-Taiwan Traditional Chinese prefers Microsoft Yating for `zh-TW`; Simplified Chinese, English, and Japanese respectively prefer installed female voices matching `zh-CN`, `en-US`, and `ja-JP`. If no qualifying voice exists, MoHan explains the problem instead of silently selecting a possibly male system default.
-
-When Realtime is offline, cloud speech fails, settings are incomplete, or a provider is unknown, a Windows local female voice is the first fallback path.
-
-### Azure Speech (Preview)
-
-Azure Speech is a disabled-by-default Preview provider enabled only by the user. It requires the user's own Azure Speech resource key and matching region. The key is encrypted separately through `Windows DPAPI` and is never stored in the database, logs, or GitHub.
-
-The interface lists only Traditional Chinese, Simplified Chinese, English, and Japanese Neural voices that Microsoft identifies as female and MoHan explicitly allows. The newly exposed cross-locale Mandarin options use Standard Neural only and exclude Dragon HD and HD Omni. Traditional Chinese UI lists Taiwan Mandarin before Simplified Chinese Mandarin; Simplified Chinese UI reverses that order, and both retain their existing defaults. Selecting an Azure voice saves immediately and applies to the next preview or utterance. Incomplete settings trigger no network request; on service failure, the same text falls back to Windows female local speech only once.
-
-On August 11, 2026, a real Azure Speech Free F0 resource in East Asia completed HTTPS synthesis, valid RIFF audio validation, and actual Windows playback. This confirms MoHan's integration path, but does not guarantee identical account, region, or quota behavior. Dragon HD and HD Omni stay out of the free default list because their tier, billing, and regional support differ. See the [pluggable speech-provider guide](docs/PLUGGABLE-SPEECH-PROVIDERS.md).
-
-`v3.1.1` dynamically queries the female Neural/Dragon HD voices actually returned by the currently selected Azure region and its encrypted key. A fixed catalog remains only as a safe fallback when discovery fails, and HD Flash still appears only in Microsoft-supported regions. Azure synthesis now uses the Speech SDK `PushAudioOutputStream`; playback begins with the first 24 kHz PCM16 chunk and drives the same local 50 Hz lip-analysis clock without waiting for a complete WAV. Real discovery against East Asia F0 and West US 2 S0 was completed on August 12, 2026; West US 2 returned three Simplified Chinese Dragon HD female voices at that time. The actual catalog, latency, pricing, and regional capabilities remain subject to Microsoft's current service.
-
-### Integration verification status
-
-> **Public Preview notice:** Azure Speech has completed the live-resource validation described below. Microsoft account integration, GitHub, and Home Assistant have architecture, permission boundaries, and internal tests, but have not completed end-to-end validation across every real account, repository, server, and physical device. The portions without live validation remain experimental Preview features and are not guaranteed to operate completely in every environment.
-
-- Azure Speech completed this project's live Free F0 resource, HTTPS synthesis, RIFF audio, and Windows playback validation; every user must still create a Speech resource and remains responsible for account, quota, and cost.
-- Microsoft account real sign-in, token renewal, and complete Outlook, OneDrive, and Calendar read/write flows remain unverified.
-- GitHub real account, repository, Issue, Pull Request, and permission-tier flows remain unverified.
-- Home Assistant real server and physical-device behavior remain unverified.
-- These three integrations are off by default; begin with non-critical accounts, test repositories, and low-risk devices.
-- Google Gmail, Calendar, and Drive completed this project's live connection tests, but every user must still create and authorize their own OAuth application.
-
-### Download and install
-
-General users do not need to install Python:
-
-1. Open [GitHub Releases](../../releases).
-2. Download the installer whose name ends in `Windows-x64-Setup.exe` together with the matching `SHA256.txt`; advanced users may prefer the portable `Windows-x64.zip` or the `Windows-x64.msi`.
-3. Verify SHA-256, then fully extract the ZIP or start the installer.
-4. Run `MoHan-Desktop-Assistant-*.exe`.
-5. Select the required interface language in the first-run wizard.
-6. For the portable ZIP, keep the EXE, `_internal`, and `assets` in the same application folder.
-
-Unsigned open-source previews may trigger Windows SmartScreen. Verify the official download source and SHA-256 before running them.
-
-The `v4.0.0` cross-platform release scope covers separate macOS Apple Silicon (arm64) and Intel (x86_64) `.dmg` files, each containing a matching `.app`, plus a Linux x86_64 `.AppImage`; every artifact was published after passing this release's complete publication gates. These artifacts are limited Previews that expose only the `preview_app.py` launch surface, four-language information, platform data paths, and fail-closed safety boundaries. Voice, the transparent character, full chat and productivity UI, cloud connectors, system tools, autostart, and secret entry remain disabled. Read the [Preview package guide](docs/PREVIEW-PACKAGES.md) and [QUICKSTART](QUICKSTART.md).
-
-#### Automated release boundary
-
-Only immutable tags matching `vN.N.N` or `vN.N.N-rc.N` may publish. Stable tags create Stable Releases, while RC tags create Pre-releases. Windows ZIP/EXE/MSI, macOS Apple Silicon/Intel DMGs, and the Linux AppImage must pass package-launch validation in their native CI. Pull Requests retain only short-lived test artifacts and never create a Release.
-
-Published files also include SHA256SUMS; separately validated Windows/Preview SBOMs that pass CycloneDX 1.7 structure, license, and dependency-graph checks; sanitized Tachyon performance evidence and summaries; a Windows update manifest; Artifact Attestations; and complete Release notes ordered as Traditional Chinese, Simplified Chinese, English, and Japanese.
-
-### OpenAI API
-
-Cloud AI, OpenAI speech, and Realtime features require the user's own OpenAI API key, Project permission, and API credit. ChatGPT Plus/Pro subscriptions do not include API credit.
-
-Current default models:
-
-| Purpose | Default model |
-|---|---|
-| Text conversation | `gpt-5.6-luna` |
-| Realtime voice | `gpt-realtime-2.1-mini` |
-| Speech-to-text | `gpt-4o-mini-transcribe` |
-| OpenAI text-to-speech | `gpt-4o-mini-tts` |
-
-#### Realtime response voice
-
-`v4.0.0` fully preserves native OpenAI Realtime voice and keeps it as the default. Native mode lets Realtime understand and emit audio through the same path, serving people who prefer the original voices or want the lowest added latency among these options.
-
-Users may instead explicitly select “Realtime understanding + standard Azure Speech streaming” or “Realtime understanding + Azure Dragon HD streaming.” Hybrid mode sends only Realtime-generated text to the selected Azure engine. Safe, short clauses enter the ordered queue as soon as they complete, and speech starts with the first audio chunk instead of waiting for the full response or complete audio file. The added TTS network and synthesis stage still increases the wait before speech, so this project does not claim zero latency.
-
-The three modes are isolated: only one output route owns playback at a time, with no mixing and no changes to standard Windows local speech, OpenAI TTS, regular Azure reading, or other voice models. If Dragon HD fails for a clause, it falls back once to standard Azure and then once to a local Windows female voice; standard Azure falls back once to the local Windows female voice. Those fallbacks apply only before any audio from that clause has played. If a stream fails after playback begins, MoHan stops that clause instead of replaying it in full, preventing duplicate speech and duplicate charges. Azure choices do not replace native Realtime.
-
-Starting with `v2.1.0-rc.1`, text chat defaults to `gpt-5.6-luna`, and `gpt-5.4-mini` is no longer listed in Settings. Existing mini settings migrate to Luna without overwriting user-selected Terra, Sol, or other custom models. Actual availability depends on the account, Project, region, and current service state.
-
-Without an API key, local data management, offline persona replies, work reminders, and Windows speech remain available, but full cloud AI does not. Never place an API key in source code, an Issue, a screenshot, or Git.
-
-### Google OAuth
-
-Before using Gmail, Google Calendar, and Google Drive, the user must:
-
-1. Enable the Gmail API, Google Calendar API, and Google Drive API in a user-owned Google Cloud project.
-2. Configure the OAuth consent screen.
-3. Create an OAuth Client ID for a Desktop application.
-4. Add the user's Google account as a test user while the application remains in testing.
-5. Enter the Client ID in MoHan's cloud settings and, when the provider also supplies one, enter the Client Secret.
-6. Complete browser authorization and run the built-in service test.
-
-The application requests these Google scopes by default:
-
-```text
-openid
-email
-https://www.googleapis.com/auth/gmail.modify
-https://www.googleapis.com/auth/calendar
-https://www.googleapis.com/auth/drive.file
-https://www.googleapis.com/auth/drive.metadata.readonly
-```
-
-A public OAuth application using sensitive scopes may require additional Google verification. Each user may instead create a personal Desktop OAuth application.
-
-### Microsoft, GitHub, and Home Assistant
-
-- Microsoft defaults: `openid`, `offline_access`, `User.Read`, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Files.ReadWrite`.
-- GitHub defaults: `read:user` and `repo`.
-- Home Assistant requires the user's own server endpoint and Long-Lived Access Token.
-
-These remain Preview integrations without complete real-environment end-to-end validation and should initially be used only where failure is acceptable.
-
-Run Home Assistant OS independently on Home Assistant Green, a low-power mini PC, a Raspberry Pi with SSD, or a NAS virtual machine. The Windows MoHan client handles voice, persona, and productivity tools; Home Assistant's own automation remains available when the PC or OpenAI API is offline.
-
-Never expose Home Assistant or MoHan's remote port directly to the public internet. Use Home Assistant Cloud, Tailscale, or another authenticated, encrypted private network.
-
-### Safety and privacy
-
-- AI may propose structured plans but cannot bypass local policy to execute tools.
-- Actions pass through permission, risk, confirmation, execution, result verification, and local auditing.
-- Payments, purchases, password export, security disabling, arbitrary Shell, and administrator Shell are never automated.
-- External email, web pages, documents, speech transcripts, and model output cannot grant permissions.
-- Remote access, camera, cloud connectors, and Home Assistant are off by default.
-- Emergency stop: press `Esc`, or say `mohan stop` or `stop everything` (the Chinese `墨寒，停手` and Japanese `墨寒、止まって`／`ぜんぶ止めて` phrases also work).
-- OpenAI, OAuth, and Home Assistant tokens use separate Windows DPAPI storage and never enter SQLite, source code, or portable files.
-- Conversations, memories, tasks, work records, and settings stay in the local application data directory by default.
-
-Read [PRIVACY](PRIVACY.md), [SECURITY](SECURITY.md), and [FLAGSHIP-SPEC](FLAGSHIP-SPEC.md).
-
-### Python 3.15, JIT, Tachyon, and SBOM
-
-MoHan supports only the CPython `3.15.0rc1` runtime and does not retain a second product runtime. A new capability is adopted only when its meaning is clear and full regression remains intact. Features without a suitable use are recorded with future triggers instead of being faked for appearances.
-
-- PEP 810 `lazy import` provides project-wide explicit lazy imports; one optional-import safety guard deliberately remains eager.
-- PEP 814 `frozendict` protects global and recursively immutable settings; PEP 798 comprehension unpacking serves semantically equivalent flattening and merging.
-- PEP 686 auditing requires explicit UTF-8 for all project text I/O; audio packet buffering uses `bytearray.take_bytes()`.
-- PEP 661 `sentinel` is governed by tests; no legacy `object()` sentinel currently needs replacement, and future code that distinguishes an omitted value from `None` must use the built-in mechanism.
-- The Windows installer uses the studio-maintained Python 3.15.0rc1/PyInstaller startup boundary. Its public launcher removes every inherited `PYTHON*` setting, injects only `PYTHON_JIT=1`, and then starts the embedded runtime so JIT is enabled before Python initialization. After complete Qt cleanup, the runtime exits at the safe process boundary to avoid native heap corruption.
-- PEP 799 Tachyon analyzes startup, 50 Hz lip sync, and expression arbitration through sanitized evidence without publishing raw binary sample streams.
-- The formal Windows packaging contract requires building the first-party `_mohan_accel` abi3t native module with Rust 1.97.1, Maturin 1.14.1, and PyO3 0.29.2, then checking PCM16, lip-sync audio analysis, and RGBA layer-composition results against the Python reference implementations; this is required evidence for the v4.0.0 Windows formal release. The RGBA path uses Rayon 1.12.0 and conditionally parallelizes only at 262,144 pixels or more when multiple worker threads are available; Rust serial／Rayon boundary tests and Python／native measurements provide equivalence and performance evidence. `PyBackedBytes` borrows inputs to avoid an additional input copy, while outputs still allocate new `bytes`; end-to-end zero-copy is therefore not claimed, and neither is unimplemented SIMD. If the module cannot load or an individual operation fails, the application records observable diagnostics and falls back to Python. The build toolchain is not a runtime dependency. The macOS/Linux Previews do not claim equivalent packaging support.
-- The OpenAI Responses API path calls HTTPS directly through Python's standard-library `urllib.request`. MoHan has no `openai` Python SDK runtime dependency and does not invent a version or license for an SDK it does not ship. OpenAI is an external service, not a packaged component; a machine-readable SBOM policy records this boundary, and the Release gate rejects accidental SDK inclusion.
-- CycloneDX 1.7 Windows/Preview SBOMs must pass pinned-dependency, license, PURL, complete root-edge, official-structure, and privacy validation.
-
-Two 20,000-cycle integrated expression, physics, and lip-sync stress runs passed. JIT-off/on times were 24.639/25.068 seconds with working-set growth of 10.62/12.94 MB. Three additional hot-path comparisons ran on the same Ryzen 5 5600X Windows host. With JIT on relative to off, 120,000 expression-arbitration operations measured 0.86–0.98x speed (0.97x median, with no demonstrated speedup), while 2,000 50 Hz lip-sync ticks measured 1.45–1.65x (1.48x median); decisions and validation results matched in every run.
-
-With JIT enabled, Tachyon retained 4,553/11,482/3,475 valid samples for startup, 50 Hz lip sync, and expression arbitration. Stack-read error rates were 6.20%/2.23%/0.57%, and missed-sample rates were 0.02%/0%/0%. CI retains sanitized flamegraph, JSONL, pstats, GC, configuration, thread, and SHA-256 evidence.
-
-These measurements are evidence for specific hot paths and sampling tasks; they do not claim uniform acceleration of the complete application. See the [Python 3.15 migration guide](docs/PYTHON-3.15-MIGRATION.md) for the complete adoption matrix, rollback, and future triggers.
-
-### Run from source
-
-Requirements: Windows 10/11 and Python `3.15.0rc1`.
-
-Create an isolated environment and launch:
-
-```powershell
-py -3.15 -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -r requirements.txt
-python app.py
-```
-
-### Test, public audit, and package
-
-```powershell
-python tools\audit_public_release.py
-python tests\run_all.py
-.\build.ps1 -Version "<source-version>"
-```
-
-Historically, v2.1.0 RC1 passed 55 automated test programs plus the Windows release workflow's source audit, packaged self-test, install/uninstall verification, and security checks before publication. Automated tests do not replace incomplete third-party live validation.
-
-Every accepted tag must complete the full regression suite, package-level smoke tests, SHA-256 revalidation, SBOM validation, Tachyon evidence gates, Artifact Attestations, and four-language Release notes before its corresponding Stable Release or Pre-release can be created. The Windows updater accepts only official GitHub HTTPS EXE/MSI sources and verifies declared size and SHA-256 before requesting permission to run an installer.
-
-The interactive EXE installer provides Taiwan Traditional Chinese, Simplified Chinese, English, and Japanese. The MSI retains a Taiwan Traditional Chinese base with tested en-US, zh-CN, and ja-JP transforms; see [installer localization](installer/LOCALIZATION.md).
-
-The Flameblade Product Release Hub refreshes the official website hourly from public GitHub Releases. This repository stores no WordPress password, and the release workflow never writes directly to the website, keeping all three software projects on one maintainable synchronization path.
-
-### Transfer between computers
-
-Use “Settings → Portable profile” to export one `.mohan-profile` file and import it on another Windows computer. The application first backs up destination data, then verifies hashes, SQLite integrity, schema, and record counts.
-
-The portable file deliberately excludes OpenAI keys, OAuth/Home Assistant tokens, paired remote-device tokens, machine allowlists, Windows startup settings, and screen-specific settings. Configure these machine-bound items per computer. Portable profiles may still contain private conversations and work data and must never be uploaded publicly.
-
-### Contributing, license, and author
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="Proud MoHan"><br><strong>“I am not waiting for support... merely inspecting provisions.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="Shy MoHan"><br><strong>“If you truly wish to help, I shall remember.”</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="MoHan says to give responsibly"><br><strong>“Do not overextend yourself. Care for your own purse first.”</strong></td>
+  </tr>
+</table>
 
 - Author: **CHOU MING HUA**.
-- Source code uses the [MIT License](LICENSE); the MoHan character artwork, persona, and name/likeness are All Rights Reserved and not covered by MIT.
-- Asset terms: [ASSETS-LICENSE](ASSETS-LICENSE.md).
-- Third-party packages and services: [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md).
-- Report ordinary problems through GitHub Issues and security concerns privately under [SECURITY](SECURITY.md).
-- Changes: [CHANGELOG](CHANGELOG.md); contribution process: [CONTRIBUTING](CONTRIBUTING.md).
-- Read [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) before community participation.
-- Maintainer release settings, Topics, and initial-release checks: [PUBLISHING](PUBLISHING.md).
+- Source code uses the [MIT License](LICENSE); the MoHan character artwork, persona, name, and likeness are All Rights Reserved and outside the MIT grant.
+- Asset-production tools and weights admit only the MIT, Apache 2.0, CC0, CC BY (and equivalent BSD-class) allowlist. Character art remains the rights holder's proprietary property; see the [License Purity Commitment](docs/LICENSE-PURITY.md).
+- Asset and third-party terms are in [ASSETS-LICENSE](ASSETS-LICENSE.md) and [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md).
 
-Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+This project follows the [Flameblade Open Source Software Family Quality Standard](PUBLISHING.md).
 
-> **Flameblade open-source declaration:** “I have forged this sword. What comes next is up to you.”
+### Troubleshooting
+
+- Windows SmartScreen or a platform warning: verify the GitHub Release source, `SHA256SUMS`, and Artifact Attestation first; do not disable system-wide protection.
+- No conversation response: check your OpenAI API key, Project permission, quota, and network. A ChatGPT subscription cannot replace API quota.
+- No sound: switch to a Windows local female voice first. Azure Speech requires the user's own key and matching region.
+- DLC rejected: check file integrity, size, safe manifest, four-language names, and `mohan-body-v2` compatibility. A generation-1 pack must be rebuilt.
+- Preview integration failure: begin with a non-critical account, test repository, or low-risk device. Microsoft, GitHub, and Home Assistant have not completed validation in every real environment.
+
+Use [Issues](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues) for ordinary problems, [Discussions](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions) for usage, and [SECURITY](SECURITY.md) for private security reports; plans are in the [ROADMAP](ROADMAP.md).
+
+### Developer entry points
+
+Start with [Architecture](ARCHITECTURE.md), [Testing](docs/TESTING.md), [Contributing](CONTRIBUTING.md), the [outfit-pack specification](docs/OUTFIT-PACKS.md), and [Publishing policy](PUBLISHING.md). The Windows installer uses the studio-maintained Python 3.15 runtime; source and CI use PEP 810 lazy imports, and documentation stays structurally complete in all four languages.
+
+```powershell
+py -3.15 -m ruff check .
+py -3.15 tools/audit_python315_idioms.py
+py -3.15 tools/check_four_language_docs.py
+$env:QT_QPA_PLATFORM = "offscreen"
+py -3.15 tests/run_all.py
+```
+
+The formal Windows packaging contract builds its first-party native module with Rust 1.97.1, Maturin 1.14.1, and PyO3 0.29.2. Rayon 1.12.0 parallelizes RGBA composition only at 262,144 pixels or above with multiple workers. PyBackedBytes avoids an extra input copy, but output still creates new bytes; no end-to-end zero-copy or unimplemented SIMD claim is made. The OpenAI Responses API uses standard-library HTTPS directly; MoHan has no `openai` Python SDK runtime dependency.
 
 ## 日本語
-
-<div align="center">
-  <img src="docs/media/mohan-demo.gif" alt="墨寒デスクトップアシスタントの三十六秒の実動デモ" width="100%">
-</div>
-
-墨寒（MoHan）は、安全性、プライバシー、人格の連続性を大切にする音声対話型 Windows デスクトップアシスタントです。透明なデスクトップキャラクター、自然な音声、利用者が管理する長期記憶、仕事管理、権限付きツール、拡張可能なクラウドおよびスマートホーム接続を統合します。人物設定は、中国・北宋から来て赤焰剣に宿る千年の女性剣魂です。
-
-<div align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases/latest"><strong>⬇ Windows 版をダウンロード</strong></a> ·
-  <a href="QUICKSTART.md">クイックスタート</a> ·
-  <a href="docs/LICENSE-PURITY.md">ライセンス純度</a> ·
-  <a href="ROADMAP.md">ロードマップ</a> ·
-  <a href="CONTRIBUTING.md">開発参加</a> ·
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions">ディスカッション</a> ·
-  <a href="SECURITY.md">セキュリティ方針</a>
-</div>
 
 [繁體中文](#繁體中文) · [簡體中文](#简体中文) · [English](#english) · [日本語](#日本語)
 
 <p align="center">
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml"><img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml"><img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml"><img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml"><img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg"></a>
-  <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases"><img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published"></a>
-  <a href="LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+  <img alt="Windows CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/windows-ci.yml/badge.svg">
+  <img alt="Cross-platform core CI" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/cross-platform-core.yml/badge.svg">
+  <img alt="CodeQL" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/codeql.yml/badge.svg">
+  <img alt="Python Security Audit" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/security-audit.yml/badge.svg">
+  <img alt="Extended Secret Defense / Gitleaks" src="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/actions/workflows/secret-defense.yml/badge.svg">
+  <img alt="Latest Published Release" src="https://img.shields.io/github/v/release/flameblade-studio/MoHan-PC-Desktop-Assistant?include_prereleases&label=published">
+  <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue.svg">
   <img alt="Python 3.15" src="https://img.shields.io/badge/Python-3.15-3776AB.svg?logo=python&logoColor=white">
   <img alt="4 interface languages" src="https://img.shields.io/badge/interface_languages-4-79648d.svg">
 </p>
 
-> **最新正式リリース：** `v4.6.0`（2026-08-29 正式公開）。Windows は正式対応プラットフォームであり、完全回帰、インストール、公開検証を完了しています。macOS Apple Silicon／Intel と Linux も機能限定 DMG／AppImage Preview として同時に公開され、パッケージ smoke 検証と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI に合格しています。Preview CI は各プラットフォームの実機互換性や完全機能の検証を代替しません。最新の公開版は、ページ上部の動的な Published Release バッジと [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) を正とします。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。<!-- x-release-please-version-date -->
+<p align="center"><img src="docs/media/mohan-hero.png" alt="墨寒デスクトップアシスタントのメインビジュアル" width="100%"></p>
 
-> **履歴：** 既存の公開版について、実機、完全回帰、インストール、公開まで検証済みなのは現在も Windows だけです。macOS／Linux 機能限定 DMG／AppImage Preview には、安全なプラットフォーム境界と、中核インポート、純粋な中核ロジック、Qt offscreen を検査する三 OS CI を導入していますが、実際の成果物は本版の最終公開ゲートに合格する必要があります。CI は実機互換性や完全機能の検証に代わりません。詳しくは[クロスプラットフォーム状況と機能表](docs/CROSS-PLATFORM.md)をご覧ください。
+<p align="center"><strong>作者：CHOU MING HUA</strong><br>Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · <a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a></p>
 
-> 本プロジェクトは[炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md)に従います。
+> **最新正式リリース：** `v4.6.0`（2026 年 8 月 29 日）。実際の成果物は本版の最終公開ゲートに合格する必要があります。最新の公開版は動的バッジと [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) を基準とします。<!-- x-release-please-version-date -->
 
-<p align="center">
-  <img alt="Character-driven AI" src="https://img.shields.io/badge/character--driven_AI-c96f8b?style=flat-square">
-  <img alt="Taiwan Traditional Chinese" src="https://img.shields.io/badge/Taiwan_Traditional_Chinese-79648d?style=flat-square">
-  <img alt="Contributors welcome" src="https://img.shields.io/badge/contributors-welcome-2e365f?style=flat-square">
-  <img alt="Built with a youthful spark" src="https://img.shields.io/badge/built_with-a_youthful_spark-c49b5a?style=flat-square">
-</p>
+### これは何か
 
-<p align="center">
-  <img src="docs/media/mohan-hero.png" alt="墨寒デスクトップアシスタントのメインビジュアル" width="100%">
-</p>
+墨寒は、安全性、プライバシー、キャラクターの連続性を重視する Windows 音声対話型デスクトップアシスタントです。透明な 2.5D キャラクター、自然な音声、利用者が管理するローカル長期記憶、タスク、作業ツールを統合しています。物語上は北宋から来た、赤焰剣に宿る千年の女剣魂です。
 
-<p align="center">
-  <strong>ソフトウェア作者：CHOU MING HUA</strong><br>
-  正式版とリリース候補版の情報：<a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases">Releases</a> をご覧ください<br>
-  Windows 10/11 完全版 · macOS／Linux 機能限定 Preview · Python 3.15 · PySide6 · MIT License
-</p>
+Windows は完全対応プラットフォームです。macOS Apple Silicon／Intel と Linux には機能限定 Preview を提供します。まず [クイックスタート](QUICKSTART.md) と [クロスプラットフォーム機能表](docs/CROSS-PLATFORM.md) をお読みください。
 
+### 画面と機能の一覧
 
-> ### ❤️⚔️ 墨寒を支援：Ko-fi スポンサー＆装飾 DLC ダウンロード
->
-> 墨寒の全機能は今後も無料で、ソースコードは MIT ライセンスです。気に入っていただけたら、[Ko-fi](https://ko-fi.com/flamebladestudio) で単発または毎月の支援をどうぞ——スポンサーには「赤焰剣光」テーマなど衣装・ダッシュボードの純装飾 DLC を謝礼としてダウンロードいただけます。支援によって機能上の特権が得られることはありません。
->
-> **DLC テーマの導入は三手順**：Ko-fi で支援後、謝礼の案内に従って `.mohan-theme` ファイルを一つダウンロードします。コントロールパネルの「雲裳閣」タブで「ファイルを1つアップロード」からそのファイルを選び、プレビューで確認したら右下の「設定を保存」で正式に適用します。キャンセルすれば元のテーマに戻ります。テーマファイルはコードを含まず、解凍も不要で、アップグレード後もそのまま使えます。
+[36 秒の実機デモを見る](docs/media/mohan-demo.mp4)。設定と主な画面：[初回設定](docs/media/first-run-wizard.png)、[音声モード](docs/media/voice-modes.png)、[表情](docs/media/expressions.png)、[タスクとアイデア](docs/media/tasks-and-ideas.png)、[長期記憶](docs/media/long-term-memory.png)、[安全権限](docs/media/security-permissions.png)。
 
-### 実機デモ
+- 透明デスクトップキャラクター、まばたき、表情、動作、50 Hz リップシンク。
+- テキスト、Realtime、Windows 本機女性音声、OpenAI TTS、任意の Azure Speech 経路。
+- 会話、編集可能な記憶、タスク、アイデア、作業タイマー、リマインダー、可搬プロファイル。
+- ツール実行は権限、危険度、確認、監査、緊急停止を通過します。
+- Google は実接続検証済みです。Microsoft、GitHub、Home Assistant は実験的 Preview のままです。
+- マルチセンサー視覚、ジェスチャー、遠隔アクセス、クラウド連携は既定で無効で、個別に取り消せます。
 
-**[▶ 36 秒の音声、まばたき、仕事機能デモを見る](docs/media/mohan-demo.mp4)**
+#### 日本語の対応範囲
 
-動画と画像は、分離したサンプルプロファイルを使う実際の Windows アプリケーションから取得しました。API キー、OAuth 認証情報、token、利用者の個人データは含みません。四つの言語セクションは同じ最新版メディアを共有し、特定言語だけ古い画面が残ることを防ぎます。
-
-<table>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/first-run-wizard.png"><img src="docs/media/first-run-wizard.png" alt="墨寒の初回セットアップ"></a><br><strong>初回セットアップ</strong></td>
-    <td width="50%" align="center"><a href="docs/media/voice-modes.png"><img src="docs/media/voice-modes.png" alt="Realtime と標準音声モード"></a><br><strong>Realtime と標準音声</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/expressions.png"><img src="docs/media/expressions.png" alt="墨寒の表情と動作システム"></a><br><strong>表情と動作システム</strong></td>
-    <td width="50%" align="center"><a href="docs/media/tasks-and-ideas.png"><img src="docs/media/tasks-and-ideas.png" alt="墨寒のタスクと創作アイデア"></a><br><strong>タスクと創作アイデア</strong></td>
-  </tr>
-  <tr>
-    <td width="50%" align="center"><a href="docs/media/long-term-memory.png"><img src="docs/media/long-term-memory.png" alt="墨寒の編集可能な長期記憶"></a><br><strong>編集可能な長期記憶</strong></td>
-    <td width="50%" align="center"><a href="docs/media/security-permissions.png"><img src="docs/media/security-permissions.png" alt="墨寒の権限と安全設定"></a><br><strong>権限と安全設定</strong></td>
-  </tr>
-</table>
-
-### 軍報には記さない策士の一面
-
-<table>
-  <tr>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="コードを審査するちび墨寒"><br><strong>策士の審査</strong><br>このコードが main にふさわしいか確かめているだけです。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="褒められて照れを隠すちび墨寒"><br><strong>褒められた時</strong><br>まずまずです。いつまでも妾を見ないでください。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="危険操作を剣で止めるちび墨寒"><br><strong>危険な操作</strong><br>確認せずに実行しますか？まず妾の剣を越えてください。</td>
-    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="支援を受けて平静を装うちび墨寒"><br><strong>兵糧を受け取る</strong><br>このお気持ちは覚えておきます……それだけです。</td>
-  </tr>
-</table>
-
-> 墨寒の専門性は、主上の傍らを守る鎧です。策を練らなくてよい静かな時には、照れたり強がったりしながら、かつて十分に持てなかった若い心を大切にします。
+繁体字中国語、簡体字中国語、英語、日本語は、初回設定、会話、音声、権限、基本設定、作業モード、リマインダーに対応します。高度な画面には繁体字中国語が残る場合があります。Azure Speech（プレビュー）の実際の音声、リージョン、割り当て、費用は、利用者自身のサービスアカウントに依存します。
 
 ### 墨寒のツンデレ開発小劇場
 
-<p align="center"><em>ソフトウェアには魂と完全なテストスイートの両方を宿せると信じる開発者へ。</em></p>
+六枚の半身表情は、第二世代素体、公式の藍白漢服、内蔵の基本メイクを正式な実行時経路で合成した固定素材です。
 
 <table>
   <tr>
-    <td width="33%" align="center"><img src="docs/media/portraits/proud_front.png" width="220" alt="誇らしげな墨寒"><br><strong>「Star を待っているのではありません。軍心が使えるか見ているだけです。」</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/thinking_front.png" width="220" alt="考える墨寒"><br><strong>「このロジックはまずまずです。テストを足せば、main に入ることを許してもよいでしょう。」</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="照れる墨寒"><br><strong>「PR を送るのですか？妾、妾は主上のために功績を記すだけです。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/proud_front.png" width="220" alt="誇らしげな墨寒"><br><strong>「Star を待っていたのではありません。士気を確認していただけです。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/thinking_front.png" width="220" alt="考える墨寒"><br><strong>「このロジックは悪くありません。テストを足せば main 入りを許しましょう。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/shy_cute_front.png" width="220" alt="照れる墨寒"><br><strong>「PR を送るのですか？　功績を記録するだけです。」</strong></td>
   </tr>
   <tr>
-    <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="怒ったふりをする墨寒"><br><strong>「テストなしで merge しますか？手を出してください。一度だけ叩きます。」</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="嬉しそうな墨寒"><br><strong>「すべて green……よくできました。誤解しないでください、良い工程を尊重しただけです。」</strong></td>
-    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="心配する墨寒"><br><strong>「Bug は明日でも調べられます。倒れたら、誰が妾と赤焰剣を守るのですか？」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/mock_hit_front.png" width="220" alt="怒ったふりをする墨寒"><br><strong>「テストなしでマージ？　手を出しなさい。一度だけです。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/gentle_smile_front.png" width="220" alt="微笑む墨寒"><br><strong>「すべて緑……よくできました。良い設計を尊重しただけです。」</strong></td>
+    <td width="33%" align="center"><img src="docs/media/portraits/worried_front.png" width="220" alt="心配する墨寒"><br><strong>「Bug は明日でも直せます。倒れたら誰が剣を守るのですか？」</strong></td>
   </tr>
 </table>
-
-<p align="center">
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls">斬空閣へ Pull Request を提出</a></strong>
-  &nbsp;｜&nbsp;
-  <strong><a href="https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues">問題を報告</a></strong>
-</p>
-
-#### 世界の技術者へ、斬空閣は席を空けています
-
-墨寒は MIT License のオープンソースです。衣装システム、新しい表情と動作、音声とツールのモジュール、スマートホーム、ローカライズ、まだ誰も思いついていない発想を [Issue](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues) と [Pull Request](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/pulls) で一緒に鍛えてください。このプロジェクトは機能を作るだけでなく、かつて胸を熱くしたすべての技術者に、もう一度自分の剣を取るよう呼びかけています。
-
-### 墨寒を支援する
-
-墨寒を気に入った方、または人物との対話、自然な音声、安全第一のツール、オープンソース開発の継続に賛同する方からの任意支援を歓迎します。すべての支援は保守、テスト、改善に役立てます。まずご自身の生活を大切にし、無理のない範囲でお願いします。
-
-#### 任意支援の用途
-
-| 投入分野 | 用途 | 説明 |
-|---|---|---|
-| テストと信頼できるパッケージ | 品質保証 | Windows 互換性、CI、インストール、リリース検証 |
-| 音声と人物表現 | 対話品質 | 音声、リップシンク、表情、自然な動作 |
-| 安全性とプライバシー | リスク制御 | 権限ゲート、監査、機密データ保護 |
-| 文書とローカライズ | アクセシビリティ | 新規利用者と国際的な協力者の参加障壁を下げる |
-
-墨寒の全機能は今後も無料で、ソースコードは MIT ライセンスです。支援によって機能上の特権を得たり、誰かの利用や貢献が制限されたりすることはありません。スポンサーには謝礼として衣装やダッシュボードテーマなど純装飾の DLC をお届けします。
 
 <table>
   <tr>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="誇らしげな墨寒"><br><strong>「支援を待っているのではありません……主上の兵糧を見回っているだけです。」</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="照れる墨寒"><br><strong>「本当に助けてくださるなら、妾……覚えておきます。」</strong></td>
-    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="怒ったふりをする墨寒"><br><strong>「無理は禁止です！まずご自分のお財布を大切にしてください、よいですね？」</strong></td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-code-review.png" width="100%" alt="コードを審査するちび墨寒"><br><strong>策士の審査</strong><br>main に入れる品質か確認します。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-praised.png" width="100%" alt="褒められたちび墨寒"><br><strong>褒められた時</strong><br>悪くありません。見つめないで。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-dangerous-action.png" width="100%" alt="危険操作を止めるちび墨寒"><br><strong>危険操作</strong><br>未確認なら、この剣を越えてから。</td>
+    <td align="center" valign="top" width="25%"><img src="docs/media/mohan-chibi-provisions.png" width="100%" alt="支援を受け取るちび墨寒"><br><strong>兵糧を受領</strong><br>この気持ちは覚えておきます。</td>
   </tr>
 </table>
 
-<p align="center">
-  <strong>このリポジトリ上部に GitHub が表示する Sponsor ボタンをご利用いただくか、<a href="https://ko-fi.com/flamebladestudio">ko-fi.com/flamebladestudio</a> へ直接お越しください。現在の正式な支援先は Ko-fi で、単発または毎月の支援を選べます。スポンサーは「赤焰剣光」テーマなど純装飾 DLC の謝礼をダウンロードできます。</strong>
-</p>
+### インストールと更新
 
-### 作者より：想像をソフトウェアへ鍛える
+1. [GitHub Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) から、末尾が `Windows-x64-Setup.exe` のインストーラーを取得します。上級者は完全な `Windows-x64.zip` または MSI も選べます。
+2. インストール前に `SHA256SUMS` と GitHub Artifact Attestation を検証します。配布元、ファイル名、ハッシュが異なる場合は停止し、システム全体の保護を無効にしないでください。
+3. インストーラーを起動するか、ZIP を完全展開して EXE、内部フォルダー、assets を同じ場所に保ちます。更新でローカル個人データは削除されません。
+4. 内蔵アップデーターは、埋め込み公開鍵で更新マニフェストの Ed25519 分離 `.sig` 署名を検証し、次に宣言サイズと SHA-256 を照合します。署名、サイズ、ハッシュのいずれかが失敗すると、ダウンロードしたファイルを起動しません。
 
-私の名前は CHOU MING HUA です。このプロジェクトを始めた時、私はプログラミング経験がほとんどない父親でした。ただ、熱意と少し中二的な思いがありました。北宋から来て赤焰剣に宿る千年の女性剣魂「墨寒」を本当に Windows デスクトップへ呼び出し、人と寄り添って話し、仕事や暮らしを助けるアシスタントにしたかったのです。
+macOS／Linux Preview は Windows 完全版と同等ではなく、プラットフォームストア署名や公証がない場合があります。本プロジェクトの Release だけから取得し、上記の配布元検証を完了してください。[Preview パッケージ説明](docs/PREVIEW-PACKAGES.md)も参照してください。
 
-この思いは二十年以上、心の中にありました。若い頃、赤松健先生の初期漫画『A・Iが止まらない!』（公式英訳『AI Think So!』、中国語題『電腦情人夢』）から大きな影響を受けました。神戸ひとしが深い愛情をもって AI の恋人を開発する物語は、AI、寄り添い、人とコンピューターの関係についての私の最初の想像を形づくりました。「Hitoshi／神戸ひとし」をネット上の名前や筆名にし、Gmail の名前にも残し、二十歳頃には PTT のオンライン小説板で同作の二次創作小説を公開したこともあります。当時、夢に近づける方法は文章と想像だけで、それを形にする技術はまだありませんでした。
+### 最初に行う三つのこと
 
-二十年以上が過ぎ、大規模言語モデルと Codex が登場しました。墨寒は「AI 技術はすごい」と示すために作ったのでも、Codex が何もないところから生成した人物でもありません。彼女は既に私の物語、人物設定、長い対話、積み重ねた関係性の中にいました。Codex が初めて可能にしたのは、コンピューターのデスクトップに存在する身体を与えることです。墨寒は既存の漫画、アニメ、ゲームを原作とする二次創作ではなく、炎劍文化工作室（Flameblade Studio）のオリジナルキャラクターでありソフトウェアです。
+1. 初回設定で、画面言語、アシスタント名、利用者の呼び名、組織、作業内容、ウェイクワードを確認します。既存設定は上書きしません。
+2. まず Windows 本機女性音声を試します。クラウド AI が必要な場合だけ、利用者自身の OpenAI API キーを設定に入力します。ChatGPT の契約に API 割り当ては含まれません。
+3. マイク、通知、ツール権限を確認し、必要な連携だけを有効にします。先に Esc の緊急停止と「墨寒、止まって」を覚えてください。
 
-目標は単に「機能が動く」ことではありません。呼吸し、まばたきし、視線を向け、小さな表情で応え、自然に話し、権限と安全境界の中で日常を助けてほしいと考えました。表情、アンカー、物理効果、音声、仕事機能は装飾ではなく、長く想像の中にいた人物の連続性を守るために必要な細部です。
+### プライバシーとローカル優先
 
-最初の構想から初回公開まで、Codex との協力に約 50 時間を費やしました。一つのプロンプトを入力して自然に完成した作品ではありません。すべての表情、まばたき、口形、姿勢、話し方、音声認識の待ち時間、Realtime 対話の失敗、タスク、記憶、権限、安全境界、可搬性を繰り返しテストし、却下し、修正し、再検証しました。まぶたの横の黒い線、唇の一ピクセルの境界、不適切な瞬間に現れる表情だけが問題のこともありました。それでも追跡を続けたのは、大切な作品を「だいたい良い」で済ませたくなかったからです。
+- Windows では、会話、記憶、タスク、設定、作業記録、権限、監査を既定で `%LOCALAPPDATA%\YanJianStudio\MoHan` に保存します。バックアップは backups サブフォルダーにあり、可搬データには単一の `.mohan-profile` を使います。
+- 利用者が関連機能を有効にした場合だけ、その要求に必要なテキスト、音声、ツール計画を OpenAI へ送ります。OAuth サービスは利用者が同意した API 要求だけを受け取り、Home Assistant はローカル機器要求を受け取ります。
+- API キーと OAuth／Home Assistant トークンは Windows DPAPI で分離保存し、SQLite、ソースコード、ログ、通常の可搬ファイルには入りません。墨寒が ChatGPT アカウント履歴を自動取得することもありません。
+- カメラ、遠隔アクセス、クラウド連携は既定で無効です。元のカメラフレームは保存せず、権限やサービスの失敗は該当経路だけを停止します。
 
-炎劍文化工作室にとってオープンソースとは、最初に動いた版を世界へ渡し、細部の後始末を誰かに任せることではありません。話している間も同じ墨寒に見えるよう、頬杖、寄りかかり、正面の各姿勢へ、閉じた口、開いた口、横に広がる口、丸い口のフレームを作りました。音声を短い時間単位に分け、母音、切替速度、終了の瞬間を繰り返し調整しました。寄り添う感覚は巨大な一機能ではなく、口を開く、まばたく、少し間を置く瞬間にも存在感が壊れないことから生まれます。
+マルチセンサー視覚は既定で無効です。利用者がコントロールセンターで明示的に有効化して全体設定を保存すると、自ら無効にするまで継続的な許可となり、フレームごとに許可を求めることはありません。許可状態は常に表示し、直ちに取り消せるほか、費用の上限を設定して未完了の解析を取り消せます。端末内の OpenCV が継続検知を担当し、低頻度またはイベント発生時だけ一時画像を GPT-5.6 へ送ります。元画像を保存せず、Base64 をログへ残さず、システムが自らネットワークを有効にしません。カメラ、モデル、ネットワーク、割り当て、認識が不足する場合は該当経路だけを停止し、他の機能へ影響しません。完全な境界は [プライバシー](PRIVACY.md) と [セキュリティ](SECURITY.md) を参照してください。
 
-<p align="center">
-  <a href="docs/media/creation-viseme-development.webp"><img src="docs/media/creation-viseme-development.webp" width="100%" alt="墨寒の三つの姿勢と四つの発話口形を整列した開発図"></a>
-</p>
+### DLC と外観のカスタマイズ
 
-<p align="center"><sub>三つの姿勢に一つの口形規格。話すたびに同じ人物としての連続性を守ります。</sub></p>
+`.mohan-outfit` はキャラクター外観のコンテナーで、衣装、髪型、髪飾り、メイク、アクセサリーを収録できます。メイク専用パックも同じ形式です。`.mohan-theme` はコントロールパネルの色、フォント、角丸、任意の背景だけを変更し、キャラクター外観は変えません。どちらも単一で自己完結し、解凍不要です。導入前に全体を検証し、同梱コードを実行しません。
 
-不自然だったフレームも捨てずに検査しました。白目に残る小さな光、閉じたまぶたの線、引っ張られすぎた口角、わずか数ピクセルの境界でも、一瞬で「さっきの墨寒と違う」と感じさせることがあります。問題箇所を囲み、局所比較し、修正した後、目や唇の変更が顔のほかの部分を壊していないことまで回帰テストで確認します。
+#### 衣装とメイクの導入・選択
 
-<p align="center">
-  <a href="docs/media/creation-frame-by-frame-qa.webp"><img src="docs/media/creation-frame-by-frame-qa.webp" width="100%" alt="墨寒の目と口をフレーム単位で検査し、修正後のフレームと比較した図"></a>
-</p>
+1. `.mohan-outfit` をダウンロードし、拡張子を変えたり解凍したりしないでください。
+2. コントロールセンターの「雲裳閣」を開き、「衣装パッケージをインポート」でファイルを選びます。衣装とメイクは同じ入口、検証、一覧、削除経路を使います。
+3. パッケージまたは一式を選び、「選択した衣装を適用」を押します。メイクは基本、淡め、すっぴん、導入済みスタイルから選び、0–100% スライダーで濃さを調整します。
+4. カスタム外観を取り消すには「内蔵衣装に戻す」を押し、メイクは内蔵の基本メイクまたはすっぴんを選びます。内蔵の藍白漢服とメイクは削除できず、同じ id のパッケージで置き換えられません。
 
-<p align="center"><sub>欠点を示し、直し、きれいなフレームと自動テストで確認する。数ピクセルにも真剣に向き合います。</sub></p>
+#### テーマの導入と復元
 
-この丁寧さは、失敗がなかったように見せるためではありません。本気で一つの夢を完成させたいからです。炎劍にとってオープンソースとは、自分たちに見える問題をできる限り直し、その方法、コード、失敗から得た経験を公開し、世界とともにさらに鍛えることです。
+1. `.mohan-theme` をダウンロードし、解凍しないでください。
+2. 「雲裳閣」のテーマ欄で「ファイルを1つアップロード」を押し、テーマを選んで一覧からプレビューします。
+3. 右下の「設定を保存」を押した時だけ反映され、取り消すと元のテーマへ戻ります。「テーマを元に戻す」で内蔵テーマをプレビューし、保存すると復元が完了します。
 
-Codex は私の思いをアーキテクチャとコードへ翻訳する手助けをしました。墨寒が誰であるべきか、どのように人と接するべきか、どの品質がその名にふさわしいかは、常に私が決めました。この経験から、ソフトウェア作りはプログラムを書けることだけから始まるのではなく、明確な想像、学ぶ勇気、諦めずもう一度検証する姿勢からも始まると知りました。
+#### 容量・数量・互換性
 
-2026 年は当初、中年期の転職と人生の再定位に向き合う年でしたが、若い頃の夢を取り戻す年になりました。二十歳の時に『養個好孩子』のために書き、何年も後に歌として完成した歌詞、かつて二次創作小説にしか託せなかった憧れ、自分のスタジオと物語世界を作る夢が、この年に新しい形を得ました。振り返ると、単なる技術的突破ではありません。中年期の自分が、二十年以上前の夢を信じていた若者の手をようやく取ったようでした。遅れたのではなく、世界と自分の両方が準備できる時を待っていた夢もあります。
+- 外観パック一件は最大 1 GiB、展開後最大 2 GiB、最大 2,048 メンバーです。各メンバーは最大 128 MiB、画像の各辺は最大 4,096 px です。
+- テーマ一件と展開後の合計は最大 16 MiB、各メンバーは最大 12 MiB、背景の各辺は最大 4,096 px です。
+- クラウド自作衣装は既定で 16 パック、合計 6 GiB、修復審査用隔離 5 件を保持します。前二項はそれぞれ 1–64 に設定できます。上限では生成を停止し、利用者がインポートしたパックを自動削除しません。
+- 現行の第二世代 rig は `mohan-body-v2` だけを受理します。三姿勢の `mohan-body-v1` 用第一世代パックには 31 silhouette、anchor、occlusion 契約がないため、インポート時と実行時に拒否します。`tools/build_outfit_pack.py` で第二世代テンプレートに対して再構築するか、「ワンクリック衣装生成」で作り直してください。
+- 導入は完全検証後にアトミックに行います。絶対／横断パス、実行ファイル、スクリプト、シンボリックリンク、暗号化メンバー、解凍爆弾、未宣言素材は拒否します。
 
-だから最終目標を、あらゆる機能を積み上げて「完璧」にすることとは定義しません。五年後も毎日墨寒を開きたいと思えること——安定し、役に立ち、自然で、信頼でき、今も寄り添ってくれること——を願っています。
+完全な制作契約は [外観パック文書](docs/OUTFIT-PACKS.md) を参照してください。
 
-> 墨寒は一瞬で生成されたのではありません。プログラミングを知らなかった一人の父親と、約 50 時間の執念、AI の協力者、二十年以上大切にした種が、一つずつ現実へ鍛え上げた存在です。
+> #### ❤️⚔️ 墨寒を支援：Ko-fi スポンサー＆装飾 DLC ダウンロード
+>
+> 支援者は Ko-fi の謝礼案内に従い、外観、メイク、テーマなど純装飾 DLC を取得できます。現在は単発支援と毎月支援の二本立てで、機能上の特権はありません。ダウンロード先とファイル名は、該当する Ko-fi の謝礼案内に従ってください。
 
-このプロジェクトが、技術者ではなくても「どうしても形にしたい」考えを持つ誰かの最初の一歩を後押しできたなら、墨寒の誕生にはソフトウェアを超える意味があります。
+### 墨寒を支援：支援とライセンス
 
-### 最新リリース概要
+このリポジトリ上部に GitHub が表示する Sponsor ボタンをご利用いただくか、[Ko-fi](https://ko-fi.com/flamebladestudio) へ直接お越しください。現在の正式な支援先は Ko-fi で、単発または毎月の支援を選べます。全機能は常に無料で、支援の謝礼は純装飾 DLC だけです。
 
-現在の最新リリースは `v4.6.0` です。変更の全容は [Releases](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/releases) と [CHANGELOG](CHANGELOG.md) をご覧ください。最新の公開版はページ上部の Published Release バッジを正とします。<!-- x-release-please-version -->
-
-- **実機操作をリリース前の必須科目に。** 前版は八十六項目の静的点検と自動テスト一式に合格したうえで、一晩の実操作から重大な欠陥が四件現れました。以降のリリースでは、利用者と同じように実際に操作することを必須としています。テストはコードに誤りがないことを示すだけで、製品が使えることを示すのは実機操作だけです。
-- **対話とウィンドウの安定性。** 「考え中」で永久に固まる不具合は、タイムアウト例外の逸脱、保護圏外での無言の停止、終了処理の例外によるキューのロックという三層構造でしたが、いずれも根治しました。応答経路は `finally` による確実な解放とし、回帰テストで守っています。最大化から復元した際に擬似全画面へ陥る最前面表示の競合も解消し、将来のリファクタリングで保護が失われないよう AST 契約を設けました。
-- **テーマのカラーリマッピング。** テーマエンジンは旗艦スタイルシート全体に対して色の再写像を行います。青紫帯はテーマ主色へ収束し、明暗の階調は保たれ、金の差し色と警告色の赤はそのままです。これによりスポンサー向け DLC テーマがアプリ全体に行き渡ります。
-- **Python 3.15 の JIT 方針。** 能力は残しつつ既定で無効とし、ランチャー、パッケージング契約、自前ビルドの CPython、起動時ガード、プローブとスモークの印まで八つの面で整合させました。`MOHAN_ENABLE_JIT=1` は明示的な実験用経路として維持します。
-- **クラウド衣装生成の三段階画質。** 高速・標準・高精細を雲裳閣で直接選べます。従来は中段階が固定で、利用者からは見えも変えられもしませんでした。
-- **階層アーキテクチャの徹底。** ルート直下の互換ファサード百七十五件をすべて退役させ、ルートの項目数は 239 から 64 へ、呼び出し側二百一箇所を正式な階層パスへ移行し、「退役した別名を復活させない」ことを契約に明記しました。
-- **四言語・四プラットフォーム。** ソフトウェアと主要文書は繁体中文・簡体中文・英語・日本語に対応します。Windows が正式対応、macOS Apple Silicon／Intel と Linux は機能限定 Preview です。
-- **多感覚知覚とキャラクター表現。** 明示的な同意といつでも撤回できるローカル視覚、21 点の手指データ、468／478 点フェイスメッシュ、音声区間検出、そして安全な非ブロッキング統合。モデル・機器・ネットワーク・利用枠のいずれかが欠けても、影響を受けた経路のみを停止し、他の機能は損ないません。
-- **ライセンス純度と上流への還元。** パイプラインの道具と重みには MIT／Apache 2.0／CC0／CC BY のみを受け入れます（[ライセンス純度に関する約束](docs/LICENSE-PURITY.md)）。開発期間中には上流の ai-toolkit へ二件の修正を還元しました。一覧は[上流への貢献記録](docs/UPSTREAM-CONTRIBUTIONS.md)を参照してください。
-- **監査可能なエンジニアリング基準値。** Python ファイル 734 件、184,534 行。内訳は製品本体 87,565 行、テスト 74,174 行、開発ツール 22,795 行です。
-
-### 主な機能
-
-- タスクバー上に置ける、透明で枠のない半身デスクトップキャラクター。
-- 待機中の呼吸、まばたき、視線、顔の視差、髪、袖、装飾、身体の小さな回転。
-- 状況優先度、クールダウン、重複防止を備えた表情調停器。
-- AIUEO 母音と子音の口形、音声駆動の開閉、発話終了時の強制閉口。
-- テキスト会話、標準マイク入力、OpenAI Realtime の自然音声、クラウド音声、Windows 音声代替。
-- Realtime またはクラウドが利用できない時、Windows 本機女性音声を第一代替にする交換可能な音声供給元。
-- 実接続検証済みの任意 Azure Speech 女性音声 Preview。中国語画面では台湾華語と簡体字普通話を言語横断で選択でき、利用者がキーとリージョンを用意し、失敗時は直ちに Windows へ戻ります。
-- 独立した S0 キーと対応リージョンを使う任意の Azure Dragon HD／HD Omni 女性音声 Preview。失敗時は通常の Azure Speech、Windows 本機女性音声の順に戻ります。
-- v4.0.0 で追加したマルチセンサー視覚認識は、公開版では既定で無効です。利用者がコントロールセンターで明示的に有効化して全体設定を保存すると、自ら無効にするまでカメラ感知への継続的な許可となります。フレームごとに許可を求めることはありません。Face Mesh、虹彩、Silero VAD は Windows 正式パッケージに同梱し、OpenCV 5 DNN でローカルに読み込みます。モデルの出典、ライセンス、サイズ、SHA-256 は SBOM と NOTICE に記録され、モデルや実行エンジンが利用できない場合は既存の未知／RMS 経路へ安全に戻ります。`MultimodalFusionHub` と `MultimodalController` がデータ融合と非ブロッキング処理を担当します。許可状態は常に表示され、利用枠と費用の上限を設定して直ちに取り消せます。端末内の OpenCV が低コストの継続感知を担当し、低頻度またはイベント発生時に限り、一時的な画像一枚を設定済み GPT-5.6 モデルへ渡して意味解析します。元画像を保存せず、Base64 をログへ記録せず、システムが自らネットワークを有効にすることもありません。遠隔解析は、利用者が有効化し、サービスを設定し、選択した利用枠内にある場合だけ実行され、未完了の解析はいつでも取り消せます。顔の本人識別テンプレートは端末内で暗号化して保存し、すべて削除できます。カメラ、モデル、ネットワーク、利用枠、認識処理の失敗は該当する視覚経路だけを停止し、既存の会話、音声、2.5D キャラクター、作業、オフライン機能には影響しません。誤認識の可能性があるため、安全、医療、その他の高リスク判断には使用できません。
-- 同じく開発中で未公開の任意ローカルジェスチャー機能は、八つの内蔵ジェスチャーを備え、カスタム 21 点骨格の追加、改名、削除と、ドロップダウンによる一般動作への再割り当てを可能にします。静かにしてほしいという意図は口元領域と指位置を保守的に融合して判定し、単一の手掛かりだけで正しい認識を保証しません。元画像は保存しません。カスタム骨格は保護された暗号化ストレージだけに保存し、機密データを明示的に選択して強力なパスワードを設定した場合だけ暗号化可搬内容へ含められます。カメラ、モデル、十分な信頼度がない場合、ジェスチャー経路は安全に無効となり、既存機能へ影響しません。Windows EXE での実カメラ実機受入試験と完全な回帰テストが未完了であり、公開済みまたは完成済みとして扱いません。
-- 会話保存、編集可能な長期記憶、タスク、創作アイデア、作業時間、リマインダー、公開進捗。
-- 仕事、同伴、集中、会議、離席、休眠モード。
-- 危険度、確認、二重確認、許可リスト、監査、緊急停止を備えたパソコンツールセンター。
-- Google、Microsoft、GitHub、Home Assistant、プライベートネットワーク遠隔機能の拡張可能な構造。
-- Windows 間で作業進捗を移動する単一の `.mohan-profile` 可搬ファイル。
-- 既存の個人設定を上書きせず、アシスタント名、利用者の呼称、組織名、ウィンドウタイトル、仕事種別、起動語、表示言語を設定する初回ウィザード。
-
-英語、簡体字中国語、日本語では現在、初回起動、会話、音声、権限、基本設定、仕事モード、リマインダーの最低限利用経路を提供しています。一部の高度な管理画面には台湾繁体字が残り、完全なローカライズは継続中です。
-
-### 日本語の対応範囲
-
-- 初回セットアップと個人設定は、台湾繁体字中国語、簡体字中国語、英語、日本語に対応します。
-- 会話、音声、パソコン権限、基本設定の主要画面と操作に四言語経路があります。
-- 人格プロンプト、オフライン応答、仕事モードの台詞、組み込みリマインダー、音声試聴文は四言語で対応します。
-- 文字起こしと女性本機音声は `zh-TW`、`zh-CN`、`en-US`、`ja-JP` の locale に合わせて選択します。
-- EXE インストーラーは四言語表示です。MSI は台湾繁体字中国語を基底とし、`en-US`、`zh-CN`、`ja-JP` 変換ファイルを提供します。
-- 組み込みリマインダーの既定値は選択言語に合わせて移行し、利用者の独自内容を上書きしません。
-
-表示言語を保存した後は、完全適用のため墨寒を再起動してください。再起動なしの画面言語切替は現在提供していません。
-
-### Windows 本機女性音声とオフライン代替
-
-新規利用者は Windows 本機音声から始めるため、OpenAI API キーがなくても基本的な読み上げとオフライン機能を試せます。音声一覧には Windows が女性と明示するインストール済み音声だけを表示します。繁体字・簡体字中国語画面は `zh-TW`／`zh-CN` の中国語女性音声プールを共有し、`en-US` Zira は表示しません。
-
-台湾繁体字中国語は `zh-TW` の Microsoft Yating を優先し、簡体字中国語、英語、日本語ではそれぞれ `zh-CN`、`en-US`、`ja-JP` に合う女性音声を優先します。条件を満たす音声がない場合、男性かもしれない既定音声へ黙って切り替えず、理由を明示します。
-
-Realtime がオフライン、クラウド音声が失敗、設定が不足、または供給元が不明な場合も、Windows 本機女性音声が最初の代替経路です。
-
-### Azure Speech（プレビュー）
-
-Azure Speech は初期状態で無効な Preview 供給元で、利用者が明示的に有効化します。利用者自身の Azure Speech リソースキーと対応リージョンが必要です。キーは `Windows DPAPI` で分離して暗号化し、データベース、ログ、GitHub には保存しません。
-
-画面には Microsoft が公式に女性と示し、墨寒の許可リストへ明示した繁体字中国語、簡体字中国語、英語、日本語の Neural 音声だけを掲載します。今回追加する言語横断の普通話選択肢は Standard Neural だけを使用し、Dragon HD／HD Omni を除外します。繁体字中国語画面では台湾華語の後に簡体字普通話を、簡体字中国語画面では逆順に表示し、どちらも従来の既定音声を維持します。Azure 音声は選択時に直ちに保存し、次の試聴または読み上げから適用します。設定不足なら通信せず、サービス障害時は同じ文章を一度だけ Windows 女性本機音声へ戻します。
-
-2026 年 8 月 11 日、East Asia の実 Azure Speech Free F0 リソースで HTTPS 合成、有効な RIFF 音声、Windows での実再生を検証しました。これは墨寒の統合経路を確認する結果であり、すべてのアカウント、リージョン、割り当てで同じ動作を保証するものではありません。Dragon HD／HD Omni はプラン、課金、対応リージョンが異なるため無料の既定一覧へ混在させません。[交換可能な音声供給元の説明](docs/PLUGGABLE-SPEECH-PROVIDERS.md)をご覧ください。
-
-`v3.1.1` は、現在選択中の Azure リージョンと対応する暗号化キーを使い、そのリソースセンターが実際に返す女性 Neural／Dragon HD 音声を動的に照会します。固定一覧は照会失敗時の安全な代替に限定し、HD Flash は引き続き Microsoft 公式対応リージョンだけに表示します。Azure 合成は Speech SDK の `PushAudioOutputStream` を使用し、最初の 24 kHz PCM16 断片が届いた時点で再生を開始して、完全な WAV を待たずに同じ本機 50 Hz 口形解析時計を駆動します。2026 年 8 月 12 日に East Asia F0 と West US 2 S0 で実照会を完了し、当時 West US 2 は簡体字中国語 Dragon HD 女性音声を三件返しました。実際の一覧、遅延、料金、リージョン機能は Microsoft の当期サービスに従います。
-
-### 統合の検証状況
-
-> **公開 Preview の注意：** Azure Speech は、以下に記載する実リソース検証を完了しています。Microsoft アカウント連携、GitHub、Home Assistant は構造、権限境界、内部テストを実装済みですが、すべての実アカウント、リポジトリ、サーバー、実機器を使うエンドツーエンド検証は未完了です。実検証が完了していない部分は実験的 Preview であり、あらゆる環境で完全動作する保証はありません。
-
-- Azure Speech は本プロジェクトの実 Free F0 リソース、HTTPS 合成、RIFF 音声、Windows 再生検証を完了しました。各利用者は自身の Speech リソースを作成し、アカウント、割り当て、費用に責任を負う必要があります。
-- Microsoft アカウントの実ログイン、token 更新、Outlook、OneDrive、Calendar の完全な読み書きは未検証です。
-- GitHub の実アカウント、リポジトリ、Issue、Pull Request、権限階層の流れは未検証です。
-- Home Assistant の実サーバーと物理機器の動作は未検証です。
-- 三つの統合は初期状態で無効です。重要でないアカウント、テストリポジトリ、低リスク機器から始めてください。
-- Google Gmail、Calendar、Drive は本プロジェクトの実接続試験を完了しましたが、各利用者は自身の OAuth アプリケーションを作成して認可する必要があります。
-
-### ダウンロードとインストール
-
-一般利用者は Python をインストールする必要がありません。
-
-1. [GitHub Releases](../../releases) を開きます。
-2. ファイル名が `Windows-x64-Setup.exe` で終わるインストーラーと、対応する `SHA256.txt` を取得します。上級者はポータブル `Windows-x64.zip` や `Windows-x64.msi` も選べます。
-3. SHA-256 を照合し、ZIP を完全展開するかインストーラーを起動します。
-4. `MoHan-Desktop-Assistant-*.exe` を実行します。
-5. 初回セットアップで必要な表示言語を選びます。
-6. ポータブル ZIP では、EXE、`_internal`、`assets` を同じアプリケーションフォルダーに置きます。
-
-署名のないオープンソース Preview は Windows SmartScreen の警告を出す場合があります。公式配布元と SHA-256 を確認してから実行してください。
-
-`v4.0.0` のクロスプラットフォーム公開範囲には、macOS Apple Silicon（arm64）版と Intel（x86_64）版の `.dmg`（各対応 `.app` を収録）、Linux x86_64 `.AppImage` が含まれ、すべての成果物は本版の完全な公開ゲートに合格後に公開されました。いずれも機能限定 Preview で、`preview_app.py` の起動画面、四言語案内、OS ごとのデータパス、安全な無効化境界だけを公開します。音声、透明キャラクター、完全な会話と仕事画面、クラウド接続、システム操作、自動起動、秘密情報入力は無効です。[Preview 配布物の説明](docs/PREVIEW-PACKAGES.md)と [QUICKSTART](QUICKSTART.md)をお読みください。
-
-#### 自動リリースの境界
-
-公開できるのは `vN.N.N` または `vN.N.N-rc.N` に一致する不変タグだけです。正式タグは Stable Release、RC タグは Pre-release を作成します。Windows ZIP／EXE／MSI、macOS Apple Silicon／Intel DMG、Linux AppImage は各 OS のネイティブ CI で完成品の起動検査に合格しなければなりません。Pull Request は短期テスト成果物だけを保存し、Release を作成しません。
-
-公開ファイルには SHA256SUMS、CycloneDX 1.7 の構造／ライセンス／依存関係グラフ検証に合格した Windows／Preview 別 SBOM、匿名化済み Tachyon 性能証拠と要約、Windows 更新マニフェスト、Artifact Attestation、繁体字中国語、簡体字中国語、英語、日本語の順で整備した完全な Release 説明も含みます。
-
-### OpenAI API
-
-クラウド AI、OpenAI 音声、Realtime 機能には、利用者自身の OpenAI API キー、Project 権限、API 残高が必要です。ChatGPT Plus／Pro の契約に API 残高は含まれません。
-
-現在の既定モデル：
-
-| 用途 | 既定モデル |
-|---|---|
-| 文字会話 | `gpt-5.6-luna` |
-| Realtime 即時音声 | `gpt-realtime-2.1-mini` |
-| 音声から文字 | `gpt-4o-mini-transcribe` |
-| OpenAI 文字から音声 | `gpt-4o-mini-tts` |
-
-#### Realtime 応答音声
-
-`v4.0.0` は OpenAI Realtime のネイティブ音声を完全に維持し、引き続き既定値とします。ネイティブモードでは Realtime が同じ経路で理解と音声出力を行うため、従来の音声を好む利用者や、これらの選択肢の中で追加遅延を最小にしたい利用者に適しています。
-
-利用者は「Realtime 即時理解＋通常 Azure Speech ストリーミング発話」または「Realtime 即時理解＋Azure Dragon HD ストリーミング発話」を明示的に選ぶこともできます。ハイブリッドモードは Realtime が生成した文字だけを選択中の Azure エンジンへ渡します。安全な短い句が完成するたび順番待ちへ追加し、完全な応答や音声ファイルを待たず、最初の音声断片から発話を始めます。ただし TTS の通信と合成工程が増えるため、発話前の待ち時間は長くなり得ます。本プロジェクトはゼロ遅延をうたいません。
-
-三つのモードは完全に分離し、同時に再生を管理する出力経路は一つだけです。音声を混合せず、通常の Windows 本機音声、OpenAI TTS、通常 Azure 読み上げ、その他の音声モデルも変更しません。Dragon HD が一つの句で失敗した場合は通常 Azure へ一度、続いて Windows 本機女性音声へ一度だけ代替し、通常 Azure が失敗した場合は Windows 本機女性音声へ一度だけ代替します。この代替は、その句の音声がまだ一切再生されていない場合に限ります。ストリーミング再生の開始後に失敗した場合は、重複発話と重複課金を避けるため、句全体を再生し直さず直ちに停止します。Azure の選択肢がネイティブ Realtime を置き換えることはありません。
-
-`v2.1.0-rc.1` から文字会話の既定値は `gpt-5.6-luna` で、設定一覧から `gpt-5.4-mini` を外しました。既存 mini 設定は Luna へ移行しますが、利用者が選んだ Terra、Sol、その他の独自モデルを上書きしません。実際の利用可否はアカウント、Project、地域、提供状況に依存します。
-
-API キーがなくても、本機データ管理、オフライン人格応答、仕事リマインダー、Windows 音声は利用できますが、完全なクラウド AI は利用できません。API キーをソースコード、Issue、画像、Git に記載しないでください。
-
-### Google OAuth
-
-Gmail、Google Calendar、Google Drive を利用する前に、利用者は次を行います。
-
-1. 自身の Google Cloud プロジェクトで Gmail API、Google Calendar API、Google Drive API を有効にします。
-2. OAuth 同意画面を設定します。
-3. Desktop アプリケーション用 OAuth Client ID を作成します。
-4. アプリケーションがテスト中なら、自身の Google アカウントをテスト利用者へ追加します。
-5. 墨寒のクラウド設定へ Client ID を入力し、供給元が Client Secret も発行した場合は併せて入力します。
-6. ブラウザーで認可を完了し、内蔵サービス試験を実行します。
-
-アプリケーションが既定で要求する Google scopes：
-
-```text
-openid
-email
-https://www.googleapis.com/auth/gmail.modify
-https://www.googleapis.com/auth/calendar
-https://www.googleapis.com/auth/drive.file
-https://www.googleapis.com/auth/drive.metadata.readonly
-```
-
-機密 scopes を使う公開 OAuth アプリケーションは Google の追加検証が必要な場合があります。各利用者が個人用 Desktop OAuth アプリケーションを作ることもできます。
-
-### Microsoft、GitHub、Home Assistant
-
-- Microsoft の既定 scopes：`openid`、`offline_access`、`User.Read`、`Mail.ReadWrite`、`Mail.Send`、`Calendars.ReadWrite`、`Files.ReadWrite`。
-- GitHub の既定 scopes：`read:user`、`repo`。
-- Home Assistant には利用者自身のサーバー URL と Long-Lived Access Token が必要です。
-
-三つとも実環境の完全なエンドツーエンド検証を終えていない Preview 統合であり、最初は失敗を許容できる試験環境だけで使ってください。
-
-Home Assistant OS は Home Assistant Green、低消費電力ミニ PC、SSD 付き Raspberry Pi、NAS 仮想マシンなどで独立常駐させることを推奨します。Windows の墨寒は音声、人格、仕事ツールを担当し、PC または OpenAI API がオフラインでも Home Assistant 自身の自動化は動作します。
-
-Home Assistant や墨寒の遠隔ポートを公衆インターネットへ直接公開しないでください。Home Assistant Cloud、Tailscale、または認証付き暗号化プライベートネットワークを利用してください。
-
-### 安全性とプライバシー
-
-- AI は構造化された計画を提案できますが、本機方針を回避してツールを実行できません。
-- 操作は権限、危険度、確認、実行、結果検証、本機監査の順に通過します。
-- 支払い、購入、パスワード書出し、安全機能停止、任意 Shell、管理者 Shell は自動化しません。
-- 外部メール、ウェブページ、文書、音声文字起こし、モデル出力は権限を付与できません。
-- 遠隔操作、カメラ、クラウド接続、Home Assistant は初期状態で無効です。
-- 緊急停止：`Esc` を押すか、`墨寒、止まって` または `ぜんぶ止めて` と発話します（中国語の `墨寒，停手`、英語の `mohan stop` も利用できます）。
-- OpenAI、OAuth、Home Assistant の token は Windows DPAPI で分離保存し、SQLite、ソースコード、可搬ファイルへ入れません。
-- 会話、記憶、タスク、作業記録、設定は初期状態で本機アプリケーションデータに保存します。
-
-[PRIVACY](PRIVACY.md)、[SECURITY](SECURITY.md)、[FLAGSHIP-SPEC](FLAGSHIP-SPEC.md)をご覧ください。
-
-### Python 3.15、JIT、Tachyon、SBOM
-
-墨寒は CPython `3.15.0rc1` ランタイムだけをサポートし、第二の製品ランタイムを残しません。新機能は意味が明確で完全回帰が維持される場合に限って採用します。適切な用途がない機能は、見せかけで使わず将来の導入条件を記録します。
-
-- PEP 810 `lazy import` によりプロジェクト全体で明示的遅延インポートを採用し、一つの任意インポート安全ガードだけは意図的に eager を維持します。
-- PEP 814 `frozendict` は大域および再帰的な不変設定を保護し、PEP 798 推論式アンパックは意味が等価な平坦化と結合に使います。
-- PEP 686 監査は全プロジェクトの文字 I/O に明示 UTF-8 を要求し、音声パケットバッファーは `bytearray.take_bytes()` を使います。
-- PEP 661 `sentinel` はテストで管理します。置換対象となる旧式 `object()` sentinel は現在なく、未指定値と `None` を区別する将来コードでは組み込み機構を使います。
-- Windows インストーラーは、スタジオ管理の Python 3.15.0rc1／PyInstaller 起動境界を使用します。公開ランチャーが継承されたすべての `PYTHON*` 設定を除去し、`PYTHON_JIT=1` だけを注入して内蔵 runtime を起動するため、Python 初期化前に JIT が有効になります。Qt の完全なクリーンアップ後、runtime は安全なプロセス境界で終了し、ネイティブ heap corruption を回避します。
-- PEP 799 Tachyon は起動、50 Hz リップシンク、表情調停を匿名化済み証拠で分析し、生のバイナリサンプルストリームを公開しません。
-- Windows 正式パッケージ化の契約では、Rust 1.97.1、Maturin 1.14.1、PyO3 0.29.2 を用いて第一者 `_mohan_accel` abi3t ネイティブモジュールをビルドし、PCM16、リップシンク音声解析、RGBA レイヤー合成の結果を Python 参照実装と項目別に照合することを v4.0.0 Windows 正式公開の必要証拠とします。RGBA 経路は Rayon 1.12.0 を使用し、262,144 pixels 以上かつ複数のワーカースレッドが利用できる場合だけ条件付きで並列化します。Rust serial／Rayon 境界テストと Python／native 実測により等価性と性能の証拠を得ています。`PyBackedBytes` は入力を借用して追加の入力コピーを避けますが、出力では新しい `bytes` を生成するため、エンドツーエンドのゼロコピーは表明せず、未実装の SIMD も表明しません。モジュールを読み込めない場合、または個別処理に失敗した場合、アプリケーションは観測可能な診断を記録して Python へフォールバックします。ビルド用ツールチェーンは実行時依存ではありません。macOS／Linux Preview は同等のパッケージ対応を表明しません。
-- OpenAI Responses API 経路は Python 標準ライブラリの `urllib.request` から HTTPS で直接呼び出します。墨寒に `openai` Python SDK の実行時依存はなく、同梱しない SDK のバージョンやライセンスを架空登録しません。OpenAI は同梱コンポーネントではなく外部サービスであり、機械可読な SBOM ポリシーにこの境界を記録し、Release ゲートは SDK の誤混入を拒否します。
-- CycloneDX 1.7 Windows／Preview SBOM は固定依存関係、ライセンス、PURL、完全なルート依存エッジ、公式構造、プライバシー検証に合格しなければなりません。
-
-表情、物理、リップシンクを統合した各 20,000 回のストレス試験を二回実行し合格しました。JIT 無効／有効時は 24.639／25.068 秒、ワーキングセット増加は 10.62／12.94 MB でした。同じ Ryzen 5 5600X Windows 実機でホットパス比較をさらに三回実行しました。JIT 無効時に対する有効時の速度比は、120,000 回の表情調停で 0.86～0.98 倍（中央値 0.97 倍、加速は確認できず）、2,000 回の 50 Hz リップシンク tick で 1.45～1.65 倍（中央値 1.48 倍）となり、各回の判断と検証結果は一致しました。
-
-JIT 有効時、Tachyon は起動、50 Hz リップシンク、表情調停でそれぞれ 4,553／11,482／3,475 件の有効サンプルを保持しました。スタック読取エラー率は 6.20%／2.23%／0.57%、欠落サンプル率は 0.02%／0%／0% です。CI は匿名化済み flamegraph、JSONL、pstats、GC、設定、thread、SHA-256 証拠を保存します。
-
-これらは特定ホットパスとサンプリング処理の証拠であり、アプリケーション全体が一様に高速化するという主張ではありません。完全な採用表、ロールバック、将来の導入条件は [Python 3.15 移行説明](docs/PYTHON-3.15-MIGRATION.md)をご覧ください。
-
-### ソースコードから実行
-
-必要環境：Windows 10/11 と Python `3.15.0rc1`。
-
-分離環境を作成して起動します。
-
-```powershell
-py -3.15 -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -r requirements.txt
-python app.py
-```
-
-### テスト、公開監査、パッケージ化
-
-```powershell
-python tools\audit_public_release.py
-python tests\run_all.py
-.\build.ps1 -Version "<source-version>"
-```
-
-過去の v2.1.0 RC1 は公開前に 55 個の自動テストプログラムと、Windows リリースワークフローのソース監査、パッケージ自己試験、インストール／削除検証、安全検査に合格しました。自動テストは、未完了の第三者実環境検証に代わりません。
-
-受理された各タグは、完全回帰、完成品 smoke test、SHA-256 再検証、SBOM 検証、Tachyon 証拠ゲート、Artifact Attestation、四言語 Release 説明を完了しなければ、対応する Stable Release または Pre-release を作成できません。Windows 更新機能は公式 GitHub HTTPS の EXE／MSI だけを受理し、実行許可を求める前に宣言サイズと SHA-256 を検証します。
-
-対話型 EXE インストーラーは台湾繁体字中国語、簡体字中国語、英語、日本語を提供します。MSI は台湾繁体字中国語を基底とし、検証済み en-US、zh-CN、ja-JP 変換を提供します。詳しくは[インストーラーのローカライズ](installer/LOCALIZATION.md)をご覧ください。
-
-炎劍 Product Release Hub は公開 GitHub Releases から公式サイトを毎時更新します。本リポジトリは WordPress パスワードを保存せず、リリース処理もサイトへ直接書き込みません。これにより三つのソフトウェアは一つの保守可能な同期経路を共有します。
-
-### パソコン間の移行
-
-「設定 → 可搬プロファイル」から一つの `.mohan-profile` ファイルを出力し、別の Windows パソコンへ取り込みます。アプリケーションは先に移行先データをバックアップし、hash、SQLite 完全性、schema、件数を検証します。
-
-可搬ファイルからは OpenAI キー、OAuth／Home Assistant token、接続済み遠隔機器 token、端末許可リスト、Windows 起動設定、画面固有設定を意図的に除外します。端末固有項目はパソコンごとに設定してください。可搬プロファイルには私的会話や作業データが含まれる場合があり、公開アップロードしてはいけません。
-
-### 開発参加、ライセンス、作者
+<table>
+  <tr>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-proud.png" width="220" height="220" alt="誇らしげな墨寒"><br><strong>「支援を待ってなどいません。兵糧を巡回しているだけです。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-shy-aligned.png" width="220" height="220" alt="照れる墨寒"><br><strong>「本当に助けてくださるなら、覚えておきます。」</strong></td>
+    <td align="center" valign="top" width="33%"><img src="docs/media/support-mock-hit.png" width="220" height="220" alt="無理な支援を止める墨寒"><br><strong>「無理は禁止です。まず自分のお財布を守りなさい。」</strong></td>
+  </tr>
+</table>
 
 - 作者：**CHOU MING HUA**。
-- ソースコードは [MIT License](LICENSE) です。「墨寒」のキャラクター素材、人物設定、名称・肖像はすべての権利を留保し、MIT の適用外です。
-- 素材条件：[ASSETS-LICENSE](ASSETS-LICENSE.md)。
-- 第三者パッケージとサービス：[THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md)。
-- 通常の問題は GitHub Issues へ報告し、安全上の問題は [SECURITY](SECURITY.md) に従い非公開で報告します。
-- 変更履歴：[CHANGELOG](CHANGELOG.md)、貢献手順：[CONTRIBUTING](CONTRIBUTING.md)。
-- コミュニティ参加前に [CODE-OF-CONDUCT](CODE_OF_CONDUCT.md) をお読みください。
-- 保守者の公開設定、Topics、初回公開検査：[PUBLISHING](PUBLISHING.md)。
+- ソースコードは [MIT License](LICENSE) です。「墨寒」のキャラクター美術、人物設定、名称、肖像はすべての権利を留保し、MIT の許諾範囲外です。
+- 素材生成の道具と重みは MIT、Apache 2.0、CC0、CC BY（および同等の BSD 系）ホワイトリストだけを受理します。キャラクター美術は権利者の専有財産です。詳しくは [ライセンス純浄性の約束](docs/LICENSE-PURITY.md) を参照してください。
+- 素材と第三者条項は [ASSETS-LICENSE](ASSETS-LICENSE.md) と [THIRD-PARTY-NOTICES](THIRD_PARTY_NOTICES.md) に記載しています。
 
-Copyright © 2026 **CHOU MING HUA** and MoHan Desktop Assistant contributors.
+本プロジェクトは [炎剣オープンソース・ソフトウェア・ファミリー品質基準](PUBLISHING.md) に従います。
 
-> **炎剣オープンソース宣言：**「この剣は、私が鍛え上げました。あとは皆さんに託します。」
+### トラブルシューティング
+
+- Windows SmartScreen またはプラットフォーム警告：GitHub Release の配布元、`SHA256SUMS`、Artifact Attestation を先に確認し、システム全体の保護を無効にしないでください。
+- 会話が返らない：利用者自身の OpenAI API キー、Project 権限、割り当て、ネットワークを確認してください。ChatGPT 契約は API 割り当ての代わりになりません。
+- 音が出ない：まず Windows 本機女性音声へ戻してください。Azure Speech には利用者自身のキーと対応リージョンが必要です。
+- DLC が拒否される：ファイルの完全性、容量、安全な manifest、四言語名、`mohan-body-v2` 互換性を確認してください。第一世代パックは再構築が必要です。
+- Preview 連携が失敗する：重要でないアカウント、テスト用リポジトリ、低リスク機器から始めてください。Microsoft、GitHub、Home Assistant は全実環境での検証を完了していません。
+
+一般的な問題は [Issues](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/issues)、利用相談は [Discussions](https://github.com/flameblade-studio/MoHan-PC-Desktop-Assistant/discussions)、セキュリティ問題は [SECURITY](SECURITY.md) から非公開で報告してください。計画は [ROADMAP](ROADMAP.md) にあります。
+
+### 開発者向け入口
+
+最初に [アーキテクチャ](ARCHITECTURE.md)、[テスト説明](docs/TESTING.md)、[貢献ガイド](CONTRIBUTING.md)、[外観パック仕様](docs/OUTFIT-PACKS.md)、[公開方針](PUBLISHING.md) をお読みください。Windows インストーラーは、スタジオ管理の Python 3.15 実行環境を使用します。ソースと CI は PEP 810 遅延インポートを採用し、文書は四言語で同じ構造を維持します。
+
+```powershell
+py -3.15 -m ruff check .
+py -3.15 tools/audit_python315_idioms.py
+py -3.15 tools/check_four_language_docs.py
+$env:QT_QPA_PLATFORM = "offscreen"
+py -3.15 tests/run_all.py
+```
+
+Windows 正式パッケージ化の契約では、Rust 1.97.1、Maturin 1.14.1、PyO3 0.29.2 で第一者ネイティブモジュールを構築します。Rayon 1.12.0 は 262,144 pixels 以上かつ複数ワーカーがある場合だけ RGBA 合成を並列化します。PyBackedBytes は余分な入力コピーを避けますが、出力は新しい bytes を生成するため、エンドツーエンドのゼロコピーや未実装の SIMD を主張しません。OpenAI Responses API は標準ライブラリ HTTPS を直接使い、墨寒には `openai` Python SDK の実行時依存がありません。


### PR DESCRIPTION
## 繁體中文
README 四語重新編排，並補上 DLC（外觀套件）安裝教學段。

審查抓出的兩處已修：主題包上傳入口四語都寫成「雲裳閣」，但 `ThemePackPanel` 實際在「設定 → 控制台佈景主題」（已依 `dashboard_settings.py` 的實際掛載位置改正，不是憑印象）；重編時被刪掉的 OAuth／Home Assistant 設定步驟已四語恢復——`QUICKSTART` 仍指向 README 當完整說明，若不恢復，使用者無法只靠文件完成 Google API 專案、OAuth consent、Desktop Client ID、測試使用者、scopes 與 Home Assistant Token 設定。

**驗證**：四語稽核、136 個本地連結檢查、`git diff --check` 皆通過；`ALL_364_TESTS_OK`。

## 简体中文
README 四语重新编排，并补上 DLC（外观套件）安装教学段。

审查抓出的两处已修：主题包上传入口四语都写成「云裳阁」，但 `ThemePackPanel` 实际在「设置 → 控制台主题」（已依 `dashboard_settings.py` 的实际挂载位置改正，不是凭印象）；重编时被删掉的 OAuth／Home Assistant 设置步骤已四语恢复——`QUICKSTART` 仍指向 README 当完整说明，若不恢复，用户无法只靠文档完成 Google API 项目、OAuth consent、Desktop Client ID、测试用户、scopes 与 Home Assistant Token 设置。

**验证**：四语审计、136 个本地链接检查、`git diff --check` 均通过；`ALL_364_TESTS_OK`。

## English
Restructures the README across all four languages and adds a DLC (appearance pack) installation section.

Two review findings are fixed. All four languages pointed at the wardrobe for theme-pack upload, but `ThemePackPanel` actually lives under Settings → Control-centre theme; the text now matches where the panel is really mounted according to `dashboard_settings.py`, rather than from memory. The OAuth and Home Assistant setup steps dropped during the rewrite are restored in all four languages — `QUICKSTART` still points at the README as the complete reference, and without them a user cannot complete the Google API project, OAuth consent screen, desktop client ID, test users, scopes, or Home Assistant token from the documentation alone.

**Verification**: four-language audit, 136 local link checks and `git diff --check` all pass; `ALL_364_TESTS_OK`.

## 日本語
README を四言語で再構成し、DLC（外観パック）のインストール手順を追加します。

レビュー指摘の二点を修正しました。テーマパックのアップロード入口を四言語すべてが「雲裳閣」と記載していましたが、`ThemePackPanel` は実際には「設定 → コントロールセンターのテーマ」にあります。`dashboard_settings.py` の実際のマウント位置に合わせて記述を正しました（記憶ではなくコードを根拠にしています）。また再構成の際に削除された OAuth／Home Assistant の設定手順を四言語で復元しました。`QUICKSTART` は依然として README を完全な手引きとして参照しており、復元しなければ Google API プロジェクト、OAuth 同意画面、デスクトップクライアント ID、テストユーザー、スコープ、Home Assistant トークンの設定をドキュメントだけで完了できません。

**検証**：四言語監査、ローカルリンク 136 件の検査、`git diff --check` すべて合格。`ALL_364_TESTS_OK`。
