### PR TITLE
修復 Tachyon 證據擷取偶發失敗／修复 Tachyon 证据采集偶发失败／Fix intermittent Tachyon evidence capture failures／Tachyon 証拠キャプチャの断続的な失敗を修正

### DIFF
--- a/changelog.d/11-tachyon-evidence-retry.md
+++ b/changelog.d/11-tachyon-evidence-retry.md
@@ -1,0 +1,3 @@
+### 未發布 — Tachyon 證據擷取重試／未发布 — Tachyon 证据采集重试／Unreleased — Tachyon evidence capture retries／未リリース — Tachyon 証拠キャプチャの再試行
+
+* 對 runtime evidence 缺失或 sample-read error 超過既有門檻的單一 target，最多重新取樣兩次並記錄各次結果；所有樣本、漏採樣、JIT 與效能門檻維持不變／对于 runtime evidence 缺失或 sample-read error 超过既有门槛的单个 target，最多重新采样两次并记录各次结果；所有样本、漏采样、JIT 与性能门槛保持不变／A single target with missing runtime evidence or a sample-read error above the existing threshold is freshly captured up to two more times with every result recorded; all sample, missed-sample, JIT, and performance thresholds remain unchanged／runtime evidence が欠落した、または既存の閾値を超える sample-read error の単一 target は最大二回まで新しく再取得し、各結果を記録します。サンプル、欠落サンプル、JIT、パフォーマンスの閾値は変更しません。

--- a/tests/test_tachyon_evidence.py
+++ b/tests/test_tachyon_evidence.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 lazy import argparse
+lazy from contextlib import redirect_stderr
+lazy from io import StringIO
 lazy import os
 lazy import sys
 lazy import tempfile
@@ -11,7 +13,10 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 lazy from tools.profile_mohan_tachyon import (
+    CaptureAttempt,
     _artifact_paths,
+    _capture_retry_exhausted_message,
+    _capture_with_retries,
     _capture_statistics,
     _frame_statistics,
     _quality_violations,
@@ -25,6 +30,7 @@ EXPECTED_MISSED_PERCENT = 2.5
 EXPECTED_TOTAL_SAMPLES = 100
 EXPECTED_FRAME_COUNT = 2
 EXPECTED_FAILURE_COUNT = 6
+EXPECTED_RETRY_SAMPLE_READ_ERROR = 0.25
 
 
 def test_capture_statistics_support_current_and_legacy_output() -> None:
@@ -212,11 +218,83 @@ def test_quality_gate_requires_samples_low_error_and_jit() -> None:
     assert any("JIT" in item for item in failing)
 
 
+def test_capture_retry_accepts_a_fresh_low_error_sample() -> None:
+    arguments = argparse.Namespace(max_sample_read_error_percent=1.0)
+    scripted_attempts = (
+        CaptureAttempt(1, 35.12, True),
+        CaptureAttempt(2, EXPECTED_RETRY_SAMPLE_READ_ERROR, True),
+    )
+    seen_attempts: list[int] = []
+
+    def capture(attempt_number: int) -> CaptureAttempt:
+        seen_attempts.append(attempt_number)
+        return scripted_attempts[attempt_number - 1]
+
+    attempts = _capture_with_retries(arguments, "expression", capture)
+
+    assert seen_attempts == [1, 2]
+    assert attempts == scripted_attempts
+    assert (
+        attempts[-1].sample_read_error_percent
+        == EXPECTED_RETRY_SAMPLE_READ_ERROR
+    )
+
+
+def test_capture_retry_recovers_missing_runtime_evidence() -> None:
+    arguments = argparse.Namespace(max_sample_read_error_percent=1.0)
+    scripted_attempts = (
+        CaptureAttempt(1, None, False),
+        CaptureAttempt(2, EXPECTED_RETRY_SAMPLE_READ_ERROR, True),
+    )
+    seen_attempts: list[int] = []
+
+    def capture(attempt_number: int) -> CaptureAttempt:
+        seen_attempts.append(attempt_number)
+        return scripted_attempts[attempt_number - 1]
+
+    attempts = _capture_with_retries(arguments, "startup", capture)
+
+    assert seen_attempts == [1, 2]
+    assert attempts == scripted_attempts
+    assert attempts[0].runtime_evidence_written is False
+    assert attempts[-1].runtime_evidence_written is True
+
+
+def test_capture_retry_limit_reports_every_sample_read_error() -> None:
+    arguments = argparse.Namespace(max_sample_read_error_percent=1.0)
+    scripted_attempts = tuple(
+        CaptureAttempt(number, 35.12, True)
+        for number in range(1, 4)
+    )
+    seen_attempts: list[int] = []
+
+    def capture(attempt_number: int) -> CaptureAttempt:
+        seen_attempts.append(attempt_number)
+        return scripted_attempts[attempt_number - 1]
+
+    stderr = StringIO()
+    with redirect_stderr(stderr):
+        attempts = _capture_with_retries(arguments, "expression", capture)
+
+    message = stderr.getvalue()
+    assert seen_attempts == [1, 2, 3]
+    assert attempts == scripted_attempts
+    assert "target=expression" in message
+    assert "sample-read-error-rates=1=35.12%, 2=35.12%, 3=35.12%" in message
+    assert "exhausted 2 retries" in _capture_retry_exhausted_message(
+        "expression",
+        attempts,
+    )
+
+
 def main() -> None:
     test_capture_statistics_support_current_and_legacy_output()
     test_chunked_tachyon_tables_and_aggregates()
     test_profile_paths_are_private_and_binary_is_temporary()
     test_quality_gate_requires_samples_low_error_and_jit()
+    test_capture_retry_accepts_a_fresh_low_error_sample()
+    test_capture_retry_recovers_missing_runtime_evidence()
+    test_capture_retry_limit_reports_every_sample_read_error()
     print("TACHYON_ENTERPRISE_EVIDENCE_OK")
 
 

--- a/tools/profile_mohan_tachyon.py
+++ b/tools/profile_mohan_tachyon.py
@@ -10,7 +10,7 @@ lazy import subprocess
 lazy import sys
 lazy import tempfile
 lazy import time
-lazy from collections.abc import Iterator, Mapping
+lazy from collections.abc import Callable, Iterator, Mapping
 lazy from dataclasses import dataclass
 lazy from datetime import UTC, datetime
 lazy from pathlib import Path
@@ -18,6 +18,11 @@ lazy from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PROFILE_TARGETS = ("startup", "lipsync", "expression")
 MAX_PERCENT = 100.0
+# A failed stack-read stream is not evidence about target performance.  Keep
+# the quality threshold strict, but allow two fresh captures to outlast a
+# transient runner or unwinder failure.
+MAX_CAPTURE_RETRIES = 2
+MAX_CAPTURE_ATTEMPTS = MAX_CAPTURE_RETRIES + 1
 TARGET_SCRIPTS = frozendict(
     {
         "startup": ROOT / "app.py",
@@ -107,6 +112,16 @@ class ProfileArtifacts:
             summary=self.summary,
         )
 
+    def in_attempt_directory(self, directory: Path) -> ProfileArtifacts:
+        return ProfileArtifacts(
+            binary=directory / self.binary.name,
+            flamegraph=directory / self.flamegraph.name,
+            jsonl=directory / self.jsonl.name,
+            pstats=directory / self.pstats.name,
+            runtime=directory / self.runtime.name,
+            summary=self.summary,
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class TargetSpec:
@@ -147,6 +162,23 @@ class ProfileOutcome:
     target: str
     summary: Path
     violations: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureAttempt:
+    number: int
+    sample_read_error_percent: float | None
+    runtime_evidence_written: bool
+    artifacts: ProfileArtifacts | None = None
+    output: str = ""
+    elapsed_seconds: float = 0.0
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "attempt": self.number,
+            "sample_read_error_percent": self.sample_read_error_percent,
+            "runtime_evidence_written": self.runtime_evidence_written,
+        }
 
 
 def arguments() -> argparse.Namespace:
@@ -895,6 +927,141 @@ def _capture_statistics(
     }
 
 
+def _capture_once(
+    args: argparse.Namespace,
+    target: str,
+    attempt_number: int,
+    artifacts: ProfileArtifacts,
+    runner: Path,
+    environment: Mapping[str, str],
+) -> CaptureAttempt:
+    completed, elapsed = _run_capture(
+        _capture_command(args, target, artifacts, runner),
+        environment,
+    )
+    combined_output = _strip_ansi(
+        f"{completed.stdout}\n{completed.stderr}"
+    )
+    if completed.returncode:
+        raise RuntimeError(
+            f"Tachyon target {target} failed with "
+            f"exit code {completed.returncode}."
+        )
+    capture = _capture_statistics(combined_output, elapsed)
+    raw_error = capture.get("sample_read_error_percent")
+    sample_read_error = (
+        float(raw_error) if isinstance(raw_error, int | float) else None
+    )
+    return CaptureAttempt(
+        number=attempt_number,
+        sample_read_error_percent=sample_read_error,
+        runtime_evidence_written=artifacts.runtime.is_file(),
+        artifacts=artifacts,
+        output=combined_output,
+        elapsed_seconds=elapsed,
+    )
+
+
+def _capture_requires_retry(
+    args: argparse.Namespace,
+    attempt: CaptureAttempt,
+) -> bool:
+    if not attempt.runtime_evidence_written:
+        return True
+    return (
+        attempt.sample_read_error_percent is not None
+        and attempt.sample_read_error_percent
+        > args.max_sample_read_error_percent
+    )
+
+
+def _capture_retry_reason(
+    args: argparse.Namespace,
+    attempt: CaptureAttempt,
+) -> str:
+    if not attempt.runtime_evidence_written:
+        return "runtime evidence missing"
+    error = attempt.sample_read_error_percent
+    if error is not None and error > args.max_sample_read_error_percent:
+        return (
+            f"sample-read error {error:.2f}% above "
+            f"{args.max_sample_read_error_percent:.2f}%"
+        )
+    return "capture did not satisfy the retryable evidence contract"
+
+
+def _sample_read_error_history(
+    attempts: tuple[CaptureAttempt, ...],
+) -> str:
+    return ", ".join(
+        (
+            f"{attempt.number}={attempt.sample_read_error_percent:.2f}%"
+            if attempt.sample_read_error_percent is not None
+            else f"{attempt.number}=unreported"
+        )
+        for attempt in attempts
+    )
+
+
+def _runtime_evidence_history(
+    attempts: tuple[CaptureAttempt, ...],
+) -> str:
+    return ", ".join(
+        f"{attempt.number}="
+        f"{'written' if attempt.runtime_evidence_written else 'missing'}"
+        for attempt in attempts
+    )
+
+
+def _capture_retry_exhausted_message(
+    target: str,
+    attempts: tuple[CaptureAttempt, ...],
+) -> str:
+    return (
+        f"Tachyon target {target} exhausted {MAX_CAPTURE_RETRIES} retries "
+        f"after {len(attempts)} invalid captures; "
+        "sample-read error rates by attempt: "
+        f"{_sample_read_error_history(attempts)}; "
+        "runtime evidence by attempt: "
+        f"{_runtime_evidence_history(attempts)}."
+    )
+
+
+def _capture_with_retries(
+    args: argparse.Namespace,
+    target: str,
+    capture_attempt: Callable[[int], CaptureAttempt],
+) -> tuple[CaptureAttempt, ...]:
+    attempts: list[CaptureAttempt] = []
+    for attempt_number in range(1, MAX_CAPTURE_ATTEMPTS + 1):
+        attempt = capture_attempt(attempt_number)
+        attempts.append(attempt)
+        if not _capture_requires_retry(args, attempt):
+            return tuple(attempts)
+        if attempt_number < MAX_CAPTURE_ATTEMPTS:
+            print(
+                "MOHAN_TACHYON_PROFILE_RETRY "
+                f"target={target} "
+                f"attempt={attempt_number}/{MAX_CAPTURE_ATTEMPTS} "
+                f"reason={_capture_retry_reason(args, attempt)}",
+                file=sys.stderr,
+            )
+            continue
+        message = _capture_retry_exhausted_message(target, tuple(attempts))
+        if not attempt.runtime_evidence_written:
+            raise RuntimeError(message)
+        print(
+            "MOHAN_TACHYON_CAPTURE_RETRIES_EXHAUSTED "
+            f"target={target} "
+            f"sample-read-error-rates={_sample_read_error_history(tuple(attempts))}",
+            file=sys.stderr,
+        )
+        return tuple(attempts)
+    raise RuntimeError(
+        f"Tachyon target {target} did not produce a capture attempt."
+    )
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -977,6 +1144,7 @@ def _build_summary(
     artifacts: ProfileArtifacts,
     capture_output: str,
     capture_elapsed: float,
+    capture_attempts: tuple[CaptureAttempt, ...] = (),
 ) -> tuple[dict[str, object], tuple[str, ...]]:
     records = _load_jsonl(artifacts.jsonl)
     total_samples, frames = _frame_statistics(records)
@@ -1021,6 +1189,9 @@ def _build_summary(
         "runtime": runtime,
         "capture": {
             **capture,
+            "attempts": [
+                attempt.as_json() for attempt in capture_attempts
+            ],
             "stored_samples": total_samples,
             "gc_direct_samples": gc_samples,
             "project_direct_samples": sum(
@@ -1070,6 +1241,19 @@ def _write_json(path: Path, value: Mapping[str, object]) -> None:
     )
 
 
+def _publish_profile_outputs(
+    source: ProfileArtifacts,
+    destination: ProfileArtifacts,
+) -> None:
+    for source_path, destination_path in zip(
+        source.published_outputs(),
+        destination.published_outputs(),
+        strict=True,
+    ):
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.replace(destination_path)
+
+
 def _profile_target(
     args: argparse.Namespace,
     target: str,
@@ -1080,44 +1264,65 @@ def _profile_target(
         args.output,
     )
     artifacts.summary.parent.mkdir(parents=True, exist_ok=True)
+    accepted: tuple[dict[str, object], tuple[str, ...]] | None = None
     with tempfile.TemporaryDirectory(
         prefix=f"mohan-tachyon-{target}-"
     ) as raw_temp_dir:
         temp_dir = Path(raw_temp_dir)
-        artifacts = artifacts.with_temporary_binary(
-            temp_dir / f"mohan-tachyon-{target}.profile.bin"
-        )
-        spec = _target_spec(target, temp_dir, args.full_session)
-        runner = _write_runner(spec, artifacts.runtime, temp_dir)
-        environment = _profile_environment(
-            temp_dir,
-            args.use_user_profile,
-        )
-        completed, elapsed = _run_capture(
-            _capture_command(args, target, artifacts, runner),
+        attempt_contexts: dict[int, tuple[Path, Mapping[str, str]]] = {}
+
+        def capture_attempt(attempt_number: int) -> CaptureAttempt:
+            attempt_dir = temp_dir / f"attempt-{attempt_number}"
+            attempt_dir.mkdir(parents=True, exist_ok=True)
+            attempt_artifacts = artifacts.in_attempt_directory(attempt_dir)
+            spec = _target_spec(target, attempt_dir, args.full_session)
+            runner = _write_runner(
+                spec,
+                attempt_artifacts.runtime,
+                attempt_dir,
+            )
+            environment = _profile_environment(
+                attempt_dir,
+                args.use_user_profile,
+            )
+            attempt_contexts[attempt_number] = (attempt_dir, environment)
+            return _capture_once(
+                args,
+                target,
+                attempt_number,
+                attempt_artifacts,
+                runner,
+                environment,
+            )
+
+        attempts = _capture_with_retries(args, target, capture_attempt)
+        final_attempt = attempts[-1]
+        if final_attempt.artifacts is None:
+            raise RuntimeError(
+                f"Tachyon target {target} produced an incomplete capture."
+            )
+        attempt_dir, environment = attempt_contexts[final_attempt.number]
+        _replay_profile(final_attempt.artifacts, environment)
+        _sanitize_profile_outputs(
+            final_attempt.artifacts,
+            attempt_dir,
             environment,
         )
-        combined_output = _strip_ansi(
-            f"{completed.stdout}\n{completed.stderr}"
+        summary, violations = _build_summary(
+            args,
+            target,
+            final_attempt.artifacts,
+            final_attempt.output,
+            final_attempt.elapsed_seconds,
+            tuple(attempts),
         )
-        if completed.returncode:
-            raise RuntimeError(
-                f"Tachyon target {target} failed with "
-                f"exit code {completed.returncode}."
-            )
-        if not artifacts.runtime.is_file():
-            raise RuntimeError(
-                f"Tachyon target {target} did not write runtime evidence."
-            )
-        _replay_profile(artifacts, environment)
-        _sanitize_profile_outputs(artifacts, temp_dir, environment)
-    summary, violations = _build_summary(
-        args,
-        target,
-        artifacts,
-        combined_output,
-        elapsed,
-    )
+        _publish_profile_outputs(final_attempt.artifacts, artifacts)
+        accepted = (summary, violations)
+    if accepted is None:
+        raise RuntimeError(
+            f"Tachyon target {target} did not produce an accepted capture."
+        )
+    summary, violations = accepted
     _write_json(artifacts.summary, summary)
     print(
         "MOHAN_TACHYON_PROFILE_"

--- a/tools/profile_mohan_tachyon.py
+++ b/tools/profile_mohan_tachyon.py
@@ -8,6 +8,7 @@ lazy import platform
 lazy import re
 lazy import subprocess
 lazy import sys
+lazy import shutil
 lazy import tempfile
 lazy import time
 lazy from collections.abc import Callable, Iterator, Mapping
@@ -1251,7 +1252,8 @@ def _publish_profile_outputs(
         strict=True,
     ):
         destination_path.parent.mkdir(parents=True, exist_ok=True)
-        source_path.replace(destination_path)
+        # shutil.move 可跨磁碟機；Path.replace 在 CI runner 的 Temp（C:）搬到工作區（D:）會失敗。
+        shutil.move(str(source_path), str(destination_path))
 
 
 def _profile_target(
@@ -1266,7 +1268,8 @@ def _profile_target(
     artifacts.summary.parent.mkdir(parents=True, exist_ok=True)
     accepted: tuple[dict[str, object], tuple[str, ...]] | None = None
     with tempfile.TemporaryDirectory(
-        prefix=f"mohan-tachyon-{target}-"
+        prefix=f"mohan-tachyon-{target}-",
+        dir=artifacts.summary.parent,
     ) as raw_temp_dir:
         temp_dir = Path(raw_temp_dir)
         attempt_contexts: dict[int, tuple[Path, Mapping[str, str]]] = {}


### PR DESCRIPTION
## 繁體中文
- 成因：CI 的 `test` 工作在 Windows runner 上，Tachyon 目標行程尚未就緒就開始取樣，堆疊讀取例外被計入 sample-read error（#178 首跑缺 runtime evidence、#188 首跑 `expression` 錯誤率 35.12%），是啟動競態，不是效能問題。
- 修法：對 runtime evidence 缺失或 sample-read error 超過既有門檻的單一 target，最多重新取樣兩次並記錄各次結果；1% 門檻、樣本數、漏採樣、JIT 與效能門檻全部不動。
- 測試：新增「首次高錯誤率、第二次正常→通過」與「連續超過重試上限→明確失敗且訊息含 target 與各次錯誤率」。
- 閘門：`ALL_386_TESTS_OK`。

## 简体中文
- 成因：CI 的 `test` 作业在 Windows runner 上，Tachyon 目标进程尚未就绪就开始采样，堆栈读取异常被计入 sample-read error（#178 首跑缺 runtime evidence、#188 首跑 `expression` 错误率 35.12%），是启动竞态，不是性能问题。
- 修法：对 runtime evidence 缺失或 sample-read error 超过既有门槛的单个 target，最多重新采样两次并记录各次结果；1% 门槛、样本数、漏采样、JIT 与性能门槛全部不动。
- 测试：新增「首次高错误率、第二次正常→通过」与「连续超过重试上限→明确失败且信息含 target 与各次错误率」。
- 闸门：`ALL_386_TESTS_OK`。

## English
- Cause: in the CI `test` job on the Windows runner, sampling started before the Tachyon target process was ready, so stack-read exceptions were counted as sample-read errors (#178 first run lacked runtime evidence; #188 first run hit a 35.12% error rate on `expression`). It is a startup race, not a performance problem.
- Fix: a single target with missing runtime evidence or a sample-read error above the existing threshold is freshly captured up to two more times with every result recorded; the 1% threshold, sample counts, missed-sample, JIT, and performance thresholds are all unchanged.
- Tests: added "first attempt high error, second attempt normal → pass" and "retries exhausted → explicit failure whose message names the target and every error rate".
- Gate: `ALL_386_TESTS_OK`.

## 日本語
- 原因：Windows runner 上の CI `test` ジョブで、Tachyon 対象プロセスの準備が整う前にサンプリングが始まり、スタック読み取り例外が sample-read error として数えられていました（#178 の初回実行は runtime evidence が欠落、#188 の初回実行は `expression` でエラー率 35.12%）。起動時の競合であり、パフォーマンスの問題ではありません。
- 修正：runtime evidence が欠落した、または既存の閾値を超える sample-read error の単一 target は最大二回まで新しく再取得し、各結果を記録します。1% の閾値、サンプル数、欠落サンプル、JIT、パフォーマンスの閾値はすべて変更しません。
- テスト：「初回は高エラー率、二回目は正常 → 合格」と「再試行上限超過 → target と各回のエラー率を含む明示的な失敗」を追加。
- ゲート：`ALL_386_TESTS_OK`。
