### PR TITLE
修正嘴角殘留與閉眼眼皮覆蓋／修正嘴角残留与闭眼眼皮覆盖／Fix mouth-corner residue and closed-eye eyelid coverage／口角の残留と閉眼時のまぶた被覆を修正

### DIFF
--- a/infrastructure/active_outfit_overlay.py
+++ b/infrastructure/active_outfit_overlay.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 lazy import hashlib
 lazy import re
 lazy import zipfile
-lazy from collections.abc import Callable
+lazy from collections.abc import Callable, Iterable
 lazy from pathlib import Path
 
 lazy from PySide6.QtCore import QRect, Qt
@@ -80,24 +80,41 @@ class ActiveOutfitOverlay:
         # 26 MB); one parse per (path, mtime, size) instead of one per view.
         self._parsed_packs: dict[tuple[Path, tuple[int, int]], object] = {}
         self._layers_by_view: dict[str, tuple[Layer, ...]] = {}
+        self._layers_by_view_without_makeup_slots: dict[
+            tuple[str, frozenset[str]], tuple[Layer, ...]
+        ] = {}
         self._protected_by_view: dict[str, QRegion] = {}
         self._feature_by_view: dict[str, QRegion] = {}
         self._hair_mask_by_view: dict[str, tuple[QImage, QRect] | None] = {}
         self._makeup_exclusion_by_view: dict[str, QRegion] = {}
         self._safe_regions = None
 
-    def apply(self, frame: QPixmap, view_id: str) -> QPixmap:
+    def apply(
+        self,
+        frame: QPixmap,
+        view_id: str,
+        *,
+        suppress_makeup_slots: Iterable[str] = (),
+    ) -> QPixmap:
         if frame.isNull():
             return frame
+        suppressed = frozenset(suppress_makeup_slots)
+        cache = (
+            self._layers_by_view
+            if not suppressed
+            else self._layers_by_view_without_makeup_slots
+        )
+        cache_key = view_id if not suppressed else (view_id, suppressed)
         try:
             self._refresh_state()
-            layers = self._layers_by_view.get(view_id)
+            layers = cache.get(cache_key)
             if layers is None:
                 layers = self._active_layers(
                     view_id,
                     frame.size().toTuple(),
+                    suppress_makeup_slots=suppressed,
                 )
-                self._layers_by_view[view_id] = layers
+                cache[cache_key] = layers
         except IncompatibleBodyProfileError:
             self._reject_stale_active_pack()
             return frame
@@ -115,9 +132,21 @@ class ActiveOutfitOverlay:
         painter.end()
         return result
 
-    def layer_count(self, view_id: str) -> int:
+    def layer_count(
+        self,
+        view_id: str,
+        *,
+        suppress_makeup_slots: Iterable[str] = (),
+    ) -> int:
         """Layers the last ``apply`` composited for ``view_id``; 0 when bare or failed closed."""
-        return len(self._layers_by_view.get(view_id) or ())
+        suppressed = frozenset(suppress_makeup_slots)
+        cache = (
+            self._layers_by_view
+            if not suppressed
+            else self._layers_by_view_without_makeup_slots
+        )
+        cache_key = view_id if not suppressed else (view_id, suppressed)
+        return len(cache.get(cache_key) or ())
 
     def _reject_stale_active_pack(self) -> None:
         """Issue #140, option 3: a generation-1 pack is never rendered on the generation-2 body.
@@ -166,6 +195,7 @@ class ActiveOutfitOverlay:
             {} if active_changed else current_package_tokens
         )
         self._layers_by_view.clear()
+        self._layers_by_view_without_makeup_slots.clear()
         self._parsed_packs.clear()
 
     def _selected_variant(self, category: str, selected) -> tuple[Path, object, object]:
@@ -211,6 +241,8 @@ class ActiveOutfitOverlay:
         self,
         view_id: str,
         canvas_size: tuple[int, int],
+        *,
+        suppress_makeup_slots: frozenset[str] = frozenset(),
     ) -> tuple[Layer, ...]:
         result: list[tuple[int, int, Layer]] = []
         for category_index, category in enumerate(SELECTION_CATEGORIES):
@@ -221,7 +253,13 @@ class ActiveOutfitOverlay:
             resolution = resolve_variant_for_view(variant, view_id)
             with zipfile.ZipFile(archive_path) as archive:
                 if category == "makeup":
-                    layers = self._makeup_layers(archive, resolution.assets, variant, view_id)
+                    layers = self._makeup_layers(
+                        archive,
+                        resolution.assets,
+                        variant,
+                        view_id,
+                        suppress_makeup_slots=suppress_makeup_slots,
+                    )
                 else:
                     layers = self._garment_layers(
                         archive, resolution.assets, category, item, variant, view_id, canvas_size
@@ -363,6 +401,8 @@ class ActiveOutfitOverlay:
         declarations,
         variant,
         view_id: str,
+        *,
+        suppress_makeup_slots: frozenset[str] = frozenset(),
     ) -> list[tuple[int, Layer]]:
         """Makeup is exempt from the protected-face mask but clipped to its safe region.
 
@@ -380,6 +420,11 @@ class ActiveOutfitOverlay:
             # region fails closed instead of reaching the face.
             if makeup_layer_escapes(encoded, region, declaration.slot):
                 raise OutfitPackError("Makeup layer paints outside its safe region.")
+            # A closed-eye authority must be able to cover open-eye makeup.
+            # Validation above still runs for every declaration, so this is a
+            # state-aware composition choice, not an import/runtime gate bypass.
+            if declaration.slot in suppress_makeup_slots:
+                continue
             if opacity <= 0.0:
                 continue
             clip = self._makeup_clip(view_id, region, declaration.slot)

--- a/infrastructure/layered_face_renderer.py
+++ b/infrastructure/layered_face_renderer.py
@@ -23,7 +23,7 @@ lazy from domain.companion_animation_contract import (
     gesture_portrait_expression,
     outfit_silhouette,
 )
-lazy from domain.face_rig import FaceMotionFrame, Viseme
+lazy from domain.face_rig import EyeState, FaceMotionFrame, Viseme, eye_state_for_blink
 lazy from infrastructure.layered_face_assets import (
     LayeredFaceManifest,
     LayeredFacePose,
@@ -193,10 +193,23 @@ class LayeredParametricFaceRenderer:
         # anchor check fail (or draw ~2.7x off), so installed outfits never
         # appeared on the half-body poses at all.
         if self._outfit_overlay is not None:
-            composed = self._outfit_overlay.apply(
-                composed,
-                outfit_silhouette(motion.expression, motion.pose.value),
+            suppress_makeup_slots = (
+                frozenset({"eyes"})
+                if eye_state_for_blink(motion.expression_shape.blink)
+                is EyeState.CLOSED
+                else frozenset()
             )
+            silhouette = outfit_silhouette(motion.expression, motion.pose.value)
+            if suppress_makeup_slots:
+                composed = self._outfit_overlay.apply(
+                    composed,
+                    silhouette,
+                    suppress_makeup_slots=suppress_makeup_slots,
+                )
+            else:
+                # Preserve the legacy port signature for open-eye callers and
+                # lightweight test doubles that implement the original port.
+                composed = self._outfit_overlay.apply(composed, silhouette)
         result = (
             composed
             if composed.size() == base.size()

--- a/presentation/companion_face_assets.py
+++ b/presentation/companion_face_assets.py
@@ -23,6 +23,7 @@ lazy from domain.companion_animation_contract import (
 )
 lazy from domain.expression_system import FaceAnchorProfile
 lazy from domain.face_rig import EyeState, eye_state_for_blink
+lazy from presentation.companion_speech_mask import recover_speech_mask_edges
 lazy from presentation.presentation_resources import resource_path
 
 __all__ = ("CompanionFaceAssetMethods",)
@@ -139,21 +140,20 @@ class CompanionFaceAssetMethods:
         painter.end()
         return mask
 
-    def _build_speech_mouth_masks(
-        self,
-        mouth_clips: frozendict[str, QRect],
-    ) -> None:
-        alpha_steps = (
-            (0, 52),
-            (1, 82),
-            (2, 128),
-            (3, 255),
-        )
+    def _build_speech_mouth_masks(self, mouth_clips: frozendict[str, QRect]) -> None:
+        alpha_steps = ((0, 52), (1, 82), (2, 128), (3, 255))
+        # Recover only authored source-backed corner pixels at the mask edge.
+        # The normal feather remains unchanged everywhere else.
         self.mouth_masks = {
-            suffix: self._soft_rounded_mask(
-                (mouth_clip,),
-                alpha_steps,
-                9,
+            suffix: recover_speech_mask_edges(
+                self.expression_pixmaps,
+                self._soft_rounded_mask(
+                    (mouth_clip,),
+                    alpha_steps,
+                    9,
+                ),
+                suffix,
+                mouth_clip,
             )
             for suffix, mouth_clip in mouth_clips.items()
         }

--- a/presentation/companion_speech_mask.py
+++ b/presentation/companion_speech_mask.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+lazy from collections.abc import Mapping
+
+lazy from PySide6.QtCore import QRect
+lazy from PySide6.QtGui import QColor, QImage, QPixmap
+
+FULL_ALPHA = 255
+OPAQUE_ALPHA_THRESHOLD = 250
+DARK_EDGE_MAX_RGB = 185
+MIN_SKIN_RED = 150
+MIN_SKIN_GREEN = 85
+MIN_SKIN_BLUE = 65
+MIN_RED_GREEN_DELTA = 20
+MIN_GREEN_BLUE_DELTA = 5
+MIN_SOURCE_LIFT = 16
+MOUTH_CORNER_EDGE_WIDTH = 14
+SOURCE_ROOTS = (
+    "viseme_mid",
+    "speaking",
+    "viseme_i",
+    "viseme_round",
+    "viseme_o",
+)
+
+
+def _max_rgb(color: QColor) -> int:
+    return max(color.red(), color.green(), color.blue())
+
+
+def _is_recovery_source(closed_max: int, source: QColor) -> bool:
+    source_max = _max_rgb(source)
+    return (
+        source.alpha() >= OPAQUE_ALPHA_THRESHOLD
+        and source_max >= closed_max + MIN_SOURCE_LIFT
+        and source.red() >= MIN_SKIN_RED
+        and source.green() >= MIN_SKIN_GREEN
+        and source.blue() >= MIN_SKIN_BLUE
+        and source.red() - source.green() >= MIN_RED_GREEN_DELTA
+        and source.green() - source.blue() >= MIN_GREEN_BLUE_DELTA
+    )
+
+
+def recover_speech_mask_edges(
+    expression_pixmaps: Mapping[str, QPixmap],
+    mask: QPixmap,
+    suffix: str,
+    mouth_clip: QRect,
+) -> QPixmap:
+    """Close source-backed dark gaps at the two existing mouth edges."""
+
+    closed_name = f"idle{suffix}" if suffix else "idle"
+    closed = expression_pixmaps.get(closed_name)
+    if closed is None or closed.isNull():
+        return mask
+    sources = tuple(
+        pixmap
+        for root in SOURCE_ROOTS
+        if (pixmap := expression_pixmaps.get(f"{root}{suffix}"))
+        is not None
+        and not pixmap.isNull()
+    )
+    if not sources:
+        return mask
+    mask_image = mask.toImage().convertToFormat(QImage.Format_ARGB32)
+    closed_image = closed.toImage().convertToFormat(QImage.Format_ARGB32)
+    source_images = tuple(
+        pixmap.toImage().convertToFormat(QImage.Format_ARGB32)
+        for pixmap in sources
+    )
+    for y in range(mouth_clip.top(), mouth_clip.bottom() + 1):
+        for x in range(mouth_clip.left(), mouth_clip.right() + 1):
+            if (
+                mouth_clip.left() + MOUTH_CORNER_EDGE_WIDTH <= x
+                <= mouth_clip.right() - MOUTH_CORNER_EDGE_WIDTH
+            ):
+                continue
+            mask_color = mask_image.pixelColor(x, y)
+            if not 0 < mask_color.alpha() < FULL_ALPHA:
+                continue
+            closed_color = closed_image.pixelColor(x, y)
+            if closed_color.alpha() < OPAQUE_ALPHA_THRESHOLD:
+                continue
+            closed_max = _max_rgb(closed_color)
+            if closed_max > DARK_EDGE_MAX_RGB:
+                continue
+            if any(
+                _is_recovery_source(closed_max, source_image.pixelColor(x, y))
+                for source_image in source_images
+            ):
+                mask_image.setPixelColor(x, y, QColor(255, 255, 255, 255))
+    return QPixmap.fromImage(mask_image)

--- a/tests/test_closed_eye_makeup_regression.py
+++ b/tests/test_closed_eye_makeup_regression.py
@@ -19,7 +19,10 @@ CANVAS_SIZE = (1254, 1254)
 DARK_PIXEL_MAX = 140
 SMALL_COMPONENT_MAX_AREA = 25
 BRIGHT_RESIDUAL_MIN = 180
-MAX_BRIGHT_RESIDUAL_PIXELS = 200
+# The repaired run leaves at most five antialiased edge pixels in the cheek
+# eye region; ten leaves a small deterministic margin without allowing a
+# visible background crescent.
+MAX_BRIGHT_RESIDUAL_PIXELS = 10
 MAX_RESIDUAL_DARK_COMPONENTS = 3
 # Fixed from the repaired three-pose run: 19,451, 21,578 and 20,796 changed
 # pixels.  18,000 keeps a conservative margin while remaining well above the

--- a/tests/test_closed_eye_makeup_regression.py
+++ b/tests/test_closed_eye_makeup_regression.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from PySide6.QtCore import QPoint
+from PySide6.QtGui import QImage, QPixmap, QRegion
+from PySide6.QtWidgets import QApplication
+
+from infrastructure.active_outfit_overlay import ActiveOutfitOverlay
+from tools.render_marketing_portraits import ROOT
+
+CANVAS_SIZE = (1254, 1254)
+DARK_PIXEL_MAX = 140
+SMALL_COMPONENT_MAX_AREA = 25
+BRIGHT_RESIDUAL_MIN = 180
+MAX_BRIGHT_RESIDUAL_PIXELS = 200
+MAX_RESIDUAL_DARK_COMPONENTS = 3
+# Fixed from the repaired three-pose run: 19,451, 21,578 and 20,796 changed
+# pixels.  18,000 keeps a conservative margin while remaining well above the
+# 2,546-pixel failure signature that exposed the too-small eye replacement.
+MIN_CLOSED_DIFF_PIXELS = 18_000
+EYE_LAYERS = (
+    "iris_left",
+    "iris_right",
+    "eyelid_left",
+    "eyelid_right",
+    "eyeliner_left",
+    "eyeliner_right",
+)
+POSES = (
+    ("cheek", "idle", "blink", "cheek-rest"),
+    ("lean", "idle_lean", "blink_lean", "left-neutral"),
+    ("front", "idle_front", "blink_front", "front-crossed"),
+)
+
+
+def _eye_region(pose: str) -> QRegion:
+    root = ROOT / "assets" / "expressions" / "layered"
+    region = QRegion()
+    for layer in EYE_LAYERS:
+        region = region.united(QRegion(QPixmap(str(root / f"{pose}_{layer}.png")).mask()))
+    return region
+
+
+def _region_points(region: QRegion):
+    bounds = region.boundingRect()
+    for y in range(bounds.top(), bounds.bottom() + 1):
+        for x in range(bounds.left(), bounds.right() + 1):
+            if region.contains(QPoint(x, y)):
+                yield x, y
+
+
+def _changed_pixels(first: QImage, second: QImage) -> int:
+    return sum(
+        first.pixel(x, y) != second.pixel(x, y)
+        for y in range(CANVAS_SIZE[1])
+        for x in range(CANVAS_SIZE[0])
+    )
+
+
+def _bright_residual_pixels(
+    closed: QImage,
+    bare_closed: QImage,
+    eye_region: QRegion,
+) -> int:
+    return sum(
+        closed.pixelColor(x, y) != bare_closed.pixelColor(x, y)
+        and sum(
+            getattr(closed.pixelColor(x, y), channel)()
+            for channel in ("red", "green", "blue")
+        )
+        / 3
+        >= BRIGHT_RESIDUAL_MIN
+        for x, y in _region_points(eye_region)
+    )
+
+
+def _small_dark_residual_components(
+    closed: QImage,
+    bare_closed: QImage,
+    eye_region: QRegion,
+) -> int:
+    points: set[tuple[int, int]] = set()
+    for x, y in _region_points(eye_region):
+        color = closed.pixelColor(x, y)
+        if (
+            color != bare_closed.pixelColor(x, y)
+            and max(color.red(), color.green(), color.blue()) < DARK_PIXEL_MAX
+        ):
+            points.add((x, y))
+    # The contract counts only isolated dark components of at most 25 pixels;
+    # the continuous authored eyelash line is intentionally not a speckle.
+    small = 0
+    while points:
+        before = len(points)
+        component = {points.pop()}
+        pending = list(component)
+        while pending:
+            x, y = pending.pop()
+            for dy in (-1, 0, 1):
+                for dx in (-1, 0, 1):
+                    point = (x + dx, y + dy)
+                    if point in points:
+                        points.remove(point)
+                        component.add(point)
+                        pending.append(point)
+        if len(component) <= SMALL_COMPONENT_MAX_AREA:
+            small += 1
+        assert len(points) < before
+    return small
+
+
+def run() -> None:
+    QApplication.instance() or QApplication([])
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        os.environ["LOCALAPPDATA"] = temp_dir
+        overlay = ActiveOutfitOverlay(Path(temp_dir) / "store", ROOT)
+        for pose, open_name, closed_name, silhouette in POSES:
+            open_image = overlay.apply(
+                QPixmap(str(ROOT / "assets" / "expressions" / f"{open_name}.png")),
+                silhouette,
+            ).toImage().convertToFormat(QImage.Format_ARGB32)
+            closed_image = overlay.apply(
+                QPixmap(str(ROOT / "assets" / "expressions" / f"{closed_name}.png")),
+                silhouette,
+                suppress_makeup_slots={"eyes"},
+            ).toImage().convertToFormat(QImage.Format_ARGB32)
+            bare_closed = QImage(
+                str(ROOT / "assets" / "expressions" / f"{closed_name}.png")
+            ).convertToFormat(QImage.Format_ARGB32)
+            eye_region = _eye_region(pose)
+            assert _changed_pixels(open_image, closed_image) >= MIN_CLOSED_DIFF_PIXELS, (
+                f"{closed_name} changed too little from {open_name}"
+            )
+            assert _bright_residual_pixels(
+                closed_image,
+                bare_closed,
+                eye_region,
+            ) <= MAX_BRIGHT_RESIDUAL_PIXELS, (
+                f"{closed_name} exposes an open-eye brightness residual"
+            )
+            assert _small_dark_residual_components(
+                closed_image,
+                bare_closed,
+                eye_region,
+            ) <= MAX_RESIDUAL_DARK_COMPONENTS, (
+                f"{closed_name} leaves isolated dark eye speckles"
+            )
+            assert overlay.layer_count(silhouette) > 0
+            assert overlay.layer_count(
+                silhouette,
+                suppress_makeup_slots={"eyes"},
+            ) > 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/tests/test_closed_eye_makeup_regression.py
+++ b/tests/test_closed_eye_makeup_regression.py
@@ -8,12 +8,12 @@ lazy from tempfile import TemporaryDirectory
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from PySide6.QtCore import QPoint
-from PySide6.QtGui import QImage, QPixmap, QRegion
-from PySide6.QtWidgets import QApplication
+lazy from PySide6.QtCore import QPoint
+lazy from PySide6.QtGui import QImage, QPixmap, QRegion
+lazy from PySide6.QtWidgets import QApplication
 
-from infrastructure.active_outfit_overlay import ActiveOutfitOverlay
-from tools.render_marketing_portraits import ROOT
+lazy from infrastructure.active_outfit_overlay import ActiveOutfitOverlay
+lazy from tools.render_marketing_portraits import ROOT
 
 CANVAS_SIZE = (1254, 1254)
 DARK_PIXEL_MAX = 140

--- a/tests/test_closed_eye_makeup_regression.py
+++ b/tests/test_closed_eye_makeup_regression.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import os
-import sys
-from pathlib import Path
-from tempfile import TemporaryDirectory
+lazy import os
+lazy import sys
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
 
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_mouth_corner_artifact_regression.py
+++ b/tests/test_mouth_corner_artifact_regression.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+lazy import os
+lazy import sys
+lazy from pathlib import Path
+lazy from tempfile import TemporaryDirectory
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+lazy from PySide6.QtCore import QRect, QTimer
+lazy from PySide6.QtGui import QImage
+lazy from PySide6.QtWidgets import QApplication
+
+lazy from presentation.companion_window import CompanionWindow
+
+OPEN_FRAMES = {
+    "C": ("mouth_mid", 0.12, ("viseme_mid", "speaking")),
+    "A": ("mouth_wide", 0.92, ("speaking",)),
+    "I": ("mouth_i", 0.42, ("viseme_i",)),
+    "U": ("mouth_round", 0.46, ("viseme_round",)),
+    "E": ("mouth_i", 0.50, ("viseme_i",)),
+    "O": ("mouth_o", 0.78, ("viseme_o",)),
+}
+FULL_ALPHA = 255
+OPAQUE_ALPHA_THRESHOLD = 250
+DARK_EDGE_MAX_RGB = 185
+DARK_EYE_MAX_RGB = 100
+MIN_SKIN_RED = 150
+MIN_SKIN_GREEN = 85
+MIN_SKIN_BLUE = 65
+MIN_RED_GREEN_DELTA = 20
+MIN_GREEN_BLUE_DELTA = 5
+MIN_SOURCE_LIFT = 16
+MAX_RENDERED_SOURCE_GAP = 8
+POSES = (
+    ("cheek", "", "idle_speech_neutral"),
+    ("lean", "_lean", "idle_lean"),
+    ("front", "_front", "idle_front"),
+)
+
+# These are deliberately small semantic probes around the source-backed face
+# edge, rather than the full mouth clip.  The latter includes hair/hand
+# silhouettes that are expected to remain dark while the mouth moves.
+MOUTH_CORNER_PROBES = {
+    "cheek": (QRect(166, 202, 26, 31), QRect(192, 202, 19, 27)),
+    "lean": (QRect(157, 193, 22, 30), QRect(193, 202, 18, 27)),
+    "front": (QRect(205, 201, 14, 12), QRect(237, 201, 14, 12)),
+}
+
+
+def _image(pixmap) -> QImage:
+    return pixmap.toImage().convertToFormat(QImage.Format_ARGB32)
+
+
+def _max_rgb(image: QImage, x: int, y: int) -> int:
+    color = image.pixelColor(x, y)
+    return max(color.red(), color.green(), color.blue())
+
+
+def _skin_like(image: QImage, x: int, y: int) -> bool:
+    color = image.pixelColor(x, y)
+    return (
+        color.alpha() >= OPAQUE_ALPHA_THRESHOLD
+        and color.red() >= MIN_SKIN_RED
+        and color.green() >= MIN_SKIN_GREEN
+        and color.blue() >= MIN_SKIN_BLUE
+        and color.red() - color.green() >= MIN_RED_GREEN_DELTA
+        and color.green() - color.blue() >= MIN_GREEN_BLUE_DELTA
+    )
+
+
+def _source_backed_residuals(
+    closed: QImage,
+    source: QImage,
+    rendered: QImage,
+    mask: QImage,
+    probes: tuple[QRect, QRect],
+) -> list[tuple[int, int]]:
+    """Find a dark closed-edge pixel left under a light open source pixel."""
+
+    residuals: list[tuple[int, int]] = []
+    for probe in probes:
+        for y in range(probe.top(), probe.bottom() + 1):
+            for x in range(probe.left(), probe.right() + 1):
+                closed_color = closed.pixelColor(x, y)
+                source_color = source.pixelColor(x, y)
+                mask_alpha = mask.pixelColor(x, y).alpha()
+                source_max = _max_rgb(source, x, y)
+                if (
+                    closed_color.alpha() >= OPAQUE_ALPHA_THRESHOLD
+                    and source_color.alpha() >= OPAQUE_ALPHA_THRESHOLD
+                    and 0 < mask_alpha < FULL_ALPHA
+                    and _max_rgb(closed, x, y) <= DARK_EDGE_MAX_RGB
+                    and source_max >= _max_rgb(closed, x, y) + MIN_SOURCE_LIFT
+                    and _skin_like(source, x, y)
+                    and _max_rgb(rendered, x, y)
+                    <= source_max - MAX_RENDERED_SOURCE_GAP
+                ):
+                    residuals.append((x, y))
+    return residuals
+
+
+def _new_dark_eye_pixels(
+    closed: QImage,
+    rendered: QImage,
+    regions: tuple[QRect, QRect],
+) -> list[tuple[int, int]]:
+    changed: list[tuple[int, int]] = []
+    for region in regions:
+        for y in range(region.top(), region.bottom() + 1):
+            for x in range(region.left(), region.right() + 1):
+                if (
+                    rendered.pixelColor(x, y).alpha() >= OPAQUE_ALPHA_THRESHOLD
+                    and _max_rgb(rendered, x, y) <= DARK_EYE_MAX_RGB
+                    and _max_rgb(closed, x, y) > DARK_EYE_MAX_RGB
+                ):
+                    changed.append((x, y))
+    return changed
+
+
+def _configure_speech(window: CompanionWindow, pose: str, suffix: str, closed: str) -> None:
+    window.state = "speaking"
+    window.idle_pose = pose
+    window.speech_pose_suffix = suffix
+    window.speech_closed_expression = closed
+    window.speech_mid_expression = f"mouth_mid{suffix}"
+    window.speech_open_expression = f"speaking{suffix}"
+    window.speech_gesture_expression = None
+    window.audio_driven_mouth = True
+    window.speech_blinking = False
+    window._set_expression(closed, fade=False)
+
+
+def _source_expression(window: CompanionWindow, roots: tuple[str, ...], suffix: str):
+    for root in roots:
+        name = f"{root}{suffix}"
+        source = window.expression_pixmaps.get(name)
+        if source is not None and not source.isNull():
+            return source
+    raise AssertionError(f"missing source expression for {roots!r}{suffix}")
+
+
+def run() -> None:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        os.environ["LOCALAPPDATA"] = temp_dir
+        app = QApplication([])
+        window = CompanionWindow(startup_speech=False)
+        failures: list[str] = []
+        try:
+            window.show()
+            app.processEvents()
+            for timer in window.findChildren(QTimer):
+                timer.stop()
+            for pose, suffix, closed_name in POSES:
+                _configure_speech(window, pose, suffix, closed_name)
+                closed = _image(window._mouth_aperture_pixmap(closed_name, 0.0))
+                eye_regions = window.dedicated_blink_regions[pose]
+                for label, (expression_root, aperture, source_roots) in OPEN_FRAMES.items():
+                    expression = f"{expression_root}{suffix}"
+                    source = _image(_source_expression(window, source_roots, suffix))
+                    rendered = _image(window._mouth_aperture_pixmap(expression, aperture))
+                    mask = _image(window.viseme_mouth_masks[suffix])
+                    mouth_residuals = _source_backed_residuals(
+                        closed,
+                        source,
+                        rendered,
+                        mask,
+                        MOUTH_CORNER_PROBES[pose],
+                    )
+                    eye_residuals = _new_dark_eye_pixels(
+                        closed,
+                        rendered,
+                        eye_regions,
+                    )
+                    if mouth_residuals:
+                        failures.append(
+                            f"{pose}/{label}: mouth={len(mouth_residuals)} "
+                            f"bbox={QRect(*mouth_residuals[0], 1, 1).united(QRect(*mouth_residuals[-1], 1, 1)).getRect()}"
+                        )
+                    if eye_residuals:
+                        failures.append(f"{pose}/{label}: eye={len(eye_residuals)}")
+        finally:
+            window.close()
+            app.processEvents()
+    assert not failures, "; ".join(failures)
+    print("MOUTH_CORNER_ARTIFACT_REGRESSION_OK")
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/render_marketing_portraits.py
+++ b/tools/render_marketing_portraits.py
@@ -41,6 +41,7 @@ lazy from infrastructure.active_outfit_overlay import ActiveOutfitOverlay
 SPRITE_ROOT = ROOT / "assets" / "expressions"
 OUTPUT_ROOT = ROOT / "docs" / "media" / "portraits"
 PORTRAIT_SIZE = (1254, 1254)
+CLOSED_EYE_MAKEUP_SLOTS = frozenset({"eyes"})
 # The six README expression cards plus the canonical idle portrait that the
 # installer artwork and the taskbar icon are derived from.
 DEFAULT_EXPRESSIONS = (
@@ -68,8 +69,20 @@ def render_portrait(overlay: ActiveOutfitOverlay, expression: str) -> QImage:
     if sprite.size().toTuple() != PORTRAIT_SIZE:
         raise RuntimeError(f"Half-body sprite is not {PORTRAIT_SIZE}: {source}")
     silhouette = silhouette_for(expression)
-    composed = overlay.apply(sprite, silhouette)
-    if overlay.layer_count(silhouette) == 0:
+    suppressed_makeup_slots = (
+        CLOSED_EYE_MAKEUP_SLOTS
+        if expression.startswith("blink") or expression.endswith("_speech_blink")
+        else frozenset()
+    )
+    composed = overlay.apply(
+        sprite,
+        silhouette,
+        suppress_makeup_slots=suppressed_makeup_slots,
+    )
+    if overlay.layer_count(
+        silhouette,
+        suppress_makeup_slots=suppressed_makeup_slots,
+    ) == 0:
         raise RuntimeError(
             f"No appearance layers were composited for {expression} ({silhouette}); "
             "the official default pack or the built-in makeup is missing."


### PR DESCRIPTION
## 繁體中文
修掉擁有者在說話特寫裡目視發現的三處臉部缺陷，全部在產品層（執行期合成），不是影片修圖。

1. **嘴角黑線**（張嘴時停在原地的深色小塊）：成因是甲——`front_base` 底圖烘進了閉嘴時的嘴角暗部，張嘴後可動層換掉、底圖那塊露出來。以嘴部遮罩在說話路徑排除，補回歸測試（`tests/test_mouth_corner_artifact_regression.py`）。
2. **閉眼時眼皮沒蓋滿、上緣殘留深線**：逐層渲染證實白色月牙與深線來自**後置的妝容 `eyes` 槽**，不是眼瞼或眼線底層。修正為眼睛 CLOSED 時抑制該槽；HALF／REST 與睜眼**逐像素不變**（獨立複測：睜眼幀修正前後差異 0）。回歸測試修正前 exit 1、修正後 exit 0。
3. 閉眼亮度殘留的測試門檻依實測收緊。

紅線遵守：既有的睜眼與閉嘴外觀未改變；未放寬任何門檻。ruff、慣用法、四語皆過；完整閘門僅 `test_perf_budget.py`（已知，#177 修正）失敗。

## 简体中文
修掉所有者在说话特写里目视发现的三处面部缺陷，全部在产品层（运行时合成），不是视频修图。

1. **嘴角黑线**（张嘴时停在原地的深色小块）：成因是甲——`front_base` 底图烘进了闭嘴时的嘴角暗部，张嘴后可动层换掉、底图那块露出来。以嘴部遮罩在说话路径排除，补回归测试（`tests/test_mouth_corner_artifact_regression.py`）。
2. **闭眼时眼皮没盖满、上缘残留深线**：逐层渲染证实白色月牙与深线来自**后置的妆容 `eyes` 槽**，不是眼睑或眼线底层。修正为眼睛 CLOSED 时抑制该槽；HALF／REST 与睁眼**逐像素不变**（独立复测：睁眼帧修正前后差异 0）。回归测试修正前 exit 1、修正后 exit 0。
3. 闭眼亮度残留的测试阈值依实测收紧。

红线遵守：既有的睁眼与闭嘴外观未改变；未放宽任何阈值。ruff、惯用法、四语皆过；完整门禁仅 `test_perf_budget.py`（已知，#177 修正）失败。

## English
Fixes three facial defects the owner spotted in the speaking close-up, all at the product level (runtime composite), not by retouching the video.

1. **Dark marks at the mouth corners** that stayed put while the mouth opened: cause A — `front_base` had the closed-mouth corner shading baked in, so once the movable lip layers changed, the base showed through. Excluded via the mouth mask on the speech path, with a regression test (`tests/test_mouth_corner_artifact_regression.py`).
2. **Eyelids not covering the eyes when closed, with a dark line along the upper edge**: per-layer rendering proved the white crescent and the line came from the **makeup `eyes` slot composited on top**, not from the eyelid or eyeliner base layers. The slot is now suppressed when the eyes are CLOSED; HALF/REST and open eyes are **pixel-identical** (independently re-measured: the open-eye frame differs by 0 pixels before/after). The regression test exits 1 before the fix and 0 after.
3. The closed-eye brightness-residue threshold is tightened to the measured value.

Red line respected: existing open-eye and closed-mouth appearance is unchanged; no threshold loosened. ruff, idiom audit and four-language audit pass; the full gate fails only on `test_perf_budget.py` (known, fixed by #177).

## 日本語
オーナーが発話時のクローズアップで目視した顔の欠陥三点を、動画の修整ではなく製品側（実行時合成）で修正します。

1. **口角の黒い小片**（口が開いても元の位置に残る）：原因は甲——`front_base` に閉口時の口角の陰影が焼き込まれており、可動する唇レイヤーが切り替わると下地が露出していました。発話経路で口のマスクにより除外し、回帰テスト（`tests/test_mouth_corner_artifact_regression.py`）を追加。
2. **閉眼時にまぶたが目を覆い切らず、上縁に濃い線が残る**：レイヤー単位の描画で、白い三日月と濃い線が**後段に合成されるメイクの `eyes` スロット**に由来し、まぶたやアイラインの下地ではないことを確認。目が CLOSED のときはそのスロットを抑制。HALF／REST と開眼は**ピクセル単位で不変**（独立に再計測：開眼フレームの修正前後差分は 0）。回帰テストは修正前 exit 1、修正後 exit 0。
3. 閉眼時の輝度残留テストのしきい値を実測値に基づき厳格化。

レッドラインを遵守：既存の開眼・閉口の外観は変更なし、しきい値の緩和なし。ruff・イディオム監査・四言語監査は合格。完全ゲートは `test_perf_budget.py`（既知、#177 で修正）のみ失敗。
