### PR TITLE
將官方外觀包裁判收進正式工具與測試閘門／将官方外观包裁判收进正式工具与测试门禁／Promote official outfit-pack judges to a formal tool and test gate／公式外観パック裁判を正式ツールとテストゲートへ昇格

### DIFF
--- a/changelog.d/feat-official-pack-qc-judges.md
+++ b/changelog.d/feat-official-pack-qc-judges.md
@@ -1,0 +1,3 @@
+### 官方外觀包裁判正式工具與閘門／官方外观包裁判正式工具与门禁／Promote official outfit-pack judges to a formal tool and gate／公式外観パック裁判を正式ツールとゲートへ昇格
+
+* 將官方包孤立雜點、低 alpha、流蘇高度與髮髻頂部殘留判準收進可重複執行的工具與測試閘門／将官方包孤立杂点、低 alpha、流苏高度与发髻顶部残留判准收进可重复执行的工具与测试门禁／Move the official-pack isolated-speck, low-alpha, tassel-height, and top-residue criteria into a repeatable tool and test gate／公式パックの孤立点、低アルファ、房飾りの高さ、髷頂部残留の判定基準を再実行可能なツールとテストゲートへ移行

--- a/tests/test_official_pack_qc_gate.py
+++ b/tests/test_official_pack_qc_gate.py
@@ -1,0 +1,78 @@
+"""Gate tests for the shipped official outfit pack."""
+
+from __future__ import annotations
+
+lazy import pytest
+lazy import sys
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy from tools import qc_official_pack as qc
+
+
+OFFICIAL_PACK = (
+    ROOT
+    / "assets"
+    / "official-packs"
+    / "mohan.official.blue-white-hanfu.mohan-outfit"
+)
+COMPOSITE = ROOT / "docs" / "media" / "portraits" / "idle_front.png"
+KNOWN_DEFECT_REASON = "#185 修正前的已知缺陷"
+
+
+@pytest.mark.xfail(strict=True, reason=KNOWN_DEFECT_REASON)
+def test_official_pack_isolated_specks() -> None:
+    layers = qc.load_pack_full_canvas_alphas(OFFICIAL_PACK)
+    measured = qc.judge_pack_isolated_specks(layers)
+
+    assert all(
+        count == qc.REQUIRED_ZERO_COUNT for count in measured.values()
+    ), measured
+
+
+@pytest.mark.xfail(strict=True, reason=KNOWN_DEFECT_REASON)
+def test_official_pack_low_alpha_residue() -> None:
+    layers = qc.load_pack_full_canvas_alphas(OFFICIAL_PACK)
+    measured = qc.judge_pack_low_alpha_residue(layers)
+
+    assert all(
+        count == qc.REQUIRED_ZERO_COUNT for count in measured.values()
+    ), measured
+
+
+def test_official_composite_stays_within_base_speck_budget() -> None:
+    measured = qc.judge_composite_isolated_specks(
+        qc.load_composite_alpha(COMPOSITE)
+    )
+
+    assert measured <= qc.COMPOSITE_MAX_ISOLATED_SPECKS, measured
+
+
+@pytest.mark.xfail(strict=True, reason=KNOWN_DEFECT_REASON)
+def test_official_headwear_tassel_height() -> None:
+    layers = qc.load_pack_full_canvas_alphas(OFFICIAL_PACK)
+    measured = qc.judge_tassel_height(layers[qc.HEADWEAR_LAYER_KEY])
+
+    assert measured.heights and measured.heights[0] >= qc.TASSEL_MIN_HEIGHT, measured
+
+
+@pytest.mark.xfail(strict=True, reason=KNOWN_DEFECT_REASON)
+def test_official_headwear_top_residue() -> None:
+    layers = qc.load_pack_full_canvas_alphas(OFFICIAL_PACK)
+    measured = qc.judge_top_residue(layers[qc.HEADWEAR_LAYER_KEY])
+
+    assert measured == (), measured
+
+
+def main() -> int:
+    result = pytest.main([str(Path(__file__)), "-q", "-p", "no:cacheprovider"])
+    if result == 0:
+        print("OFFICIAL_PACK_QC_GATE_TESTS_OK")
+    return int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qc_official_pack.py
+++ b/tests/test_qc_official_pack.py
@@ -1,0 +1,174 @@
+"""Synthetic tests for the official outfit-pack QC judges."""
+
+from __future__ import annotations
+
+lazy import cv2
+lazy import pytest
+lazy import sys
+lazy import zipfile
+lazy from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+lazy import numpy as np
+
+lazy from tools import qc_official_pack as qc
+
+
+EXPECTED_ONE = 1
+EXPECTED_EIGHT_PIXEL_AREA = 8
+EXPECTED_ALPHA_RESIDUE = 1
+EXPECTED_SHORT_TASSEL_HEIGHT = 40
+EXPECTED_TOP_RESIDUE_AREA = 100
+EXPECTED_TOP_RESIDUE_BBOX = (630, 100, 10, 10)
+VALID_TASSEL_HEIGHT = 100
+OPAQUE_ALPHA = 255
+
+
+def _canvas() -> np.ndarray:
+    return np.zeros(
+        (qc.CANVAS_SIZE, qc.CANVAS_SIZE, qc.RGBA_CHANNELS),
+        dtype=np.uint8,
+    )
+
+
+def _valid_headwear() -> np.ndarray:
+    image = _canvas()
+    image[200:200 + VALID_TASSEL_HEIGHT, 760:764, qc.ALPHA_CHANNEL] = 255
+    return image
+
+
+def _encode(image: np.ndarray) -> bytes:
+    encoded_ok, encoded = cv2.imencode(".png", image)
+    assert encoded_ok
+    return encoded.tobytes()
+
+
+def _pack(tmp_path: Path, layers: dict[str, np.ndarray]) -> Path:
+    path = tmp_path / "synthetic.mohan-outfit"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for key, image in layers.items():
+            archive.writestr(f"assets/synthetic-{key}", _encode(image))
+    return path
+
+
+def _clean_layers() -> dict[str, np.ndarray]:
+    return {
+        qc.FRONT_LAYER_KEY: _canvas(),
+        qc.BACK_LAYER_KEY: _canvas(),
+        qc.HEADWEAR_LAYER_KEY: _valid_headwear(),
+    }
+
+
+def _alpha_layers(layers: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    return {
+        key: image[:, :, qc.ALPHA_CHANNEL]
+        for key, image in layers.items()
+    }
+
+
+def _write_composite(tmp_path: Path, image: np.ndarray) -> Path:
+    path = tmp_path / "composite.png"
+    assert cv2.imwrite(str(path), image)
+    return path
+
+
+def test_clean_layers_pass(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    pack = _pack(tmp_path, _clean_layers())
+    composite = _write_composite(tmp_path, _canvas())
+
+    assert qc.main([str(pack), "--composite", str(composite)]) == 0
+    assert capsys.readouterr().out.rstrip().endswith("OFFICIAL_PACK_QC_OK")
+
+
+def test_eight_pixel_isolated_point_fails_and_reports_one() -> None:
+    rgba_layers = _clean_layers()
+    layers = _alpha_layers(rgba_layers)
+    point = layers[qc.FRONT_LAYER_KEY]
+    point[300:302, 400:404] = OPAQUE_ALPHA
+
+    measured = qc.judge_pack_isolated_specks(layers)
+
+    assert EXPECTED_EIGHT_PIXEL_AREA == int(
+        (point[300:302, 400:404] > qc.SOLID_ALPHA_THRESHOLD).sum()
+    )
+    assert measured[qc.FRONT_LAYER_KEY] == EXPECTED_ONE
+    assert measured[qc.FRONT_LAYER_KEY] != qc.REQUIRED_ZERO_COUNT
+
+
+def test_alpha_twenty_residue_fails() -> None:
+    layers = _alpha_layers(_clean_layers())
+    layers[qc.FRONT_LAYER_KEY][300, 400] = 20
+
+    measured = qc.judge_pack_low_alpha_residue(layers)
+
+    assert measured[qc.FRONT_LAYER_KEY] == EXPECTED_ALPHA_RESIDUE
+    assert measured[qc.FRONT_LAYER_KEY] != qc.REQUIRED_ZERO_COUNT
+
+
+def test_short_tassel_component_fails() -> None:
+    headwear = _canvas()[:, :, qc.ALPHA_CHANNEL]
+    headwear[200:240, 760:764] = OPAQUE_ALPHA
+
+    measured = qc.judge_tassel_height(headwear)
+
+    assert measured.component_count == EXPECTED_ONE
+    assert measured.heights == (EXPECTED_SHORT_TASSEL_HEIGHT,)
+    assert measured.heights[0] < qc.TASSEL_MIN_HEIGHT
+
+
+def test_top_residue_fails_and_prints_bbox(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    layers = _clean_layers()
+    headwear = layers[qc.HEADWEAR_LAYER_KEY]
+    headwear[300:330, 300:330, qc.ALPHA_CHANNEL] = OPAQUE_ALPHA
+    headwear[EXPECTED_TOP_RESIDUE_BBOX[1] : EXPECTED_TOP_RESIDUE_BBOX[1] + 10,
+             EXPECTED_TOP_RESIDUE_BBOX[0] : EXPECTED_TOP_RESIDUE_BBOX[0] + 10,
+             qc.ALPHA_CHANNEL] = OPAQUE_ALPHA
+    pack = _pack(tmp_path, layers)
+
+    assert qc.main([str(pack)]) == 1
+    output = capsys.readouterr().out
+    assert (
+        "TOP_RESIDUE area=100 bbox=x630..640 y100..110"
+        in output
+    )
+    assert output.rstrip().endswith("OFFICIAL_PACK_QC_FAIL")
+    residues = qc.judge_top_residue(headwear[:, :, qc.ALPHA_CHANNEL])
+    assert len(residues) == EXPECTED_ONE
+    assert residues[0].area == EXPECTED_TOP_RESIDUE_AREA
+    assert residues[0].bbox == EXPECTED_TOP_RESIDUE_BBOX
+
+
+def test_cropped_layer_is_padded_at_top_left_and_warns(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    layers = _clean_layers()
+    cropped = np.zeros((20, 30, qc.RGBA_CHANNELS), dtype=np.uint8)
+    cropped[5, 6, qc.ALPHA_CHANNEL] = 255
+    layers[qc.FRONT_LAYER_KEY] = cropped
+    pack = _pack(tmp_path, layers)
+
+    loaded = qc.load_pack_full_canvas_alphas(pack)
+
+    output = capsys.readouterr().out
+    assert "pasted at top-left" in output
+    assert loaded[qc.FRONT_LAYER_KEY].shape == qc.CANVAS_SHAPE
+    assert loaded[qc.FRONT_LAYER_KEY][5, 6] == OPAQUE_ALPHA
+    assert loaded[qc.FRONT_LAYER_KEY][6, 5] == 0
+
+
+def main() -> int:
+    result = pytest.main([str(Path(__file__)), "-q", "-p", "no:cacheprovider"])
+    if result == 0:
+        print("QC_OFFICIAL_PACK_TESTS_OK")
+    return int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/qc_official_pack.py
+++ b/tools/qc_official_pack.py
@@ -1,0 +1,357 @@
+"""Official outfit-pack quality judges.
+
+The thresholds in this module are the two owner-provided judges moved from the
+temporary root scripts.  Keep the geometry and comparisons exact: this tool is
+an acceptance gate, not a cleanup or a heuristic tuning pass.
+"""
+
+from __future__ import annotations
+
+lazy import argparse
+lazy import cv2
+lazy import numpy as np
+lazy import sys
+lazy import zipfile
+lazy from collections.abc import Mapping, Sequence
+lazy from dataclasses import dataclass
+lazy from pathlib import Path
+lazy from typing import Final
+
+
+CANVAS_SIZE: Final = 1254  # Cropped pack layers previously lost their canvas registration.
+CANVAS_SHAPE: Final = (CANVAS_SIZE, CANVAS_SIZE)
+RGBA_CHANNELS: Final = 4
+CHANNEL_DIMENSION: Final = 2
+ALPHA_CHANNEL: Final = 3
+CONNECTED_COMPONENTS_8: Final = 8
+BACKGROUND_LABEL: Final = 0
+FIRST_FOREGROUND_LABEL: Final = 1
+
+# These three member suffixes are the front-crossed layers whose alpha defects
+# previously escaped a pack-level inspection.
+FRONT_LAYER_KEY: Final = "front-crossed-front.png"
+BACK_LAYER_KEY: Final = "front-crossed-back.png"
+HEADWEAR_LAYER_KEY: Final = "front-crossed-headwear.png"
+PACK_LAYER_KEYS: Final = (FRONT_LAYER_KEY, BACK_LAYER_KEY, HEADWEAR_LAYER_KEY)
+
+# This ROI is the owner box for isolated specks that appeared in cropped layers.
+SPECK_ROI: Final = (300, 100, 1000, 520)  # x0, y0, x1, y1.
+# A solid pixel is part of the historical isolated-speck judge only above alpha 30.
+SOLID_ALPHA_THRESHOLD: Final = 30
+# Components at or below 12 pixels are the small residuals this judge rejects.
+SMALL_COMPONENT_MAX_AREA: Final = 12
+# Components above 60 pixels are the nearby legitimate regions used as anchors.
+LARGE_COMPONENT_MIN_AREA: Final = 60
+# A 7x7 dilation means an isolated speck must be more than 3 pixels from an anchor.
+SPECK_CLEARANCE_PIXELS: Final = 3
+# The pack layer judge accepts no isolated specks or alpha 1--30 residue.
+REQUIRED_ZERO_COUNT: Final = 0
+# Alpha 1--30 was the low-alpha residue class found in earlier sealed layers.
+LOW_ALPHA_MINIMUM: Final = 0
+LOW_ALPHA_MAXIMUM: Final = 30
+
+# This column is the owner box for the silver tassel body.
+TASSEL_ROI: Final = (720, 180, 820, 450)  # x0, y0, x1, y1.
+# A 40-pixel tassel was a known incomplete extraction; the body must reach 80.
+TASSEL_MIN_HEIGHT: Final = 80
+
+# This top box catches the detached hair-bun residue seen in the official pack.
+TOP_RESIDUE_ROI: Final = (600, 90, 740, 150)  # x0, y0, x1, y1.
+# Top residues from 12 through 400 pixels are suspicious rather than the main mass.
+TOP_RESIDUE_MIN_AREA: Final = 12
+TOP_RESIDUE_MAX_AREA: Final = 400
+# A 5x5 dilation makes the top-residue distance rule exactly greater than 2 pixels.
+TOP_RESIDUE_CLEARANCE_PIXELS: Final = 2
+# The bare base body carries nine isolated specks; composites may not exceed it.
+COMPOSITE_MAX_ISOLATED_SPECKS: Final = 9
+
+
+@dataclass(frozen=True)
+class TasselJudgement:
+    """Numeric output for the tassel-height criterion."""
+
+    component_count: int
+    heights: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class TopResidue:
+    """One top-residue component reported by its measured area and bbox."""
+
+    area: int
+    bbox: tuple[int, int, int, int]
+
+
+def _decode_rgba(encoded: bytes, label: str) -> np.ndarray:
+    image = cv2.imdecode(
+        np.frombuffer(encoded, dtype=np.uint8),
+        cv2.IMREAD_UNCHANGED,
+    )
+    if (
+        image is None
+        or image.ndim != RGBA_CHANNELS - 1
+        or image.shape[CHANNEL_DIMENSION] != RGBA_CHANNELS
+    ):
+        raise ValueError(f"Expected RGBA PNG: {label}")
+    return image
+
+
+def _full_canvas_alpha(image: np.ndarray, key: str) -> np.ndarray:
+    alpha = image[:, :, ALPHA_CHANNEL]
+    if alpha.shape == CANVAS_SHAPE:
+        return alpha
+    height, width = alpha.shape
+    if height > CANVAS_SIZE or width > CANVAS_SIZE:
+        raise ValueError(
+            f"Layer {key} is larger than the {CANVAS_SIZE}x{CANVAS_SIZE} canvas: "
+            f"{width}x{height}"
+        )
+    canvas = np.zeros(CANVAS_SHAPE, dtype=np.uint8)
+    canvas[:height, :width] = alpha
+    print(
+        f"WARNING: {key} is cropped at {width}x{height}; "
+        f"pasted at top-left on the {CANVAS_SIZE}x{CANVAS_SIZE} canvas"
+    )
+    return canvas
+
+
+def load_pack_full_canvas_alphas(pack: Path) -> dict[str, np.ndarray]:
+    """Load front, back, and headwear alpha masks on one full canvas."""
+
+    with zipfile.ZipFile(pack) as archive:
+        names = tuple(archive.namelist())
+        layers: dict[str, np.ndarray] = {}
+        for key in PACK_LAYER_KEYS:
+            member = next((name for name in names if name.endswith(key)), None)
+            if member is None:
+                raise ValueError(f"Missing official layer: {key}")
+            layers[key] = _full_canvas_alpha(
+                _decode_rgba(archive.read(member), member),
+                key,
+            )
+    return layers
+
+
+def load_composite_alpha(composite: Path) -> np.ndarray:
+    """Load the alpha channel from a composed RGBA portrait."""
+
+    return _decode_rgba(composite.read_bytes(), str(composite))[:, :, ALPHA_CHANNEL]
+
+
+def _roi(alpha: np.ndarray, box: tuple[int, int, int, int]) -> np.ndarray:
+    x0, y0, x1, y1 = box
+    return alpha[y0:y1, x0:x1]
+
+
+def _square_kernel(clearance_pixels: int) -> np.ndarray:
+    kernel_size = clearance_pixels * 2 + 1
+    return np.ones((kernel_size, kernel_size), dtype=np.uint8)
+
+
+def count_isolated_specks(alpha: np.ndarray) -> int:
+    """Count small solid components farther than the owner clearance."""
+
+    solid = (alpha > SOLID_ALPHA_THRESHOLD).astype(np.uint8)
+    if solid.size == REQUIRED_ZERO_COUNT or not solid.any():
+        return REQUIRED_ZERO_COUNT
+    component_count, labels, stats, _centroids = (
+        cv2.connectedComponentsWithStats(
+            solid,
+            connectivity=CONNECTED_COMPONENTS_8,
+        )
+    )
+    large = np.zeros_like(solid)
+    for label in range(FIRST_FOREGROUND_LABEL, component_count):
+        if stats[label, cv2.CC_STAT_AREA] > LARGE_COMPONENT_MIN_AREA:
+            large[labels == label] = 1
+    far = cv2.dilate(
+        large,
+        _square_kernel(SPECK_CLEARANCE_PIXELS),
+    ) == BACKGROUND_LABEL
+    count = REQUIRED_ZERO_COUNT
+    for label in range(FIRST_FOREGROUND_LABEL, component_count):
+        if stats[label, cv2.CC_STAT_AREA] <= SMALL_COMPONENT_MAX_AREA:
+            ys, xs = np.nonzero(labels == label)
+            if far[ys, xs].all():
+                count += 1
+    return count
+
+
+def judge_pack_isolated_specks(
+    layers: Mapping[str, np.ndarray],
+) -> dict[str, int]:
+    """Apply the isolated-speck criterion to each official pack layer."""
+
+    return {
+        key: count_isolated_specks(_roi(layers[key], SPECK_ROI))
+        for key in PACK_LAYER_KEYS
+    }
+
+
+def judge_pack_low_alpha_residue(
+    layers: Mapping[str, np.ndarray],
+) -> dict[str, int]:
+    """Count alpha 1--30 pixels in each official pack layer."""
+
+    return {
+        key: int(
+            (
+                (layers[key] > LOW_ALPHA_MINIMUM)
+                & (layers[key] <= LOW_ALPHA_MAXIMUM)
+            ).sum()
+        )
+        for key in PACK_LAYER_KEYS
+    }
+
+
+def judge_composite_isolated_specks(composite_alpha: np.ndarray) -> int:
+    """Apply the isolated-speck criterion to the optional composite portrait."""
+
+    return count_isolated_specks(_roi(composite_alpha, SPECK_ROI))
+
+
+def judge_tassel_height(headwear_alpha: np.ndarray) -> TasselJudgement:
+    """Require one alpha>30 component at least 80 pixels high in the tassel box."""
+
+    column = (_roi(headwear_alpha, TASSEL_ROI) > SOLID_ALPHA_THRESHOLD).astype(
+        np.uint8
+    )
+    component_count, _labels, stats, _centroids = (
+        cv2.connectedComponentsWithStats(
+            column,
+            connectivity=CONNECTED_COMPONENTS_8,
+        )
+    )
+    heights = tuple(
+        sorted(
+            (
+                int(stats[label, cv2.CC_STAT_HEIGHT])
+                for label in range(FIRST_FOREGROUND_LABEL, component_count)
+            ),
+            reverse=True,
+        )
+    )
+    return TasselJudgement(component_count - FIRST_FOREGROUND_LABEL, heights)
+
+
+def judge_top_residue(headwear_alpha: np.ndarray) -> tuple[TopResidue, ...]:
+    """Find detached alpha>30 components in the owner top-residue box."""
+
+    solid = (headwear_alpha > SOLID_ALPHA_THRESHOLD).astype(np.uint8)
+    component_count, labels, stats, _centroids = (
+        cv2.connectedComponentsWithStats(
+            solid,
+            connectivity=CONNECTED_COMPONENTS_8,
+        )
+    )
+    large = np.zeros_like(solid)
+    for label in range(FIRST_FOREGROUND_LABEL, component_count):
+        if stats[label, cv2.CC_STAT_AREA] > TOP_RESIDUE_MAX_AREA:
+            large[labels == label] = 1
+    far = cv2.dilate(
+        large,
+        _square_kernel(TOP_RESIDUE_CLEARANCE_PIXELS),
+    ) == BACKGROUND_LABEL
+    x0, y0, x1, y1 = TOP_RESIDUE_ROI
+    residues: list[TopResidue] = []
+    for label in range(FIRST_FOREGROUND_LABEL, component_count):
+        x, y, width, height, area = (
+            int(value) for value in stats[label]
+        )
+        if not (
+            TOP_RESIDUE_MIN_AREA <= area <= TOP_RESIDUE_MAX_AREA
+            and x0 <= x
+            and x + width <= x1
+            and y0 <= y
+            and y + height <= y1
+        ):
+            continue
+        ys, xs = np.nonzero(labels == label)
+        if far[ys, xs].all():
+            residues.append(TopResidue(area, (x, y, width, height)))
+    return tuple(residues)
+
+
+def _print_pack_judgements(layers: Mapping[str, np.ndarray]) -> bool:
+    ok = True
+    isolated = judge_pack_isolated_specks(layers)
+    low_alpha = judge_pack_low_alpha_residue(layers)
+    for key in PACK_LAYER_KEYS:
+        nontransparent = int((layers[key] > LOW_ALPHA_MINIMUM).sum())
+        print(
+            f"PACK_LAYER {key} isolated_specks={isolated[key]} "
+            f"low_alpha_1_30={low_alpha[key]} "
+            f"nontransparent={nontransparent}"
+        )
+        ok = ok and isolated[key] == REQUIRED_ZERO_COUNT
+        ok = ok and low_alpha[key] == REQUIRED_ZERO_COUNT
+    return ok
+
+
+def _print_tassel_judgement(headwear_alpha: np.ndarray) -> bool:
+    result = judge_tassel_height(headwear_alpha)
+    print(
+        f"TASSEL_HEIGHT component_count={result.component_count} "
+        f"heights={list(result.heights[:3])} minimum={TASSEL_MIN_HEIGHT}"
+    )
+    return bool(result.heights) and result.heights[0] >= TASSEL_MIN_HEIGHT
+
+
+def _print_top_residue_judgement(headwear_alpha: np.ndarray) -> bool:
+    residues = judge_top_residue(headwear_alpha)
+    for residue in residues:
+        x, y, width, height = residue.bbox
+        print(
+            f"TOP_RESIDUE area={residue.area} "
+            f"bbox=x{x}..{x + width} y{y}..{y + height}"
+        )
+    print(f"TOP_RESIDUE count={len(residues)}")
+    return not residues
+
+
+def run_qc(pack: Path, composite: Path | None = None) -> int:
+    """Run every available official-pack criterion and print its numbers."""
+
+    try:
+        layers = load_pack_full_canvas_alphas(pack)
+        ok = _print_pack_judgements(layers)
+        if composite is None:
+            print("COMPOSITE isolated_specks=SKIPPED (no --composite supplied)")
+        else:
+            composite_count = judge_composite_isolated_specks(
+                load_composite_alpha(composite)
+            )
+            print(
+                f"COMPOSITE isolated_specks={composite_count} "
+                f"maximum={COMPOSITE_MAX_ISOLATED_SPECKS}"
+            )
+            ok = ok and composite_count <= COMPOSITE_MAX_ISOLATED_SPECKS
+        headwear = layers[HEADWEAR_LAYER_KEY]
+        tassel_ok = _print_tassel_judgement(headwear)
+        top_residue_ok = _print_top_residue_judgement(headwear)
+        ok = ok and tassel_ok and top_residue_ok
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(f"QC_INPUT_ERROR: {error}", file=sys.stderr)
+        ok = False
+    print("OFFICIAL_PACK_QC_OK" if ok else "OFFICIAL_PACK_QC_FAIL")
+    return 0 if ok else 1
+
+
+def _arguments(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pack", type=Path, help="official .mohan-outfit archive")
+    parser.add_argument(
+        "--composite",
+        type=Path,
+        help="optional RGBA composite portrait to check against the base budget",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _arguments(argv)
+    return run_qc(arguments.pack, arguments.composite)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 繁體中文
- 新增 `tools/qc_official_pack.py`：把這兩天實際抓到 main 素材缺陷的裁判（孤立雜點、低 alpha 殘留、流蘇本體高度、髮髻頂部殘留）收成一支可重複執行的工具，判準數值一個都沒改。
- 新增 `tests/test_qc_official_pack.py`：以程式合成小圖逐條驗證每個判準會正確判失敗。
- 新增 `tests/test_official_pack_qc_gate.py`：對真實官方包跑整套裁判。main 現況在孤立雜點、低 alpha、流蘇高度、頂部殘留四條會失敗，這是 #185 正在修的已知缺陷，故以嚴格 `xfail` 標記；#185 併入後這四條會因反而通過而失敗，提醒解除標記。
- 之後派素材任務的規則：沒有會判失敗的裁判就不派。

## 简体中文
- 新增 `tools/qc_official_pack.py`：把这两天实际抓到 main 素材缺陷的裁判（孤立杂点、低 alpha 残留、流苏本体高度、发髻顶部残留）收成一支可重复执行的工具，判准数值一个都没改。
- 新增 `tests/test_qc_official_pack.py`：以程序合成小图逐条验证每个判准会正确判失败。
- 新增 `tests/test_official_pack_qc_gate.py`：对真实官方包跑整套裁判。main 现状在孤立杂点、低 alpha、流苏高度、顶部残留四条会失败，这是 #185 正在修的已知缺陷，故以严格 `xfail` 标记；#185 并入后这四条会因反而通过而失败，提醒解除标记。
- 之后派素材任务的规则：没有会判失败的裁判就不派。

## English
- Add `tools/qc_official_pack.py`: the judges that actually caught the asset defects on main these past two days (isolated specks, low-alpha residue, tassel body height, bun-top residue) become one repeatable tool; not a single criterion value changed.
- Add `tests/test_qc_official_pack.py`: synthetic images verify that every criterion fails when it should.
- Add `tests/test_official_pack_qc_gate.py`: runs the whole judge set on the real official pack. Current main fails four criteria (isolated specks, low alpha, tassel height, top residue); these are the known defects #185 is fixing, so they are marked strict `xfail`. Once #185 lands they will fail by passing, prompting removal of the markers.
- Rule for future asset tasks: no dispatch without a judge that already fails.

## 日本語
- `tools/qc_official_pack.py` を追加：この二日間で main の素材欠陥を実際に捉えた裁判（孤立点、低アルファ残留、房飾り本体の高さ、髷頂部の残留）を再実行可能な一つのツールへ集約。判定値は一つも変更していません。
- `tests/test_qc_official_pack.py` を追加：合成画像で各判定が正しく失敗することを検証。
- `tests/test_official_pack_qc_gate.py` を追加：実際の公式パックに裁判一式を実行。現行 main は孤立点、低アルファ、房飾りの高さ、頂部残留の四項目で失敗しますが、これは #185 が修正中の既知欠陥のため厳格な `xfail` で標記。#185 取り込み後は逆に合格して失敗となり、標記の解除を促します。
- 今後の素材タスク派遣ルール：失敗すると分かっている裁判がなければ派遣しない。
