### PR TITLE
發版與 Dependabot 標題四語化並收緊治理豁免／发版与 Dependabot 标题四语化并收紧治理豁免／Four-language release and Dependabot titles with narrower governance exemption／リリースと Dependabot のタイトルを四言語化しガバナンス免除を縮小

### DIFF
--- a/.github/workflows/dependabot-title-normalization.yml
+++ b/.github/workflows/dependabot-title-normalization.yml
@@ -28,6 +28,12 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Set up Python 3.15
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.15.0-rc.1"
+          allow-prereleases: true
+
       - name: Normalize Dependabot title when it matches the safe grammar
         shell: bash
         env:

--- a/.github/workflows/dependabot-title-normalization.yml
+++ b/.github/workflows/dependabot-title-normalization.yml
@@ -1,0 +1,51 @@
+name: Dependabot four-language title normalization
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  normalize-dependabot-title:
+    name: Normalize Dependabot PR title
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # This target workflow checks out only the trusted base branch.  It never
+      # executes files supplied by the pull request while holding write access.
+      - name: Check out trusted base tools
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Normalize Dependabot title when it matches the safe grammar
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          normalized_title="$(python tools/normalize_dependabot_title.py)"
+          if [[ -z "$normalized_title" ]]; then
+            echo "DEPENDABOT_TITLE_PARSE_FAILED_NO_CHANGE"
+            exit 0
+          fi
+          if [[ "$normalized_title" == "$PR_TITLE" ]]; then
+            echo "DEPENDABOT_TITLE_ALREADY_NORMALIZED"
+            exit 0
+          fi
+          gh pr edit "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$normalized_title"
+          echo "DEPENDABOT_TITLE_NORMALIZED"

--- a/.github/workflows/pr-language-governance.yml
+++ b/.github/workflows/pr-language-governance.yml
@@ -15,30 +15,55 @@ jobs:
     name: 四語 PR 說明 / 四语 PR 说明 / Four-language PR body / 四言語 PR 本文
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - name: Require minimum four-language PR metadata
+      - name: Require four-language PR title and body metadata
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Release Please auto-generates its release PRs with a single-language
-          # title and a robot body.  Those PRs are machine-authored version bumps,
-          # not human prose, so they are exempt from the four-language metadata
-          # requirement.  This prevents every automated release PR from failing
-          # the governance check and needing a manual title/body rewrite.
-          # The exemption is only for PRs actually authored by the GitHub
-          # Actions bot; a branch name alone must not bypass governance.
+          # Release Please 的標題是可控的版本識別資料，必須通過四語標題檢查，
+          # 才能讓自動發版在 main 歷史中留下四語標題。
+          # Release Please 的說明是機器產生的變更清單，不是人寫的敘述，
+          # 因此只豁免 body 的四語章節檢查，不豁免標題。
+          # 豁免仍須同時符合 release-please 分支與 github-actions[bot] 作者；
+          # 單靠分支名不能繞過治理。
           head_ref=$(jq -r '.pull_request.head.ref // ""' "$GITHUB_EVENT_PATH")
           pr_author=$(jq -r '.pull_request.user.login // ""' "$GITHUB_EVENT_PATH")
-          if [[ "$head_ref" == release-please--branches--* \
-                && "$pr_author" == "github-actions[bot]" ]]; then
-            echo "RELEASE_PLEASE_PR_EXEMPT"
-            exit 0
-          fi
           title=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
           body=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
           # GitHub's web editor stores CRLF. Normalize line endings before
           # applying exact, platform-independent heading checks.
           title=${title//$'\r'/}
           body=${body//$'\r'/}
+          # Dependabot title normalization writes through a separate trusted
+          # workflow.  GITHUB_TOKEN edits do not create an automatic `edited`
+          # workflow run, so read the live title before validating this run.
+          # Human and other bot PRs keep the original event-driven behavior.
+          if [[ "$pr_author" == "dependabot[bot]" && "$title" != *'／'* ]]; then
+            live_title="$title"
+            for attempt in {1..12}; do
+              live_title=$(gh pr view "$PR_NUMBER" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json title \
+                --jq '.title')
+              if [[ "$live_title" != "$title" ]]; then
+                break
+              fi
+              sleep 5
+            done
+            if [[ "$live_title" != "$title" ]]; then
+              title=${live_title//$'\r'/}
+              current_event="$RUNNER_TEMP/pr-event-current.json"
+              jq --arg current_title "$title" \
+                '.pull_request.title = $current_title' \
+                "$GITHUB_EVENT_PATH" > "$current_event"
+              printf 'GITHUB_EVENT_PATH=%s\n' "$current_event" >> "$GITHUB_ENV"
+            fi
+          fi
           IFS='／' read -r -a title_parts <<< "$title"
           if [[ ${#title_parts[@]} -ne 4 ]]; then
             echo "標題必須有四段翻譯 / 标题必须有四段翻译 / Title requires four translations / タイトルには四つの翻訳が必要です" >&2
@@ -50,6 +75,11 @@ jobs:
               exit 1
             fi
           done
+          if [[ "$head_ref" == release-please--branches--* \
+                && "$pr_author" == "github-actions[bot]" ]]; then
+            echo "RELEASE_PLEASE_BODY_EXEMPT"
+            exit 0
+          fi
           headings=(
             "## 繁體中文"
             "## 简体中文"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,9 @@ jobs:
       # ignores ``config-file``/``manifest-file`` whenever ``release-type`` is
       # set, which silently disables extra-files version bumps and the
       # four-language changelog sections.
+      # The v5-bundled 17.6.0 title builder replaces each placeholder once;
+      # keep the one version token as a title-wide prefix so all four language
+      # segments are generated without an empty component.
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "include-v-in-tag": true,
+  "pull-request-title-pattern": "發版 ${version}／发版 ${version}／Release ${version}／リリース ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "✨ 新功能 / 新功能 / New features / 新機能", "hidden": false },
     { "type": "fix", "section": "🐛 修正 / 修复 / Fixes / 修正", "hidden": false },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "python",
   "include-v-in-tag": true,
-  "pull-request-title-pattern": "發版 ${version}／发版 ${version}／Release ${version}／リリース ${version}",
+  "pull-request-title-pattern": "${version} 發版／发版／Release／リリース",
   "changelog-sections": [
     { "type": "feat", "section": "✨ 新功能 / 新功能 / New features / 新機能", "hidden": false },
     { "type": "fix", "section": "🐛 修正 / 修复 / Fixes / 修正", "hidden": false },

--- a/tests/test_four_language_pr.py
+++ b/tests/test_four_language_pr.py
@@ -103,7 +103,7 @@ def test_release_please_body_exemption_requires_bot_author_and_four_language_tit
     # has to satisfy the four-language contract.
     assert _run_main_with_payload(payload) == 1
 
-    payload["pull_request"]["title"] = "發版 4.5.1／发版 4.5.1／Release 4.5.1／リリース 4.5.1"
+    payload["pull_request"]["title"] = "4.5.1 發版／发版／Release／リリース"
     assert _run_main_with_payload(payload) == 0
 
     payload["pull_request"]["head"]["ref"] = "feature/normal-branch"

--- a/tests/test_four_language_pr.py
+++ b/tests/test_four_language_pr.py
@@ -86,7 +86,7 @@ def _run_main_with_payload(payload: dict) -> int:
                 os.environ["GITHUB_EVENT_PATH"] = previous
 
 
-def test_release_please_exemption_requires_bot_author() -> None:
+def test_release_please_body_exemption_requires_bot_author_and_four_language_title() -> None:
     payload = {
         "pull_request": {
             "title": "single-language title",
@@ -99,6 +99,11 @@ def test_release_please_exemption_requires_bot_author() -> None:
     assert _run_main_with_payload(payload) == 1
 
     payload["pull_request"]["user"]["login"] = "github-actions[bot]"
+    # The release bot may skip the machine-generated body, but its title still
+    # has to satisfy the four-language contract.
+    assert _run_main_with_payload(payload) == 1
+
+    payload["pull_request"]["title"] = "發版 4.5.1／发版 4.5.1／Release 4.5.1／リリース 4.5.1"
     assert _run_main_with_payload(payload) == 0
 
     payload["pull_request"]["head"]["ref"] = "feature/normal-branch"
@@ -109,7 +114,7 @@ def main() -> None:
     test_valid_pull_request_metadata()
     test_title_requires_exactly_four_nonempty_segments()
     test_body_requires_fixed_order_and_structural_parity()
-    test_release_please_exemption_requires_bot_author()
+    test_release_please_body_exemption_requires_bot_author_and_four_language_title()
     print("FOUR_LANGUAGE_PR_TESTS_OK")
 
 

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+lazy import json
+lazy import os
 lazy import re
 lazy import struct
+lazy import subprocess
+lazy import sys
 lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
 
 ROOT = Path(__file__).resolve().parents[1]
 MIN_PREVIEW_BYTES = 100_000
@@ -38,6 +43,128 @@ def assert_external_actions_pinned(workflow: str) -> None:
     assert not unpinned, (
         "external GitHub Actions must be pinned to complete 40-character "
         f"commit SHAs: {unpinned}"
+    )
+
+
+def _run_pr_checker(payload: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    with TemporaryDirectory() as temporary_directory:
+        event_path = Path(temporary_directory) / "event.json"
+        event_path.write_text(
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        environment = os.environ.copy()
+        environment["GITHUB_EVENT_PATH"] = str(event_path)
+        return subprocess.run(
+            [sys.executable, str(ROOT / "tools/check_four_language_pr.py")],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+
+def _run_dependabot_normalizer(title: str) -> str:
+    environment = os.environ.copy()
+    environment["PR_TITLE"] = title
+    completed = subprocess.run(
+        [sys.executable, str(ROOT / "tools/normalize_dependabot_title.py")],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout.rstrip("\r\n")
+
+
+def test_pr_language_governance_and_dependabot_normalization() -> None:
+    language_guard = read(".github/workflows/pr-language-governance.yml")
+    normalizer_workflow = read(
+        ".github/workflows/dependabot-title-normalization.yml"
+    )
+    checker = read("tools/check_four_language_pr.py")
+
+    assert "RELEASE_PLEASE_PR_EXEMPT" not in language_guard
+    assert "RELEASE_PLEASE_BODY_EXEMPT" in language_guard
+    assert "RELEASE_PLEASE_PR_EXEMPT" not in checker
+    assert language_guard.index("title=$(jq") < language_guard.index(
+        "RELEASE_PLEASE_BODY_EXEMPT"
+    )
+    assert "pull_request_target:" in normalizer_workflow
+    assert (
+        "if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}"
+        in normalizer_workflow
+    )
+    assert "contents: read\n      pull-requests: write" in normalizer_workflow
+    assert "tools/normalize_dependabot_title.py" in normalizer_workflow
+    assert 'gh pr edit "$PR_NUMBER"' in normalizer_workflow
+    assert '--repo "$GITHUB_REPOSITORY"' in normalizer_workflow
+    assert '--title "$normalized_title"' in normalizer_workflow
+    assert "bash -c" not in normalizer_workflow
+    assert_action_pinned(normalizer_workflow, "actions/checkout")
+
+    release_payload = {
+        "pull_request": {
+            "title": "發版 4.5.1／发版 4.5.1／Release 4.5.1／リリース 4.5.1",
+            "body": "",
+            "head": {"ref": "release-please--branches--main"},
+            "user": {"login": "github-actions[bot]"},
+        }
+    }
+    release_result = _run_pr_checker(release_payload)
+    assert release_result.returncode == 0, release_result.stderr
+    assert "RELEASE_PLEASE_BODY_EXEMPT" in release_result.stdout
+
+    release_with_invalid_title = {
+        **release_payload,
+        "pull_request": {
+            **release_payload["pull_request"],
+            "title": "chore(main): release 4.5.1",
+        },
+    }
+    invalid_release_result = _run_pr_checker(release_with_invalid_title)
+    assert invalid_release_result.returncode == 1
+    assert "pull-request title" in invalid_release_result.stderr
+
+    dependabot_payload = {
+        "pull_request": {
+            "title": "更新／更新／Update／更新",
+            "body": "",
+            "head": {"ref": "dependabot/pip/example-1.2.3"},
+            "user": {"login": "dependabot[bot]"},
+        }
+    }
+    dependabot_result = _run_pr_checker(dependabot_payload)
+    assert dependabot_result.returncode == 1
+    assert "pull-request body" in dependabot_result.stderr
+
+    normalization_cases = (
+        (
+            "build(deps): bump actions/checkout from 4 to 5",
+            "相依套件更新：actions/checkout 4 → 5／"
+            "依赖项更新：actions/checkout 4 → 5／"
+            "Dependency update: actions/checkout 4 → 5／"
+            "依存関係の更新：actions/checkout 4 → 5",
+        ),
+        (
+            "build(deps): bump github/codeql-action/analyze from 4.37.6 to 4.37.9",
+            "相依套件更新：github/codeql-action/analyze 4.37.6 → 4.37.9／"
+            "依赖项更新：github/codeql-action/analyze 4.37.6 → 4.37.9／"
+            "Dependency update: github/codeql-action/analyze 4.37.6 → 4.37.9／"
+            "依存関係の更新：github/codeql-action/analyze 4.37.6 → 4.37.9",
+        ),
+    )
+    for source_title, expected_title in normalization_cases:
+        normalized_title = _run_dependabot_normalizer(source_title)
+        assert normalized_title == expected_title
+        assert _run_dependabot_normalizer(normalized_title) == normalized_title
+
+    assert (
+        _run_dependabot_normalizer("build(deps): bump actions/checkout four to five")
+        == ""
     )
 
 
@@ -433,6 +560,7 @@ def test_secret_defense_and_community_files() -> None:
 
 def main() -> None:
     test_workspace_workflow_policy()
+    test_pr_language_governance_and_dependabot_normalization()
     test_funding_configuration()
     test_security_workflows()
     test_release_workflow()

--- a/tests/test_github_governance.py
+++ b/tests/test_github_governance.py
@@ -11,6 +11,7 @@ lazy from tempfile import TemporaryDirectory
 
 ROOT = Path(__file__).resolve().parents[1]
 MIN_PREVIEW_BYTES = 100_000
+LANGUAGE_COUNT = 4
 
 
 def read(relative: str) -> str:
@@ -86,7 +87,15 @@ def test_pr_language_governance_and_dependabot_normalization() -> None:
         ".github/workflows/dependabot-title-normalization.yml"
     )
     checker = read("tools/check_four_language_pr.py")
+    config = json.loads(read("release-please-config.json"))
+    title_pattern = config["pull-request-title-pattern"]
 
+    assert title_pattern == "${version} 發版／发版／Release／リリース"
+    assert len(title_pattern.split("／")) == LANGUAGE_COUNT
+    assert title_pattern.replace("${version}", "4.5.1") == (
+        "4.5.1 發版／发版／Release／リリース"
+    )
+    assert "${component}" not in title_pattern
     assert "RELEASE_PLEASE_PR_EXEMPT" not in language_guard
     assert "RELEASE_PLEASE_BODY_EXEMPT" in language_guard
     assert "RELEASE_PLEASE_PR_EXEMPT" not in checker
@@ -105,10 +114,11 @@ def test_pr_language_governance_and_dependabot_normalization() -> None:
     assert '--title "$normalized_title"' in normalizer_workflow
     assert "bash -c" not in normalizer_workflow
     assert_action_pinned(normalizer_workflow, "actions/checkout")
+    assert_action_pinned(normalizer_workflow, "actions/setup-python")
 
     release_payload = {
         "pull_request": {
-            "title": "發版 4.5.1／发版 4.5.1／Release 4.5.1／リリース 4.5.1",
+            "title": "4.5.1 發版／发版／Release／リリース",
             "body": "",
             "head": {"ref": "release-please--branches--main"},
             "user": {"login": "github-actions[bot]"},

--- a/tools/check_four_language_pr.py
+++ b/tools/check_four_language_pr.py
@@ -26,6 +26,27 @@ def _title_errors(title: object) -> list[str]:
     return []
 
 
+def _is_release_please_pull_request(pull_request: dict[str, object]) -> bool:
+    head = pull_request.get("head")
+    user = pull_request.get("user")
+    head_ref = head.get("ref") if isinstance(head, dict) else None
+    author = user.get("login") if isinstance(user, dict) else None
+    return (
+        isinstance(head_ref, str)
+        and head_ref.startswith("release-please--branches--")
+        and author == "github-actions[bot]"
+    )
+
+
+def _is_release_please_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    pull_request = payload.get("pull_request")
+    return isinstance(pull_request, dict) and _is_release_please_pull_request(
+        pull_request
+    )
+
+
 def audit_pull_request(payload: object) -> list[str]:
     if not isinstance(payload, dict):
         return ["GitHub event payload must be a JSON object"]
@@ -34,6 +55,8 @@ def audit_pull_request(payload: object) -> list[str]:
         return ["GitHub event payload is missing pull_request metadata"]
 
     errors = _title_errors(pull_request.get("title"))
+    if _is_release_please_pull_request(pull_request):
+        return errors
     body = pull_request.get("body")
     if not isinstance(body, str):
         errors.append("pull-request body must be a string")
@@ -55,24 +78,15 @@ def main() -> int:
         print(f"FAIL: cannot read GitHub event payload: {error}", file=sys.stderr)
         return 2
 
-    pull_request = payload.get("pull_request", {})
-    head_ref = (pull_request.get("head") or {}).get("ref", "")
-    pr_author = (pull_request.get("user") or {}).get("login", "")
-    # The branch name alone must not bypass governance: the exemption only
-    # applies to release PRs actually authored by the GitHub Actions bot.
-    if (
-        head_ref.startswith("release-please--branches--")
-        and pr_author == "github-actions[bot]"
-    ):
-        print("RELEASE_PLEASE_PR_EXEMPT")
-        return 0
-
     errors = audit_pull_request(payload)
     if errors:
         for error in errors:
             print(f"FAIL: {error}", file=sys.stderr)
         return 1
-    print("FOUR_LANGUAGE_PR_METADATA_OK")
+    if _is_release_please_payload(payload):
+        print("RELEASE_PLEASE_BODY_EXEMPT")
+    else:
+        print("FOUR_LANGUAGE_PR_METADATA_OK")
     return 0
 
 

--- a/tools/normalize_dependabot_title.py
+++ b/tools/normalize_dependabot_title.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+lazy import os
+lazy import re
+
+TITLE_SEPARATOR = "／"
+LANGUAGE_COUNT = 4
+PACKAGE_PATTERN = r"[A-Za-z0-9@][A-Za-z0-9._/@+-]*"
+VERSION_PATTERN = (
+    r"v?[0-9]+(?:\.[0-9]+){0,2}"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?"
+)
+DEPENDABOT_TITLE = re.compile(
+    rf"build\(deps(?:-[a-z0-9]+)?\): bump "
+    rf"(?P<package>{PACKAGE_PATTERN}) from "
+    rf"(?P<from_version>{VERSION_PATTERN}) to "
+    rf"(?P<to_version>{VERSION_PATTERN})"
+)
+
+
+def normalize_title(title: str) -> str | None:
+    """Return a safe four-language title, or None when parsing must stop."""
+
+    parts = title.split(TITLE_SEPARATOR)
+    if len(parts) == LANGUAGE_COUNT and all(part.strip() for part in parts):
+        return title
+
+    match = DEPENDABOT_TITLE.fullmatch(title)
+    if match is None:
+        return None
+
+    package = match.group("package")
+    from_version = match.group("from_version")
+    to_version = match.group("to_version")
+    change = f"{package} {from_version} → {to_version}"
+    return TITLE_SEPARATOR.join(
+        (
+            f"相依套件更新：{change}",
+            f"依赖项更新：{change}",
+            f"Dependency update: {change}",
+            f"依存関係の更新：{change}",
+        )
+    )
+
+
+def main() -> int:
+    title = os.environ.get("PR_TITLE", "")
+    normalized = normalize_title(title)
+    if normalized is not None:
+        print(normalized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 繁體中文
讓發版 PR 與 Dependabot PR 的標題也是四語，並把治理檢查從「整份豁免」收緊為「只豁免說明」。

本專案堅持四語（含日文）是對赤松健的致敬，不是可權衡的工程規範。但歷史上 61 筆合併提交是單語，其中 5 筆是 release-please 的發版 PR、1 筆是 Dependabot——因為它們被整份豁免，標題從未受檢。

**做了三件事**：
1. `release-please-config.json` 加 `pull-request-title-pattern`（欄位名經官方文件與 schema 確認），發版 PR 標題自動成為四段式。
2. `pr-language-governance.yml`：release-please 只豁免**說明**（機器產生的變更清單），**標題仍受檢**。
3. Dependabot：不豁免、改**自動正規化**——作者為 `dependabot[bot]` 且標題尚無四段時，解析套件名與版本後以 `gh pr edit` 改寫成四語標題，再讓檢查照常執行。標題視為不可信輸入（嚴格解析、失敗不改寫）、參數化傳遞不做字串拼接、權限只給 `pull-requests: write`、冪等。

測試釘住新行為：發版 PR 標題不再豁免、三組正規化輸入→輸出、冪等。ruff、慣用法、四語、actionlint 皆通過。

## 简体中文
让发版 PR 与 Dependabot PR 的标题也是四语，并把治理检查从「整份豁免」收紧为「只豁免说明」。

本项目坚持四语（含日文）是对赤松健的致敬，不是可权衡的工程规范。但历史上 61 笔合并提交是单语，其中 5 笔是 release-please 的发版 PR、1 笔是 Dependabot——因为它们被整份豁免，标题从未受检。

**做了三件事**：
1. `release-please-config.json` 加 `pull-request-title-pattern`（字段名经官方文档与 schema 确认），发版 PR 标题自动成为四段式。
2. `pr-language-governance.yml`：release-please 只豁免**说明**（机器生成的变更清单），**标题仍受检**。
3. Dependabot：不豁免、改**自动正规化**——作者为 `dependabot[bot]` 且标题尚无四段时，解析包名与版本后以 `gh pr edit` 改写成四语标题，再让检查照常执行。标题视为不可信输入（严格解析、失败不改写）、参数化传递不做字符串拼接、权限只给 `pull-requests: write`、幂等。

测试钉住新行为：发版 PR 标题不再豁免、三组正规化输入→输出、幂等。ruff、惯用法、四语、actionlint 皆通过。

## English
Makes release PRs and Dependabot PRs carry four-language titles too, and narrows the governance exemption from "whole PR" to "body only".

This project's four-language rule (Japanese included) is a tribute to Ken Akamatsu, not a negotiable engineering convention. Yet 61 merge commits in history are single-language; five are release-please release PRs and one is Dependabot — their titles were never checked because those PRs were exempt wholesale.

**Three changes**:
1. `release-please-config.json` gains `pull-request-title-pattern` (field name confirmed against the official docs and schema), so release PR titles are generated in four segments.
2. `pr-language-governance.yml`: release-please PRs are exempt only for the **body** (a machine-generated change list); the **title is still checked**.
3. Dependabot: no exemption — **automatic normalisation** instead. When the author is `dependabot[bot]` and the title has no four segments yet, the package name and versions are parsed and the title is rewritten in four languages via `gh pr edit`, after which the check runs as usual. The title is treated as untrusted input (strict parsing, no rewrite on failure), passed as arguments rather than string-concatenated, with permissions limited to `pull-requests: write`, and the step is idempotent.

Tests pin the new behaviour: release PR titles are no longer exempt, three normalisation input→output cases, and idempotence. ruff, idiom audit, four-language audit and actionlint all pass.

## 日本語
リリース PR と Dependabot PR のタイトルも四言語にし、ガバナンス検査の免除を「PR 全体」から「本文のみ」へ絞ります。

本プロジェクトの四言語（日本語を含む）の方針は赤松健氏への敬意であり、妥協可能な工学上の規約ではありません。しかし履歴上 61 件のマージコミットが単一言語で、うち 5 件は release-please のリリース PR、1 件は Dependabot でした。これらは PR 全体が免除されていたため、タイトルが一度も検査されていなかったのです。

**三つの変更**：
1. `release-please-config.json` に `pull-request-title-pattern` を追加（項目名は公式ドキュメントと schema で確認）。リリース PR のタイトルは四分節で自動生成されます。
2. `pr-language-governance.yml`：release-please は**本文のみ**免除（機械生成の変更一覧）。**タイトルは引き続き検査**します。
3. Dependabot：免除せず**自動正規化**へ。作者が `dependabot[bot]` でタイトルがまだ四分節でない場合、パッケージ名とバージョンを解析し `gh pr edit` で四言語タイトルに書き換えてから検査を通常どおり実行します。タイトルは信頼できない入力として扱い（厳格な解析、失敗時は書き換えない）、文字列連結ではなく引数で渡し、権限は `pull-requests: write` のみ、処理は冪等です。

テストで新しい挙動を固定：リリース PR タイトルの免除撤廃、正規化の入出力三組、冪等性。ruff・イディオム監査・四言語監査・actionlint はすべて合格。
